### PR TITLE
Fix ffi null service

### DIFF
--- a/src/compiler_ffi.nit
+++ b/src/compiler_ffi.nit
@@ -305,13 +305,15 @@ redef class MNullableType
 	do
 		super
 
+		var base_cname = "null_{mtype.mangled_cname}"
+		var full_cname = "NIT_NULL___{base_cname}"
+
 		# In nitni files, declare internal function as extern 
-		var full_friendly_csignature = "{cname} {v.compiler.mainmodule.name}___null_{mtype.mangled_cname}()"
+		var full_friendly_csignature = "{cname_blind} {full_cname}()"
 		ccu.header_decl.add("extern {full_friendly_csignature};\n")
 
 		# In nitni files, #define friendly as extern
-		var base_cname = "null_{mtype.mangled_cname}"
-		ccu.header_decl.add("#define {base_cname} {v.compiler.mainmodule.name}___{base_cname}\n")
+		ccu.header_decl.add("#define {base_cname} {full_cname}\n")
 
 		# FIXME: This is ugly an broke the separate compilation principle
 		# The real function MUST be compiled only once, #define pragma only protect the compiler, not the loader
@@ -322,7 +324,7 @@ redef class MNullableType
 		# Internally, implement internal function
 		var nitni_visitor = v.compiler.new_visitor
 		nitni_visitor.frame = v.frame
-		var full_internal_csignature = "{cname_blind} {v.compiler.mainmodule.name}___null_{mtype.mangled_cname}()"
+		var full_internal_csignature = "{cname_blind} {full_cname}()"
 		nitni_visitor.add("{full_internal_csignature} \{")
 		nitni_visitor.add("struct nitni_instance* ret_for_c;")
 		nitni_visitor.add("ret_for_c = malloc(sizeof(struct nitni_instance));")


### PR DESCRIPTION
With nitg-g, the linker could fail when the same two piece of code will be in distinct files,
since the #ifndef trick does not cross compilation units.

This PR is just a workaroud where we use a global flag to avoid multiple definition.
While it works (thus is an improvement) it is ugly and broke the separate compilation concerns.
