### PR TITLE
Makefile: Document deeply-nested libraries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ doc/stdlib/index.html: bin/nitdoc bin/nitls
 	@echo '***************************************************************'
 	@echo '* Generate doc for NIT standard library                       *'
 	@echo '***************************************************************'
-	bin/nitdoc $$(bin/nitls lib -r --path) -d doc/stdlib \
+	bin/nitdoc $$(bin/nitls lib -rs --path) -d doc/stdlib \
 		--custom-title "Nit Standard Library" \
 		--custom-brand "<a href=\"http://nitlanguage.org/\">Nitlanguage.org</a>" \
 		--custom-overview-text "<p>Documentation for the standard library of Nit<br/>Version $$(git describe)<br/>Date: $$(git show --format="%cd" | head -1)</p>" \
@@ -52,8 +52,8 @@ doc/stdlib/index.html: bin/nitdoc bin/nitls
 		--piwik-tracker "pratchett.info.uqam.ca/piwik/" \
 		--piwik-site-id "2" \
 
-doc/nitc/index.html: bin/nitdoc
-	bin/nitdoc $$(bin/nitls lib -r --path) src/nit*.nit src/test_*.nit -d doc/nitc \
+doc/nitc/index.html: bin/nitdoc bin/nitls
+	bin/nitdoc $$(bin/nitls lib -rs --path) src/nit*.nit src/test_*.nit -d doc/nitc \
 		--private \
 		--custom-title "Nit Compilers and Tools" \
 		--custom-brand "<a href=\"http://nitlanguage.org/\">Nitlanguage.org</a>" \


### PR DESCRIPTION
Ensure that every module in `/lib` is included when calling nitdoc.

Closes #704
