### PR TITLE
Compiler fixes

### DIFF
--- a/src/abstract_compiler.nit
+++ b/src/abstract_compiler.nit
@@ -1406,7 +1406,7 @@ redef class AInternMethPropdef
 				v.add("printf(\"%c\", {arguments.first});")
 				return
 			else if pname == "object_id" then
-				v.ret(arguments.first)
+				v.ret(v.new_expr("(long){arguments.first}", ret.as(not null)))
 				return
 			else if pname == "+" then
 				v.ret(v.new_expr("{arguments[0]} + {arguments[1]}", ret.as(not null)))
@@ -1451,7 +1451,7 @@ redef class AInternMethPropdef
 				v.add("printf({arguments.first}?\"true\\n\":\"false\\n\");")
 				return
 			else if pname == "object_id" then
-				v.ret(arguments.first)
+				v.ret(v.new_expr("(long){arguments.first}", ret.as(not null)))
 				return
 			else if pname == "==" then
 				v.ret(v.equal_test(arguments[0], arguments[1]))
@@ -1510,24 +1510,6 @@ redef class AInternMethPropdef
 				return
 			else if pname == "to_i" then
 				v.ret(v.new_expr("(long){arguments[0]}", ret.as(not null)))
-				return
-			end
-		else if cname == "Char" then
-			if pname == "output" then
-				v.add("printf(\"%c\", {arguments.first});")
-				return
-			else if pname == "object_id" then
-				v.ret(arguments.first)
-				return
-			else if pname == "==" then
-				v.ret(v.equal_test(arguments[0], arguments[1]))
-				return
-			else if pname == "!=" then
-				var res = v.equal_test(arguments[0], arguments[1])
-				v.ret(v.new_expr("!{res}", ret.as(not null)))
-				return
-			else if pname == "ascii" then
-				v.ret(v.new_expr("{arguments[0]}", ret.as(not null)))
 				return
 			end
 		else if cname == "NativeString" then

--- a/tests/test_obj_id.nit
+++ b/tests/test_obj_id.nit
@@ -1,0 +1,17 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+true.object_id.output
+
+'d'.object_id.output


### PR DESCRIPTION
Fixed two bugs :
- One introduced in a previous patch, a monomorphic send that provoked a bug when refactoring the String model
- Another on Bool and Char when using the object_id method, returned a cast error to Int.
