### PR TITLE
lib/android: Typo fix for shared_preferences module

### DIFF
--- a/lib/android/shared_preferences/shared_preferences_api11.nit
+++ b/lib/android/shared_preferences/shared_preferences_api11.nit
@@ -22,6 +22,7 @@ import shared_preferences
 in "Java" `{ 
 	import java.util.HashSet;
  	import java.util.Set;
+	import android.content.Context; 
 `}
 
 redef extern class NativeSharedPreferences
@@ -66,7 +67,7 @@ redef class SharedPreferences
 	end
 
 	# File access mode
-	private fun multi_process_mode: Int in "Java" `{ return Content.MODE_MULTI_PROCESS; `}
+	private fun multi_process_mode: Int in "Java" `{ return Context.MODE_MULTI_PROCESS; `}
 
 	# Returns the `HashSet[JavaString]` value corresponding the given key or `null` if none
 	#


### PR DESCRIPTION
Fixed typo and added import to shared_preferences_api11 module

Signed-off-by: Frédéric Vachon fredvac@gmail.com
