### PR TITLE
src: reduce warnings and spelling errors

### DIFF
--- a/src/location.nit
+++ b/src/location.nit
@@ -42,7 +42,7 @@ class SourceFile
 	end
 
 	# Position of each line start
-	var line_starts: Array[Int] = new Array[Int]
+	var line_starts = new Array[Int]
 end
 
 # A location inside a source file
@@ -100,6 +100,7 @@ class Location
 		return true
 	end
 
+	# Is `self` included (or equals) to `loc`?
 	fun located_in(loc: nullable Location): Bool do
 		if loc == null then return false
 
@@ -136,6 +137,9 @@ class Location
 		end
 	end
 
+	# Return a location message according to an observer.
+	#
+	# Currently, if both are in the same file, the file information is not present in the result.
 	fun relative_to(loc: nullable Location): String do
 		var relative: Location
 		if loc != null and loc.file == self.file then
@@ -158,7 +162,7 @@ class Location
 		return column_end < other.column_end
 	end
 
-	# Return the associated line with the location highlihted with color and a carret under the starting position
+	# Return the associated line with the location highlighted with color and a caret under the starting position
 	# `color` must be and terminal escape sequence used as `"{escape}[{color}m;"`
 	# * `"0;31"` for red
 	# * `"1;31"` for bright red
@@ -204,4 +208,3 @@ class Location
 		return "\t{lstart}{col}{lmid}{def}{lend}\n\t{indent}^"
 	end
 end
-

--- a/src/model/mmodule.nit
+++ b/src/model/mmodule.nit
@@ -25,19 +25,19 @@ private import more_collections
 # A model knows modules, classes and properties and can retrieve them.
 redef class Model
 	# All known modules
-	var mmodules: Array[MModule] = new Array[MModule]
+	var mmodules = new Array[MModule]
 
 	# placebo for old module nesting hierarchy.
 	# where mainmodule < mainmodule::nestedmodule
 	#
 	# TODO REMOVE, rely on mgroup instead
-	var mmodule_nesting_hierarchy: POSet[MModule] = new POSet[MModule]
+	var mmodule_nesting_hierarchy = new POSet[MModule]
 
 	# Full module importation hierarchy including private or nested links.
-	var mmodule_importation_hierarchy: POSet[MModule] = new POSet[MModule]
+	var mmodule_importation_hierarchy = new POSet[MModule]
 
 	# Collections of modules grouped by their short names
-	private var mmodules_by_name: MultiHashMap[String, MModule] = new MultiHashMap[String, MModule]
+	private var mmodules_by_name = new MultiHashMap[String, MModule]
 
 	# Return all module named `name`
 	# If such a module does not exist, null is returned (instead of an empty array)
@@ -150,9 +150,9 @@ class MModule
 		end
 	end
 
-	private var intrude_mmodules: HashSet[MModule] = new HashSet[MModule]
-	private var public_mmodules: HashSet[MModule] = new HashSet[MModule]
-	private var private_mmodules: HashSet[MModule] = new HashSet[MModule]
+	private var intrude_mmodules = new HashSet[MModule]
+	private var public_mmodules = new HashSet[MModule]
+	private var private_mmodules = new HashSet[MModule]
 
 	# Return the visibility level of an imported module `m`
 	fun visibility_for(m: MModule): MVisibility
@@ -204,9 +204,9 @@ class MModule
 		end
 	end
 
-	# Is the mmodule created for internal purpose?
-	# Fictive module are instantied internally but they should not be
-	# exposed to the final user
+	# Is `self` created for internal purpose?
+	# Fictive modules are instantiated internally but they should not be
+	# exposed to the final user.
 	var is_fictive: Bool = false is writable
 
 	redef fun parent_concern do return mgroup

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -32,16 +32,16 @@ private import more_collections
 
 redef class Model
 	# All known classes
-	var mclasses: Array[MClass] = new Array[MClass]
+	var mclasses = new Array[MClass]
 
 	# All known properties
-	var mproperties: Array[MProperty] = new Array[MProperty]
+	var mproperties = new Array[MProperty]
 
 	# Hierarchy of class definition.
 	#
 	# Each classdef is associated with its super-classdefs in regard to
 	# its module of definition.
-	var mclassdef_hierarchy: POSet[MClassDef] = new POSet[MClassDef]
+	var mclassdef_hierarchy = new POSet[MClassDef]
 
 	# Class-type hierarchy restricted to the introduction.
 	#
@@ -52,7 +52,7 @@ redef class Model
 	# This poset will evolve in a monotonous way:
 	# * Two non connected nodes will remain unconnected
 	# * New nodes can appear with new edges
-	private var intro_mtype_specialization_hierarchy: POSet[MClassType] = new POSet[MClassType]
+	private var intro_mtype_specialization_hierarchy = new POSet[MClassType]
 
 	# Global overlapped class-type hierarchy.
 	# The hierarchy when all modules are combined.
@@ -61,10 +61,10 @@ redef class Model
 	# This poset will evolve in an anarchic way. Loops can even be created.
 	#
 	# FIXME decide what to do on loops
-	private var full_mtype_specialization_hierarchy: POSet[MClassType] = new POSet[MClassType]
+	private var full_mtype_specialization_hierarchy = new POSet[MClassType]
 
 	# Collections of classes grouped by their short name
-	private var mclasses_by_name: MultiHashMap[String, MClass] = new MultiHashMap[String, MClass]
+	private var mclasses_by_name = new MultiHashMap[String, MClass]
 
 	# Return all class named `name`.
 	#
@@ -82,7 +82,7 @@ redef class Model
 	end
 
 	# Collections of properties grouped by their short name
-	private var mproperties_by_name: MultiHashMap[String, MProperty] = new MultiHashMap[String, MProperty]
+	private var mproperties_by_name = new MultiHashMap[String, MProperty]
 
 	# Return all properties named `name`.
 	#
@@ -100,7 +100,7 @@ redef class Model
 	end
 
 	# The only null type
-	var null_type: MNullType = new MNullType(self)
+	var null_type = new MNullType(self)
 
 	# Build an ordered tree with from `concerns`
 	fun concerns_tree(mconcerns: Collection[MConcern]): ConcernsTree do
@@ -134,11 +134,11 @@ end
 
 redef class MModule
 	# All the classes introduced in the module
-	var intro_mclasses: Array[MClass] = new Array[MClass]
+	var intro_mclasses = new Array[MClass]
 
 	# All the class definitions of the module
 	# (introduction and refinement)
-	var mclassdefs: Array[MClassDef] = new Array[MClassDef]
+	var mclassdefs = new Array[MClassDef]
 
 	# Does the current module has a given class `mclass`?
 	# Return true if the mmodule introduces, refines or imports a class.
@@ -175,14 +175,14 @@ redef class MModule
 		return res
 	end
 
-	# Sort a given array of classes using the linerarization order of the module
+	# Sort a given array of classes using the linearization order of the module
 	# The most general is first, the most specific is last
 	fun linearize_mclasses(mclasses: Array[MClass])
 	do
 		self.flatten_mclass_hierarchy.sort(mclasses)
 	end
 
-	# Sort a given array of class definitions using the linerarization order of the module
+	# Sort a given array of class definitions using the linearization order of the module
 	# the refinement link is stronger than the specialisation link
 	# The most general is first, the most specific is last
 	fun linearize_mclassdefs(mclassdefs: Array[MClassDef])
@@ -191,7 +191,7 @@ redef class MModule
 		sorter.sort(mclassdefs)
 	end
 
-	# Sort a given array of property definitions using the linerarization order of the module
+	# Sort a given array of property definitions using the linearization order of the module
 	# the refinement link is stronger than the specialisation link
 	# The most general is first, the most specific is last
 	fun linearize_mpropdefs(mpropdefs: Array[MPropDef])
@@ -237,6 +237,8 @@ redef class MModule
 		return get_primitive_class("Sys").mclass_type
 	end
 
+	# The primitive type `Finalizable`
+	# Used to tag classes that need to be finalized.
 	fun finalizable_type: nullable MClassType
 	do
 		var clas = self.model.get_mclasses_by_name("Finalizable")
@@ -408,7 +410,7 @@ class MClass
 	redef fun model do return intro_mmodule.model
 
 	# All class definitions (introduction and refinements)
-	var mclassdefs: Array[MClassDef] = new Array[MClassDef]
+	var mclassdefs = new Array[MClassDef]
 
 	# Alias for `name`
 	redef fun to_s do return self.name
@@ -467,7 +469,7 @@ class MClass
 		return res
 	end
 
-	private var get_mtype_cache: Array[MGenericType] = new Array[MGenericType]
+	private var get_mtype_cache = new Array[MGenericType]
 end
 
 
@@ -529,7 +531,7 @@ class MClassDef
 
 	# All declared super-types
 	# FIXME: quite ugly but not better idea yet
-	var supertypes: Array[MClassType] = new Array[MClassType]
+	var supertypes = new Array[MClassType]
 
 	# Register some super-types for the class (ie "super SomeType")
 	#
@@ -582,10 +584,10 @@ class MClassDef
 	fun is_intro: Bool do return mclass.intro == self
 
 	# All properties introduced by the classdef
-	var intro_mproperties: Array[MProperty] = new Array[MProperty]
+	var intro_mproperties = new Array[MProperty]
 
 	# All property definitions in the class (introductions and redefinitions)
-	var mpropdefs: Array[MPropDef] = new Array[MPropDef]
+	var mpropdefs = new Array[MPropDef]
 end
 
 # A global static type
@@ -638,8 +640,8 @@ abstract class MType
 		end
 
 		# First, resolve the formal types to a common version in the receiver
-		# The trick here is that fixed formal type will be associed to the bound
-		# And unfixed formal types will be associed to a canonical formal type.
+		# The trick here is that fixed formal type will be associated to the bound
+		# And unfixed formal types will be associated to a canonical formal type.
 		if sub isa MParameterType or sub isa MVirtualType then
 			assert anchor != null
 			sub = sub.resolve_for(anchor.mclass.mclass_type, anchor, mmodule, false)
@@ -904,7 +906,7 @@ abstract class MType
 	# Is the type is already not nullable, then self is returned.
 	#
 	# Note: this just remove the `nullable` notation, but the result can still contains null.
-	# For instance if `self isa MNullType` or self is a a formal type bounded by a nullable type.
+	# For instance if `self isa MNullType` or self is a formal type bounded by a nullable type.
 	fun as_notnullable: MType
 	do
 		return self
@@ -913,7 +915,7 @@ abstract class MType
 	private var as_nullable_cache: nullable MType = null
 
 
-	# The deph of the type seen as a tree.
+	# The depth of the type seen as a tree.
 	#
 	# * A -> 1
 	# * G[A] -> 2
@@ -991,7 +993,7 @@ class MClassType
 
 	# The formal arguments of the type
 	# ENSURE: `result.length == self.mclass.arity`
-	var arguments: Array[MType] = new Array[MType]
+	var arguments = new Array[MType]
 
 	redef fun to_s do return mclass.to_s
 
@@ -1066,9 +1068,9 @@ class MClassType
 		collect_mtypes_cache[mmodule] = types
 	end
 
-	private var collect_mclassdefs_cache: HashMap[MModule, Set[MClassDef]] = new HashMap[MModule, Set[MClassDef]]
-	private var collect_mclasses_cache: HashMap[MModule, Set[MClass]] = new HashMap[MModule, Set[MClass]]
-	private var collect_mtypes_cache: HashMap[MModule, Set[MClassType]] = new HashMap[MModule, Set[MClassType]]
+	private var collect_mclassdefs_cache = new HashMap[MModule, Set[MClassDef]]
+	private var collect_mclasses_cache = new HashMap[MModule, Set[MClass]]
+	private var collect_mtypes_cache = new HashMap[MModule, Set[MClassType]]
 
 end
 
@@ -1208,19 +1210,19 @@ class MVirtualType
 		var verbatim_bound = lookup_bound(mmodule, resolved_reciever)
 		# The bound is exactly as declared in the "type" property, so we must resolve it again
 		var res = verbatim_bound.resolve_for(mtype, anchor, mmodule, cleanup_virtual)
-		#print "{class_name}: {self}/{mtype}/{anchor} -> {self}/{resolved_reciever}/{anchor} -> {verbatim_bound}/{mtype}/{anchor} -> {res}"
+		#print "{class_name}: {self}/{mtype}/{anchor} -> {self}/{resolved_receiver}/{anchor} -> {verbatim_bound}/{mtype}/{anchor} -> {res}"
 
 		# What to return here? There is a bunch a special cases:
 		# If 'cleanup_virtual' we must return the resolved type, since we cannot return self
 		if cleanup_virtual then return res
-		# If the reciever is a intern class, then the virtual type cannot be redefined since there is no possible subclass. self is just fixed. so simply return the resolution
+		# If the receiver is a intern class, then the virtual type cannot be redefined since there is no possible subclass. self is just fixed. so simply return the resolution
 		if resolved_reciever isa MNullableType then resolved_reciever = resolved_reciever.mtype
 		if resolved_reciever.as(MClassType).mclass.kind == enum_kind then return res
 		# If the resolved type isa MVirtualType, it means that self was bound to it, and cannot be unbound. self is just fixed. so return the resolution.
 		if res isa MVirtualType then return res
 		# If we are final, just return the resolution
 		if is_fixed(mmodule, resolved_reciever) then return res
-		# It the resolved type isa intern class, then there is no possible valid redefinition is any potentiel subclass. self is just fixed. so simply return the resolution
+		# If the resolved type isa intern class, then there is no possible valid redefinition in any potential subclass. self is just fixed. so simply return the resolution
 		if res isa MClassType and res.mclass.kind == enum_kind then return res
 		# TODO: Add 'fixed' virtual type in the specification.
 		# TODO: What if bound to a MParameterType?
@@ -1247,7 +1249,7 @@ class MVirtualType
 	end
 end
 
-# The type associated the a formal parameter generic type of a class
+# The type associated to a formal parameter generic type of a class
 #
 # Each parameter type is associated to a specific class.
 # It means that all refinements of a same class "share" the parameter type,
@@ -1324,7 +1326,7 @@ class MParameterType
 		# self is a parameter type of mtype (or of a super-class of mtype)
 		# The point of the function it to get the bound of the virtual type that make sense for mtype
 		# But because mtype is maybe a virtual/formal type, we need to get a real receiver first
-		# FIXME: What happend here is far from clear. Thus this part must be validated and clarified
+		# FIXME: What happens here is far from clear. Thus this part must be validated and clarified
 		var resolved_receiver
 		if mtype.need_anchor then
 			assert anchor != null
@@ -1642,7 +1644,7 @@ abstract class MProperty
 	# All definitions of the property.
 	# The first is the introduction,
 	# The other are redefinitions (in refinements and in subclasses)
-	var mpropdefs: Array[MPROPDEF] = new Array[MPROPDEF]
+	var mpropdefs = new Array[MPROPDEF]
 
 	# The definition that introduced the property
 	# Warning: the introduction is the first `MPropDef` object
@@ -1690,7 +1692,7 @@ abstract class MProperty
 		return select_most_specific(mmodule, candidates)
 	end
 
-	private var lookup_definitions_cache: HashMap2[MModule, MType, Array[MPROPDEF]] = new HashMap2[MModule, MType, Array[MPROPDEF]]
+	private var lookup_definitions_cache = new HashMap2[MModule, MType, Array[MPROPDEF]]
 
 	# Return the most specific property definitions inherited by a type.
 	# The selection knows that refinement is stronger than specialization;
@@ -1765,7 +1767,7 @@ abstract class MProperty
 	# If you want to know the next properties in the linearization,
 	# look at `MPropDef::lookup_next_definition`.
 	#
-	# FIXME: the linearisation is still unspecified
+	# FIXME: the linearization is still unspecified
 	#
 	# REQUIRE: `not mtype.need_anchor`
 	# REQUIRE: `mtype.has_mproperty(mmodule, self)`
@@ -1775,8 +1777,8 @@ abstract class MProperty
 		return lookup_all_definitions(mmodule, mtype).first
 	end
 
-	# Return all definitions in a linearisation order
-	# Most speficic first, most general last
+	# Return all definitions in a linearization order
+	# Most specific first, most general last
 	fun lookup_all_definitions(mmodule: MModule, mtype: MType): Array[MPROPDEF]
 	do
 		assert not mtype.need_anchor
@@ -1808,7 +1810,7 @@ abstract class MProperty
 		return candidates
 	end
 
-	private var lookup_all_definitions_cache: HashMap2[MModule, MType, Array[MPROPDEF]] = new HashMap2[MModule, MType, Array[MPROPDEF]]
+	private var lookup_all_definitions_cache = new HashMap2[MModule, MType, Array[MPROPDEF]]
 end
 
 # A global method
@@ -1834,7 +1836,7 @@ class MMethod
 	# The constructor is a (the) root init with empty signature but a set of initializers
 	var is_root_init: Bool = false is writable
 
-	# The the property a 'new' contructor?
+	# Is the property a 'new' constructor?
 	var is_new: Bool = false is writable
 
 	# Is the property a legal constructor for a given class?
@@ -1870,7 +1872,7 @@ class MVirtualTypeProp
 	end
 
 	# The formal type associated to the virtual type property
-	var mvirtualtype: MVirtualType = new MVirtualType(self)
+	var mvirtualtype = new MVirtualType(self)
 end
 
 # A definition of a property (local property)
@@ -2039,7 +2041,7 @@ class MClassKind
 			# no other case for interfaces
 			return false
 		else if self == extern_kind then
-			# only compatible with themselve
+			# only compatible with themselves
 			return self == other
 		else if other == enum_kind or other == extern_kind then
 			# abstract_kind and concrete_kind are incompatible
@@ -2050,8 +2052,13 @@ class MClassKind
 	end
 end
 
+# The class kind `abstract`
 fun abstract_kind: MClassKind do return once new MClassKind("abstract class", true)
+# The class kind `concrete`
 fun concrete_kind: MClassKind do return once new MClassKind("class", true)
+# The class kind `interface`
 fun interface_kind: MClassKind do return once new MClassKind("interface", false)
+# The class kind `enum`
 fun enum_kind: MClassKind do return once new MClassKind("enum", false)
+# The class kind `extern`
 fun extern_kind: MClassKind do return once new MClassKind("extern class", false)

--- a/src/model/model_base.nit
+++ b/src/model/model_base.nit
@@ -23,7 +23,7 @@ class Model
 end
 
 # A named and possibly documented entity in the model.
-# This class is usefull to generalize presentation of entities to the human.
+# This class is useful to generalize presentation of entities to the human.
 abstract class MEntity
 	# The short (unqualified) name of this model entity
 	fun name: String is abstract
@@ -72,8 +72,13 @@ class MVisibility
 	end
 end
 
+# The visibility level `intrude`
 fun intrude_visibility: MVisibility do return once new MVisibility("intrude", 5)
+# The visibility level `public`
 fun public_visibility: MVisibility do return once new MVisibility("public", 4)
+# The visibility level `protected`
 fun protected_visibility: MVisibility do return once new MVisibility("protected", 3)
+# The visibility level `private`
 fun private_visibility: MVisibility do return once new MVisibility("private", 2)
+# The visibility level `none` (no visibility)
 fun none_visibility: MVisibility do return once new MVisibility("none", 1)

--- a/src/model/model_viz.nit
+++ b/src/model/model_viz.nit
@@ -47,7 +47,7 @@ class MProjectTree
 		sort_with(alpha_comparator)
 	end
 
-	# Sort modules and groups with a loosly adaptation of the linerarisation of modules
+	# Sort modules and groups with a loosely adaptation of the linearization of modules
 	fun sort_with_linex
 	do
 		var c = linex_comparator
@@ -132,7 +132,7 @@ end
 
 # Generate graphiz files based on projects, groups and modules
 #
-# Interessing elements must be selected. See `mmodules`, ``
+# Interesting elements must be selected. See `mmodules`, ``
 # Display configuration can be set. See `cluster_group`, `project_group`
 class MProjectDot
 	super Streamable
@@ -159,7 +159,7 @@ class MProjectDot
 	# Should projects be shown as clusters?
 	var project_group = true is writable
 
-	# Recursively generate noed ans clusters for a mroup
+	# Recursively generate node and clusters for a mgroup
 	private fun dot_cluster(o: OStream, mgroup: MGroup)
 	do
 		# Open the cluster, if required
@@ -180,7 +180,7 @@ class MProjectDot
 			o.write("\t{node_for(mmodule)} [label=\"{mmodule.name}\",color=green]\n")
 		end
 
-		# recusively progress on sub-clusters
+		# recursively progress on sub-clusters
 		for d in mgroup.in_nesting.direct_smallers do
 			dot_cluster(o, d)
 		end
@@ -193,7 +193,7 @@ class MProjectDot
 		end
 	end
 
-	# Extends the set of `mmodules` by recurdively adding the most specific imported modules of foreign projects
+	# Extends the set of `mmodules` by recursively adding the most specific imported modules of foreign projects
 	fun collect_important_importation
 	do
 		var todo = new List[MModule]
@@ -215,7 +215,7 @@ class MProjectDot
 	# Generate the dot content with the current configuration
 	redef fun write_to(stream)
 	do
-		# Collect interessing nodes
+		# Collect interesting nodes
 		for m in model.mmodules do
 			# filter out modules outside wanted projects
 			if m.mgroup == null then continue
@@ -226,7 +226,7 @@ class MProjectDot
 
 		collect_important_importation
 
-		# Collect interessing edges
+		# Collect interesting edges
 		var sub_hierarchy = new POSet[MModule]
 		for m in mmodules do
 			sub_hierarchy.add_node(m)

--- a/src/model/mproject.nit
+++ b/src/model/mproject.nit
@@ -19,7 +19,7 @@ import model_base
 private import more_collections
 import poset
 
-# A Nit project, thas encompass a product
+# A Nit project, that encompass a product
 class MProject
 	super MConcern
 
@@ -57,7 +57,7 @@ class MGroup
 	# empty name for a default group in a single-module project
 	redef var name: String
 
-	# The englobing project
+	# The enclosing project
 	var mproject: MProject
 
 	# The parent group if any
@@ -73,14 +73,14 @@ class MGroup
 	end
 
 	# The group is the group tree on the project (`mproject.mgroups`)
-	# nested groups (children) are smallers
+	# nested groups (children) are smaller
 	# nesting group (see `parent`) is bigger
 	var in_nesting: POSetElement[MGroup]
 
 	# Is `self` the root of its project?
 	fun is_root: Bool do return mproject.root == self
 
-	# The filepath (usualy a directory) of the group, if any
+	# The filepath (usually a directory) of the group, if any
 	var filepath: nullable String is writable
 
 	init (name: String, mproject: MProject, parent: nullable MGroup)
@@ -110,7 +110,7 @@ redef class Model
 	var mprojects = new Array[MProject]
 
 	# Collections of project grouped by their names
-	private var mproject_by_name: MultiHashMap[String, MProject] = new MultiHashMap[String, MProject]
+	private var mproject_by_name = new MultiHashMap[String, MProject]
 
 	# Return all project named `name`
 	# If such a project is not yet loaded, null is returned (instead of an empty array)

--- a/src/modelbuilder.nit
+++ b/src/modelbuilder.nit
@@ -31,16 +31,16 @@ private import more_collections
 
 redef class ToolContext
 	# Option --path
-	var opt_path: OptionArray = new OptionArray("Set include path for loaders (may be used more than once)", "-I", "--path")
+	var opt_path = new OptionArray("Set include path for loaders (may be used more than once)", "-I", "--path")
 
 	# Option --only-metamodel
-	var opt_only_metamodel: OptionBool = new OptionBool("Stop after meta-model processing", "--only-metamodel")
+	var opt_only_metamodel = new OptionBool("Stop after meta-model processing", "--only-metamodel")
 
 	# Option --only-parse
-	var opt_only_parse: OptionBool = new OptionBool("Only proceed to parse step of loaders", "--only-parse")
+	var opt_only_parse = new OptionBool("Only proceed to parse step of loaders", "--only-parse")
 
 	# Option --ignore-visibility
-	var opt_ignore_visibility: OptionBool = new OptionBool("Do not check, and produce errors, on visibility issues.", "--ignore-visibility")
+	var opt_ignore_visibility = new OptionBool("Do not check, and produce errors, on visibility issues.", "--ignore-visibility")
 
 	redef init
 	do
@@ -48,7 +48,9 @@ redef class ToolContext
 		option_context.add_option(opt_path, opt_only_parse, opt_only_metamodel, opt_ignore_visibility)
 	end
 
+	# The modelbuilder 1-to-1 associated with the toolcontext
 	fun modelbuilder: ModelBuilder do return modelbuilder_real.as(not null)
+
 	private var modelbuilder_real: nullable ModelBuilder = null
 
 	# Run `process_mainmodule` on all phases
@@ -273,7 +275,7 @@ class ModelBuilder
 		return res
 	end
 
-	private var try_get_mproperty_by_name2_cache: HashMap3[MModule, MType, String, nullable MProperty] = new HashMap3[MModule, MType, String, nullable MProperty]
+	private var try_get_mproperty_by_name2_cache = new HashMap3[MModule, MType, String, nullable MProperty]
 
 
 	# Alias for try_get_mproperty_by_name2(anode, mclassdef.mmodule, mclassdef.mtype, name)
@@ -288,7 +290,7 @@ class ModelBuilder
 	#   * the NIT_PATH environment variable
 	#   * `toolcontext.nit_dir`
 	# Path can be added (or removed) by the client
-	var paths: Array[String] = new Array[String]
+	var paths = new Array[String]
 
 	# Like (an used by) `get_mmodule_by_name` but just return the ModulePath
 	private fun search_mmodule_by_name(anode: ANode, mgroup: nullable MGroup, name: String): nullable ModulePath
@@ -539,7 +541,6 @@ class ModelBuilder
 		var parser = new Parser(lexer)
 		var tree = parser.parse
 		file.close
-		var mod_name = filename.basename(".nit")
 
 		# Handle lexer and parser error
 		var nmodule = tree.n_base
@@ -586,6 +587,8 @@ class ModelBuilder
 		return nmodule
 	end
 
+	# Injection of a new module without source.
+	# Used by the interpreted
 	fun load_rt_module(parent: MModule, nmodule: AModule, mod_name: String): nullable AModule
 	do
 		# Create the module
@@ -702,11 +705,11 @@ class ModelBuilder
 	end
 
 	# All the loaded modules
-	var nmodules: Array[AModule] = new Array[AModule]
+	var nmodules = new Array[AModule]
 
 	# Register the nmodule associated to each mmodule
 	# FIXME: why not refine the `MModule` class with a nullable attribute?
-	var mmodule2nmodule: HashMap[MModule, AModule] = new HashMap[MModule, AModule]
+	var mmodule2nmodule = new HashMap[MModule, AModule]
 
 	# Helper function to display an error on a node.
 	# Alias for `self.toolcontext.error(n.hot_location, text)`

--- a/src/parser/lexer_work.nit
+++ b/src/parser/lexer_work.nit
@@ -98,7 +98,7 @@ class Lexer
 	# Current column in the input stream
 	var pos: Int = 0
 
-	# Was the last character a cariage-return?
+	# Was the last character a carriage-return?
 	var cr: Bool = false
 
 	# Constante state values

--- a/src/parser/parser_nodes.nit
+++ b/src/parser/parser_nodes.nit
@@ -92,7 +92,7 @@ abstract class ANode
 	private fun replace_child(old_child: ANode, new_child: nullable ANode) is abstract
 
 	# Detach a node from its parent
-	# Aborts if the node is not detashable. use `replace_with` instead
+	# Aborts if the node is not detachable. use `replace_with` instead
 	# REQUIRE: parent != null
 	# REQUIRE: is_detachable
 	# ENDURE: parent == null
@@ -120,7 +120,7 @@ abstract class ANode
 end
 
 # A sequence of nodes
-# There is a specifc class (instead of a using Array) to track the parent/child relation when nodes are added or removed
+# It is a specific class (instead of using a Array) to track the parent/child relation when nodes are added or removed
 class ANodes[E: ANode]
 	super Sequence[E]
 	private var parent: ANode
@@ -180,7 +180,7 @@ class ANodes[E: ANode]
 		e.parent = null
 	end
 
-	# Used in parent contructor to fill elements
+	# Used in parent constructor to fill elements
 	private fun unsafe_add_all(nodes: Collection[Object])
 	do
 		var parent = self.parent
@@ -222,14 +222,16 @@ abstract class Token
 
 	# The raw content on the token
 	fun text: String is abstract
+
+	# The raw content on the token
 	fun text=(text: String) is abstract
 
 	# The previous token in the Lexer.
-	# May have disapeared in the AST
+	# May have disappeared in the AST
 	var prev_token: nullable Token = null
 
 	# The next token in the Lexer.
-	# May have disapeared in the AST
+	# May have disappeared in the AST
 	var next_token: nullable Token = null
 
 	# The verbatim blank text between `prev_token` and `self`
@@ -251,11 +253,11 @@ end
 
 redef class SourceFile
 	# The first token parser by the lexer
-	# May have disapeared in the final AST
+	# May have disappeared in the final AST
 	var first_token: nullable Token = null
 
 	# The first token parser by the lexer
-	# May have disapeared in the final AST
+	# May have disappeared in the final AST
 	var last_token: nullable Token = null
 end
 
@@ -321,174 +323,288 @@ abstract class TokenKeyword
 		return "keyword '{text}'"
 	end
 end
+
+# The deprecated keyword `package`.
 class TKwpackage
 	super TokenKeyword
 end
+
+# The keyword `module`
 class TKwmodule
 	super TokenKeyword
 end
+
+# The keyword `import`
 class TKwimport
 	super TokenKeyword
 end
+
+# The keyword `class`
 class TKwclass
 	super TokenKeyword
 end
+
+# The keyword `abstract`
 class TKwabstract
 	super TokenKeyword
 end
+
+# The keyword `interface`
 class TKwinterface
 	super TokenKeyword
 end
+
+# The keywords `enum` ane `universal`
 class TKwenum
 	super TokenKeyword
 end
+
+# The keyword `end`
 class TKwend
 	super TokenKeyword
 end
+
+# The keyword `fun`
 class TKwmeth
 	super TokenKeyword
 end
+
+# The keyword `type`
 class TKwtype
 	super TokenKeyword
 end
+
+# The keyword `init`
 class TKwinit
 	super TokenKeyword
 end
+
+# The keyword `redef`
 class TKwredef
 	super TokenKeyword
 end
+
+# The keyword `is`
 class TKwis
 	super TokenKeyword
 end
+
+# The keyword `do`
 class TKwdo
 	super TokenKeyword
 end
+
+# The keyword `var`
 class TKwvar
 	super TokenKeyword
 end
+
+# The keyword `extern`
 class TKwextern
 	super TokenKeyword
 end
+
+# The keyword `public`
 class TKwpublic
 	super TokenKeyword
 end
+
+# The keyword `protected`
 class TKwprotected
 	super TokenKeyword
 end
+
+# The keyword `private`
 class TKwprivate
 	super TokenKeyword
 end
+
+# The keyword `intrude`
 class TKwintrude
 	super TokenKeyword
 end
+
+# The keyword `if`
 class TKwif
 	super TokenKeyword
 end
+
+# The keyword `then`
 class TKwthen
 	super TokenKeyword
 end
+
+# The keyword `else`
 class TKwelse
 	super TokenKeyword
 end
+
+# The keyword `while`
 class TKwwhile
 	super TokenKeyword
 end
+
+# The keyword `loop`
 class TKwloop
 	super TokenKeyword
 end
+
+# The keyword `for`
 class TKwfor
 	super TokenKeyword
 end
+
+# The keyword `in`
 class TKwin
 	super TokenKeyword
 end
+
+# The keyword `and`
 class TKwand
 	super TokenKeyword
 end
+
+# The keyword `or`
 class TKwor
 	super TokenKeyword
 end
+
+# The keyword `implies`
 class TKwimplies
 	super TokenKeyword
 end
+
+# The keyword `not`
 class TKwnot
 	super TokenKeyword
 end
+
+# The keyword `return`
 class TKwreturn
 	super TokenKeyword
 end
+
+# The keyword `continue`
 class TKwcontinue
 	super TokenKeyword
 end
+
+# The keyword `break`
 class TKwbreak
 	super TokenKeyword
 end
+
+# The keyword `abort`
 class TKwabort
 	super TokenKeyword
 end
+
+# The keyword `assert`
 class TKwassert
 	super TokenKeyword
 end
+
+# The keyword `new`
 class TKwnew
 	super TokenKeyword
 end
+
+# The keyword `isa`
 class TKwisa
 	super TokenKeyword
 end
+
+# The keyword `once`
 class TKwonce
 	super TokenKeyword
 end
+
+# The keyword `super`
 class TKwsuper
 	super TokenKeyword
 end
+
+# The keyword `self`
 class TKwself
 	super TokenKeyword
 end
+
+# The keyword `true`
 class TKwtrue
 	super TokenKeyword
 end
+
+# The keyword `false`
 class TKwfalse
 	super TokenKeyword
 end
+
+# The keyword `null`
 class TKwnull
 	super TokenKeyword
 end
+
+# The keyword `as`
 class TKwas
 	super TokenKeyword
 end
+
+# The keyword `nullable`
 class TKwnullable
 	super TokenKeyword
 end
+
+# The keyword `isset`
 class TKwisset
 	super TokenKeyword
 end
+
+# The keyword `label`
 class TKwlabel
 	super TokenKeyword
 end
+
+# The special keyword `__DEBUG__`
 class TKwdebug
 	super Token
 end
+
+# The symbol `(`
 class TOpar
 	super Token
 end
+
+# The symbol `)`
 class TCpar
 	super Token
 end
+
+# The symbol `[`
 class TObra
 	super Token
 end
+
+# The symbol `]`
 class TCbra
 	super Token
 end
+
+# The symbol `,`
 class TComma
 	super Token
 end
+
+# The symbol `:`
 class TColumn
 	super Token
 end
+
+# The symbol `::`
 class TQuad
 	super Token
 end
+
+# The symbol `=`
 class TAssign
 	super Token
 end
@@ -501,69 +617,113 @@ abstract class TokenOperator
 		return "operator '{text}'"
 	end
 end
+
+# The operator `+=`
 class TPluseq
 	super TokenOperator
 end
+
+# The operator `-=`
 class TMinuseq
 	super TokenOperator
 end
+
+# The symbol `...`
 class TDotdotdot
 	super Token
 end
+
+# The symbol `..`
 class TDotdot
 	super Token
 end
+
+# The symbol `.`
 class TDot
 	super Token
 end
+
+# The operator `+`
 class TPlus
 	super TokenOperator
 end
+
+# The operator `-`
 class TMinus
 	super TokenOperator
 end
+
+# The operator `*`
 class TStar
 	super TokenOperator
 end
+
+# The operator `**`
 class TStarstar
 	super TokenOperator
 end
+
+# The operator `/`
 class TSlash
 	super TokenOperator
 end
+
+# The operator `+%
 class TPercent
 	super TokenOperator
 end
+
+# The operator `==`
 class TEq
 	super TokenOperator
 end
+
+# The operator `!=`
 class TNe
 	super TokenOperator
 end
+
+# The operator `<`
 class TLt
 	super TokenOperator
 end
+
+# The operator `<=`
 class TLe
 	super TokenOperator
 end
+
+# The operator `<<`
 class TLl
 	super TokenOperator
 end
+
+# The operator `>`
 class TGt
 	super TokenOperator
 end
+
+# The operator `>=`
 class TGe
 	super TokenOperator
 end
+
+# The operator `>>`
 class TGg
 	super TokenOperator
 end
+
+# The operator `<=>`
 class TStarship
 	super TokenOperator
 end
+
+# The operator `!`
 class TBang
 	super TokenOperator
 end
+
+# The symbol `@`
 class TAt
 	super Token
 end
@@ -603,27 +763,43 @@ abstract class TokenLiteral
 		do return "literal value '{text}'"
 	end
 end
+
+# A literal decimal integer
 class TNumber
 	super TokenLiteral
 end
+
+# A literal hexadecimal integer
 class THexNumber
 	super TokenLiteral
 end
+
+# A literal floating point number
 class TFloat
 	super TokenLiteral
 end
+
+# A literal character
 class TChar
 	super TokenLiteral
 end
+
+# A literal string
 class TString
 	super TokenLiteral
 end
+
+# The starting part of a super string (between `"` and `{`)
 class TStartString
 	super TokenLiteral
 end
+
+# The middle part of a super string (between `}` and `{`)
 class TMidString
 	super TokenLiteral
 end
+
+# The final part of a super string (between `}` and `"`)
 class TEndString
 	super TokenLiteral
 end
@@ -646,6 +822,7 @@ class TBadChar
 	end
 end
 
+# A extern code block
 class TExternCodeSegment
 	super Token
 end
@@ -663,9 +840,11 @@ end
 class AError
 	super EOF
 end
+# A lexical error (unexpected character)
 class ALexerError
 	super AError
 end
+# A syntactic error (unexpected token)
 class AParserError
 	super AError
 end
@@ -675,9 +854,9 @@ class AModule
 	super Prod
 
 	var n_moduledecl: nullable AModuledecl = null is writable
-	var n_imports: ANodes[AImport] = new ANodes[AImport](self)
-	var n_extern_code_blocks: ANodes[AExternCodeBlock] = new ANodes[AExternCodeBlock](self)
-	var n_classdefs: ANodes[AClassdef] = new ANodes[AClassdef](self)
+	var n_imports = new ANodes[AImport](self)
+	var n_extern_code_blocks = new ANodes[AExternCodeBlock](self)
+	var n_classdefs = new ANodes[AClassdef](self)
 end
 
 # The declaration of the module with the documentation, name, and annotations
@@ -720,18 +899,23 @@ end
 abstract class AVisibility
 	super Prod
 end
+
+# An implicit or explicit public visibility modifier
 class APublicVisibility
 	super AVisibility
 	var n_kwpublic: nullable TKwpublic is writable
 end
+# An explicit private visibility modifier
 class APrivateVisibility
 	super AVisibility
 	var n_kwprivate: TKwprivate is writable, noinit
 end
+# An explicit protected visibility modifier
 class AProtectedVisibility
 	super AVisibility
 	var n_kwprotected: TKwprotected is writable, noinit
 end
+# An explicit intrude visibility modifier
 class AIntrudeVisibility
 	super AVisibility
 	var n_kwintrude: TKwintrude is writable, noinit
@@ -742,7 +926,7 @@ end
 # There is tow special case of class definition
 abstract class AClassdef
 	super Prod
-	var n_propdefs: ANodes[APropdef] = new ANodes[APropdef](self)
+	var n_propdefs = new ANodes[APropdef](self)
 end
 
 # A standard class definition with a name, superclasses and properties
@@ -753,9 +937,9 @@ class AStdClassdef
 	var n_visibility: AVisibility is writable, noinit
 	var n_classkind: AClasskind is writable, noinit
 	var n_id: nullable TClassid = null is writable
-	var n_formaldefs: ANodes[AFormaldef] = new ANodes[AFormaldef](self)
+	var n_formaldefs = new ANodes[AFormaldef](self)
 	var n_extern_code_block: nullable AExternCodeBlock = null is writable
-	var n_superclasses: ANodes[ASuperclass] = new ANodes[ASuperclass](self)
+	var n_superclasses = new ANodes[ASuperclass](self)
 	var n_kwend: TKwend is writable, noinit
 	redef fun hot_location do return n_id.location
 end
@@ -774,23 +958,33 @@ end
 abstract class AClasskind
 	super Prod
 end
+
+# A default, or concrete class modifier (just `class`)
 class AConcreteClasskind
 	super AClasskind
 	var n_kwclass: TKwclass is writable, noinit
 end
+
+# An abstract class modifier (`abstract class`)
 class AAbstractClasskind
 	super AClasskind
 	var n_kwabstract: TKwabstract is writable, noinit
 	var n_kwclass: TKwclass is writable, noinit
 end
+
+# An interface class modifier (`interface`)
 class AInterfaceClasskind
 	super AClasskind
 	var n_kwinterface: TKwinterface is writable, noinit
 end
+
+# An enum/universal class modifier (`enum class`)
 class AEnumClasskind
 	super AClasskind
 	var n_kwenum: TKwenum is writable, noinit
 end
+
+# An extern class modifier (`extern class`)
 class AExternClasskind
 	super AClasskind
 	var n_kwextern: TKwextern is writable, noinit
@@ -875,33 +1069,49 @@ class AExternCalls
 	var n_kwimport: TKwimport is writable, noinit
 	var n_extern_calls: ANodes[AExternCall] = new ANodes[AExternCall](self)
 end
+
+# A single callback declaration
 abstract class AExternCall
 	super Prod
 end
+
+# A single callback declaration on a method
 abstract class APropExternCall
 	super AExternCall
 end
+
+# A single callback declaration on a method on the current receiver
 class ALocalPropExternCall
 	super APropExternCall
 	var n_methid: AMethid is writable, noinit
 end
+
+# A single callback declaration on a method on an explicit receiver type.
 class AFullPropExternCall
 	super APropExternCall
 	var n_type: AType is writable, noinit
 	var n_dot: nullable TDot = null is writable
 	var n_methid: AMethid is writable, noinit
 end
+
+# A single callback declaration on a method on a constructor
 class AInitPropExternCall
 	super APropExternCall
 	var n_type: AType is writable, noinit
 end
+
+# A single callback declaration on a `super` call
 class ASuperExternCall
 	super AExternCall
 	var n_kwsuper: TKwsuper is writable, noinit
 end
+
+# A single callback declaration on a cast
 abstract class ACastExternCall
 	super AExternCall
 end
+
+# A single callback declaration on a cast to a given type
 class ACastAsExternCall
 	super ACastExternCall
 	var n_from_type: AType is writable, noinit
@@ -909,12 +1119,16 @@ class ACastAsExternCall
 	var n_kwas: TKwas is writable, noinit
 	var n_to_type: AType is writable, noinit
 end
+
+# A single callback declaration on a cast to a nullable type
 class AAsNullableExternCall
 	super ACastExternCall
 	var n_type: AType is writable, noinit
 	var n_kwas: TKwas is writable, noinit
 	var n_kwnullable: TKwnullable is writable, noinit
 end
+
+# A single callback declaration on a cast to a non-nullable type
 class AAsNotNullableExternCall
 	super ACastExternCall
 	var n_type: AType is writable, noinit
@@ -936,80 +1150,118 @@ end
 abstract class AMethid
 	super Prod
 end
+
+# A method name with a simple identifier
 class AIdMethid
 	super AMethid
 	var n_id: TId is writable, noinit
 end
+
+# A method name `+`
 class APlusMethid
 	super AMethid
 	var n_plus: TPlus is writable, noinit
 end
+
+# A method name `-`
 class AMinusMethid
 	super AMethid
 	var n_minus: TMinus is writable, noinit
 end
+
+# A method name `*`
 class AStarMethid
 	super AMethid
 	var n_star: TStar is writable, noinit
 end
+
+# A method name `**`
 class AStarstarMethid
 	super AMethid
 	var n_starstar: TStarstar is writable, noinit
 end
+
+# A method name `/`
 class ASlashMethid
 	super AMethid
 	var n_slash: TSlash is writable, noinit
 end
+
+# A method name `%`
 class APercentMethid
 	super AMethid
 	var n_percent: TPercent is writable, noinit
 end
+
+# A method name `==`
 class AEqMethid
 	super AMethid
 	var n_eq: TEq is writable, noinit
 end
+
+# A method name `!=`
 class ANeMethid
 	super AMethid
 	var n_ne: TNe is writable, noinit
 end
+
+# A method name `<=`
 class ALeMethid
 	super AMethid
 	var n_le: TLe is writable, noinit
 end
+
+# A method name `>=`
 class AGeMethid
 	super AMethid
 	var n_ge: TGe is writable, noinit
 end
+
+# A method name `<`
 class ALtMethid
 	super AMethid
 	var n_lt: TLt is writable, noinit
 end
+
+# A method name `>`
 class AGtMethid
 	super AMethid
 	var n_gt: TGt is writable, noinit
 end
+
+# A method name `<<`
 class ALlMethid
 	super AMethid
 	var n_ll: TLl is writable, noinit
 end
+
+# A method name `>>`
 class AGgMethid
 	super AMethid
 	var n_gg: TGg is writable, noinit
 end
+
+# A method name `[]`
 class ABraMethid
 	super AMethid
 	var n_obra: TObra is writable, noinit
 	var n_cbra: TCbra is writable, noinit
 end
+
+# A method name `<=>`
 class AStarshipMethid
 	super AMethid
 	var n_starship: TStarship is writable, noinit
 end
+
+# A setter method name with a simple identifier (with a `=`)
 class AAssignMethid
 	super AMethid
 	var n_id: TId is writable, noinit
 	var n_assign: TAssign is writable, noinit
 end
+
+# A method name `[]=`
 class ABraassignMethid
 	super AMethid
 	var n_obra: TObra is writable, noinit
@@ -1021,7 +1273,7 @@ end
 class ASignature
 	super Prod
 	var n_opar: nullable TOpar = null is writable
-	var n_params: ANodes[AParam] = new ANodes[AParam](self)
+	var n_params = new ANodes[AParam](self)
 	var n_cpar: nullable TCpar = null is writable
 	var n_type: nullable AType = null is writable
 end
@@ -1043,7 +1295,7 @@ class AType
 	var n_id: TClassid is writable, noinit
 
 	# Type arguments for a generic type
-	var n_types: ANodes[AType] = new ANodes[AType](self)
+	var n_types = new ANodes[AType](self)
 end
 
 # A label at the end of a block or in a break/continue statement. eg `label x`
@@ -1059,11 +1311,11 @@ abstract class AExpr
 	super Prod
 end
 
-# A sequence of AExpr (usually statements)
-# The last AExpr gives the value of the whole block
+# A sequence of `AExpr` (usually statements)
+# The last `AExpr` gives the value of the whole block
 class ABlockExpr
 	super AExpr
-	var n_expr: ANodes[AExpr] = new ANodes[AExpr](self)
+	var n_expr = new ANodes[AExpr](self)
 	var n_kwend: nullable TKwend = null is writable
 end
 
@@ -1165,7 +1417,7 @@ class AForExpr
 	super AExpr
 	super ALabelable
 	var n_kwfor: TKwfor is writable, noinit
-	var n_ids: ANodes[TId] = new ANodes[TId](self)
+	var n_ids = new ANodes[TId](self)
 	var n_expr: AExpr is writable, noinit
 	var n_kwdo: TKwdo is writable, noinit
 	var n_block: nullable AExpr = null is writable
@@ -1201,7 +1453,7 @@ class AOnceExpr
 end
 
 # A polymorphic invocation of a method
-# The form of the invocation (name, arguments, etc) are specific
+# The form of the invocation (name, arguments, etc.) are specific
 abstract class ASendExpr
 	super AExpr
 	# The receiver of the method invocation
@@ -1417,7 +1669,7 @@ class ACallAssignExpr
 end
 
 # A complex setter call with a standard method-name and any number of arguments. eg `x.m(y)+=z`. OR just a simple complex assignment.
-# Note: because the parser cannot distinguish a variable write with a compex setter call with an implicit receiver and no arguments, it always returns a `ACallReassignExpr`.
+# Note: because the parser cannot distinguish a variable write with a complex setter call with an implicit receiver and no arguments, it always returns a `ACallReassignExpr`.
 # Semantic analysis have to transform them to instance of `AVarReassignExpr`.
 class ACallReassignExpr
 	super ACallFormExpr
@@ -1433,7 +1685,7 @@ class ASuperExpr
 end
 
 # A call to the `init` constructor.
-# Note: because `init` is a keyword and not a `TId`, the explicit call to init cannot be a ACallFormExpr.
+# Note: because `init` is a keyword and not a `TId`, the explicit call to init cannot be a `ACallFormExpr`.
 class AInitExpr
 	super ASendExpr
 	var n_kwinit: TKwinit is writable, noinit
@@ -1475,7 +1727,7 @@ class AVarExpr
 	super AVarFormExpr
 end
 
-# A local variable simple assigment access
+# A local variable simple assignment access
 # The parser cannot instantiate them, see `ACallAssignExpr`.
 class AVarAssignExpr
 	super AVarFormExpr
@@ -1596,10 +1848,10 @@ class AEndStringExpr
 end
 
 # A superstring literal. eg `"a{x}b{y}c"`
-# Each part is modelized a sequence of expression. eg. `["a{, x, }b{, y, }c"]`
+# Each part is modeled a sequence of expression. eg. `["a{, x, }b{, y, }c"]`
 class ASuperstringExpr
 	super AExpr
-	var n_exprs: ANodes[AExpr] = new ANodes[AExpr](self)
+	var n_exprs = new ANodes[AExpr](self)
 end
 
 # A simple parenthesis. eg `(x)`
@@ -1609,7 +1861,7 @@ class AParExpr
 	var n_cpar: TCpar is writable, noinit
 end
 
-# Whatevej just contains (and mimic) an other expression
+# Whatever just contains (and mimic) an other expression
 abstract class AProxyExpr
 	super AExpr
 	var n_expr: AExpr is writable, noinit
@@ -1642,7 +1894,7 @@ class AIssetAttrExpr
 	var n_kwisset: TKwisset is writable, noinit
 end
 
-# A elyspis notation used to pass an expression as it in a vararg parameter
+# An ellipsis notation used to pass an expression as it, in a vararg parameter
 class AVarargExpr
 	super AExpr
 	var n_expr: AExpr is writable, noinit
@@ -1652,10 +1904,10 @@ end
 # A list of expression separated with commas (arguments for instance)
 abstract class AExprs
 	super Prod 
-	var n_exprs: ANodes[AExpr] = new ANodes[AExpr](self)
+	var n_exprs = new ANodes[AExpr](self)
 end
 
-
+# A special expression to debug types
 class ADebugTypeExpr
 	super AExpr
 	var n_kwdebug: TKwdebug is writable, noinit
@@ -1683,39 +1935,50 @@ class ABraExprs
 	var n_cbra: TCbra is writable, noinit
 end
 
-# A complex assignment operator. eg `+=`
+# A complex assignment operator. (`+=` and `-=`)
 abstract class AAssignOp
 	super Prod
 end
+
+# The `+=` assignment operation
 class APlusAssignOp
 	super AAssignOp
 	var n_pluseq: TPluseq is writable, noinit
 end
+
+# The `-=` assignment operator
 class AMinusAssignOp
 	super AAssignOp
 	var n_minuseq: TMinuseq is writable, noinit
 end
 
+# A possibly fully-qualified module identifier
 class AModuleName
 	super Prod
 	var n_quad: nullable TQuad = null is writable
-	var n_path: ANodes[TId] = new ANodes[TId](self)
+	var n_path = new ANodes[TId](self)
 	var n_id: TId is writable, noinit
 end
+
+# A language declaration for an extern block
 class AInLanguage
 	super Prod
 	var n_kwin: TKwin is writable, noinit
 	var n_string: TString is writable, noinit
 end
+
+# An full extern block
 class AExternCodeBlock
 	super Prod
 	var n_in_language: nullable AInLanguage = null is writable
 	var n_extern_code_segment: TExternCodeSegment is writable, noinit
 end
+
+# A possible full method qualifier.
 class AQualified
 	super Prod
 	var n_quad: nullable TQuad = null is writable
-	var n_id: ANodes[TId] = new ANodes[TId](self)
+	var n_id = new ANodes[TId](self)
 	var n_classid: nullable TClassid = null is writable
 end
 
@@ -1723,16 +1986,19 @@ end
 # It contains the block of comments just above the declaration
 class ADoc
 	super Prod
-	var n_comment: ANodes[TComment] = new ANodes[TComment](self)
+	var n_comment = new ANodes[TComment](self)
 end
 
+# A group of annotation on a node
 class AAnnotations
 	super Prod
 	var n_at: nullable TAt = null is writable
 	var n_opar: nullable TOpar = null is writable
-	var n_items: ANodes[AAnnotation] = new ANodes[AAnnotation](self)
+	var n_items = new ANodes[AAnnotation](self)
 	var n_cpar: nullable TCpar = null is writable
 end
+
+# A single annotation
 class AAnnotation
 	super Prod
 	var n_doc: nullable ADoc = null is writable
@@ -1740,36 +2006,54 @@ class AAnnotation
 	var n_visibility: nullable AVisibility is writable
 	var n_atid: AAtid is writable, noinit
 	var n_opar: nullable TOpar = null is writable
-	var n_args: ANodes[AAtArg] = new ANodes[AAtArg](self)
+	var n_args = new ANodes[AAtArg](self)
 	var n_cpar: nullable TCpar = null is writable
 end
+
+# A single argument of an annotation
 abstract class AAtArg
 	super Prod
 end
+
+# A type-like argument of an annotation
 class ATypeAtArg
 	super AAtArg
 	var n_type: AType is writable, noinit
 end
+
+# An expression-like argument of an annotation
 class AExprAtArg
 	super AAtArg
 	var n_expr: AExpr is writable, noinit
 end
+
+# An annotation-like argument of an annotation
 class AAtAtArg
 	super AAtArg
 end
+
+# An annotation name
 abstract class AAtid
 	super Prod
 	var n_id: Token is writable, noinit
 end
+
+# An annotation name based on an identifier
 class AIdAtid
 	super AAtid
 end
+
+# An annotation name based on the keyword `extern`
 class AKwexternAtid
 	super AAtid
 end
+
+# An annotation name based on the keyword `import`
 class AKwimportAtid
 	super AAtid
 end
+
+# An annotation name based on the keyword `abstract`
 class AKwabstractAtid
 	super AAtid
 end

--- a/src/parser/parser_work.nit
+++ b/src/parser/parser_work.nit
@@ -32,6 +32,7 @@ private class State
 	end
 end
 
+# The parser of the Nit language.
 class Parser
 	super TablesCapable
 	# Associated lexer
@@ -168,7 +169,7 @@ end
 
 redef class Prod
 	# Location on the first token after the start of a production
-	# So outside the production for epilon production
+	# So outside the production for epsilon production
 	var first_location: nullable Location
 end
 
@@ -176,11 +177,11 @@ end
 # Uses existing token locations to infer location of productions.
 private class ComputeProdLocationVisitor
 	super Visitor
-	# Currenlty visited productions that need a first token
-	var need_first_prods: Array[Prod] = new Array[Prod]
+	# Currently visited productions that need a first token
+	var need_first_prods = new Array[Prod]
 
 	# Already visited epsilon productions that waits something after them
-	var need_after_epsilons: Array[Prod] = new Array[Prod]
+	var need_after_epsilons = new Array[Prod]
 
 	# Location of the last visited token in the current production
 	var last_location: nullable Location = null
@@ -240,7 +241,7 @@ private class ComputeProdLocationVisitor
 	init do end
 end
 
-# Each reduca action has its own class, this one is the root of the hierarchy.
+# Each reduce action has its own class, this one is the root of the hierarchy.
 private abstract class ReduceAction
 	fun action(p: Parser) is abstract
 	fun concat(l1, l2 : Array[Object]): Array[Object]

--- a/src/platform.nit
+++ b/src/platform.nit
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Platform system, used to customize the behavior of the compiler according
-# to the target platform. Also detects conflicts between targetted platforms.
+# Platform system, used to customize the behavior of the compiler.
+#
+# Customisation is done accordingly to the target platform.
+# Also detects conflicts between targeted platforms.
 module platform
 
 import modelize
@@ -83,7 +85,7 @@ end
 redef class MModule
 	private var local_target_platform: nullable Platform = null
 
-	# Recusively get the platform targetted by this module or imported modules
+	# Recursively get the platform targeted by this module or imported modules
 	fun target_platform: nullable Platform
 	do
 		var ltp = local_target_platform
@@ -102,8 +104,10 @@ end
 #
 # Services will be added to this class in other modules.
 abstract class Platform
+	# Does the platform provide and support the library `unwind`?
 	fun supports_libunwind: Bool do return true
 
+	# Does the platform provide and supports the Boehm's GC library?
 	fun supports_libgc: Bool do return true
 
 	# Does this platform declare its own main function? If so, we won't generate one in Nit.

--- a/src/rapid_type_analysis.nit
+++ b/src/rapid_type_analysis.nit
@@ -31,6 +31,7 @@ private import ordered_tree # for live_methods_to_tree
 private import more_collections
 
 redef class ModelBuilder
+	# Performs a rapid-type-analysis on the program associated with `mainmodule`.
 	fun do_rapid_type_analysis(mainmodule: MModule): RapidTypeAnalysis
 	do
 		var analysis = new RapidTypeAnalysis(self, mainmodule)

--- a/src/semantize/auto_super_init.nit
+++ b/src/semantize/auto_super_init.nit
@@ -53,6 +53,7 @@ redef class AMethPropdef
 	# In case of redefined constructors, is an implicit call-to-super required?
 	var auto_super_call = false
 
+	# Collect initializers and build the auto-init
 	fun do_auto_super_init(modelbuilder: ModelBuilder)
 	do
 		var mclassdef = self.parent.as(AClassdef).mclassdef.as(not null)

--- a/src/semantize/flow.nit
+++ b/src/semantize/flow.nit
@@ -29,7 +29,7 @@ private class FlowPhase
 	redef fun process_npropdef(npropdef) do npropdef.do_flow(toolcontext)
 end
 
-# The visitor that derermine flowcontext for nodes
+# The visitor that determine flowcontext for nodes
 private class FlowVisitor
 	super Visitor
 
@@ -74,7 +74,7 @@ private class FlowVisitor
 		return node.after_flow_context.as(not null)
 	end
 
-	var flows: Array[FlowContext] = new Array[FlowContext]
+	var flows = new Array[FlowContext]
 
 	fun printflow
 	do
@@ -187,18 +187,18 @@ end
 # A same `FlowContext` can be shared by more than one `ANode`.
 class FlowContext
 	# The reachable previous flow
-	var previous: Array[FlowContext] = new Array[FlowContext]
+	var previous = new Array[FlowContext]
 
 	# Additional reachable flow that loop up to self.
-	# Loops apears in `loop`, `while`, `for`, and with `continue`
-	var loops: Array[FlowContext] = new Array[FlowContext]
+	# Loops appears in `loop`, `while`, `for`, and with `continue`
+	var loops = new Array[FlowContext]
 
 	private var is_marked_unreachable: Bool = false
 
 	# Is the flow dead?
 	fun is_unreachable: Bool
 	do
-		# Are we explicitely marked unreachable?
+		# Are we explicitly marked unreachable?
 		if self.is_marked_unreachable then return true
 
 		# Are we the starting flow context?
@@ -209,17 +209,17 @@ class FlowContext
 		return false
 	end
 
-	# Flag to avoid repeaed errors
+	# Flag to avoid repeated errors
 	var is_already_unreachable: Bool = false
 
 	# Mark that self is the starting flow context.
 	# Such a context is reachable even if there is no previous flow
 	var is_start: Bool = false
 
-	# The node that introduce the flow (for debuging)
+	# The node that introduce the flow (for debugging)
 	var node: nullable ANode = null
 
-	# Additional information for the flor (for debuging)
+	# Additional information for the flow (for debugging)
 	var name: String = ""
 
 	# The sub-flow to use if the associated expr is true

--- a/src/semantize/local_var_init.nit
+++ b/src/semantize/local_var_init.nit
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Verify that local variables are initialized before their usage
-# Require that the scope and the flow analaysis are already performed
+# Require that the scope and the flow analysis are already performed
 module local_var_init
 
 import flow
@@ -49,7 +49,7 @@ private class LocalVarInitVisitor
 		self.toolcontext = toolcontext
 	end
 
-	# Local variables that are possibily unset (ie local variable without an initial value)
+	# Local variables that are possibly unset (ie local variable without an initial value)
 	var maybe_unset_vars: Set[Variable] = new HashSet[Variable]
 
 	fun mark_is_unset(node: AExpr, variable: nullable Variable)
@@ -75,7 +75,7 @@ private class LocalVarInitVisitor
 		var flow = node.after_flow_context.as(not null)
 		if not flow.is_variable_set(variable) then
 			self.toolcontext.error(node.hot_location, "Error: variable '{variable}' is possibly unset.")
-			# Remove the variable to avoid repetting errors
+			# Remove the variable to avoid repeating errors
 			self.maybe_unset_vars.remove(variable)
 		end
 	end
@@ -116,7 +116,7 @@ redef class AVardeclExpr
 		super
 		# The variable is unset only if there is no initial value.
 
-		# Note: loops in inital value are not a problem
+		# Note: loops in initial value are not a problem
 		# Example:
 		#
 		#     var foo = foo + 1 #-> Error during typing: "self.foo" unknown

--- a/src/semantize/scope.nit
+++ b/src/semantize/scope.nit
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Identification and scping of local variables and labels.
+# Identification and scoping of local variables and labels.
 module scope
 
 import phase
@@ -50,15 +50,15 @@ class EscapeMark
 	# The name of the label (unless the mark is an anonymous loop mark)
 	var name: nullable String
 
-	# Is the mark atached to a loop (loop, while, for)
+	# Is the mark attached to a loop (loop, while, for)
 	# Such a mark is a candidate to a labelless 'continue' or 'break'
 	var for_loop: Bool
 
 	# Each 'continue' attached to the mark
-	var continues: Array[AContinueExpr] = new Array[AContinueExpr]
+	var continues = new Array[AContinueExpr]
 
 	# Each 'break' attached to the mark
-	var breaks: Array[ABreakExpr] = new Array[ABreakExpr]
+	var breaks = new Array[ABreakExpr]
 end
 
 # Visit a npropdef and:
@@ -72,7 +72,7 @@ private class ScopeVisitor
 	# The tool context used to display errors
 	var toolcontext: ToolContext
 
-	var selfvariable: Variable = new Variable("self")
+	var selfvariable = new Variable("self")
 
 	init(toolcontext: ToolContext)
 	do
@@ -81,7 +81,7 @@ private class ScopeVisitor
 	end
 
 	# All stacked scope. `scopes.first` is the current scope
-	private var scopes: List[Scope] = new List[Scope]
+	private var scopes = new List[Scope]
 
 	# Shift and check the last scope
 	fun shift_scope
@@ -95,7 +95,7 @@ private class ScopeVisitor
 		end
 	end
 
-	# Regiter a local variable.
+	# Register a local variable.
 	# Display an error on toolcontext if a variable with the same name is masked.
 	fun register_variable(node: ANode, variable: Variable): Bool
 	do
@@ -130,7 +130,7 @@ private class ScopeVisitor
 
 	# Enter in a statement block `node` as inside a new scope.
 	# The block can be optionally attached to an `escapemark`.
-	private fun enter_visit_block(node: nullable AExpr, escapemark: nullable EscapeMark)
+	fun enter_visit_block(node: nullable AExpr, escapemark: nullable EscapeMark)
 	do
 		if node == null then return
 		var scope = new Scope
@@ -141,8 +141,8 @@ private class ScopeVisitor
 	end
 
 	# Look for a label `name`.
-	# Return nulll if no such a label is found.
-	private fun search_label(name: String): nullable EscapeMark
+	# Return null if no such a label is found.
+	fun search_label(name: String): nullable EscapeMark
 	do
 		for scope in scopes do
 			var res = scope.escapemark
@@ -155,7 +155,7 @@ private class ScopeVisitor
 
 	# Create a new escape mark (possibly with a label)
 	# Display an error on toolcontext if a label with the same name is masked.
-	private fun make_escape_mark(nlabel: nullable ALabel, for_loop: Bool): EscapeMark
+	fun make_escape_mark(nlabel: nullable ALabel, for_loop: Bool): EscapeMark
 	do
 		var name: nullable String
 		if nlabel != null then
@@ -181,11 +181,11 @@ private class ScopeVisitor
 	end
 
 	# Look for an escape mark optionally associated with a label.
-	# If a label is given, the the escapemark of this label is returned.
+	# If a label is given, the escapemark of this label is returned.
 	# If there is no label, the nearest escapemark that is `for loop` is returned.
 	# If there is no valid escapemark, then an error is displayed ans null is returned.
-	# Return nulll if no such a label is found.
-	private fun get_escapemark(node: ANode, nlabel: nullable ALabel): nullable EscapeMark
+	# Return null if no such a label is found.
+	fun get_escapemark(node: ANode, nlabel: nullable ALabel): nullable EscapeMark
 	do
 		if nlabel != null then
 			var nid = nlabel.n_id
@@ -211,20 +211,20 @@ private class ScopeVisitor
 					return res
 				end
 			end
-			self.error(node, "Syntax Error: 'break' statment outside block.")
+			self.error(node, "Syntax Error: 'break' statement outside block.")
 			return null
 		end
 	end
 
 	# Display an error
-	private fun error(node: ANode, message: String)
+	fun error(node: ANode, message: String)
 	do
 		self.toolcontext.error(node.hot_location, message)
 	end
 end
 
 private class Scope
-	var variables: HashMap[String, Variable] = new HashMap[String, Variable]
+	var variables = new HashMap[String, Variable]
 
 	var escapemark: nullable EscapeMark = null
 
@@ -283,7 +283,7 @@ redef class AVardeclExpr
 end
 
 redef class ASelfExpr
-	# The variable associated with the self reciever
+	# The variable associated with the self receiver
 	var variable: nullable Variable
 	redef fun accept_scope_visitor(v)
 	do
@@ -423,7 +423,7 @@ redef class ACallFormExpr
 		super
 	end
 
-	# Create a variable acces corresponding to the call form
+	# Create a variable access corresponding to the call form
 	private fun variable_create(variable: Variable): AVarFormExpr is abstract
 end
 

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -101,9 +101,9 @@ private class TypeVisitor
 	end
 
 	# Check that `sub` is a subtype of `sup`.
-	# If `sub` is not a valud suptype, then display an error on `node` an return null.
+	# If `sub` is not a valid suptype, then display an error on `node` an return null.
 	# If `sub` is a safe subtype of `sup` then return `sub`.
-	# If `sub` is an insafe subtype (ie an imlicit cast is required), then return `sup`.
+	# If `sub` is an unsafe subtype (ie an implicit cast is required), then return `sup`.
 	#
 	# The point of the return type is to determinate the usable type on an expression:
 	# If the suptype is safe, then the return type is the one on the expression typed by `sub`.
@@ -112,7 +112,7 @@ private class TypeVisitor
 	do
 		if self.is_subtype(sub, sup) then return sub
 		if self.is_subtype(sub, self.anchor_to(sup)) then
-			# FIXME workarround to the current unsafe typing policy. To remove once fixed virtual types exists.
+			# FIXME workaround to the current unsafe typing policy. To remove once fixed virtual types exists.
 			#node.debug("Unsafe typing: expected {sup}, got {sub}")
 			return sup
 		end
@@ -304,7 +304,7 @@ private class TypeVisitor
 		return callsite
 	end
 
-	# Visit the expressions of args and cheik their conformity with the corresponding typi in signature
+	# Visit the expressions of args and check their conformity with the corresponding type in signature
 	# The point of this method is to handle varargs correctly
 	# Note: The signature must be correctly adapted
 	fun check_signature(node: ANode, args: Array[AExpr], name: String, msignature: MSignature): Bool
@@ -409,7 +409,7 @@ end
 
 # A specific method call site with its associated informations.
 class CallSite
-	# The assiciated node for location
+	# The associated node for location
 	var node: ANode
 
 	# The static type of the receiver (possibly unresolved)
@@ -422,7 +422,7 @@ class CallSite
 	var anchor: nullable MClassType
 
 	# Is the receiver self?
-	# If "for_self", virtual types of the signature are keeped
+	# If "for_self", virtual types of the signature are kept
 	# If "not_for_self", virtual type are erased
 	var recv_is_self: Bool
 
@@ -457,7 +457,7 @@ redef class FlowContext
 
 	# Adapt the variable to a static type
 	# Warning1: do not modify vars directly.
-	# Warning2: sub-flow may have cached a unadapted variabial
+	# Warning2: sub-flow may have cached a unadapted variable
 	private fun set_var(variable: Variable, mtype: nullable MType)
 	do
 		self.vars[variable] = mtype
@@ -501,7 +501,7 @@ redef class APropdef
 	do
 	end
 
-	# The variable associated to the reciever (if any)
+	# The variable associated to the receiver (if any)
 	var selfvariable: nullable Variable
 end
 
@@ -1555,7 +1555,7 @@ redef class ASuperExpr
 			var errcount = v.modelbuilder.toolcontext.error_count
 			var candidate = v.try_get_mproperty_by_name2(self, msupertype, mproperty.name).as(nullable MMethod)
 			if candidate == null then
-				if v.modelbuilder.toolcontext.error_count > errcount then return # Forard error
+				if v.modelbuilder.toolcontext.error_count > errcount then return # Forward error
 				continue # Try next super-class
 			end
 			if superprop != null and candidate.is_root_init then
@@ -1571,7 +1571,7 @@ redef class ASuperExpr
 				candidatedefs.add(superprop)
 			end
 			if candidatedefs.length > 1 then
-				v.error(self, "Error: confliting property definitions for property {mproperty} in {recvtype}: {candidatedefs.join(", ")}")
+				v.error(self, "Error: conflicting property definitions for property {mproperty} in {recvtype}: {candidatedefs.join(", ")}")
 				return
 			end
 			superprop = candidatedefs.first

--- a/src/toolcontext.nit
+++ b/src/toolcontext.nit
@@ -63,12 +63,13 @@ class Message
 		end
 	end
 
+	# A colored version of the message including the original source line
 	fun to_color_string: String
 	do
 		var esc = 27.ascii
-		var red = "{esc}[0;31m"
-		var bred = "{esc}[1;31m"
-		var green = "{esc}[0;32m"
+		#var red = "{esc}[0;31m"
+		#var bred = "{esc}[1;31m"
+		#var green = "{esc}[0;32m"
 		var yellow = "{esc}[0;33m"
 		var def = "{esc}[0m"
 
@@ -101,9 +102,11 @@ class ToolContext
 	var log_directory: String = "logs"
 
 	# Messages
-	private var messages: Array[Message] = new Array[Message]
-	private var message_sorter: ComparableSorter[Message] = new ComparableSorter[Message]
+	private var messages = new Array[Message]
+	private var message_sorter = new ComparableSorter[Message]
 
+	# Output all current stacked messages.
+	# If some errors occurred, exits the program.
 	fun check_errors
 	do
 		if messages.length > 0 then
@@ -226,43 +229,43 @@ class ToolContext
         end
 
 	# Global OptionContext
-	var option_context: OptionContext = new OptionContext
+	var option_context = new OptionContext
 
 	# Option --warn
-	var opt_warn: OptionCount = new OptionCount("Show more warnings", "-W", "--warn")
+	var opt_warn = new OptionCount("Show more warnings", "-W", "--warn")
 
 	# Option --warning
 	var opt_warning = new OptionArray("Show/hide a specific warning", "-w", "--warning")
 
 	# Option --quiet
-	var opt_quiet: OptionBool = new OptionBool("Do not show warnings", "-q", "--quiet")
+	var opt_quiet = new OptionBool("Do not show warnings", "-q", "--quiet")
 
 	# Option --log
-	var opt_log: OptionBool = new OptionBool("Generate various log files", "--log")
+	var opt_log = new OptionBool("Generate various log files", "--log")
 
 	# Option --log-dir
-	var opt_log_dir: OptionString = new OptionString("Directory where to generate log files", "--log-dir")
+	var opt_log_dir = new OptionString("Directory where to generate log files", "--log-dir")
 
 	# Option --help
-	var opt_help: OptionBool = new OptionBool("Show Help (This screen)", "-h", "-?", "--help")
+	var opt_help = new OptionBool("Show Help (This screen)", "-h", "-?", "--help")
 
 	# Option --version
-	var opt_version: OptionBool = new OptionBool("Show version and exit", "--version")
+	var opt_version = new OptionBool("Show version and exit", "--version")
 
 	# Option --set-dummy-tool
-	var opt_set_dummy_tool: OptionBool = new OptionBool("Set toolname and version to DUMMY. Useful for testing", "--set-dummy-tool")
+	var opt_set_dummy_tool = new OptionBool("Set toolname and version to DUMMY. Useful for testing", "--set-dummy-tool")
 
 	# Option --verbose
-	var opt_verbose: OptionCount = new OptionCount("Verbose", "-v", "--verbose")
+	var opt_verbose = new OptionCount("Verbose", "-v", "--verbose")
 
 	# Option --stop-on-first-error
-	var opt_stop_on_first_error: OptionBool = new OptionBool("Stop on first error", "--stop-on-first-error")
+	var opt_stop_on_first_error = new OptionBool("Stop on first error", "--stop-on-first-error")
 
 	# Option --no-color
-	var opt_no_color: OptionBool = new OptionBool("Do not use color to display errors and warnings", "--no-color")
+	var opt_no_color = new OptionBool("Do not use color to display errors and warnings", "--no-color")
 
 	# Option --bash-completion
-	var opt_bash_completion: OptionBool = new OptionBool("Generate bash_completion file for this program", "--bash-completion")
+	var opt_bash_completion = new OptionBool("Generate bash_completion file for this program", "--bash-completion")
 
 	# Verbose level
 	var verbose_level: Int = 0


### PR DESCRIPTION
Thanks to the new detected warnings, it is easier to remove them.
Also fix some spelling errors because vim colored them in red.
