### PR TITLE
FFI with C++: generated callback functions are static (and test it)

### DIFF
--- a/src/common_ffi/cpp.nit
+++ b/src/common_ffi/cpp.nit
@@ -218,7 +218,7 @@ redef class MExplicitCall
 
 		var cpp_signature = mproperty.build_csignature(recv_mtype, mainmodule, null, short_signature, from_cpp_call_context)
 		var ccall = mproperty.build_ccall(recv_mtype, mainmodule, null, long_signature, from_cpp_call_context, null)
-		var fc = new CFunction(cpp_signature)
+		var fc = new CFunction("static " + cpp_signature)
 		fc.exprs.add(ccall)
 		mmodule.cpp_file.add_local_function( fc )
 	end

--- a/tests/sav/test_ffi_cpp_import.res
+++ b/tests/sav/test_ffi_cpp_import.res
@@ -1,0 +1,1 @@
+Hello from `a`.

--- a/tests/sav/test_ffi_cpp_import2.res
+++ b/tests/sav/test_ffi_cpp_import2.res
@@ -1,0 +1,2 @@
+Hello from `a`.
+Hello from `b`.

--- a/tests/test_ffi_cpp_import.nit
+++ b/tests/test_ffi_cpp_import.nit
@@ -1,0 +1,25 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Copyright 2014 Alexis Laferrière <alexis.laf@xymus.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+in "C++ header" `{
+	#include <stdio.h>
+`}
+
+fun print_a(str: String) import String.to_cstring, String.as(Object) in "C++" `{
+	puts(String_to_cstring(str));
+`}
+
+print_a "Hello from `a`."

--- a/tests/test_ffi_cpp_import2.nit
+++ b/tests/test_ffi_cpp_import2.nit
@@ -1,0 +1,28 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Copyright 2014 Alexis Laferrière <alexis.laf@xymus.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import test_ffi_cpp_import
+
+in "C++ header" `{
+	#include <stdio.h>
+`}
+
+fun print_b(str: String) import String.to_cstring, String.as(Object) in "C++" `{
+	puts(String_to_cstring(str));
+`}
+
+print_a "Hello from `a`."
+print_b "Hello from `b`."


### PR DESCRIPTION
Fix #737

Reported-by: Jean-Christophe Beaupré
Signed-off-by: Alexis Laferrière alexis.laf@xymus.net
