### PR TITLE
compiler: compile_dir can be anywhere

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -330,7 +330,7 @@ class MakefileToolchain
 
 		var outname = outfile(mainmodule)
 
-		var orig_dir=".." # FIXME only works if `compile_dir` is a subdirectory of cwd
+		var orig_dir = compile_dir.relpath(".")
 		var outpath = orig_dir.join_path(outname).simplify_path
 		var makename = makefile_name(mainmodule)
 		var makepath = "{compile_dir}/{makename}"


### PR DESCRIPTION
Fix an old TODO. Now you can compile where you want and stop having a bunch of fat .nit_compile directories everywhere.

``` sh
$ nitg --compile-dir /tmp/nit_compile examples/hello_word.nit
```
