### PR TITLE
nitdoc: cache `concern_rank`

### DIFF
--- a/src/model_utils.nit
+++ b/src/model_utils.nit
@@ -34,7 +34,7 @@ redef class MConcern
 end
 
 redef class MProject
-	redef fun concern_rank do
+	redef fun concern_rank is cached do
 		var max = 0
 		for mgroup in mgroups do
 			var mmax = mgroup.concern_rank
@@ -87,7 +87,7 @@ redef class MGroup
 		return res
 	end
 
-	redef fun concern_rank do
+	redef fun concern_rank is cached do
 		var max = 0
 		for mmodule in collect_mmodules do
 			var mmax = mmodule.concern_rank
@@ -201,7 +201,7 @@ redef class MModule
 		return res
 	end
 
-	redef fun concern_rank do
+	redef fun concern_rank is cached do
 		var max = 0
 		for p in in_importation.direct_greaters do
 			var pmax = p.concern_rank


### PR DESCRIPTION
Improve performance of nitdoc by 60 times in some cases!

Fixes #692, nitdoc on RnR goes from 8 min to 7 sec.

Thanks-to: Jean Privat jean@pryen.org
