### PR TITLE
nitdoc: displays full namespace in MModule::tpl_declaration.

### DIFF
--- a/src/doc/doc_model.nit
+++ b/src/doc/doc_model.nit
@@ -237,7 +237,7 @@ redef class MModule
 	redef fun tpl_declaration do
 		var tpl = new Template
 		tpl.add "<span>module "
-		tpl.add tpl_link
+		tpl.add tpl_namespace
 		tpl.add "</span>"
 		return tpl
 	end


### PR DESCRIPTION
Fixes #693
