### PR TITLE
nitg: use libunwind instead of gperf by default for stacktraces

### DIFF
--- a/src/abstract_compiler.nit
+++ b/src/abstract_compiler.nit
@@ -519,7 +519,7 @@ abstract class AbstractCompiler
 		var ost = modelbuilder.toolcontext.opt_stacktrace.value
 
 		if ost == null then
-			ost = "gperf"
+			ost = "libunwind"
 			modelbuilder.toolcontext.opt_stacktrace.value = ost
 		end
 


### PR DESCRIPTION
f54e52e activate gperf by default, but gperf is in fact quite slow.
It was unnoticed since time regressions are
tracked by valgrind (and gperf was unmonitored because run in a subprocess).

However, the effect was noticeable:

```
$ time nitg nitg.nit --stacktrace gperf
user    1m13.377s

$ time nitg nitg.nit --stacktrace libunwind
user    0m14.189s
```

Signed-off-by: Jean Privat jean@pryen.org
