### PR TITLE
Update list.nit

### DIFF
--- a/lib/standard/collection/list.nit
+++ b/lib/standard/collection/list.nit
@@ -251,7 +251,7 @@ class List[E]
 end
 
 # This is the iterator class of List
-class ListIterator[E]
+private class ListIterator[E]
 	super IndexedIterator[E]
 	redef fun item do return _node.item
 


### PR DESCRIPTION
ListIterator devient private, car il n'y a pas d’intérêt à ce que le développeur utilise cette classe tel quel.
