### PR TITLE
neo: Forces MParameter ranking in MSignatures

### DIFF
--- a/src/test_neo.nit
+++ b/src/test_neo.nit
@@ -57,34 +57,49 @@ read_model.load(neo_model)
 # Compare model
 var sorter = new MEntityNameSorter
 
-print "mprojects:"
+print "# mprojects:"
 var org_mprojects = org_model.mprojects.to_a
 sorter.sort org_mprojects
 print org_mprojects.join(" ")
+print "------------------------------------"
 var neo_mprojects = neo_model.mprojects.to_a
 sorter.sort neo_mprojects
 print neo_mprojects.join(" ")
 
-print "mmodules:"
+print "\n# mmodules:"
 var org_mmodules = org_model.mmodules.to_a
 sorter.sort org_mmodules
 print org_mmodules.join(" ")
+print "------------------------------------"
 var neo_mmodules = neo_model.mmodules.to_a
 sorter.sort neo_mmodules
 print neo_mmodules.join(" ")
 
-print "mclasses:"
+print "\n# mclasses:"
 var org_mclasses = org_model.mclasses.to_a
 sorter.sort org_mclasses
 print org_mclasses.join(" ")
+print "------------------------------------"
 var neo_mclasses = neo_model.mclasses.to_a
 sorter.sort neo_mclasses
 print neo_mclasses.join(" ")
 
-print "mproperties:"
+print "\n# mproperties:"
 var org_mproperties = org_model.mproperties.to_a
 sorter.sort org_mproperties
 print org_mproperties.join(" ")
+print "------------------------------------"
 var neo_mproperties = neo_model.mproperties.to_a
 sorter.sort neo_mproperties
 print neo_mproperties.join(" ")
+
+print "\n# msignatures:"
+for org_mprop in org_mproperties do
+	if not org_mprop isa MMethod then continue
+	print "{org_mprop.name}{org_mprop.intro.msignature or else ""}"
+end
+print "------------------------------------"
+for neo_mprop in neo_mproperties do
+	if not neo_mprop isa MMethod then continue
+	print "{neo_mprop.name}{neo_mprop.intro.msignature or else ""}"
+end

--- a/tests/sav/test_neo_args1.res
+++ b/tests/sav/test_neo_args1.res
@@ -1,12 +1,136 @@
-mprojects:
+# mprojects:
 test_prog
+------------------------------------
 test_prog
-mmodules:
+
+# mmodules:
 careers character combat game platform races rpg test_prog
+------------------------------------
 careers character combat game platform races rpg test_prog
-mclasses:
+
+# mclasses:
 Alcoholic Bool Career Character Combatable Dwarf Elf Float Game Human Int List Magician Object Race Starter String Sys Warrior Weapon
+------------------------------------
 Alcoholic Bool Career Character Combatable Dwarf Elf Float Game Human Int List Magician Object Race Starter String Sys Warrior Weapon
-mproperties:
+
+# mproperties:
 != * * + + - - / / == > > OTHER _age _base_endurance _base_intelligence _base_strength _career _endurance_bonus _health _intelligence_bonus _name _race _sex _strength_bonus age age= attack base_endurance base_endurance= base_intelligence base_intelligence= base_strength base_strength= career career= computer_characters defend direct_attack dps endurance_bonus endurance_bonus= health health= hit_points init intelligence_bonus intelligence_bonus= is_dead main max_health name name= pause_game player_characters quit race race= sex sex= start start_game stop_game strength_bonus strength_bonus= to_f total_endurance total_intelligence total_strengh unary -
+------------------------------------
 != * * + + - - / / == > > OTHER _age _base_endurance _base_intelligence _base_strength _career _endurance_bonus _health _intelligence_bonus _name _race _sex _strength_bonus age age= attack base_endurance base_endurance= base_intelligence base_intelligence= base_strength base_strength= career career= computer_characters defend direct_attack dps endurance_bonus endurance_bonus= health health= hit_points init intelligence_bonus intelligence_bonus= is_dead main max_health name name= pause_game player_characters quit race race= sex sex= start start_game stop_game strength_bonus strength_bonus= to_f total_endurance total_intelligence total_strengh unary -
+
+# msignatures:
+!=(other: OTHER): Bool
+*(f: Float): Float
+*(i: Int): Int
++(f: Float): Float
++(i: Int): Int
+-(i: Int): Int
+-(f: Float): Float
+/(f: Float): Float
+/(i: Int): Int
+==(other: OTHER): Bool
+>(f: Float): Bool
+>(i: Int): Bool
+age: Int
+age=(age: Int)
+attack(target: Combatable, weapon: Weapon): Int
+base_endurance: Int
+base_endurance=(base_endurance: Int)
+base_intelligence: Int
+base_intelligence=(base_intelligence: Int)
+base_strength: Int
+base_strength=(base_strength: Int)
+career: nullable Career
+career=(career: nullable Career)
+computer_characters: List[Character]
+defend(hit: Int): Int
+direct_attack(target: Combatable, weapon: Weapon): Int
+dps: Float
+endurance_bonus: Int
+endurance_bonus=(endurance_bonus: Int)
+health: Int
+health=(health: Int)
+hit_points: Int
+init
+intelligence_bonus: Int
+intelligence_bonus=(intelligence_bonus: Int)
+is_dead: Bool
+main
+max_health: Int
+name: String
+name=(name: String)
+pause_game
+player_characters: List[Character]
+quit
+race: Race
+race=(race: Race)
+sex: Bool
+sex=(sex: Bool)
+start
+start_game
+stop_game
+strength_bonus: Int
+strength_bonus=(strength_bonus: Int)
+to_f: Float
+total_endurance: Int
+total_intelligence: Int
+total_strengh: Int
+unary -: Int
+------------------------------------
+!=(other: OTHER): Bool
+*(f: Float): Float
+*(i: Int): Int
++(f: Float): Float
++(i: Int): Int
+-(i: Int): Int
+-(f: Float): Float
+/(f: Float): Float
+/(i: Int): Int
+==(other: OTHER): Bool
+>(f: Float): Bool
+>(i: Int): Bool
+age: Int
+age=(age: Int)
+attack(target: Combatable, weapon: Weapon): Int
+base_endurance: Int
+base_endurance=(base_endurance: Int)
+base_intelligence: Int
+base_intelligence=(base_intelligence: Int)
+base_strength: Int
+base_strength=(base_strength: Int)
+career: nullable Career
+career=(career: nullable Career)
+computer_characters: List[Character]
+defend(hit: Int): Int
+direct_attack(target: Combatable, weapon: Weapon): Int
+dps: Float
+endurance_bonus: Int
+endurance_bonus=(endurance_bonus: Int)
+health: Int
+health=(health: Int)
+hit_points: Int
+init
+intelligence_bonus: Int
+intelligence_bonus=(intelligence_bonus: Int)
+is_dead: Bool
+main
+max_health: Int
+name: String
+name=(name: String)
+pause_game
+player_characters: List[Character]
+quit
+race: Race
+race=(race: Race)
+sex: Bool
+sex=(sex: Bool)
+start
+start_game
+stop_game
+strength_bonus: Int
+strength_bonus=(strength_bonus: Int)
+to_f: Float
+total_endurance: Int
+total_intelligence: Int
+total_strengh: Int
+unary -: Int


### PR DESCRIPTION
Also update corresponding test and make test sav more easy to read.

This PR provides two fixes and close #725:

1- use the MParameter `rank` node property to order the mparameters in the signature
2- use the MSignature `parameter_names` to get the declaration order of the parameters (so you don't have to load the MParameters nodes to display the short `MSignature`).
