### PR TITLE
doc: Typo in Nit Reference

### DIFF
--- a/doc/nitreference/nitreference-main.tex
+++ b/doc/nitreference/nitreference-main.tex
@@ -296,7 +296,7 @@ else
 end
 \end{lst}
 \end{multicols}
-Note that the following example is invalid since the fist line is syntactically complete thus the newline terminate the whole @if@ structure\goto{syntax}; then an error is signaled since a statement cannot begin with @else@.
+Note that the following example is invalid since the first line is syntactically complete thus the newline terminate the whole @if@ structure\goto{syntax}; then an error is signaled since a statement cannot begin with @else@.
 \begin{lst}
 if exp then stm # OK: complete 'if' structure
 else stm # Syntax error: unexpected 'else'


### PR DESCRIPTION
doc: Typo in Nit Reference

Signed-off-by: Alexandre Terrasa alexandre@moz-concept.com
