### PR TITLE
Text::is_int bugfix

### DIFF
--- a/lib/standard/fixed_ints.nit
+++ b/lib/standard/fixed_ints.nit
@@ -883,7 +883,9 @@ redef class Text
 	#     assert "0b1011".is_int
 	#     assert not "0x_".is_int
 	#     assert not "0xGE".is_int
+	#     assert not "".is_int
 	fun is_int: Bool do
+		if bytelen == 0 then return false
 		var s = remove_all('_')
 		var pos = 0
 		while s[pos] == '-' do


### PR DESCRIPTION
Fix a bug that caused an assert failed when accessing an empty string in `Text::is_int`

Reported by @xymus with PR #1649 