### PR TITLE
Do not force static type on local variable

### DIFF
--- a/contrib/pep8analysis/src/ast/rich_instructions.nit
+++ b/contrib/pep8analysis/src/ast/rich_instructions.nit
@@ -32,7 +32,7 @@ redef class AInstructionLine
 	# TODO move to AnalysisManager as private?
 	private fun enrich
 	do
-		var instr = n_instruction
+		var instr: AInstruction = n_instruction
 		var new_instr : AInstruction
 
 		var id = instr.n_id.text.to_upper

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -526,7 +526,7 @@ end
 # FIXME less hideous hacks...
 redef class DefinitionArticle
 	redef fun init_html_render(v, doc, page) do
-		var mentity = self.mentity
+		var mentity: MEntity = self.mentity
 		if mentity isa MProject or mentity isa MModule then
 			var title = new Template
 			title.add mentity.html_icon

--- a/src/metrics/detect_covariance.nit
+++ b/src/metrics/detect_covariance.nit
@@ -211,8 +211,8 @@ private class DetectCovariancePhase
 		var caseknown = false
 
 		# Detect the pattern
-		var n = node
-		while n isa AType or n isa AExprs do n = n.parent.as(not null)
+		var n: nullable ANode = node
+		while n isa AType or n isa AExprs do n = n.parent
 		cpt_nodes.inc(n.class_name)
 		if n isa AVarAssignExpr or n isa AAttrPropdef and elem isa AExpr then
 			cpt_pattern.inc("1.assign")

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -433,7 +433,7 @@ redef class ModelBuilder
 
 		while not todo.is_empty do
 			# The visited type
-			var t = todo.pop
+			var t: MType = todo.pop
 
 			if not t.need_anchor then continue
 

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -847,11 +847,7 @@ redef class AVardeclExpr
 		var nexpr = self.n_expr
 		if nexpr != null then
 			if mtype != null then
-				var etype = v.visit_expr_subtype(nexpr, mtype)
-				if etype == mtype then
-					assert ntype != null
-					v.modelbuilder.advice(ntype, "useless-type", "Warning: useless type definition for variable `{variable.name}`")
-				end
+				v.visit_expr_subtype(nexpr, mtype)
 			else
 				mtype = v.visit_expr(nexpr)
 				if mtype == null then return # Skip error

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -842,6 +842,7 @@ redef class AVardeclExpr
 			mtype = v.resolve_mtype(ntype)
 			if mtype == null then return # Skip error
 		end
+		var decltype = mtype
 
 		var nexpr = self.n_expr
 		if nexpr != null then
@@ -857,8 +858,7 @@ redef class AVardeclExpr
 			end
 		end
 
-		var decltype = mtype
-		if mtype == null or mtype isa MNullType then
+		if decltype == null or decltype isa MNullType then
 			var objclass = v.get_mclass(self, "Object")
 			if objclass == null then return # skip error
 			decltype = objclass.mclass_type.as_nullable

--- a/tests/base_adaptive_loop4.nit
+++ b/tests/base_adaptive_loop4.nit
@@ -1,0 +1,30 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import standard::kernel
+
+class N
+	var next: nullable N
+end
+
+var n0 = new N
+var n1 = new N(n0)
+var n2 = new N(n1)
+var n3 = new N(n2)
+
+var n = n3
+while n != null do
+	1.output
+	n = n.next
+end

--- a/tests/base_upcast.nit
+++ b/tests/base_upcast.nit
@@ -14,13 +14,13 @@ end
 
 fun maybe: Bool do return true
 
-var ai = new A[Int]
-var ab = new A[Bool]
-var bi = new B[Int]
-var bb = new B[Bool]
-var ci = new C[Int]
-var cb = new C[Bool]
-var d = new D
+var ai: A[Int] = new A[Int]
+var ab: A[Bool] = new A[Bool]
+var bi: B[Int] = new B[Int]
+var bb: B[Bool] = new B[Bool]
+var ci: C[Int] = new C[Int]
+var cb: C[Bool] = new C[Bool]
+var d: D = new D
 
 if maybe then ai = ai
 #alt1#if maybe then ai = ab

--- a/tests/base_upcast2.nit
+++ b/tests/base_upcast2.nit
@@ -17,11 +17,11 @@ class X
 	#1alt5#type T: C
 	fun toto
 	do
-		var ai = new A[Int]
-		var ab = new A[Bool]
-		var bi = new B[Int]
-		var bb = new B[Bool]
-		var c = new C
+		var ai: A[Int] = new A[Int]
+		var ab: A[Bool] = new A[Bool]
+		var bi: B[Int] = new B[Int]
+		var bb: B[Bool] = new B[Bool]
+		var c: C = new C
 
 		var t: T = c.as(T)
 		#alt1#if maybe then t = ai

--- a/tests/base_virtual_type.nit
+++ b/tests/base_virtual_type.nit
@@ -34,7 +34,7 @@ end
 
 var b = new B
 var t = new T
-var i = 2
+var i: Int = 2
 var t2 = b.e
 #alt1#i = b.e
 #alt2#b.e = i

--- a/tests/base_virtual_type3.nit
+++ b/tests/base_virtual_type3.nit
@@ -28,5 +28,5 @@ c.tab = new Array[T]
 c.tab.add(new U)
 c.tab.first.foo
 
-var i = 2
+var i: Int = 2
 #alt1#i = c.tab.first

--- a/tests/sav/base_adaptive_loop4.res
+++ b/tests/sav/base_adaptive_loop4.res
@@ -1,0 +1,5 @@
+base_adaptive_loop4.nit:27,7: Warning: expression is not null, since it is a `N`.
+1
+1
+1
+1

--- a/tests/sav/base_adaptive_loop_alt1.res
+++ b/tests/sav/base_adaptive_loop_alt1.res
@@ -1,2 +1,2 @@
 alt/base_adaptive_loop_alt1.nit:30,6: Type Error: expected `Int`, got `nullable Int`.
-alt/base_adaptive_loop_alt1.nit:31,6: Type Error: expected `Int`, got `nullable Int`.
+alt/base_adaptive_loop_alt1.nit:33,5: Type Error: expected `Int`, got `nullable Int`.

--- a/tests/sav/base_var_alt5.res
+++ b/tests/sav/base_var_alt5.res
@@ -1,1 +1,8 @@
-alt/base_var_alt5.nit:44,6--7: Type Error: expected `Int`, got `Float`.
+5
+5.500000
+5
+5.500000
+5.500000
+5.500000
+1
+1

--- a/tests/sav/base_var_alt6.res
+++ b/tests/sav/base_var_alt6.res
@@ -1,1 +1,8 @@
-alt/base_var_alt6.nit:45,6--7: Type Error: expected `Float`, got `Int`.
+5
+5.500000
+5
+5.500000
+5
+5
+1
+1

--- a/tests/sav/base_var_type_evolution_alt2.res
+++ b/tests/sav/base_var_type_evolution_alt2.res
@@ -1,1 +1,2 @@
-alt/base_var_type_evolution_alt2.nit:50,3: Error: method `b` does not exists in `A`.
+alt/base_var_type_evolution_alt2.nit:49,3: Error: method `a` does not exists in `nullable Object`.
+alt/base_var_type_evolution_alt2.nit:50,3: Error: method `b` does not exists in `nullable Object`.

--- a/tests/sav/base_var_type_evolution_alt4.res
+++ b/tests/sav/base_var_type_evolution_alt4.res
@@ -1,1 +1,2 @@
-alt/base_var_type_evolution_alt4.nit:62,3: Error: method `b` does not exists in `A`.
+alt/base_var_type_evolution_alt4.nit:61,3: Error: method `a` does not exists in `nullable Object`.
+alt/base_var_type_evolution_alt4.nit:62,3: Error: method `b` does not exists in `nullable Object`.

--- a/tests/sav/base_var_type_evolution_alt5.res
+++ b/tests/sav/base_var_type_evolution_alt5.res
@@ -1,1 +1,2 @@
-alt/base_var_type_evolution_alt5.nit:62,3: Error: method `b` does not exists in `A`.
+alt/base_var_type_evolution_alt5.nit:61,3: Error: method `a` does not exists in `nullable Object`.
+alt/base_var_type_evolution_alt5.nit:62,3: Error: method `b` does not exists in `nullable Object`.

--- a/tests/sav/base_var_type_evolution_alt6.res
+++ b/tests/sav/base_var_type_evolution_alt6.res
@@ -1,1 +1,2 @@
-alt/base_var_type_evolution_alt6.nit:73,3: Error: method `b` does not exists in `A`.
+alt/base_var_type_evolution_alt6.nit:72,3: Error: method `a` does not exists in `nullable Object`.
+alt/base_var_type_evolution_alt6.nit:73,3: Error: method `b` does not exists in `nullable Object`.


### PR DESCRIPTION
This PR changes the semantic of local variable declarations.

~~~nit
fun foo: Foo # ...

var i = foo
var j
j = foo
var k: Foo = foo
~~~

Before the PR, `i` and `k` where equivalent and statically bounded by `Foo` while `j` was bounded by `nullable Object`.

Now `i` and `j` are equivalent and are both bounded with `nullable Object`.
If a static type is given explicitly (like in `k`), the behavior is unchanged. Therefore `k` and `i` that where equivalent before the PR are now different. This cause the warning `useless type declaration` to be removed by the PR.

Anyway, the change is not that invasive since, thanks to adaptive typing, the static type of `i` and `j` after the code is `Foo` both before and after the PR.

Beside the POLA thing, the other reason of this feature change is to simplify some pattern with loops and an initial value that can evolve. e.g.

~~~nit
class N
        var next: nullable N
end

var n0 = new N
var n1 = new N(n0)
var n2 = new N(n1)
var n3 = new N(n2)

var n = n3
while n != null do
        1.output
        n = n.next # here
end
~~~

Without the PR, the `here` line causes the error *Type Error: expected `N`, got `nullable N`.*, and forces to programmer to declare `n` with `var n: nullable N = n3`, or to split the declaration into `var n; n = n3`. Now the code is accepted as is.