### PR TITLE
Added more explicit comment for eof method in lib/standard/stream.nit

### DIFF
--- a/lib/standard/stream.nit
+++ b/lib/standard/stream.nit
@@ -76,7 +76,8 @@ interface IStream
 		end
 	end
 
-	# Is there something to read. Returns "false" if there is something to read.
+	# Is there something to read.
+	# This function returns 'false' if there is something to read.
 	fun eof: Bool is abstract
 end
 


### PR DESCRIPTION
The comment for 'eof' method could be misunderstood, and is now more explicit.

signed-off-by: Johan Kayser johan.kayser@viacesi.fr
