### PR TITLE
tests: permit multiple inputs on a single test

### DIFF
--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -451,6 +451,13 @@ END
 					# Sould we skip the input for this engine?
 					need_skip $bff "  $name" $pack && continue
 
+					# use a specific inputs file, if required
+					if [ -f "$bff.inputs" ]; then
+						ffinputs="$bff.inputs"
+					else
+						ffinputs=$inputs
+					fi
+
 					rm -rf "$fff.res" "$fff.err" "$fff.write" 2> /dev/null
 					if [ "x$verbose" = "xtrue" ]; then
 						echo ""
@@ -459,7 +466,7 @@ END
 					test -z "$tap" && echo -n "==> $name "
 					echo "./$ff.bin $args" > "./$fff.bin"
 					chmod +x "./$fff.bin"
-					WRITE="$fff.write" sh -c "NIT_NO_STACK=1 $TIMEOUT ./$fff.bin < $inputs > $fff.res 2>$fff.err"
+					WRITE="$fff.write" sh -c "NIT_NO_STACK=1 $TIMEOUT ./$fff.bin < $ffinputs > $fff.res 2>$fff.err"
 					if [ "x$verbose" = "xtrue" ]; then
 						cat "$fff.res"
 						cat >&2 "$fff.err"


### PR DESCRIPTION
Currently, for each program, if a `name.inputs` file exists, it is used for input for
all executions (for a total of alts \* (args+1) executions).

Now a specific input can be used for each specific args.
This distinct input file is the one named with the basename of the res file.

eg. for the program `some_test.nit`, the file `some_test_args2.inputs` is
used as input for the execution associated to the second
line of the `some_test.args` file.
The result of the execution is still `some_test_args2.res`.

If there is no specific inputs file, the previous behavior remains:
`some_test.inputs` is used if it exists, else `/dev/null` is used.

The point of this patch is to enable specific CLI interactive programs,
like the debugger or nitx, to have automatizable regression tests.

Signed-off-by: Jean Privat jean@pryen.org
