### PR TITLE
nitx: only depends on modelize_property instead of the full frontend

### DIFF
--- a/src/nitx.nit
+++ b/src/nitx.nit
@@ -17,7 +17,6 @@ module nitx
 
 import model_utils
 import modelize_property
-import frontend
 
 # Main class of the nit index tool
 # NitIndex build the model using the toolcontext argument
@@ -265,7 +264,7 @@ end
 # Code Analysis
 
 redef class ToolContext
-	private var nitx_phase: NitxPhase = new NitxPhase(self, [typing_phase])
+	private var nitx_phase: NitxPhase = new NitxPhase(self, [modelize_property_phase])
 end
 
 # Compiler phase for nitx


### PR DESCRIPTION
```
$ time ../bin/nitx nitg.nit :q # before
real    0m2.775s
user    0m2.660s
sys 0m0.112s
$ time ./nitx nitg.nit :q # after
real    0m1.436s
user    0m1.328s
sys 0m0.104s
```

Signed-off-by: Jean Privat jean@pryen.org
