### PR TITLE
String hash function fix

### DIFF
--- a/lib/standard/string.nit
+++ b/lib/standard/string.nit
@@ -532,11 +532,9 @@ abstract class Text
 		if hash_cache == null then
 			# djb2 hash algorithm
 			var h = 5381
-			var i = length - 1
 
 			for char in self.chars do
-				h = (h * 32) + h + char.ascii
-				i -= 1
+				h = h.lshift(5) + h + char.ascii
 			end
 
 			hash_cache = h
@@ -862,18 +860,15 @@ class FlatString
 	redef fun hash
 	do
 		if hash_cache == null then
-			# djb2 hash algorythm
+			# djb2 hash algorithm
 			var h = 5381
-			var i = length - 1
+			var i = index_from
 
 			var myitems = items
-			var strStart = index_from
 
-			i += strStart
-
-			while i >= strStart do
-				h = (h * 32) + h + self.items[i].ascii
-				i -= 1
+			while i <= index_to do
+				h = h.lshift(5) + h + myitems[i].ascii
+				i += 1
 			end
 
 			hash_cache = h

--- a/tests/sav/test_hash_text.res
+++ b/tests/sav/test_hash_text.res
@@ -1,0 +1,8 @@
+true
+true
+true
+true
+true
+true
+true
+true

--- a/tests/test_hash_text.nit
+++ b/tests/test_hash_text.nit
@@ -1,0 +1,32 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+var x = "string__NativeString__to_s_with_length"
+
+var y = "string" + "__" + "NativeString" + "__" + "to_s_with_length"
+
+var z = new FlatBuffer.from("string") + "__" + "NativeString" + "__" + "to_s_with_length"
+
+var a = ["string", "NativeString", "to_s_with_length"].join("__")
+
+print x.hash == y.hash
+print y.hash == z.hash
+print z.hash == a.hash
+print a.hash == x.hash
+
+print x.substring(8,12).hash == y.substring(8,12).hash
+print y.substring(8,12).hash == z.substring(8,12).hash
+print z.substring(8,12).hash == a.substring(8,12).hash
+print a.substring(8,12).hash == x.substring(8,12).hash
+


### PR DESCRIPTION
The generic implementation for hash on Text was not compliant with the optimized version for Strings, however no test was able to catch it since we've never used Buffer and String at the same time in a Hash structure.

Signed-off-by: Lucas Bajolet r4pass@hotmail.com
