### PR TITLE
Small fix to iOS support

### DIFF
--- a/lib/cocoa/examples/cocoa_message_box.nit
+++ b/lib/cocoa/examples/cocoa_message_box.nit
@@ -19,7 +19,11 @@ module cocoa_message_box
 
 import cocoa
 
-fun dialog in "ObjC" `{
+in "ObjC" `{
+	#import <AppKit/AppKit.h>
+`}
+
+private fun dialog in "ObjC" `{
 	NSAlert *alert = [[[NSAlert alloc] init] autorelease];
 	[alert setMessageText:@"Hello world!"];
 	[alert runModal];

--- a/src/platform/ios.nit
+++ b/src/platform/ios.nit
@@ -110,6 +110,7 @@ private class IOSToolchain
 			"xcodebuild -target '{project_name}' " +
 			"-destination 'platform=iOS Simulator,name=iPhone' " +
 			"-configuration {if release then "Release" else "Debug"} " +
+			 "ONLY_ACTIVE_ARCH=NO "+
 			"-sdk iphonesimulator build"]
 		toolcontext.exec_and_check(args, "iOS project error")
 


### PR DESCRIPTION
Add `ONLY_ACTIVE_ARCH=NO` to the xcode call because it is required by the latest xcode.

For the iOS example, you would expect `AppKit.h` to be included by the imported module. It is, but at the same time it is ignored for performance reason since none of the imported module services are used. This will be fixed in a future PR. For now, we add the include locally as it is a better example and happen to avoid the problem.