### PR TITLE
grammar: allow '`' inside foreign code blocks

### DIFF
--- a/src/parser/nit.sablecc3xx
+++ b/src/parser/nit.sablecc3xx
@@ -78,6 +78,7 @@ long_sstr_body = long_sstr_part*;
 extern_code_char
 	= [all - ['`' + '\']]
 	| '\' all
+	| '`' [all - '}']
 	;
 extern_code_body = extern_code_char*;
 

--- a/src/parser/tables_nit.c
+++ b/src/parser/tables_nit.c
@@ -783,19 +783,21 @@ static const int lexer_goto_row148[] = {
 	0, 255, 204
 };
 static const int lexer_goto_row149[] = {
-	1,
-	125, 125, 205
+	3,
+	0, 124, 205,
+	125, 125, 206,
+	126, 255, 205
 };
 static const int lexer_goto_row150[] = {
 	3,
 	48, 113, -33,
-	114, 114, 206,
+	114, 114, 207,
 	115, 122, 86
 };
 static const int lexer_goto_row151[] = {
 	3,
 	48, 115, -98,
-	116, 116, 207,
+	116, 116, 208,
 	117, 122, 86
 };
 static const int lexer_goto_row152[] = {
@@ -805,31 +807,31 @@ static const int lexer_goto_row152[] = {
 static const int lexer_goto_row153[] = {
 	3,
 	48, 100, -42,
-	101, 101, 208,
+	101, 101, 209,
 	102, 122, 86
 };
 static const int lexer_goto_row154[] = {
 	3,
 	48, 95, -32,
-	97, 97, 209,
+	97, 97, 210,
 	98, 122, 86
 };
 static const int lexer_goto_row155[] = {
 	3,
 	48, 114, -91,
-	115, 115, 210,
+	115, 115, 211,
 	116, 122, 86
 };
 static const int lexer_goto_row156[] = {
 	3,
 	48, 115, -98,
-	116, 116, 211,
+	116, 116, 212,
 	117, 122, 86
 };
 static const int lexer_goto_row157[] = {
 	3,
 	48, 100, -42,
-	101, 101, 212,
+	101, 101, 213,
 	102, 122, 86
 };
 static const int lexer_goto_row158[] = {
@@ -840,19 +842,19 @@ static const int lexer_goto_row159[] = {
 	4,
 	48, 95, -32,
 	97, 108, 86,
-	109, 109, 213,
+	109, 109, 214,
 	110, 122, 86
 };
 static const int lexer_goto_row160[] = {
 	3,
 	48, 100, -42,
-	101, 101, 214,
+	101, 101, 215,
 	102, 122, 86
 };
 static const int lexer_goto_row161[] = {
 	3,
 	48, 114, -91,
-	115, 115, 215,
+	115, 115, 216,
 	116, 122, 86
 };
 static const int lexer_goto_row162[] = {
@@ -866,23 +868,23 @@ static const int lexer_goto_row163[] = {
 static const int lexer_goto_row164[] = {
 	5,
 	48, 107, -34,
-	108, 108, 216,
+	108, 108, 217,
 	109, 110, 86,
-	111, 111, 217,
+	111, 111, 218,
 	112, 122, 86
 };
 static const int lexer_goto_row165[] = {
 	3,
 	48, 115, -98,
-	116, 116, 218,
+	116, 116, 219,
 	117, 122, 86
 };
 static const int lexer_goto_row166[] = {
 	5,
 	48, 100, -42,
-	101, 101, 219,
+	101, 101, 220,
 	102, 113, 86,
-	114, 114, 220,
+	114, 114, 221,
 	115, 122, 86
 };
 static const int lexer_goto_row167[] = {
@@ -892,25 +894,25 @@ static const int lexer_goto_row167[] = {
 static const int lexer_goto_row168[] = {
 	3,
 	48, 100, -42,
-	101, 101, 221,
+	101, 101, 222,
 	102, 122, 86
 };
 static const int lexer_goto_row169[] = {
 	3,
 	48, 100, -42,
-	101, 101, 222,
+	101, 101, 223,
 	102, 122, 86
 };
 static const int lexer_goto_row170[] = {
 	3,
 	48, 111, -103,
-	112, 112, 223,
+	112, 112, 224,
 	113, 122, 86
 };
 static const int lexer_goto_row171[] = {
 	3,
 	48, 116, -121,
-	117, 117, 224,
+	117, 117, 225,
 	118, 122, 86
 };
 static const int lexer_goto_row172[] = {
@@ -924,87 +926,87 @@ static const int lexer_goto_row173[] = {
 static const int lexer_goto_row174[] = {
 	3,
 	48, 107, -34,
-	108, 108, 225,
+	108, 108, 226,
 	109, 122, 86
 };
 static const int lexer_goto_row175[] = {
 	3,
 	48, 100, -42,
-	101, 101, 226,
+	101, 101, 227,
 	102, 122, 86
 };
 static const int lexer_goto_row176[] = {
 	4,
 	48, 95, -32,
 	97, 106, 86,
-	107, 107, 227,
+	107, 107, 228,
 	108, 122, 86
 };
 static const int lexer_goto_row177[] = {
 	4,
 	48, 95, -32,
 	97, 117, 86,
-	118, 118, 228,
+	118, 118, 229,
 	119, 122, 86
 };
 static const int lexer_goto_row178[] = {
 	3,
 	48, 115, -98,
-	116, 116, 229,
+	116, 116, 230,
 	117, 122, 86
 };
 static const int lexer_goto_row179[] = {
 	3,
 	48, 107, -34,
-	108, 108, 230,
+	108, 108, 231,
 	109, 122, 86
 };
 static const int lexer_goto_row180[] = {
 	3,
 	48, 100, -42,
-	101, 101, 231,
+	101, 101, 232,
 	102, 122, 86
 };
 static const int lexer_goto_row181[] = {
 	3,
 	48, 116, -121,
-	117, 117, 232,
+	117, 117, 233,
 	118, 122, 86
 };
 static const int lexer_goto_row182[] = {
 	3,
 	48, 101, -39,
-	102, 102, 233,
+	102, 102, 234,
 	103, 122, 86
 };
 static const int lexer_goto_row183[] = {
 	3,
 	48, 100, -42,
-	101, 101, 234,
+	101, 101, 235,
 	102, 122, 86
 };
 static const int lexer_goto_row184[] = {
 	3,
 	48, 109, -43,
-	110, 110, 235,
+	110, 110, 236,
 	111, 122, 86
 };
 static const int lexer_goto_row185[] = {
 	3,
 	48, 100, -42,
-	101, 101, 236,
+	101, 101, 237,
 	102, 122, 86
 };
 static const int lexer_goto_row186[] = {
 	3,
 	48, 100, -42,
-	101, 101, 237,
+	101, 101, 238,
 	102, 122, 86
 };
 static const int lexer_goto_row187[] = {
 	3,
 	48, 117, -178,
-	118, 118, 238,
+	118, 118, 239,
 	119, 122, 86
 };
 static const int lexer_goto_row188[] = {
@@ -1014,7 +1016,7 @@ static const int lexer_goto_row188[] = {
 static const int lexer_goto_row189[] = {
 	3,
 	48, 107, -34,
-	108, 108, 239,
+	108, 108, 240,
 	109, 122, 86
 };
 static const int lexer_goto_row190[] = {
@@ -1023,17 +1025,17 @@ static const int lexer_goto_row190[] = {
 };
 static const int lexer_goto_row191[] = {
 	11,
-	0, 9, 240,
-	10, 10, 241,
-	11, 12, 240,
-	13, 13, 242,
-	14, 33, 240,
-	34, 34, 243,
-	35, 91, 240,
-	92, 92, 244,
-	93, 122, 240,
-	123, 123, 245,
-	124, 255, 240
+	0, 9, 241,
+	10, 10, 242,
+	11, 12, 241,
+	13, 13, 243,
+	14, 33, 241,
+	34, 34, 244,
+	35, 91, 241,
+	92, 92, 245,
+	93, 122, 241,
+	123, 123, 246,
+	124, 255, 241
 };
 static const int lexer_goto_row192[] = {
 	1,
@@ -1050,23 +1052,23 @@ static const int lexer_goto_row194[] = {
 static const int lexer_goto_row195[] = {
 	5,
 	0, 33, -132,
-	34, 34, 246,
+	34, 34, 247,
 	35, 122, -132,
-	123, 123, 247,
+	123, 123, 248,
 	124, 255, 191
 };
 static const int lexer_goto_row196[] = {
 	3,
-	0, 9, 248,
-	11, 12, 248,
-	14, 255, 248
+	0, 9, 249,
+	11, 12, 249,
+	14, 255, 249
 };
 static const int lexer_goto_row197[] = {
 	5,
 	0, 33, -132,
-	34, 34, 249,
+	34, 34, 250,
 	35, 122, -132,
-	123, 123, 250,
+	123, 123, 251,
 	124, 255, 191
 };
 static const int lexer_goto_row198[] = {
@@ -1083,41 +1085,39 @@ static const int lexer_goto_row200[] = {
 };
 static const int lexer_goto_row201[] = {
 	9,
-	0, 9, 251,
-	10, 10, 252,
-	11, 12, 251,
-	13, 13, 253,
-	14, 38, 251,
-	39, 39, 254,
-	40, 91, 251,
-	92, 92, 255,
-	93, 255, 251
+	0, 9, 252,
+	10, 10, 253,
+	11, 12, 252,
+	13, 13, 254,
+	14, 38, 252,
+	39, 39, 255,
+	40, 91, 252,
+	92, 92, 256,
+	93, 255, 252
 };
 static const int lexer_goto_row202[] = {
 	3,
-	0, 9, 256,
-	11, 12, 256,
-	14, 255, 256
+	0, 9, 257,
+	11, 12, 257,
+	14, 255, 257
 };
 static const int lexer_goto_row204[] = {
 	1,
-	98, 98, 257
+	98, 98, 258
 };
 static const int lexer_goto_row205[] = {
 	1,
 	0, 255, -84
 };
-static const int lexer_goto_row207[] = {
-	3,
-	48, 115, -98,
-	116, 116, 258,
-	117, 122, 86
+static const int lexer_goto_row206[] = {
+	1,
+	0, 255, -84
 };
 static const int lexer_goto_row208[] = {
 	3,
-	48, 113, -33,
-	114, 114, 259,
-	115, 122, 86
+	48, 115, -98,
+	116, 116, 259,
+	117, 122, 86
 };
 static const int lexer_goto_row209[] = {
 	3,
@@ -1127,107 +1127,107 @@ static const int lexer_goto_row209[] = {
 };
 static const int lexer_goto_row210[] = {
 	3,
-	48, 106, -177,
-	107, 107, 261,
-	108, 122, 86
+	48, 113, -33,
+	114, 114, 261,
+	115, 122, 86
 };
 static const int lexer_goto_row211[] = {
 	3,
-	48, 114, -91,
-	115, 115, 262,
-	116, 122, 86
+	48, 106, -177,
+	107, 107, 262,
+	108, 122, 86
 };
 static const int lexer_goto_row212[] = {
 	3,
-	48, 104, -104,
-	105, 105, 263,
-	106, 122, 86
+	48, 114, -91,
+	115, 115, 263,
+	116, 122, 86
 };
 static const int lexer_goto_row213[] = {
-	1,
-	48, 122, -38
+	3,
+	48, 104, -104,
+	105, 105, 264,
+	106, 122, 86
 };
 static const int lexer_goto_row214[] = {
 	1,
 	48, 122, -38
 };
 static const int lexer_goto_row215[] = {
-	3,
-	48, 113, -33,
-	114, 114, 264,
-	115, 122, 86
-};
-static const int lexer_goto_row216[] = {
-	3,
-	48, 100, -42,
-	101, 101, 265,
-	102, 122, 86
-};
-static const int lexer_goto_row217[] = {
-	3,
-	48, 104, -104,
-	105, 105, 266,
-	106, 122, 86
-};
-static const int lexer_goto_row218[] = {
-	3,
-	48, 113, -33,
-	114, 114, 267,
-	115, 122, 86
-};
-static const int lexer_goto_row219[] = {
 	1,
 	48, 122, -38
 };
-static const int lexer_goto_row220[] = {
+static const int lexer_goto_row216[] = {
+	3,
+	48, 113, -33,
+	114, 114, 265,
+	115, 122, 86
+};
+static const int lexer_goto_row217[] = {
+	3,
+	48, 100, -42,
+	101, 101, 266,
+	102, 122, 86
+};
+static const int lexer_goto_row218[] = {
+	3,
+	48, 104, -104,
+	105, 105, 267,
+	106, 122, 86
+};
+static const int lexer_goto_row219[] = {
 	3,
 	48, 113, -33,
 	114, 114, 268,
 	115, 122, 86
 };
-static const int lexer_goto_row221[] = {
-	3,
-	48, 116, -121,
-	117, 117, 269,
-	118, 122, 86
-};
-static const int lexer_goto_row222[] = {
-	3,
-	48, 115, -98,
-	116, 116, 270,
-	117, 122, 86
-};
-static const int lexer_goto_row223[] = {
-	3,
-	48, 107, -34,
-	108, 108, 271,
-	109, 122, 86
-};
-static const int lexer_goto_row224[] = {
+static const int lexer_goto_row220[] = {
 	1,
 	48, 122, -38
 };
-static const int lexer_goto_row225[] = {
+static const int lexer_goto_row221[] = {
+	3,
+	48, 113, -33,
+	114, 114, 269,
+	115, 122, 86
+};
+static const int lexer_goto_row222[] = {
+	3,
+	48, 116, -121,
+	117, 117, 270,
+	118, 122, 86
+};
+static const int lexer_goto_row223[] = {
+	3,
+	48, 115, -98,
+	116, 116, 271,
+	117, 122, 86
+};
+static const int lexer_goto_row224[] = {
 	3,
 	48, 107, -34,
 	108, 108, 272,
 	109, 122, 86
 };
-static const int lexer_goto_row226[] = {
-	3,
-	48, 95, -32,
-	97, 97, 273,
-	98, 122, 86
-};
-static const int lexer_goto_row227[] = {
+static const int lexer_goto_row225[] = {
 	1,
 	48, 122, -38
 };
-static const int lexer_goto_row228[] = {
+static const int lexer_goto_row226[] = {
+	3,
+	48, 107, -34,
+	108, 108, 273,
+	109, 122, 86
+};
+static const int lexer_goto_row227[] = {
 	3,
 	48, 95, -32,
 	97, 97, 274,
 	98, 122, 86
+};
+static const int lexer_goto_row228[] = {
+	1,
+	48, 122, -38
 };
 static const int lexer_goto_row229[] = {
 	3,
@@ -1237,41 +1237,43 @@ static const int lexer_goto_row229[] = {
 };
 static const int lexer_goto_row230[] = {
 	3,
-	48, 100, -42,
-	101, 101, 276,
-	102, 122, 86
+	48, 95, -32,
+	97, 97, 276,
+	98, 122, 86
 };
 static const int lexer_goto_row231[] = {
 	3,
-	48, 104, -104,
-	105, 105, 277,
-	106, 122, 86
+	48, 100, -42,
+	101, 101, 277,
+	102, 122, 86
 };
 static const int lexer_goto_row232[] = {
 	3,
-	48, 101, -39,
-	102, 102, 278,
-	103, 122, 86
+	48, 104, -104,
+	105, 105, 278,
+	106, 122, 86
 };
 static const int lexer_goto_row233[] = {
 	3,
-	48, 113, -33,
-	114, 114, 279,
-	115, 122, 86
+	48, 101, -39,
+	102, 102, 279,
+	103, 122, 86
 };
 static const int lexer_goto_row234[] = {
-	1,
-	48, 122, -38
-};
-static const int lexer_goto_row235[] = {
 	3,
 	48, 113, -33,
 	114, 114, 280,
 	115, 122, 86
 };
-static const int lexer_goto_row236[] = {
+static const int lexer_goto_row235[] = {
 	1,
 	48, 122, -38
+};
+static const int lexer_goto_row236[] = {
+	3,
+	48, 113, -33,
+	114, 114, 281,
+	115, 122, 86
 };
 static const int lexer_goto_row237[] = {
 	1,
@@ -1282,10 +1284,8 @@ static const int lexer_goto_row238[] = {
 	48, 122, -38
 };
 static const int lexer_goto_row239[] = {
-	3,
-	48, 100, -42,
-	101, 101, 281,
-	102, 122, 86
+	1,
+	48, 122, -38
 };
 static const int lexer_goto_row240[] = {
 	3,
@@ -1294,80 +1294,82 @@ static const int lexer_goto_row240[] = {
 	102, 122, 86
 };
 static const int lexer_goto_row241[] = {
+	3,
+	48, 100, -42,
+	101, 101, 283,
+	102, 122, 86
+};
+static const int lexer_goto_row242[] = {
 	1,
 	0, 255, -192
 };
-static const int lexer_goto_row242[] = {
-	11,
-	0, 9, 283,
-	10, 10, 241,
-	11, 12, 283,
-	13, 13, 242,
-	14, 33, 283,
-	34, 34, 284,
-	35, 91, 283,
-	92, 92, 285,
-	93, 122, 283,
-	123, 123, 286,
-	124, 255, 283
-};
 static const int lexer_goto_row243[] = {
-	1,
-	0, 255, -243
+	11,
+	0, 9, 284,
+	10, 10, 242,
+	11, 12, 284,
+	13, 13, 243,
+	14, 33, 284,
+	34, 34, 285,
+	35, 91, 284,
+	92, 92, 286,
+	93, 122, 284,
+	123, 123, 287,
+	124, 255, 284
 };
 static const int lexer_goto_row244[] = {
-	5,
-	0, 33, -243,
-	34, 34, 287,
-	35, 122, -243,
-	123, 123, 288,
-	124, 255, 283
+	1,
+	0, 255, -244
 };
 static const int lexer_goto_row245[] = {
-	3,
-	0, 9, 289,
-	11, 12, 289,
-	14, 255, 289
+	5,
+	0, 33, -244,
+	34, 34, 288,
+	35, 122, -244,
+	123, 123, 289,
+	124, 255, 284
 };
 static const int lexer_goto_row246[] = {
-	5,
-	0, 33, -243,
-	34, 34, 290,
-	35, 122, -243,
-	123, 123, 291,
-	124, 255, 283
+	3,
+	0, 9, 290,
+	11, 12, 290,
+	14, 255, 290
 };
 static const int lexer_goto_row247[] = {
-	3,
-	0, 33, -132,
-	34, 34, 292,
-	35, 255, -196
+	5,
+	0, 33, -244,
+	34, 34, 291,
+	35, 122, -244,
+	123, 123, 292,
+	124, 255, 284
 };
 static const int lexer_goto_row248[] = {
 	3,
-	0, 122, -198,
-	123, 123, 293,
-	124, 255, 191
+	0, 33, -132,
+	34, 34, 293,
+	35, 255, -196
 };
 static const int lexer_goto_row249[] = {
+	3,
+	0, 122, -198,
+	123, 123, 294,
+	124, 255, 191
+};
+static const int lexer_goto_row250[] = {
 	1,
 	0, 255, -132
 };
-static const int lexer_goto_row250[] = {
-	3,
-	0, 33, -132,
-	34, 34, 294,
-	35, 255, -196
-};
 static const int lexer_goto_row251[] = {
 	3,
-	0, 122, -198,
-	123, 123, 295,
-	124, 255, 191
+	0, 33, -132,
+	34, 34, 295,
+	35, 255, -196
 };
 static const int lexer_goto_row252[] = {
-	1,
-	0, 255, -136
+	3,
+	0, 122, -198,
+	123, 123, 296,
+	124, 255, 191
 };
 static const int lexer_goto_row253[] = {
 	1,
@@ -1378,60 +1380,58 @@ static const int lexer_goto_row254[] = {
 	0, 255, -136
 };
 static const int lexer_goto_row255[] = {
-	9,
-	0, 9, 296,
-	10, 10, 297,
-	11, 12, 296,
-	13, 13, 298,
-	14, 38, 296,
-	39, 39, 299,
-	40, 91, 296,
-	92, 92, 300,
-	93, 255, 296
-};
-static const int lexer_goto_row256[] = {
-	3,
-	0, 9, 301,
-	11, 12, 301,
-	14, 255, 301
-};
-static const int lexer_goto_row257[] = {
 	1,
 	0, 255, -136
 };
+static const int lexer_goto_row256[] = {
+	9,
+	0, 9, 297,
+	10, 10, 298,
+	11, 12, 297,
+	13, 13, 299,
+	14, 38, 297,
+	39, 39, 300,
+	40, 91, 297,
+	92, 92, 301,
+	93, 255, 297
+};
+static const int lexer_goto_row257[] = {
+	3,
+	0, 9, 302,
+	11, 12, 302,
+	14, 255, 302
+};
 static const int lexer_goto_row258[] = {
 	1,
-	117, 117, 302
+	0, 255, -136
 };
 static const int lexer_goto_row259[] = {
 	1,
-	48, 122, -38
+	117, 117, 303
 };
 static const int lexer_goto_row260[] = {
-	3,
-	48, 95, -32,
-	97, 97, 303,
-	98, 122, 86
+	1,
+	48, 122, -38
 };
 static const int lexer_goto_row261[] = {
 	3,
-	48, 115, -98,
-	116, 116, 304,
-	117, 122, 86
+	48, 95, -32,
+	97, 97, 304,
+	98, 122, 86
 };
 static const int lexer_goto_row262[] = {
-	1,
-	48, 122, -38
+	3,
+	48, 115, -98,
+	116, 116, 305,
+	117, 122, 86
 };
 static const int lexer_goto_row263[] = {
 	1,
 	48, 122, -38
 };
 static const int lexer_goto_row264[] = {
-	3,
-	48, 109, -43,
-	110, 110, 305,
-	111, 122, 86
+	1,
+	48, 122, -38
 };
 static const int lexer_goto_row265[] = {
 	3,
@@ -1440,71 +1440,71 @@ static const int lexer_goto_row265[] = {
 	111, 122, 86
 };
 static const int lexer_goto_row266[] = {
-	1,
-	48, 122, -38
+	3,
+	48, 109, -43,
+	110, 110, 307,
+	111, 122, 86
 };
 static const int lexer_goto_row267[] = {
-	3,
-	48, 100, -42,
-	101, 101, 307,
-	102, 122, 86
+	1,
+	48, 122, -38
 };
 static const int lexer_goto_row268[] = {
 	3,
-	48, 115, -98,
-	116, 116, 308,
-	117, 122, 86
+	48, 100, -42,
+	101, 101, 308,
+	102, 122, 86
 };
 static const int lexer_goto_row269[] = {
 	3,
-	48, 101, -39,
-	102, 102, 309,
-	103, 122, 86
+	48, 115, -98,
+	116, 116, 309,
+	117, 122, 86
 };
 static const int lexer_goto_row270[] = {
 	3,
-	48, 99, -90,
-	100, 100, 310,
-	101, 122, 86
+	48, 101, -39,
+	102, 102, 310,
+	103, 122, 86
 };
 static const int lexer_goto_row271[] = {
-	1,
-	48, 122, -38
+	3,
+	48, 99, -90,
+	100, 100, 311,
+	101, 122, 86
 };
 static const int lexer_goto_row272[] = {
 	1,
 	48, 122, -38
 };
 static const int lexer_goto_row273[] = {
-	3,
-	48, 100, -42,
-	101, 101, 311,
-	102, 122, 86
+	1,
+	48, 122, -38
 };
 static const int lexer_goto_row274[] = {
 	3,
-	48, 97, -32,
-	98, 98, 312,
-	99, 122, 86
+	48, 100, -42,
+	101, 101, 312,
+	102, 122, 86
 };
 static const int lexer_goto_row275[] = {
+	3,
+	48, 97, -32,
+	98, 98, 313,
+	99, 122, 86
+};
+static const int lexer_goto_row276[] = {
 	4,
 	48, 95, -32,
 	97, 102, 86,
-	103, 103, 313,
+	103, 103, 314,
 	104, 122, 86
-};
-static const int lexer_goto_row276[] = {
-	3,
-	48, 115, -98,
-	116, 116, 314,
-	117, 122, 86
 };
 static const int lexer_goto_row277[] = {
 	3,
-	48, 98, -112,
-	99, 99, 315,
-	100, 122, 86
+	48, 115, -98,
+	116, 116, 315,
+	117, 122, 86
 };
 static const int lexer_goto_row278[] = {
 	3,
@@ -1513,94 +1513,96 @@ static const int lexer_goto_row278[] = {
 	100, 122, 86
 };
 static const int lexer_goto_row279[] = {
-	1,
-	48, 122, -38
+	3,
+	48, 98, -112,
+	99, 99, 317,
+	100, 122, 86
 };
 static const int lexer_goto_row280[] = {
-	3,
-	48, 109, -43,
-	110, 110, 317,
-	111, 122, 86
+	1,
+	48, 122, -38
 };
 static const int lexer_goto_row281[] = {
-	1,
-	48, 122, -38
+	3,
+	48, 109, -43,
+	110, 110, 318,
+	111, 122, 86
 };
 static const int lexer_goto_row282[] = {
-	3,
-	48, 113, -33,
-	114, 114, 318,
-	115, 122, 86
-};
-static const int lexer_goto_row283[] = {
 	1,
 	48, 122, -38
+};
+static const int lexer_goto_row283[] = {
+	3,
+	48, 113, -33,
+	114, 114, 319,
+	115, 122, 86
 };
 static const int lexer_goto_row284[] = {
 	1,
-	0, 255, -243
+	48, 122, -38
 };
 static const int lexer_goto_row285[] = {
 	1,
-	0, 255, -245
+	0, 255, -244
 };
 static const int lexer_goto_row286[] = {
-	3,
-	0, 9, 319,
-	11, 12, 319,
-	14, 255, 319
+	1,
+	0, 255, -246
 };
 static const int lexer_goto_row287[] = {
-	1,
-	0, 255, -247
+	3,
+	0, 9, 320,
+	11, 12, 320,
+	14, 255, 320
 };
 static const int lexer_goto_row288[] = {
-	3,
-	0, 33, -243,
-	34, 34, 320,
-	35, 255, -245
-};
-static const int lexer_goto_row289[] = {
-	3,
-	0, 122, -247,
-	123, 123, 321,
-	124, 255, 283
-};
-static const int lexer_goto_row290[] = {
-	1,
-	0, 255, -192
-};
-static const int lexer_goto_row291[] = {
-	3,
-	0, 33, -243,
-	34, 34, 322,
-	35, 255, -245
-};
-static const int lexer_goto_row292[] = {
-	3,
-	0, 122, -247,
-	123, 123, 323,
-	124, 255, 283
-};
-static const int lexer_goto_row293[] = {
-	1,
-	34, 34, 324
-};
-static const int lexer_goto_row294[] = {
-	1,
-	0, 255, -252
-};
-static const int lexer_goto_row295[] = {
 	1,
 	0, 255, -248
 };
+static const int lexer_goto_row289[] = {
+	3,
+	0, 33, -244,
+	34, 34, 321,
+	35, 255, -246
+};
+static const int lexer_goto_row290[] = {
+	3,
+	0, 122, -248,
+	123, 123, 322,
+	124, 255, 284
+};
+static const int lexer_goto_row291[] = {
+	1,
+	0, 255, -192
+};
+static const int lexer_goto_row292[] = {
+	3,
+	0, 33, -244,
+	34, 34, 323,
+	35, 255, -246
+};
+static const int lexer_goto_row293[] = {
+	3,
+	0, 122, -248,
+	123, 123, 324,
+	124, 255, 284
+};
+static const int lexer_goto_row294[] = {
+	1,
+	34, 34, 325
+};
+static const int lexer_goto_row295[] = {
+	1,
+	0, 255, -253
+};
 static const int lexer_goto_row296[] = {
 	1,
-	123, 123, 325
+	0, 255, -249
 };
 static const int lexer_goto_row297[] = {
 	1,
-	0, 255, -136
+	123, 123, 326
 };
 static const int lexer_goto_row298[] = {
 	1,
@@ -1610,77 +1612,75 @@ static const int lexer_goto_row299[] = {
 	1,
 	0, 255, -136
 };
-static const int lexer_goto_row301[] = {
-	3,
-	0, 9, 326,
-	11, 12, 326,
-	14, 255, 326
-};
-static const int lexer_goto_row302[] = {
+static const int lexer_goto_row300[] = {
 	1,
 	0, 255, -136
 };
+static const int lexer_goto_row302[] = {
+	3,
+	0, 9, 327,
+	11, 12, 327,
+	14, 255, 327
+};
 static const int lexer_goto_row303[] = {
 	1,
-	103, 103, 327
+	0, 255, -136
 };
 static const int lexer_goto_row304[] = {
-	3,
-	48, 98, -112,
-	99, 99, 328,
-	100, 122, 86
+	1,
+	103, 103, 328
 };
 static const int lexer_goto_row305[] = {
-	1,
-	48, 122, -38
+	3,
+	48, 98, -112,
+	99, 99, 329,
+	100, 122, 86
 };
 static const int lexer_goto_row306[] = {
-	3,
-	48, 116, -121,
-	117, 117, 329,
-	118, 122, 86
+	1,
+	48, 122, -38
 };
 static const int lexer_goto_row307[] = {
-	1,
-	48, 122, -38
+	3,
+	48, 116, -121,
+	117, 117, 330,
+	118, 122, 86
 };
 static const int lexer_goto_row308[] = {
-	3,
-	48, 114, -91,
-	115, 115, 330,
-	116, 122, 86
-};
-static const int lexer_goto_row309[] = {
 	1,
 	48, 122, -38
 };
-static const int lexer_goto_row310[] = {
+static const int lexer_goto_row309[] = {
 	3,
-	48, 95, -32,
-	97, 97, 331,
-	98, 122, 86
+	48, 114, -91,
+	115, 115, 331,
+	116, 122, 86
+};
+static const int lexer_goto_row310[] = {
+	1,
+	48, 122, -38
 };
 static const int lexer_goto_row311[] = {
 	3,
-	48, 100, -42,
-	101, 101, 332,
-	102, 122, 86
+	48, 95, -32,
+	97, 97, 332,
+	98, 122, 86
 };
 static const int lexer_goto_row312[] = {
+	3,
+	48, 100, -42,
+	101, 101, 333,
+	102, 122, 86
+};
+static const int lexer_goto_row313[] = {
 	1,
 	48, 122, -38
 };
-static const int lexer_goto_row313[] = {
-	3,
-	48, 107, -34,
-	108, 108, 333,
-	109, 122, 86
-};
 static const int lexer_goto_row314[] = {
 	3,
-	48, 100, -42,
-	101, 101, 334,
-	102, 122, 86
+	48, 107, -34,
+	108, 108, 334,
+	109, 122, 86
 };
 static const int lexer_goto_row315[] = {
 	3,
@@ -1690,163 +1690,169 @@ static const int lexer_goto_row315[] = {
 };
 static const int lexer_goto_row316[] = {
 	3,
-	48, 115, -98,
-	116, 116, 336,
-	117, 122, 86
+	48, 100, -42,
+	101, 101, 336,
+	102, 122, 86
 };
 static const int lexer_goto_row317[] = {
-	1,
-	48, 122, -38
+	3,
+	48, 115, -98,
+	116, 116, 337,
+	117, 122, 86
 };
 static const int lexer_goto_row318[] = {
 	1,
 	48, 122, -38
 };
 static const int lexer_goto_row319[] = {
-	3,
-	48, 114, -91,
-	115, 115, 337,
-	116, 122, 86
+	1,
+	48, 122, -38
 };
 static const int lexer_goto_row320[] = {
-	1,
-	0, 255, -243
+	3,
+	48, 114, -91,
+	115, 115, 338,
+	116, 122, 86
 };
 static const int lexer_goto_row321[] = {
 	1,
-	34, 34, 338
+	0, 255, -244
 };
 static const int lexer_goto_row322[] = {
 	1,
-	0, 255, -293
+	34, 34, 339
 };
 static const int lexer_goto_row323[] = {
 	1,
-	0, 255, -289
+	0, 255, -294
 };
 static const int lexer_goto_row324[] = {
 	1,
-	123, 123, 339
+	0, 255, -290
 };
 static const int lexer_goto_row325[] = {
 	1,
-	34, 34, 324
+	123, 123, 340
 };
 static const int lexer_goto_row326[] = {
 	1,
-	123, 123, 325
+	34, 34, 325
 };
 static const int lexer_goto_row327[] = {
 	1,
-	0, 255, -136
+	123, 123, 326
 };
 static const int lexer_goto_row328[] = {
 	1,
-	95, 95, 340
+	0, 255, -136
 };
 static const int lexer_goto_row329[] = {
-	3,
-	48, 115, -98,
-	116, 116, 341,
-	117, 122, 86
+	1,
+	95, 95, 341
 };
 static const int lexer_goto_row330[] = {
 	3,
-	48, 100, -42,
-	101, 101, 342,
-	102, 122, 86
+	48, 115, -98,
+	116, 116, 342,
+	117, 122, 86
 };
 static const int lexer_goto_row331[] = {
-	1,
-	48, 122, -38
-};
-static const int lexer_goto_row332[] = {
-	3,
-	48, 98, -112,
-	99, 99, 343,
-	100, 122, 86
-};
-static const int lexer_goto_row333[] = {
-	1,
-	48, 122, -38
-};
-static const int lexer_goto_row334[] = {
 	3,
 	48, 100, -42,
-	101, 101, 344,
+	101, 101, 343,
 	102, 122, 86
 };
-static const int lexer_goto_row335[] = {
+static const int lexer_goto_row332[] = {
 	1,
 	48, 122, -38
+};
+static const int lexer_goto_row333[] = {
+	3,
+	48, 98, -112,
+	99, 99, 344,
+	100, 122, 86
+};
+static const int lexer_goto_row334[] = {
+	1,
+	48, 122, -38
+};
+static const int lexer_goto_row335[] = {
+	3,
+	48, 100, -42,
+	101, 101, 345,
+	102, 122, 86
 };
 static const int lexer_goto_row336[] = {
 	1,
 	48, 122, -38
 };
 static const int lexer_goto_row337[] = {
-	3,
-	48, 100, -42,
-	101, 101, 345,
-	102, 122, 86
+	1,
+	48, 122, -38
 };
 static const int lexer_goto_row338[] = {
 	3,
-	48, 95, -32,
-	97, 97, 346,
-	98, 122, 86
+	48, 100, -42,
+	101, 101, 346,
+	102, 122, 86
 };
 static const int lexer_goto_row339[] = {
-	1,
-	34, 34, 338
+	3,
+	48, 95, -32,
+	97, 97, 347,
+	98, 122, 86
 };
 static const int lexer_goto_row340[] = {
 	1,
-	123, 123, 339
+	34, 34, 339
 };
 static const int lexer_goto_row341[] = {
 	1,
-	95, 95, 347
+	123, 123, 340
 };
 static const int lexer_goto_row342[] = {
 	1,
-	48, 122, -38
+	95, 95, 348
 };
 static const int lexer_goto_row343[] = {
 	1,
 	48, 122, -38
 };
 static const int lexer_goto_row344[] = {
-	3,
-	48, 100, -42,
-	101, 101, 348,
-	102, 122, 86
-};
-static const int lexer_goto_row345[] = {
 	1,
 	48, 122, -38
 };
-static const int lexer_goto_row346[] = {
+static const int lexer_goto_row345[] = {
 	3,
-	48, 99, -90,
-	100, 100, 349,
-	101, 122, 86
+	48, 100, -42,
+	101, 101, 349,
+	102, 122, 86
+};
+static const int lexer_goto_row346[] = {
+	1,
+	48, 122, -38
 };
 static const int lexer_goto_row347[] = {
 	3,
-	48, 107, -34,
-	108, 108, 350,
-	109, 122, 86
+	48, 99, -90,
+	100, 100, 350,
+	101, 122, 86
 };
-static const int lexer_goto_row349[] = {
-	1,
-	48, 122, -38
+static const int lexer_goto_row348[] = {
+	3,
+	48, 107, -34,
+	108, 108, 351,
+	109, 122, 86
 };
 static const int lexer_goto_row350[] = {
 	1,
 	48, 122, -38
 };
 static const int lexer_goto_row351[] = {
+	1,
+	48, 122, -38
+};
+static const int lexer_goto_row352[] = {
 	1,
 	48, 122, -38
 };
@@ -2057,8 +2063,8 @@ const int* const lexer_goto_table[] = {
 	lexer_goto_row_null,
 	lexer_goto_row204,
 	lexer_goto_row205,
+	lexer_goto_row206,
 	lexer_goto_row_null,
-	lexer_goto_row207,
 	lexer_goto_row208,
 	lexer_goto_row209,
 	lexer_goto_row210,
@@ -2151,8 +2157,8 @@ const int* const lexer_goto_table[] = {
 	lexer_goto_row297,
 	lexer_goto_row298,
 	lexer_goto_row299,
+	lexer_goto_row300,
 	lexer_goto_row_null,
-	lexer_goto_row301,
 	lexer_goto_row302,
 	lexer_goto_row303,
 	lexer_goto_row304,
@@ -2199,14 +2205,15 @@ const int* const lexer_goto_table[] = {
 	lexer_goto_row345,
 	lexer_goto_row346,
 	lexer_goto_row347,
+	lexer_goto_row348,
 	lexer_goto_row_null,
-	lexer_goto_row349,
 	lexer_goto_row350,
-	lexer_goto_row351
+	lexer_goto_row351,
+	lexer_goto_row352
 };
 
 const int lexer_accept_table[] = {
-	-1,0,1,1,0,80,93,2,70,-1,52,53,67,65,56,66,64,69,85,85,57,73,59,76,81,82,54,55,-1,-1,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,93,1,72,93,88,-1,89,2,2,2,94,94,94,68,60,61,63,87,-1,-1,-1,58,75,74,71,77,78,82,82,82,82,-1,84,-1,83,83,83,83,83,83,47,83,83,83,16,83,83,83,83,83,83,23,83,29,15,83,83,83,83,83,83,83,31,83,83,83,83,83,83,83,83,83,83,83,83,93,91,-1,90,93,88,93,93,2,92,93,94,62,86,86,86,79,-1,84,84,84,84,-1,-1,-1,83,83,30,83,83,83,83,83,10,83,83,83,28,11,83,83,83,40,83,83,83,83,39,32,83,83,83,83,83,83,83,83,83,83,83,83,83,83,17,83,93,93,93,93,93,-1,-1,-1,93,93,93,-1,-1,92,-1,-1,95,83,83,83,83,83,83,25,9,83,83,83,83,13,83,83,83,83,27,83,46,41,83,83,83,83,83,83,43,83,24,44,12,83,83,93,-1,-1,91,-1,90,-1,-1,93,-1,-1,93,93,93,-1,-1,93,-1,37,83,83,36,6,83,83,45,83,83,83,83,49,50,83,83,83,83,83,83,14,83,42,83,26,-1,-1,-1,-1,-1,-1,93,-1,-1,88,-1,-1,89,93,93,93,88,-1,93,-1,83,38,83,18,83,5,83,83,4,83,83,83,83,19,34,83,-1,91,-1,-1,90,88,89,93,-1,83,83,33,83,22,83,3,21,83,83,91,90,-1,7,35,83,48,83,83,51,8,20,9
+	-1,0,1,1,0,80,93,2,70,-1,52,53,67,65,56,66,64,69,85,85,57,73,59,76,81,82,54,55,-1,-1,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,83,93,1,72,93,88,-1,89,2,2,2,94,94,94,68,60,61,63,87,-1,-1,-1,58,75,74,71,77,78,82,82,82,82,-1,84,-1,83,83,83,83,83,83,47,83,83,83,16,83,83,83,83,83,83,23,83,29,15,83,83,83,83,83,83,83,31,83,83,83,83,83,83,83,83,83,83,83,83,93,91,-1,90,93,88,93,93,2,92,93,94,62,86,86,86,79,-1,84,84,84,84,-1,-1,-1,83,83,30,83,83,83,83,83,10,83,83,83,28,11,83,83,83,40,83,83,83,83,39,32,83,83,83,83,83,83,83,83,83,83,83,83,83,83,17,83,93,93,93,93,93,-1,-1,-1,93,93,93,-1,-1,92,-1,-1,-1,95,83,83,83,83,83,83,25,9,83,83,83,83,13,83,83,83,83,27,83,46,41,83,83,83,83,83,83,43,83,24,44,12,83,83,93,-1,-1,91,-1,90,-1,-1,93,-1,-1,93,93,93,-1,-1,93,-1,37,83,83,36,6,83,83,45,83,83,83,83,49,50,83,83,83,83,83,83,14,83,42,83,26,-1,-1,-1,-1,-1,-1,93,-1,-1,88,-1,-1,89,93,93,93,88,-1,93,-1,83,38,83,18,83,5,83,83,4,83,83,83,83,19,34,83,-1,91,-1,-1,90,88,89,93,-1,83,83,33,83,22,83,3,21,83,83,91,90,-1,7,35,83,48,83,83,51,8,20,9
 };
 
 static int parser_action_row1[] = {


### PR DESCRIPTION
This was an old bug causing the use of ``` within a foreign code block to break the block. Example:

```
fun foo `{
    // Some comment on entity `foo` would prevent the whole block to be recognize
`}
```
