### PR TITLE
java: intro pop_from_local_frame

### DIFF
--- a/lib/java.nit
+++ b/lib/java.nit
@@ -163,4 +163,17 @@ redef extern class JavaObject
 		JNIEnv *env = Sys_jni_env(sys);
 		(*env)->DeleteLocalRef(env, recv);
 	`}
+
+	# Pops the current local reference frame and return a valid reference to self
+	#
+	# Similiar to `JavaVM::pop_local_frame` but returns a value.
+	fun pop_from_local_frame: SELF
+	do
+		var jni_env = sys.jni_env
+		return pop_from_local_frame_with_env(jni_env)
+	end
+	
+	private fun pop_from_local_frame_with_env(jni_env: JniEnv): SELF `{
+		return (*jni_env)->PopLocalFrame(jni_env, recv);
+	`}
 end

--- a/lib/jvm.nit
+++ b/lib/jvm.nit
@@ -381,6 +381,8 @@ extern class JniEnv `{JNIEnv *`}
 	`}
 
 	# Pops the current local reference frame on the JNI stack
+	#
+	# Similiar to `JavaObject::pop_from_local_frame` which returns a value.
 	fun pop_local_frame `{
 		(*recv)->PopLocalFrame(recv, NULL);
 	`}


### PR DESCRIPTION
A very useful features when using the JNI reference stack to clean up local references.

Signed-off-by: Alexis Laferrière alexis.laf@xymus.net
