### PR TITLE
Memcpy -> memmove

### DIFF
--- a/src/abstract_compiler.nit
+++ b/src/abstract_compiler.nit
@@ -2008,7 +2008,7 @@ redef class AMethPropdef
 				v.add("{arguments[0]}[{arguments[1]}]={arguments[2]};")
 				return
 			else if pname == "copy_to" then
-				v.add("memcpy({arguments[1]}+{arguments[4]},{arguments[0]}+{arguments[3]},{arguments[2]});")
+				v.add("memmove({arguments[1]}+{arguments[4]},{arguments[0]}+{arguments[3]},{arguments[2]});")
 				return
 			else if pname == "atoi" then
 				v.ret(v.new_expr("atoi({arguments[0]});", ret.as(not null)))

--- a/src/global_compiler.nit
+++ b/src/global_compiler.nit
@@ -356,7 +356,7 @@ class GlobalCompilerVisitor
 			return
 		else if pname == "copy_to" then
 			var recv1 = "((struct {arguments[1].mcasttype.c_name}*){arguments[1]})->values"
-			self.add("memcpy({recv1},{recv},{arguments[2]}*sizeof({elttype.ctype}));")
+			self.add("memmove({recv1},{recv},{arguments[2]}*sizeof({elttype.ctype}));")
 			return
 		end
 	end

--- a/src/separate_compiler.nit
+++ b/src/separate_compiler.nit
@@ -1644,7 +1644,7 @@ class SeparateCompilerVisitor
 			return
 		else if pname == "copy_to" then
 			var recv1 = "((struct instance_{nclass.c_instance_name}*){arguments[1]})->values"
-			self.add("memcpy({recv1}, {recv}, {arguments[2]}*sizeof({elttype.ctype}));")
+			self.add("memmove({recv1}, {recv}, {arguments[2]}*sizeof({elttype.ctype}));")
 			return
 		end
 	end


### PR DESCRIPTION
As discussed in #655, this PR replaces the uses of memcpy in standard by memmove, a safer alternative while not costing that much more.

Before : 0m15.584s
After : 0m15.748s
