### PR TITLE
neo: do not instantiate types directly, use the model API

### DIFF
--- a/src/neo.nit
+++ b/src/neo.nit
@@ -742,12 +742,13 @@ class NeoModel
 			return  mtype
 		else if node.labels.has("MNullableType") then
 			var intype = to_mtype(model, node.out_nodes("TYPE").first)
-			var mtype = new MNullableType(intype)
+			var mtype = intype.as_nullable
 			mentities[node] = mtype
 			return mtype
 		else if node.labels.has("MVirtualType") then
 			var mproperty = to_mproperty(model, node.out_nodes("PROPERTY").first)
-			var mtype = new MVirtualType(mproperty)
+			assert mproperty isa MVirtualTypeProp
+			var mtype = mproperty.mvirtualtype
 			mentities[node] = mtype
 			return mtype
 		else if node.labels.has("MSignature") then


### PR DESCRIPTION
Since visibility on constructor is disabled in nitg, the errors was not detected.
