### PR TITLE
model: fix a compiler crash on access to null constructor signature

### DIFF
--- a/src/modelize_property.nit
+++ b/src/modelize_property.nit
@@ -96,9 +96,13 @@ redef class ModelBuilder
 			if not c.kind.need_init then continue
 			st = st.anchor_to(mmodule, mclassdef.bound_mtype)
 			var candidate = self.try_get_mproperty_by_name2(nclassdef, mmodule, st, "init").as(nullable MMethod)
-			if candidate != null and candidate.intro.msignature.arity == 0 then
-				combine.add(candidate)
-				continue
+			if candidate != null then
+				if candidate.intro.msignature != null then
+					if candidate.intro.msignature.arity == 0 then
+						combine.add(candidate)
+						continue
+					end
+				end
 			end
 			var inhc2 = c.inherit_init_from
 			if inhc2 == null then inhc2 = c

--- a/tests/sav/test_super_param2.res
+++ b/tests/sav/test_super_param2.res
@@ -1,0 +1,1 @@
+test_super_param2.nit:20,10: Type error: class C not found in module test_super_param2.

--- a/tests/test_super_param2.nit
+++ b/tests/test_super_param2.nit
@@ -1,0 +1,29 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Copyright 2006-2008 Jean Privat <jean@pryen.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import kernel
+
+class A
+	init(i: C)
+	do
+		print i
+	end
+end
+
+class B
+	super A
+end
+


### PR DESCRIPTION
Before this patch, compilation process stopped on a null pointer exception.
Because of the compilation workflow, nitg tried to access a super init even
if this init was malformed (type error) and thus not modelized properly.

This commit add one more condition to ensure that msignature is initialized before the test
and raise the correct error instead of crashing.

Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
