### PR TITLE
lib/socket: Bugfix

### DIFF
--- a/lib/socket/socket_c.nit
+++ b/lib/socket/socket_c.nit
@@ -124,13 +124,11 @@ extern FFSocket `{ S_DESCRIPTOR* `}
 		static char c[1024];
 		int n = read(*recv, c, 1024);
 		if(n < 0) {
-			free(c);
 			return NativeString_to_s_with_length("",0);
 		}
 		char* ret = malloc(n + 1);
 		memcpy(ret, c, n);
 		ret[n] = '\0';
-		free(c);
 		return NativeString_to_s_with_length(ret, n);
 	`}
 


### PR DESCRIPTION
Bug introduced in pull request #377, in the read function of FFSocket, a free is called on a static variable, which provokes a warning and probably bugs at runtime.

Signed-off-by: Lucas Bajolet r4pass@hotmail.com
