### PR TITLE
nitg: fixed conflicting module error when env var NIT_DIR is specified a...

### DIFF
--- a/src/modelbuilder.nit
+++ b/src/modelbuilder.nit
@@ -316,7 +316,12 @@ class ModelBuilder
 				if candidate == null then
 					candidate = try_file
 				else if candidate != try_file then
-					error(anode, "Error: conflicting module file for {name}: {candidate} {try_file}")
+					# try to disambiguate conflicting modules
+					var abs_candidate = module_absolute_path(candidate)
+					var abs_try_file = module_absolute_path(try_file)
+					if abs_candidate != abs_try_file then
+						error(anode, "Error: conflicting module file for {name}: {candidate} {try_file}")
+					end
 				end
 			end
 			try_file = (dirname + "/" + name + "/" + name + ".nit").simplify_path
@@ -324,7 +329,12 @@ class ModelBuilder
 				if candidate == null then
 					candidate = try_file
 				else if candidate != try_file then
-					error(anode, "Error: conflicting module file for {name}: {candidate} {try_file}")
+					# try to disambiguate conflicting modules
+					var abs_candidate = module_absolute_path(candidate)
+					var abs_try_file = module_absolute_path(try_file)
+					if abs_candidate != abs_try_file then
+						error(anode, "Error: conflicting module file for {name}: {candidate} {try_file}")
+					end
 				end
 			end
 		end
@@ -339,6 +349,14 @@ class ModelBuilder
 		var res = self.load_module(mmodule, candidate)
 		if res == null then return null # Forward error
 		return res.mmodule.as(not null)
+	end
+
+	# Transform relative paths (starting with '../') into absolute paths
+	private fun module_absolute_path(path: String): String do
+		if path.has_prefix("..") then
+			return getcwd.join_path(path).simplify_path
+		end
+		return path
 	end
 
 	# Try to load a module using a path.

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -21,6 +21,8 @@
 export LANG=C
 export NIT_TESTING=true
 
+unset NIT_DIR
+
 usage()
 {
 	e=`basename "$0"`


### PR DESCRIPTION
...nd compiling in /bin

Fixes issue #68:

NIT_DIR env var creates module conflicts when compiling in /nit dir

With NIT_DIR env var setted to /home/ME/nit/, when I compile from /nit/bin like:
    nitg something.nit
I get a compile error saying that there is a module conflict between /home/ME/nit/lib/module1.nit and ../lib/module1.nit.

Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
