### PR TITLE
Vim syntax checker syntastic

### DIFF
--- a/misc/vim/syntax_checkers/nit/nitc.vim
+++ b/misc/vim/syntax_checkers/nit/nitc.vim
@@ -37,7 +37,7 @@ function! SyntaxCheckers_nit_nitc_IsAvailable()
 endfunction
 
 function! SyntaxCheckers_nit_nitc_GetLocList()
-	let makeprg = s:nitc . " --no-color --only-metamodel 2>&1 " . shellescape(expand("%"))
+	let makeprg = s:nitc . " --no-color --only-metamodel "
 
 	" custom NIT_DIR
 	if exists('g:syntastic_nit_dir')
@@ -55,6 +55,16 @@ function! SyntaxCheckers_nit_nitc_GetLocList()
 			let makeprg .= " -I " . d
 		endfor
 	end
+
+	" alternative main module
+	if exists('g:nit_main')
+		let makeprg .= " " . g:nit_main
+	else
+		let makeprg .= " " . shellescape(expand("%"))
+	end
+
+	" pipe stderr
+	let makeprg .= " 2>&1 "
 
 	" possible combinations of error messages
 	let ef_start = [ '%f:%l\,%c--%*[0-9]:',


### PR DESCRIPTION
To set the mainmodule, use the following vim command with a path relative to the current working directory:

let g:nit_main="src/nitg.nit"
