### PR TITLE
Fix app.nit Calc example

### DIFF
--- a/examples/calculator/Makefile
+++ b/examples/calculator/Makefile
@@ -10,7 +10,7 @@ bin/calculator: $(shell ${NITLS} -M src/calculator.nit -m linux) ${NITC}
 bin/calculator.apk: $(shell ${NITLS} -M src/calculator.nit -m android) ${NITC} ../../contrib/inkscape_tools/bin/svg_to_icons
 	mkdir -p bin res
 	../../contrib/inkscape_tools/bin/svg_to_icons art/icon.svg --android --out res/
-	${NITC} -o $@ src/calculator.nit -m ../../lib/android/ui/
+	${NITC} -o $@ src/calculator.nit -m ../../lib/android/ui/ -D debug
 
 ../../contrib/inkscape_tools/bin/svg_to_icons:
 	make -C ../../contrib/inkscape_tools/

--- a/examples/calculator/Makefile
+++ b/examples/calculator/Makefile
@@ -10,7 +10,7 @@ bin/calculator: $(shell ${NITLS} -M src/calculator.nit -m linux) ${NITC}
 bin/calculator.apk: $(shell ${NITLS} -M src/calculator.nit -m android) ${NITC} ../../contrib/inkscape_tools/bin/svg_to_icons
 	mkdir -p bin res
 	../../contrib/inkscape_tools/bin/svg_to_icons art/icon.svg --android --out res/
-	${NITC} -o $@ src/calculator.nit -m android
+	${NITC} -o $@ src/calculator.nit -m ../../lib/android/ui/
 
 ../../contrib/inkscape_tools/bin/svg_to_icons:
 	make -C ../../contrib/inkscape_tools/

--- a/examples/calculator/src/calculator.nit
+++ b/examples/calculator/src/calculator.nit
@@ -29,9 +29,14 @@ import android::aware
 
 import calculator_logic
 
+# Show debug output?
+fun debug: Bool do return false
+
 redef class App
 	redef fun on_create
 	do
+		if debug then print "App::on_create"
+
 		# Create the main window
 		window = new CalculatorWindow
 		super
@@ -56,6 +61,8 @@ class CalculatorWindow
 
 	init
 	do
+		if debug then print "CalculatorWindow::init"
+
 		# All the button labels, row by row
 		var rows = [["7", "8", "9", "+"],
 		            ["4", "5", "6", "-"],
@@ -76,6 +83,8 @@ class CalculatorWindow
 
 	redef fun on_event(event)
 	do
+		if debug then print "CalculatorWindow::on_event {event}"
+
 		if event isa ButtonPressEvent then
 
 			var op = event.sender.text
@@ -96,12 +105,16 @@ class CalculatorWindow
 
 	redef fun on_save_state
 	do
+		if debug then print "CalculatorWindow::on_save_state"
+
 		app.data_store["context"] = context
 		super
 	end
 
 	redef fun on_restore_state
 	do
+		if debug then print "CalculatorWindow::on_restore_state"
+
 		super
 
 		var context = app.data_store["context"]

--- a/examples/calculator/src/calculator_logic.nit
+++ b/examples/calculator/src/calculator_logic.nit
@@ -101,26 +101,27 @@ class CalculatorContext
 	protected fun apply_last_op_if_any
 	do
 		var op = last_op
-
 		var result = result
-
 		var current = current
-		if current == null then current = new FlatBuffer
+		self.current = null
+
+		if current == null then return
 
 		if op == null then
 			result = current.to_n
-		else if op == '+' then
-			result = result.add(current.to_n)
-		else if op == '-' then
-			result = result.sub(current.to_n)
-		else if op == '/' then
-			result = result.div(current.to_n)
-		else if op == '*' then
-			result = result.mul(current.to_n)
+		else if result != null then
+			if op == '+' then
+				result = result.add(current.to_n)
+			else if op == '-' then
+				result = result.sub(current.to_n)
+			else if op == '/' then
+				result = result.div(current.to_n)
+			else if op == '*' then
+				result = result.mul(current.to_n)
+			end
 		end
 
 		self.result = result
-		self.current = null
 	end
 end
 

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -20,7 +20,7 @@ import app_base
 # Platform variations
 # TODO: move on the platform once qualified names are understand in the condition
 import linux::ui is conditional(linux)
-import android::ui is conditional(android)
+import android::ui is conditional(android) # FIXME it should be conditional to `android::platform`
 
 redef class App
 	super AppComponent

--- a/lib/standard/numeric.nit
+++ b/lib/standard/numeric.nit
@@ -30,9 +30,11 @@ redef class Text
 	# assert "0.0".to_n == 0.0
 	# assert ".12345".to_n == 0.12345
 	# assert "12345".to_n == 12345
+	# assert "".to_n == 0
 	# ~~~~
 	fun to_n: Numeric
 	do
+		if is_empty then return 0
 		if chars.has('.') then return to_f
 		return to_i
 	end


### PR DESCRIPTION
Partial revert of cbbb5225 because the Android version of Calc need only `android::ui` and not `android`. The default entry point of `android` use `native_app_glue` as base activity/framework, whereas UI apps use `nit_activity`. This caused the apk file to show 2 activities in the launch menu.

Also recent changes (probably) make calling `to_i` and thus `to_n` on empty strings crash. I've updated the calculator to avoid this with a new friendlier behavior in such cases.

I've also updated `to_n` to return 0 on empty strings. This preserve the old behavior, it is a neutral fallback value and it fits with `"".is_numeric == true`. I did not touch `to_i`.