### PR TITLE
Report check contrib

### DIFF
--- a/contrib/nitiwiki/tests/res/wiki1_nitiwiki_render.res
+++ b/contrib/nitiwiki/tests/res/wiki1_nitiwiki_render.res
@@ -1,1 +1,3 @@
-Render section out
+Render section pages -> out
+Render article index -> wiki1/out/index.html
+Render article sitemap -> wiki1/out/sitemap.html

--- a/contrib/nitiwiki/tests/res/wiki1_nitiwiki_status.res
+++ b/contrib/nitiwiki/tests/res/wiki1_nitiwiki_status.res
@@ -1,10 +1,9 @@
 nitiWiki
 name: wiki1
 config: wiki1/config.ini
-url: http://localhost/
 
 There is modified files:
- + pages
+ * pages
  + pages/index.md
 
 Use nitiwiki --render to render modified files

--- a/contrib/nitiwiki/tests/res/wiki2_nitiwiki_render.res
+++ b/contrib/nitiwiki/tests/res/wiki2_nitiwiki_render.res
@@ -1,5 +1,5 @@
-Custom config for section sec2
-Render section out
+Render section pages -> out
+Render article contact -> wiki2/out/contact.html
 Warning: unknown wikilink `not found` (in pages/index.md)
 Warning: unknown wikilink `Not Found` (in pages/index.md)
 Warning: unknown wikilink `/not/found` (in pages/index.md)
@@ -7,8 +7,11 @@ Warning: unknown wikilink `not/found` (in pages/index.md)
 Warning: unknown wikilink `not found` (in pages/index.md)
 Warning: unknown wikilink `not found` (in pages/index.md)
 Warning: unknown wikilink `not found` (in pages/index.md)
-Render section out/sec1
-Render section out/sec2
+Render article index -> wiki2/out/index.html
+Render article other_page -> wiki2/out/other_page.html
+Render section sec1 -> out/sec1
+Render article index -> wiki2/out/sec1/index.html
+Render section sec2 -> out/sec2
 Warning: unknown wikilink `not found` (in pages/sec2/index.md)
 Warning: unknown wikilink `Not Found` (in pages/sec2/index.md)
 Warning: unknown wikilink `/not/found` (in pages/sec2/index.md)
@@ -16,5 +19,10 @@ Warning: unknown wikilink `not/found` (in pages/sec2/index.md)
 Warning: unknown wikilink `not found` (in pages/sec2/index.md)
 Warning: unknown wikilink `not found` (in pages/sec2/index.md)
 Warning: unknown wikilink `not found` (in pages/sec2/index.md)
-Render section out/sec2/sub-sec21
-Render section out/sec2/sub-sec22
+Render article index -> wiki2/out/sec2/index.html
+Render section sub-sec21 -> out/sec2/sub-sec21
+Render article index -> wiki2/out/sec2/sub-sec21/index.html
+Render section sub-sec22 -> out/sec2/sub-sec22
+Render article index -> wiki2/out/sec2/sub-sec22/index.html
+Render article other -> wiki2/out/sec2/sub-sec22/other.html
+Render article sitemap -> wiki2/out/sitemap.html

--- a/contrib/nitiwiki/tests/res/wiki2_nitiwiki_status.res
+++ b/contrib/nitiwiki/tests/res/wiki2_nitiwiki_status.res
@@ -1,16 +1,15 @@
 nitiWiki
 name: wiki2
 config: wiki2/config.ini
-url: http://localhost/
 
 There is modified files:
- + pages
+ * pages
  + pages/contact.md
  + pages/index.md
  + pages/other_page.md
  + pages/sec1
  + pages/sec1/index.md
- + pages/sec2
+ * pages/sec2
  + pages/sec2/index.md
  + pages/sec2/sub-sec21
  + pages/sec2/sub-sec21/index.md

--- a/contrib/nitiwiki/tests/res/wiki3_nitiwiki_render.res
+++ b/contrib/nitiwiki/tests/res/wiki3_nitiwiki_render.res
@@ -1,1 +1,5 @@
-Render section out
+Render section pages -> out
+Render article contact -> wiki3/out/contact.html
+Render article index -> wiki3/out/index.html
+Render article other_page -> wiki3/out/other_page.html
+Render article sitemap -> wiki3/out/sitemap.html

--- a/contrib/nitiwiki/tests/res/wiki3_nitiwiki_status.res
+++ b/contrib/nitiwiki/tests/res/wiki3_nitiwiki_status.res
@@ -1,7 +1,6 @@
 nitiWiki
 name: wiki3
 config: wiki3/config.ini
-url: http://localhost/
 
 There is modified files:
  + pages

--- a/contrib/nitiwiki/tests/tests.sh
+++ b/contrib/nitiwiki/tests/tests.sh
@@ -90,3 +90,6 @@ for file in `ls *.args`; do
 done
 echo ""
 echo "==> success $ok/$all ($ko tests failed, $sk skipped)"
+
+# return result
+test "$ok" == "$all"

--- a/contrib/pep8analysis/Makefile
+++ b/contrib/pep8analysis/Makefile
@@ -7,7 +7,8 @@ doc/index.html:
 
 check: tests
 tests: bin/pep8analysis
-	bin/pep8analysis --cfg-long tests/privat/*.pep tests/micro/*.pep tests/terrasa/*.pep
+	bin/pep8analysis --cfg-long tests/privat/*.pep tests/micro/*.pep tests/terrasa/*.pep | tee test.out
+	diff test.out test.sav
 
 www/pep8analysis.js:
 	../../bin/nitc -o www/pep8analysis.js --semi-global src/pep8analysis_web.nit

--- a/contrib/pep8analysis/test.sav
+++ b/contrib/pep8analysis/test.sav
@@ -1,0 +1,79 @@
+Analyzing tests/privat/02-fibo.pep
+Analyzing tests/privat/04-abc.pep
+Analyzing tests/privat/04-leplusgrand.pep
+Analyzing tests/privat/05-0et100.pep
+Analyzing tests/privat/05-1a100.pep
+Analyzing tests/privat/05-aei.pep
+Analyzing tests/privat/05-otan.pep
+Analyzing tests/privat/05-simul_3n.pep
+Analyzing tests/privat/05-simul_n.pep
+Analyzing tests/privat/05-simul_x.pep
+Analyzing tests/privat/05-sommeVec.pep
+Analyzing tests/privat/06-calc-non-pur.pep
+Analyzing tests/privat/06-compte1.pep
+Analyzing tests/privat/06-majuscules.pep
+Analyzing tests/privat/06-menu.pep
+Analyzing tests/privat/06-print-non-pur.pep
+Analyzing tests/privat/06-processVec.pep
+Analyzing tests/privat/06-puissance2.pep
+Analyzing tests/privat/06-sommes1.pep
+Analyzing tests/privat/06-sommes2.pep
+Analyzing tests/privat/06-sommes3.pep
+Analyzing tests/privat/06-x100.pep
+Analyzing tests/privat/07-matrice.pep
+Analyzing tests/privat/07-stri.pep
+Analyzing tests/privat/07-stris.pep
+Analyzing tests/privat/07-tri.pep
+Analyzing tests/privat/07-tri2.pep
+Analyzing tests/privat/08-abus.pep
+Analyzing tests/privat/08-div-stack.pep
+Analyzing tests/privat/08-div-vars.pep
+Analyzing tests/privat/08-div.pep
+Analyzing tests/privat/08-fib.pep
+Analyzing tests/privat/08-incr.pep
+Analyzing tests/privat/08-liretab-stack.pep
+Analyzing tests/privat/08-liretab.pep
+Analyzing tests/privat/08-pile.pep
+Analyzing tests/privat/08-tab.pep
+Analyzing tests/privat/08-triforce.pep
+Analyzing tests/privat/08-varlocales.pep
+Analyzing tests/privat/09-liste.pep
+Analyzing tests/privat/09-produit.pep
+Analyzing tests/privat/fib.pep
+Analyzing tests/micro/directive-in-code.pep
+Analyzing tests/micro/range.pep
+Analyzing tests/micro/to-graph.pep
+Analyzing tests/micro/types.pep
+Analyzing tests/terrasa/addition_stro.pep
+Analyzing tests/terrasa/boucle.pep
+Analyzing tests/terrasa/chari_charo.pep
+Analyzing tests/terrasa/division.pep
+Analyzing tests/terrasa/hello.pep
+Analyzing tests/terrasa/if_else.pep
+Analyzing tests/terrasa/if_elseif_else.pep
+Analyzing tests/terrasa/lecture_chaine.pep
+Analyzing tests/terrasa/matrice.pep
+Analyzing tests/terrasa/max_tableau.pep
+Analyzing tests/terrasa/multiplication.pep
+Analyzing tests/terrasa/reverse_tableau.pep
+Analyzing tests/terrasa/somme_tableau.pep
+Analyzing tests/terrasa/soustraction.pep
+Analyzing tests/terrasa/tri_bulles.pep
+# Notes:
+Warning: tests/privat/05-1a100.pep:10; using data of unsupported type in memory address 1, expected word (got two byte of code)
+Error:   tests/privat/06-calc-non-pur.pep:32; this instruction is not followed by valid code as it should (misplaced data or missing BR?)
+Error:   tests/privat/06-calc-non-pur.pep:32; unreachable instructions (dead code?)
+Warning: tests/privat/06-calc-non-pur.pep:14; overwriting code at instr@m76 with byte of code (code rewriting?)
+Warning: tests/privat/06-menu.pep:13; jumps to a dynamic address, this may be OK but the CFG may be wrong
+Warning: tests/privat/07-stri.pep:7; printing uninitialized data, exepected ASCII
+Warning: tests/privat/07-stri.pep:9; printing uninitialized data, exepected ASCII
+Error:   tests/privat/07-stris.pep:39; unreachable instructions (dead code?)
+Warning: tests/privat/08-abus.pep:8--10; unreachable instructions (dead code?)
+Error:   tests/micro/directive-in-code.pep:4; unreachable instructions (dead code?)
+Error:   tests/micro/directive-in-code.pep:2; data in program flow (missing BR?)
+Warning: tests/micro/types.pep:1; using data of unsupported type in register A, expected word (got two uninitialized byte)
+Warning: tests/micro/types.pep:1; using data of unsupported type in memory address 123, expected word (got two uninitialized byte)
+Warning: tests/micro/types.pep:3; using a partial word in register A, expected a full word (got a 1st byte of word followed by byte of code)
+Warning: tests/micro/types.pep:3; using data of unsupported type in memory address 123, expected word (got two uninitialized byte)
+Warning: tests/micro/types.pep:6; using data of unsupported type in register A, expected word (got two byte of code)
+Warning: tests/micro/types.pep:6; using data of unsupported type in memory address 123, expected word (got two uninitialized byte)

--- a/contrib/refund/tests/tests.sh
+++ b/contrib/refund/tests/tests.sh
@@ -83,3 +83,6 @@ rm stats.json
 
 echo ""
 echo "==> success $ok/$all ($ko tests failed, $sk skipped)"
+
+# return result
+test "$ok" == "$all"


### PR DESCRIPTION
Thanks to `misc/jenkins/check_contrib.sh`, programs in contrib can be tested for regressions.
Unfortunately, sometime the result of the test is not reported (only printed on screen). This PR update some of these to really report things.