### PR TITLE
nitdoc: display UML class diagram in mmodule pages

### DIFF
--- a/src/doc/doc_base.nit
+++ b/src/doc/doc_base.nit
@@ -134,12 +134,31 @@ abstract class DocComposite
 		return toc_title == null or is_hidden
 	end
 
-	# Add a `child` to `self`.
+	# Append a `child` to `self`.
 	#
-	# Shortcut for `children.add`.
+	# This method should be prefered to `children.add` since it also sets the
+	# `child.parent`.
 	fun add_child(child: DocComposite) do
 		child.parent = self
 		children.add child
+	end
+
+	# Insert `child` before existing `children`.
+	#
+	# This method should be prefered to `children.prepend` since it also sets the
+	# `child.parent`.
+	fun prepend_child(child: DocComposite) do
+		child.parent = self
+		children.unshift child
+	end
+
+	# Insert `child` at position `pos` in `children`.
+	#
+	# This method should be prefered to `children.insert` since it also sets the
+	# `child.parent`.
+	fun insert_child(child: DocComposite, pos: Int) do
+		child.parent = self
+		children.insert(child, pos)
 	end
 
 	# Depth of `self` in the composite tree.

--- a/src/doc/doc_phases/doc_graphs.nit
+++ b/src/doc/doc_phases/doc_graphs.nit
@@ -18,6 +18,7 @@ module doc_graphs
 import doc_structure
 import doc_poset
 import html_templates::html_model # FIXME maybe this phase should depend on `html_render`
+import uml
 
 redef class ToolContext
 
@@ -49,6 +50,7 @@ end
 
 redef class MModulePage
 	redef fun build_graphs(v, doc) do
+		build_class_diagram(v, doc)
 		build_dependencies_graph(v, doc)
 	end
 
@@ -70,6 +72,19 @@ redef class MModulePage
 		op.append("\}\n")
 		dependencies_section.prepend_child new GraphArticle(
 			"{mentity.nitdoc_id}.graph", "Importation Graph", name, op)
+	end
+
+	# Builds a class diagram with the classes contained in self.
+	fun build_class_diagram(v: GraphPhase, doc: DocModel) do
+		var name = "uml_classdiag_{mentity.nitdoc_id}"
+		var uml = new UMLModel(doc.model, doc.mainmodule, v.ctx)
+		var mclasses = new Array[MClass]
+		for mclass in mentity.intro_mclasses do
+			if doc.mentities.has(mclass) then mclasses.add mclass
+		end
+		var dot = uml.class_diagram(mclasses)
+		dependencies_section.prepend_child new GraphArticle(
+			"{mentity.nitdoc_id}.classdiag", "Class Diagram", name, dot.write_to_string)
 	end
 end
 

--- a/src/doc/doc_phases/doc_hierarchies.nit
+++ b/src/doc/doc_phases/doc_hierarchies.nit
@@ -41,7 +41,7 @@ end
 redef class MModulePage
 	redef fun build_inh_list(v, doc) do
 		var id = mentity.nitdoc_id
-		var section = new TabbedGroup("{id}.importation", "Dependencies")
+		var section = dependencies_section
 		var group = new PanelGroup("list.group", "List")
 		var imports = self.imports.to_a
 		v.name_sorter.sort(imports)
@@ -50,15 +50,13 @@ redef class MModulePage
 		v.name_sorter.sort(clients)
 		group.add_child new MEntitiesListArticle("{id}.clients", "Clients", clients)
 		section.add_child group
-		section.parent = root.children.first
-		root.children.first.children.insert(section, 1)
 	end
 end
 
 redef class MClassPage
 	redef fun build_inh_list(v, doc) do
 		var id = mentity.nitdoc_id
-		var section = new TabbedGroup("{id}.inheritance", "Inheritance")
+		var section = inheritance_section
 		var group = new PanelGroup("list.group", "List")
 		var parents = self.parents.to_a
 		v.name_sorter.sort(parents)
@@ -73,7 +71,5 @@ redef class MClassPage
 		v.name_sorter.sort(descendants)
 		group.add_child new MEntitiesListArticle("{id}.descendants", "Descendants", descendants)
 		section.add_child group
-		section.parent = root.children.first
-		root.children.first.children.insert(section, 1)
 	end
 end

--- a/src/doc/doc_phases/doc_structure.nit
+++ b/src/doc/doc_phases/doc_structure.nit
@@ -102,10 +102,17 @@ redef class MGroupPage
 end
 
 redef class MModulePage
+
+	# Place holder for dependencies and inheritance
+	var dependencies_section: DocSection is lazy do
+		return new TabbedGroup("{mentity.nitdoc_id}.importation", "Dependencies")
+	end
+
 	redef fun apply_structure(v, doc) do
 		var section = new MEntitySection("{mentity.nitdoc_name}.section", mentity)
 		root.add_child section
 		section.add_child new IntroArticle("{mentity.nitdoc_id}.intro", mentity)
+		section.add_child dependencies_section
 		var concerns = self.concerns
 		if concerns == null or concerns.is_empty then return
 		# FIXME avoid diff
@@ -167,10 +174,17 @@ redef class MModulePage
 end
 
 redef class MClassPage
+
+	# Place holder for inheritance section
+	var inheritance_section: DocSection is lazy do
+		return new TabbedGroup("{mentity.nitdoc_id}.inheritance", "Inheritance")
+	end
+
 	redef fun apply_structure(v, doc) do
 		var section = new MEntitySection("{mentity.nitdoc_name}.section", mentity)
 		root.add_child section
 		section.add_child new IntroArticle("{mentity.nitdoc_id}.intro", mentity)
+		section.add_child inheritance_section
 		var concerns = self.concerns
 		if concerns == null or concerns.is_empty then return
 		# FIXME diff hack

--- a/src/doc/html_templates/html_templates.nit
+++ b/src/doc/html_templates/html_templates.nit
@@ -565,10 +565,8 @@ redef class GraphArticle
 	var map: String is noinit, writable
 
 	redef fun render_body do
-		addn "<div class=\"text-center\">"
-		addn " <img src='{graph_id}.png' usemap='#{graph_id}' style='margin:auto'"
-		addn "  alt='{title or else ""}'/>"
+		addn """<img src="{{{graph_id}}}.png" usemap="#{{{graph_id}}}"
+				  class="img-responsive center-block" alt="{{{title or else ""}}}"/>"""
 		add map
-		addn "</div>"
 	end
 end

--- a/src/uml/uml_class.nit
+++ b/src/uml/uml_class.nit
@@ -21,6 +21,16 @@ import model::model_collect
 redef class UMLModel
 	# Generates a UML class diagram from a `Model`
 	fun generate_class_uml: Writable do
+		var mclasses = new Array[MClass]
+		for mclass in model.mclasses do
+			if not ctx.private_gen and mclass.visibility != public_visibility then continue
+			mclasses.add mclass
+		end
+		return class_diagram(mclasses)
+	end
+
+	# Generates a UML class diagram containing `mclasses`.
+	fun class_diagram(mclasses: Array[MClass]): Writable do
 		var tpl = new Template
 		tpl.add "digraph G \{\n"
 		tpl.add """	fontname = "Bitstream Vera Sans"
@@ -35,25 +45,13 @@ redef class UMLModel
 					fontname = "Bitstream Vera Sans"
 					fontsize = 8
 				]\n"""
-		tpl.add model.tpl_class(ctx, mainmodule)
+		for mclass in mclasses do
+			tpl.add mclass.tpl_class(ctx, mainmodule)
+			tpl.add "\n"
+		end
 		tpl.add "\}"
 		return tpl
 	end
-end
-
-redef class Model
-
-	# Generates a UML Class diagram from the entities of a `Model`
-	fun tpl_class(ctx: ToolContext, main: MModule): Writable do
-		var t = new Template
-		for i in mclasses do
-			if not ctx.private_gen and i.visibility != public_visibility then continue
-			t.add i.tpl_class(ctx, main)
-			t.add "\n"
-		end
-		return t
-	end
-
 end
 
 redef class MEntity

--- a/src/uml/uml_module.nit
+++ b/src/uml/uml_module.nit
@@ -21,6 +21,16 @@ import uml_class
 redef class UMLModel
 	# Generates a UML package diagram from a `Model`
 	fun generate_package_uml: Writable do
+		var mclasses = new Array[MClass]
+		for mclass in model.mclasses do
+			if not ctx.private_gen and mclass.visibility != public_visibility then continue
+			mclasses.add mclass
+		end
+		return package_diagram([mainmodule])
+	end
+
+	# Generates a UML package diagram containing `mmodules`
+	fun package_diagram(mmodules: Array[MModule]): Writable do
 		var tpl = new Template
 		tpl.add "digraph G \{\n"
 		tpl.add """	fontname = "Bitstream Vera Sans"
@@ -34,17 +44,14 @@ redef class UMLModel
 				fontname = "Bitstream Vera Sans"
 				fontsize = 8
 			]\n"""
-		tpl.add model.tpl_module(ctx, mainmodule)
+		for mmodule in mmodules do
+			tpl.add mmodule.tpl_module(ctx, mainmodule)
+			tpl.add "\n"
+		end
 		tpl.add "\}"
 		return tpl
 	end
-end
 
-redef class Model
-	# Returns a UML package diagram of `main`
-	fun tpl_module(ctx: ToolContext, main: MModule): Writable do
-		return main.tpl_module(ctx, main)
-	end
 end
 
 redef class MModule

--- a/tests/sav/nitdoc_args1.res
+++ b/tests/sav/nitdoc_args1.res
@@ -52,4 +52,12 @@ property_module_95d1-__B__all25.html
 quicksearch-list.js
 resources/
 search.html
+uml_classdiag_module_95d0-.dot
+uml_classdiag_module_95d0-.map
+uml_classdiag_module_95d0-.png
+uml_classdiag_module_95d0-.s.dot
+uml_classdiag_module_95d1-.dot
+uml_classdiag_module_95d1-.map
+uml_classdiag_module_95d1-.png
+uml_classdiag_module_95d1-.s.dot
 vendors/

--- a/tests/sav/nitdoc_args2.res
+++ b/tests/sav/nitdoc_args2.res
@@ -59,4 +59,8 @@ property_base_attr_nullable-__Sys__main.html
 quicksearch-list.js
 resources/
 search.html
+uml_classdiag_base_attr_nullable-.dot
+uml_classdiag_base_attr_nullable-.map
+uml_classdiag_base_attr_nullable-.png
+uml_classdiag_base_attr_nullable-.s.dot
 vendors/

--- a/tests/sav/nitdoc_args3.res
+++ b/tests/sav/nitdoc_args3.res
@@ -67,4 +67,8 @@ property_base_attr_nullable-__Sys__main.html
 quicksearch-list.js
 resources/
 search.html
+uml_classdiag_base_attr_nullable-.dot
+uml_classdiag_base_attr_nullable-.map
+uml_classdiag_base_attr_nullable-.png
+uml_classdiag_base_attr_nullable-.s.dot
 vendors/

--- a/tests/sav/nitdoc_args4.res
+++ b/tests/sav/nitdoc_args4.res
@@ -24,6 +24,7 @@ MModulePage test_prog
 		## test_prog-.intro
 		## test_prog-.importation
 			### test_prog-.graph
+			### test_prog-.classdiag
 			### list.group
 				#### test_prog-.imports
 				#### test_prog-.clients
@@ -106,6 +107,7 @@ MModulePage game
 		## test_prog__game-.intro
 		## test_prog__game-.importation
 			### test_prog__game-.graph
+			### test_prog__game-.classdiag
 			### list.group
 				#### test_prog__game-.imports
 				#### test_prog__game-.clients
@@ -183,6 +185,7 @@ MModulePage platform
 		## test_prog__platform-.intro
 		## test_prog__platform-.importation
 			### test_prog__platform-.graph
+			### test_prog__platform-.classdiag
 			### list.group
 				#### test_prog__platform-.imports
 				#### test_prog__platform-.clients
@@ -453,6 +456,7 @@ MModulePage careers
 		## test_prog__rpg__careers.intro
 		## test_prog__rpg__careers.importation
 			### test_prog__rpg__careers.graph
+			### test_prog__rpg__careers.classdiag
 			### list.group
 				#### test_prog__rpg__careers.imports
 				#### test_prog__rpg__careers.clients
@@ -582,6 +586,7 @@ MModulePage character
 		## test_prog__rpg__character.intro
 		## test_prog__rpg__character.importation
 			### test_prog__rpg__character.graph
+			### test_prog__rpg__character.classdiag
 			### list.group
 				#### test_prog__rpg__character.imports
 				#### test_prog__rpg__character.clients
@@ -684,6 +689,7 @@ MModulePage combat
 		## test_prog__rpg__combat.intro
 		## test_prog__rpg__combat.importation
 			### test_prog__rpg__combat.graph
+			### test_prog__rpg__combat.classdiag
 			### list.group
 				#### test_prog__rpg__combat.imports
 				#### test_prog__rpg__combat.clients
@@ -804,6 +810,7 @@ MModulePage races
 		## test_prog__rpg__races.intro
 		## test_prog__rpg__races.importation
 			### test_prog__rpg__races.graph
+			### test_prog__rpg__races.classdiag
 			### list.group
 				#### test_prog__rpg__races.imports
 				#### test_prog__rpg__races.clients
@@ -936,6 +943,7 @@ MModulePage rpg
 		## test_prog__rpg__rpg.intro
 		## test_prog__rpg__rpg.importation
 			### test_prog__rpg__rpg.graph
+			### test_prog__rpg__rpg.classdiag
 			### list.group
 				#### test_prog__rpg__rpg.imports
 				#### test_prog__rpg__rpg.clients

--- a/tests/sav/nituml_args1.res
+++ b/tests/sav/nituml_args1.res
@@ -19,4 +19,5 @@ base_prot_sig2D [
 	label = "{D|- _vpubA: nullable A\l- _vpriA: nullable A\l- _vpubA2: A\l- _vpriA2: A\l|- pubA(a: A)\l- priA(a: A)\l- vpubA(): nullable A\l- vpubA=(vpubA: nullable A)\l- vpriA(): nullable A\l- vpriA=(vpriA: nullable A)\l- vpubA2(): A\l- vpubA2=(vpubA2: A)\l- vpriA2(): A\l- vpriA2=(vpriA2: A)\l+ init()\l}"color="#58B26A"
 ]
 }
+
 }

--- a/tests/sav/nituml_args2.res
+++ b/tests/sav/nituml_args2.res
@@ -16,4 +16,5 @@ base_prot_sig2C [
 	label = "{C||+ init()\l}"color="#58B26A"
 ]
 }
+
 }


### PR DESCRIPTION
Jenkins in busy with CI-nitdoc for now with PRs #1447 and #1446. The demo will have to wait.

Démo is up. Un example of diagram can be found in the burger menu of the dependencies graph: [stdlib](http://moz-code.org/demos/nitdoc-uml/stdlib/module_standard__collection__array.html)

Do not consider commits before 32d81a1 since they are from #1446. 