### PR TITLE
lib/standard/math: Added round method to floats

### DIFF
--- a/lib/standard/math.nit
+++ b/lib/standard/math.nit
@@ -138,6 +138,14 @@ redef class Float
 	#     assert 2.0.floor == 2.0
 	#     assert (-1.5).floor == -2.0
 	fun floor: Float `{ return floor(recv); `}
+
+	# Rounds the value of a float to its nearest integer value
+	#
+	#     assert 1.67.round == 2.0
+	#     assert 1.34.round == 1.0
+	#     assert -1.34.round == -1.0
+	#     assert -1.67.round == -2.0
+	fun round: Float is extern "round"
 	
 	# Returns a random `Float` in `[0.0 .. self[`.
 	fun rand: Float is extern "kernel_Float_Float_rand_0"

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -901,6 +901,8 @@ redef class AMethPropdef
 				return v.bool_instance(args[0].to_f.is_nan)
 			else if pname == "is_inf_extern" then
 				return v.bool_instance(args[0].to_f.is_inf != 0)
+			else if pname == "round" then
+				return v.float_instance(args[0].to_f.round)
 			end
 		else if cname == "NativeString" then
 			if pname == "new" then


### PR DESCRIPTION
Yes, I know, it can be done right now using a simple trick like `1.34.to_i.to_f`, but it seems counter-intuitive to me, why not have a round method in Float (besides, it should be a bit faster) ?

I leave it to you, is it worth it to add this to standard ?

If it is, well +1 and let's merge this :)
