### PR TITLE
names and concerns in model

### DIFF
--- a/src/model/mmodule.nit
+++ b/src/model/mmodule.nit
@@ -69,7 +69,7 @@ end
 
 # A Nit module is usually associated with a Nit source file.
 class MModule
-	super MEntity
+	super MConcern
 
 	# The model considered
 	var model: Model
@@ -221,4 +221,6 @@ class MModule
 			abort
 		end
 	end
+
+	redef fun parent_concern do return mgroup
 end

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -33,6 +33,7 @@ import poset
 import location
 import mmodule
 import mdoc
+import ordered_tree
 private import more_collections
 
 redef class Model
@@ -106,6 +107,35 @@ redef class Model
 
 	# The only null type
 	var null_type: MNullType = new MNullType(self)
+
+	# Build an ordered tree with from `concerns`
+	fun concerns_tree(mconcerns: Collection[MConcern]): ConcernsTree do
+		var seen = new HashSet[MConcern]
+		var res = new ConcernsTree
+
+		var todo = new Array[MConcern]
+		todo.add_all mconcerns
+
+		while not todo.is_empty do
+			var c = todo.pop
+			if seen.has(c) then continue
+			var pc = c.parent_concern
+			if pc == null then
+				res.add(null, c)
+			else
+				res.add(pc, c)
+				todo.add(pc)
+			end
+			seen.add(c)
+		end
+
+		return res
+	end
+end
+
+# An OrderedTree that can be easily refined for display purposes
+class ConcernsTree
+	super OrderedTree[MConcern]
 end
 
 redef class MModule

--- a/src/model/model_base.nit
+++ b/src/model/model_base.nit
@@ -29,6 +29,13 @@ abstract class MEntity
 	fun name: String is abstract
 end
 
+# Something that represents a concern
+abstract class MConcern
+	super MEntity
+	# The concern that contains `self` or null if `self` is the root of the concern hierarchy
+	fun parent_concern: nullable MConcern is abstract
+end
+
 # A visibility (for modules, class and properties)
 # Valid visibility are:
 #

--- a/src/model/mproject.nit
+++ b/src/model/mproject.nit
@@ -21,7 +21,7 @@ import poset
 
 # A Nit project, thas encompass a product
 class MProject
-	super MEntity
+	super MConcern
 
 	# The name of the project
 	redef var name: String
@@ -44,11 +44,14 @@ class MProject
 		model.mprojects.add(self)
 		model.mproject_by_name.add_one(name, self)
 	end
+
+	# MProject are always roots of the concerns hierarchy
+	redef fun parent_concern do return null
 end
 
 # A group of modules in a project
 class MGroup
-	super MEntity
+	super MConcern
 
 	# The name of the group
 	# empty name for a default group in a single-module project
@@ -74,6 +77,9 @@ class MGroup
 	# nesting group (see `parent`) is bigger
 	var in_nesting: POSetElement[MGroup]
 
+	# Is `self` the root of its project?
+	fun is_root: Bool do return mproject.root == self
+
 	# The filepath (usualy a directory) of the group, if any
 	var filepath: nullable String writable
 
@@ -87,6 +93,11 @@ class MGroup
 		if parent != null then
 			tree.add_edge(self, parent)
 		end
+	end
+
+	redef fun parent_concern do
+		if not is_root then return parent
+		return mproject
 	end
 
 	redef fun to_s do return name


### PR DESCRIPTION
First commit adapt the MEntity implementation to it's documentation by moving up the `name` property.

Second commit introduce a new kind of MEntity: MConcern that will be used in documentation tools as a common interface for MProject, MGroup and MModule.
