### PR TITLE
lib/hashcol: forgot to nullify a link in `HashCollection::enlarge`

### DIFF
--- a/lib/standard/collection/hash_collection.nit
+++ b/lib/standard/collection/hash_collection.nit
@@ -178,6 +178,7 @@ private abstract class HashCollection[K: Object, N: HashNode[Object]]
 			# Then store it in the array
 			var next = new_array[index]
 			new_array[index] = node
+			node._prev_in_bucklet = null
 			node._next_in_bucklet = next
 			if next != null then next._prev_in_bucklet = node
 			node = node._next_item


### PR DESCRIPTION
Thus caused buggy bucklet-link update in `HashSet::remove`
Thus caused buggy transitive reduction in `POSet::add_edge`
Thus caused buggy coloration in `layout_builders`
Thus caused buggy type test tables in `SeparateCompiler::compile_type_to_c`
Thus caused buggy type tests in programs

Fixes #307
Signed-off-by: Jean Privat jean@pryen.org
