### PR TITLE
Less OES in opengles

### DIFF
--- a/lib/mnit/opengles1.nit
+++ b/lib/mnit/opengles1.nit
@@ -15,16 +15,13 @@
 # limitations under the License.
 
 # OpenGL ES1 general support (most of it)
-module opengles1 is pkgconfig("glesv1_cm", "x11", "egl")
+module opengles1 is pkgconfig("glesv1_cm", "egl")
 
 import mnit_display
 
 in "C header" `{
 	#include <EGL/egl.h>
 	#include <GLES/gl.h>
-	#define GL_GLEXT_PROTOTYPES 1
-	#include <GLES/glext.h>
-	#include <errno.h>
 
 	EGLDisplay mnit_display;
 	EGLSurface mnit_surface;

--- a/lib/mnit_linux/linux_opengles1.nit
+++ b/lib/mnit_linux/linux_opengles1.nit
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module linux_opengles1
+module linux_opengles1 is pkgconfig("x11")
 
 import mnit::opengles1
 


### PR DESCRIPTION
Because of things explained in the debian bug [754397](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=754397), the compilation of mnit project fails on linux systems with a recent mesa library.

One way to solve the problem is to not rely on the OES symbols that cause the issue.
Fortunately, it seems that classes and methods that use those symbols are unused and tagged broken, so just remove them.

Closes #689
Closes #677
