### PR TITLE
nitdoc: display redefined methods when mmodule.public_owner is null

### DIFF
--- a/src/nitdoc.nit
+++ b/src/nitdoc.nit
@@ -792,9 +792,11 @@ class NitdocClass
 	private fun mclass_intro_mpropdefs: Set[MPropDef] do
 		var res = new HashSet[MPropDef]
 		for mclassdef in mclass.mclassdefs do
+			var owner = mclassdef.mmodule.public_owner
+			if owner == null then owner = mclassdef.mmodule
 			for mpropdef in mclassdef.mpropdefs do
 				if not mpropdef.is_intro then continue
-				if mclassdef.mmodule.public_owner != mclass.public_owner then continue
+				if owner != mclass.public_owner then continue
 				var mprop = mpropdef.mproperty
 				if mprop isa MMethod and mprop.is_init and mclass.is_abstract then continue
 				if mprop.visibility < ctx.min_visibility then continue
@@ -808,8 +810,10 @@ class NitdocClass
 		var res = new HashSet[MPropDef]
 		for mclassdef in mclass.mclassdefs do
 			if mclassdef == mclass.intro then continue
+			var owner = mclassdef.mmodule.public_owner
+			if owner == null then owner = mclassdef.mmodule
 			for mpropdef in mclassdef.mpropdefs do
-				if mclassdef.mmodule.public_owner == mclass.public_owner then continue
+				if owner == mclass.public_owner then continue
 				if mpropdef.mproperty.visibility < ctx.min_visibility then continue
 				res.add mpropdef
 			end


### PR DESCRIPTION
Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
