### PR TITLE
src/android: Modified annotations names to avoid ambiguities

### DIFF
--- a/src/android_annotations.nit
+++ b/src/android_annotations.nit
@@ -45,13 +45,13 @@ class AndroidProject
 	var manifest_application_lines = new Array[String]
 
 	# Minimum API level required for the application to run
-	var min_sdk: nullable Int = null
+	var min_api: nullable Int = null
 
 	# Build target API level
-	var target_sdk: nullable Int = null
+	var target_api: nullable Int = null
 
 	# Maximum API level on which the application will be allowed to run
-	var max_sdk: nullable Int = null
+	var max_api: nullable Int = null
 
 	redef fun to_s do return """
 name: {{{name or else "null"}}}
@@ -74,14 +74,14 @@ redef class ModelBuilder
 		annot = priority_annotation_on_modules("java_package", mmodule)
 		if annot != null then project.java_package = annot.arg_as_string(self)
 
-		var annots = collect_annotations_on_modules("min_sdk_version", mmodule)
-		for an in annots do project.min_sdk = an.arg_as_int(self)
+		var annots = collect_annotations_on_modules("min_api_version", mmodule)
+		for an in annots do project.min_api = an.arg_as_int(self)
 
-		annots = collect_annotations_on_modules("max_sdk_version", mmodule)
-		for an in annots do project.max_sdk = an.arg_as_int(self)
+		annots = collect_annotations_on_modules("max_api_version", mmodule)
+		for an in annots do project.max_api = an.arg_as_int(self)
 
-		annots = collect_annotations_on_modules("target_sdk_version", mmodule)
-		for an in annots do project.target_sdk = an.arg_as_int(self)
+		annots = collect_annotations_on_modules("target_api_version", mmodule)
+		for an in annots do project.target_api = an.arg_as_int(self)
 
 		annots = collect_annotations_on_modules("android_manifest", mmodule)
 		for an in annots do project.manifest_lines.add an.arg_as_string(self)

--- a/src/android_platform.nit
+++ b/src/android_platform.nit
@@ -67,14 +67,14 @@ class AndroidToolchain
 		var app_version = project.version
 		if app_version == null then app_version = "1.0"
 
-		var app_min_sdk = project.min_sdk
-		if app_min_sdk == null then app_min_sdk = 10
+		var app_min_api = project.min_api
+		if app_min_api == null then app_min_api = 10
 
-		var app_target_sdk = project.target_sdk
-		if app_target_sdk == null then app_target_sdk = app_min_sdk
+		var app_target_api = project.target_api
+		if app_target_api == null then app_target_api = app_min_api
 
-		var app_max_sdk = ""
-		if project.max_sdk != null then app_max_sdk = "android:maxSdkVersion=\"{app_max_sdk}\""
+		var app_max_api = ""
+		if project.max_api != null then app_max_api = "android:maxSdkVersion=\"{project.max_api.as(not null)}\""
 
 		# Clear the previous android project, so there is no "existing project warning"
 		# or conflict between Java files of different projects
@@ -83,7 +83,7 @@ class AndroidToolchain
 		var args = ["android", "-s",
 			"create", "project",
 			"--name", short_project_name,
-			"--target", "android-{app_target_sdk}",
+			"--target", "android-{app_target_api}",
 			"--path", android_project_root,
 			"--package", app_package,
 			"--activity", short_project_name]
@@ -139,9 +139,9 @@ $(call import-module,android/native_app_glue)
 
     <!-- This is the platform API where NativeActivity was introduced. -->
     <uses-sdk 
-        android:minSdkVersion="{{{app_min_sdk}}}" 
-        android:targetSdkVersion="{{{app_target_sdk}}}" 
-        {{{app_max_sdk}}} /> 
+        android:minSdkVersion="{{{app_min_api}}}" 
+        android:targetSdkVersion="{{{app_target_api}}}" 
+        {{{app_max_api}}} /> 
 
     <application
 		android:label="@string/app_name"


### PR DESCRIPTION
As discussed with @xymus, modified the 3 recently merged annotations names from `min_sdk_version`, `target_sdk_version`, `max_sdk_version` to `min_api_version`, `target_api_version`, `max_api_version` to avoid ambiguities as the android documentation related to these AndroidManifest entries always refers to it as _API Level_ settings. 
#568 depends on this PR because the annotations will be renamed on the test files.

Signed-off-by: Frédéric Vachon fredvac@gmail.com
