### PR TITLE
nitunit: fix verbose display

### DIFF
--- a/src/nitunit.nit
+++ b/src/nitunit.nit
@@ -110,7 +110,7 @@ class NitUnitExecutor
 		cpt += 1
 		var file = "{prefix}{cpt}.nit"
 
-		toolcontext.info("Execute {tc.attrs["classname"]}.{tc.attrs["name"]} in {file}", 1)
+		toolcontext.info("Execute {tc.attrs["name"]} in {file}", 1)
 
 		var dir = file.dirname
 		if dir != "" then dir.mkdir


### PR DESCRIPTION
Minor fix:
`tc.attrs["name"]}` already contains the class namespace

Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
