### PR TITLE
nitunit: accept an absolute path for `--dir`.

### DIFF
--- a/lib/standard/file.nit
+++ b/lib/standard/file.nit
@@ -348,6 +348,22 @@ redef class String
 		return "{self}/{path}"
 	end
 
+	# Convert the path (`self`) to a program name.
+	#
+	# Ensure the path (`self`) will be treated as-is by POSIX shells when it is
+	# used as a program name. In order to do that, prepend `./` if needed.
+	#
+	#     assert "foo".to_program_name == "./foo"
+	#     assert "/foo".to_program_name == "/foo"
+	#     assert "".to_program_name == "./" # At least, your shell will detect the error.
+	fun to_program_name: String do
+		if self.has_prefix("/") then
+			return self
+		else
+			return "./{self}"
+		end
+	end
+
 	# Alias for `join_path`
 	#
 	#     assert "hello" / "world"      ==  "hello/world"

--- a/src/testing/testing_doc.nit
+++ b/src/testing/testing_doc.nit
@@ -136,7 +136,7 @@ class NitUnitExecutor
 		var res = sys.system(cmd)
 		var res2 = 0
 		if res == 0 then
-			res2 = sys.system("./{file}.bin >>'{file}.out1' 2>&1 </dev/null")
+			res2 = sys.system("{file.to_program_name}.bin >>'{file}.out1' 2>&1 </dev/null")
 		end
 
 		var msg

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -244,7 +244,7 @@ class TestCase
 		if toolcontext.opt_noact.value then return
 		# execute
 		var file = test_file
-		var res = sys.system("./{file}.bin > '{file}.out1' 2>&1 </dev/null")
+		var res = sys.system("{file.to_program_name}.bin > '{file}.out1' 2>&1 </dev/null")
 		var f = new IFStream.open("{file}.out1")
 		var msg = f.read_all
 		f.close


### PR DESCRIPTION
When I passed an absolute path to the `--dir` option of `nitunit`, I got errors like this one:

```
ERROR: test_unread_order (in file /my/costum/dir/.nitunit/test_push_back_reader_TestPushBackDecorator_test_unread_order.nit): sh: 1: .//my/costum/dir/.nitunit/test_push_back_reader_TestPushBackDecorator_test_unread_order.bin: not found
```

It was a trivial bug so I fixed this.
