### PR TITLE
Layout_builders: introduce posets for better performances

### DIFF
--- a/src/abstract_compiler.nit
+++ b/src/abstract_compiler.nit
@@ -2384,208 +2384,25 @@ redef class Array[E]
 end
 
 redef class MModule
-
-	# Return a linearization of a set of mtypes
-	fun linearize_mtypes(mtypes: Set[MType]): Array[MType] do
-		var lin = new Array[MType].from(mtypes)
-		var sorter = new TypeSorter(self)
-		sorter.sort(lin)
-		return lin
-	end
-
-	# Return a reverse linearization of a set of mtypes
-	fun reverse_linearize_mtypes(mtypes: Set[MType]): Array[MType] do
-		var lin = new Array[MType].from(mtypes)
-		var sorter = new ReverseTypeSorter(self)
-		sorter.sort(lin)
-		return lin
-	end
-
-	# Return super types of a `mtype` in `self`
-	fun super_mtypes(mtype: MType, mtypes: Set[MType]): Set[MType] do
-		if not self.super_mtypes_cache.has_key(mtype) then
-			var supers = new HashSet[MType]
-			for otype in mtypes do
-				if otype == mtype then continue
-				if mtype.is_subtype(self, null, otype) then
-					supers.add(otype)
-				end
-			end
-			self.super_mtypes_cache[mtype] = supers
-		end
-		return self.super_mtypes_cache[mtype]
-	end
-
-	private var super_mtypes_cache: Map[MType, Set[MType]] = new HashMap[MType, Set[MType]]
-
-	# Return all sub mtypes (directs and indirects) of a `mtype` in `self`
-	fun sub_mtypes(mtype: MType, mtypes: Set[MType]): Set[MType] do
-		if not self.sub_mtypes_cache.has_key(mtype) then
-			var subs = new HashSet[MType]
-			for otype in mtypes do
-				if otype == mtype then continue
-				if otype.is_subtype(self, null, mtype) then
-					subs.add(otype)
-				end
-			end
-			self.sub_mtypes_cache[mtype] = subs
-		end
-		return self.sub_mtypes_cache[mtype]
-	end
-
-	private var sub_mtypes_cache: Map[MType, Set[MType]] = new HashMap[MType, Set[MType]]
-
-	# Return a linearization of a set of mclasses
-	fun linearize_mclasses_2(mclasses: Set[MClass]): Array[MClass] do
-		var lin = new Array[MClass].from(mclasses)
-		var sorter = new ClassSorter(self)
-		sorter.sort(lin)
-		return lin
-	end
-
-	# Return a reverse linearization of a set of mtypes
-	fun reverse_linearize_mclasses(mclasses: Set[MClass]): Array[MClass] do
-		var lin = new Array[MClass].from(mclasses)
-		var sorter = new ReverseClassSorter(self)
-		sorter.sort(lin)
-		return lin
-	end
-
-	# Return all super mclasses (directs and indirects) of a `mclass` in `self`
-	fun super_mclasses(mclass: MClass): Set[MClass] do
-		if not self.super_mclasses_cache.has_key(mclass) then
-			var supers = new HashSet[MClass]
-			if self.flatten_mclass_hierarchy.has(mclass) then
-				for sup in self.flatten_mclass_hierarchy[mclass].greaters do
-					if sup == mclass then continue
-					supers.add(sup)
-				end
-			end
-			self.super_mclasses_cache[mclass] = supers
-		end
-		return self.super_mclasses_cache[mclass]
-	end
-
-	private var super_mclasses_cache: Map[MClass, Set[MClass]] = new HashMap[MClass, Set[MClass]]
-
-	# Return all parents of a `mclass` in `self`
-	fun parent_mclasses(mclass: MClass): Set[MClass] do
-		if not self.parent_mclasses_cache.has_key(mclass) then
-			var parents = new HashSet[MClass]
-			if self.flatten_mclass_hierarchy.has(mclass) then
-				for sup in self.flatten_mclass_hierarchy[mclass].direct_greaters do
-					if sup == mclass then continue
-					parents.add(sup)
-				end
-			end
-			self.parent_mclasses_cache[mclass] = parents
-		end
-		return self.parent_mclasses_cache[mclass]
-	end
-
-	private var parent_mclasses_cache: Map[MClass, Set[MClass]] = new HashMap[MClass, Set[MClass]]
-
-	# Return all sub mclasses (directs and indirects) of a `mclass` in `self`
-	fun sub_mclasses(mclass: MClass): Set[MClass] do
-		if not self.sub_mclasses_cache.has_key(mclass) then
-			var subs = new HashSet[MClass]
-			if self.flatten_mclass_hierarchy.has(mclass) then
-				for sub in self.flatten_mclass_hierarchy[mclass].smallers do
-					if sub == mclass then continue
-					subs.add(sub)
-				end
-			end
-			self.sub_mclasses_cache[mclass] = subs
-		end
-		return self.sub_mclasses_cache[mclass]
-	end
-
-	private var sub_mclasses_cache: Map[MClass, Set[MClass]] = new HashMap[MClass, Set[MClass]]
-
 	# All 'mproperties' associated to all 'mclassdefs' of `mclass`
 	fun properties(mclass: MClass): Set[MProperty] do
 		if not self.properties_cache.has_key(mclass) then
 			var properties = new HashSet[MProperty]
-			var parents = self.super_mclasses(mclass)
+			var parents = new Array[MClass]
+			if self.flatten_mclass_hierarchy.has(mclass) then
+				parents.add_all(mclass.in_hierarchy(self).direct_greaters)
+			end
 			for parent in parents do
 				properties.add_all(self.properties(parent))
 			end
-
 			for mclassdef in mclass.mclassdefs do
-				for mpropdef in mclassdef.mpropdefs do
-					properties.add(mpropdef.mproperty)
+				for mprop in mclassdef.intro_mproperties do
+					properties.add(mprop)
 				end
 			end
 			self.properties_cache[mclass] = properties
 		end
 		return properties_cache[mclass]
 	end
-
 	private var properties_cache: Map[MClass, Set[MProperty]] = new HashMap[MClass, Set[MProperty]]
-end
-
-# A sorter for linearize list of types
-private class TypeSorter
-	super AbstractSorter[MType]
-
-	private var mmodule: MModule
-
-	init(mmodule: MModule) do self.mmodule = mmodule
-
-	redef fun compare(a, b) do
-		if a == b then
-			return 0
-		else if a.is_subtype(self.mmodule, null, b) then
-			return -1
-		end
-		return 1
-	end
-end
-
-# A sorter for reverse linearization
-private class ReverseTypeSorter
-	super TypeSorter
-
-	init(mmodule: MModule) do end
-
-	redef fun compare(a, b) do
-		if a == b then
-			return 0
-		else if a.is_subtype(self.mmodule, null, b) then
-			return 1
-		end
-		return -1
-	end
-end
-
-# A sorter for linearize list of classes
-private class ClassSorter
-	super AbstractSorter[MClass]
-
-	var mmodule: MModule
-
-	redef fun compare(a, b) do
-		if a == b then
-			return 0
-		else if self.mmodule.flatten_mclass_hierarchy.has(a) and self.mmodule.flatten_mclass_hierarchy[a].greaters.has(b) then
-			return -1
-		end
-		return 1
-	end
-end
-
-# A sorter for reverse linearization
-private class ReverseClassSorter
-	super AbstractSorter[MClass]
-
-	var mmodule: MModule
-
-	redef fun compare(a, b) do
-		if a == b then
-			return 0
-		else if self.mmodule.flatten_mclass_hierarchy.has(a) and self.mmodule.flatten_mclass_hierarchy[a].greaters.has(b) then
-			return 1
-		end
-		return -1
-	end
 end

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -140,6 +140,7 @@ redef class MModule
 		for m in self.in_importation.greaters do
 			for cd in m.mclassdefs do
 				var c = cd.mclass
+				res.add_node(c)
 				for s in cd.supertypes do
 					res.add_edge(c, s.mclass)
 				end

--- a/src/separate_compiler.nit
+++ b/src/separate_compiler.nit
@@ -233,8 +233,11 @@ class SeparateCompiler
 		#	method_layout_builder = new MMethodHasher(new PHAndOperator, self.mainmodule)
 		#	attribute_layout_builder = new MAttributeHasher(new PHAndOperator, self.mainmodule)
 		#else
-		method_layout_builder = new MMethodColorer(self.mainmodule)
-		attribute_layout_builder = new MAttributeColorer(self.mainmodule)
+
+		var class_layout_builder = new MClassColorer(self.mainmodule)
+		class_layout_builder.build_layout(mclasses)
+		method_layout_builder = new MMethodColorer(self.mainmodule, class_layout_builder)
+		attribute_layout_builder = new MAttributeColorer(self.mainmodule, class_layout_builder)
 		#end
 
 		# methods coloration
@@ -255,9 +258,13 @@ class SeparateCompiler
 		for mclass in mclasses do
 			var table = new Array[nullable MPropDef]
 			# first, fill table from parents by reverse linearization order
-			var parents = self.mainmodule.super_mclasses(mclass)
-			var lin = self.mainmodule.reverse_linearize_mclasses(parents)
-			for parent in lin do
+			var parents = new Array[MClass]
+			if mainmodule.flatten_mclass_hierarchy.has(mclass) then
+				parents = mclass.in_hierarchy(mainmodule).greaters.to_a
+				self.mainmodule.linearize_mclasses(parents)
+			end
+			for parent in parents do
+				if parent == mclass then continue
 				for mproperty in self.mainmodule.properties(parent) do
 					if not mproperty isa MMethod then continue
 					var color = layout.pos[mproperty]
@@ -299,9 +306,13 @@ class SeparateCompiler
 		for mclass in mclasses do
 			var table = new Array[nullable MPropDef]
 			# first, fill table from parents by reverse linearization order
-			var parents = self.mainmodule.super_mclasses(mclass)
-			var lin = self.mainmodule.reverse_linearize_mclasses(parents)
-			for parent in lin do
+			var parents = new Array[MClass]
+			if mainmodule.flatten_mclass_hierarchy.has(mclass) then
+				parents = mclass.in_hierarchy(mainmodule).greaters.to_a
+				self.mainmodule.linearize_mclasses(parents)
+			end
+			for parent in parents do
+				if parent == mclass then continue
 				for mproperty in self.mainmodule.properties(parent) do
 					if not mproperty isa MAttribute then continue
 					var color = layout.pos[mproperty]
@@ -339,7 +350,7 @@ class SeparateCompiler
 	end
 
 	# colorize live types of the program
-	private fun do_type_coloring: Set[MType] do
+	private fun do_type_coloring: POSet[MType] do
 		var mtypes = new HashSet[MType]
 		mtypes.add_all(self.runtime_type_analysis.live_types)
 		mtypes.add_all(self.runtime_type_analysis.live_cast_types)
@@ -367,24 +378,22 @@ class SeparateCompiler
 
 		# colorize types
 		self.type_layout = layout_builder.build_layout(mtypes)
-		self.type_tables = self.build_type_tables(mtypes)
+		var poset = layout_builder.poset.as(not null)
+		self.type_tables = self.build_type_tables(poset)
 
 		# VT and FT are stored with other unresolved types in the big resolution_tables
 		self.compile_resolution_tables(mtypes)
 
-		return mtypes
+		return poset
 	end
 
 	# Build type tables
-	fun build_type_tables(mtypes: Set[MType]): Map[MType, Array[nullable MType]] do
+	fun build_type_tables(mtypes: POSet[MType]): Map[MType, Array[nullable MType]] do
 		var tables = new HashMap[MType, Array[nullable MType]]
 		var layout = self.type_layout
 		for mtype in mtypes do
 			var table = new Array[nullable MType]
-			var supers = new HashSet[MType]
-			supers.add_all(self.mainmodule.super_mtypes(mtype, mtypes))
-			supers.add(mtype)
-			for sup in supers do
+			for sup in mtypes[mtype].greaters do
 				var color: Int
 				if layout isa PHLayout[MType, MType] then
 					color = layout.hashes[mtype][sup]


### PR DESCRIPTION
J'ai corrigé le problème dans flatten_mclass_hierarchy qui casse les tests base_no_object et base_empty_module. Le problème venait du fait que dans la création du poset seul un add_edge était utilisé, dans le cas d'un element sans parent, le add_edge n'était jamais appelé. Du coup j'ai juste rajouté un add_node avant.

Pour la création du Poset des mtypes appelé deux fois c'était bien vallgrind qui se plantait. Parcontre le poset des mclass était construit deux fois, une fois pour les methodes, une fois pour les attributs, j'ai corrigé ça.

Au final on passe de 21,23 à 18,5 sec. Ces chiffres sont obtenus grâce à la commande `/usr/bin/time -f "\n%E elapsed,\n%U user,\n%S system,\n%M memory\n%x status" $NITG ../src/nitg.nit -o out.tmp`. La commande est lancée 5 fois de suite d'abord avec $NITG = nitg issu du commit précédent puis 5 fois avec $NITG = nitg après changement. La première exécution est écartée avant de faire la moyenne.
