### PR TITLE
nitg: Detection of double local redefinitions

### DIFF
--- a/src/modelize_property.nit
+++ b/src/modelize_property.nit
@@ -158,6 +158,10 @@ redef class MClass
 	var inherit_init_from: nullable MClass = null
 end
 
+redef class MClassDef
+	private var propdef_names = new HashSet[String]
+end
+
 redef class AClassdef
 	var build_properties_is_done: Bool = false
 	# The list of super-constructor to call at the start of the free constructor
@@ -391,6 +395,20 @@ redef class AMethPropdef
 		nclassdef.mprop2npropdef[mprop] = self
 
 		var mpropdef = new MMethodDef(mclassdef, mprop, self.location)
+
+		if mclassdef.propdef_names.has(mprop.name) then
+			var loc: nullable Location = null
+			for i in mclassdef.mpropdefs do
+				if i.mproperty.name == mprop.name then
+					loc = i.location
+					break
+				end
+			end
+			if loc == null then abort
+			modelbuilder.error(self, "Error: a property {mprop} is already defined in class {mclassdef.mclass} at {loc}")
+		end
+
+		mclassdef.propdef_names.add(mpropdef.mproperty.name)
 
 		self.mpropdef = mpropdef
 		modelbuilder.mpropdef2npropdef[mpropdef] = self

--- a/tests/base_error_doubledef.nit
+++ b/tests/base_error_doubledef.nit
@@ -1,0 +1,29 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import end
+
+class A
+	fun foo do end
+end
+
+class B
+	super A
+
+	redef fun foo do end
+
+	redef fun foo do end
+
+end
+

--- a/tests/sav/base_error_doubledef.res
+++ b/tests/sav/base_error_doubledef.res
@@ -1,0 +1,1 @@
+base_error_doubledef.nit:26,12--14: Error: a property foo is already defined in class B at base_error_doubledef.nit:24,2--21


### PR DESCRIPTION
Now produces an clear error when redefining the same method twice locally instead of breaking later with a strange error.

Complementary to pull request : https://github.com/privat/nit/pull/265

Signed-off-by: Lucas Bajolet r4pass@hotmail.com
