### PR TITLE
proposal for model: Generalize access to `model` form `MEntitiy`.

### DIFF
--- a/src/model/mmodule.nit
+++ b/src/model/mmodule.nit
@@ -72,7 +72,7 @@ class MModule
 	super MConcern
 
 	# The model considered
-	var model: Model
+	redef var model: Model
 
 	# placebo for old module nesting hierarchy
 	# return null if self is not nested (ie. is a top-level module)

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -380,6 +380,8 @@ class MClass
 		end
 	end
 
+	redef fun model do return intro_mmodule.model
+
 	# All class definitions (introduction and refinements)
 	var mclassdefs: Array[MClassDef] = new Array[MClassDef]
 
@@ -496,6 +498,8 @@ class MClassDef
 	# Actually the name of the `mclass`
 	redef fun name do return mclass.name
 
+	redef fun model do return mmodule.model
+
 	# All declared super-types
 	# FIXME: quite ugly but not better idea yet
 	var supertypes: Array[MClassType] = new Array[MClassType]
@@ -588,8 +592,6 @@ abstract class MType
 	super MEntity
 
 	redef fun name do return to_s
-	# The model of the type
-	fun model: Model is abstract
 
 	# Return true if `self` is an subtype of `sup`.
 	# The typing is done using the standard typing policy of Nit.
@@ -1530,6 +1532,8 @@ class MParameter
 		var res = new MParameter(self.name, newtype, self.is_vararg)
 		return res
 	end
+
+	redef fun model do return mtype.model
 end
 
 # A service (global property) that generalize method, attribute, etc.
@@ -1589,6 +1593,8 @@ abstract class MProperty
 	# associated to self. If self is just created without having any
 	# associated definition, this method will abort
 	fun intro: MPROPDEF do return mpropdefs.first
+
+	redef fun model do return intro.model
 
 	# Alias for `name`
 	redef fun to_s do return name
@@ -1843,6 +1849,8 @@ abstract class MPropDef
 
 	# Actually the name of the `mproperty`
 	redef fun name do return mproperty.name
+
+	redef fun model do return mclassdef.model
 
 	# Internal name combining the module, the class and the property
 	# Example: "mymodule#MyClass#mymethod"

--- a/src/model/model_base.nit
+++ b/src/model/model_base.nit
@@ -27,6 +27,9 @@ end
 abstract class MEntity
 	# The short (unqualified) name of this model entity
 	fun name: String is abstract
+
+	# A Model Entity has a direct link to its model
+	fun model: Model is abstract
 end
 
 # Something that represents a concern

--- a/src/model/mproject.nit
+++ b/src/model/mproject.nit
@@ -27,7 +27,7 @@ class MProject
 	redef var name: String
 
 	# The model of the project
-	var model: Model
+	redef var model: Model
 
 	# The root of the group tree
 	var root: nullable MGroup writable = null
@@ -94,6 +94,8 @@ class MGroup
 			tree.add_edge(self, parent)
 		end
 	end
+
+	redef fun model do return mproject.model
 
 	redef fun parent_concern do
 		if not is_root then return parent


### PR DESCRIPTION
Since, MEntity are model things, let the user access to the model from them.

Signed-off-by: Alexandre Terrasa alexandre@moz-code.org
