### PR TITLE
phase: remove a useless verbose line

### DIFF
--- a/src/phase.nit
+++ b/src/phase.nit
@@ -98,7 +98,6 @@ redef class ToolContext
 				end
 				errcount = self.error_count
 				for nclassdef in nmodule.n_classdefs do
-					self.info(" phase: {phase} for {nclassdef.location}", 3)
 					assert phase.toolcontext == self
 					phase.process_nclassdef(nclassdef)
 					for npropdef in nclassdef.n_propdefs do


### PR DESCRIPTION
Was called nb_classdefs*nb_phases times, so approximatively 50.000 for nitg.
Without it, the gain is 6% in compiling nitg
