### PR TITLE
Text optimization

### DIFF
--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -1817,6 +1817,12 @@ redef class NativeString
 
 	# Returns `self` as a String of `length`.
 	fun to_s_with_length(length: Int): String is abstract
+
+	# Returns `self` as a String with `bytelen` and `length` set
+	#
+	# SEE: `abstract_text::Text` for more infos on the difference
+	# between `Text::bytelen` and `Text::length`
+	fun to_s_full(bytelen, unilen: Int): String is abstract
 end
 
 redef class NativeArray[E]

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -885,6 +885,10 @@ redef class NativeString
 		return str
 	end
 
+	redef fun to_s_full(bytelen, unilen) do
+		return new FlatString.full(self, bytelen, 0, bytelen - 1, unilen)
+	end
+
 	# Returns `self` as a new String.
 	redef fun to_s_with_copy: FlatString
 	do

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -589,7 +589,7 @@ class FlatBuffer
 	do
 		written = true
 		if bytelen == 0 then items = new NativeString(1)
-		return new FlatString.with_infos(items, bytelen, 0, bytelen - 1)
+		return new FlatString.full(items, bytelen, 0, bytelen - 1, length)
 	end
 
 	redef fun to_cstring
@@ -700,7 +700,7 @@ class FlatBuffer
 
 	redef fun times(repeats)
 	do
-		var x = new FlatString.with_infos(items, bytelen, 0, bytelen - 1)
+		var x = new FlatString.full(items, bytelen, 0, bytelen - 1, length)
 		for i in [1 .. repeats[ do
 			append(x)
 		end

--- a/lib/core/text/ropes.nit
+++ b/lib/core/text/ropes.nit
@@ -559,7 +559,7 @@ redef class FlatString
 			var ns = new NativeString(nlen + 1)
 			mits.copy_to(ns, mlen, mifrom, 0)
 			sits.copy_to(ns, slen, sifrom, mlen)
-			return ns.to_s_with_length(nlen)
+			return new FlatString.full(ns, nlen, 0, nlen - 1, length + s.length)
 		else if s isa Concat then
 			var sl = s.left
 			var sllen = sl.bytelen

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -1598,8 +1598,9 @@ abstract class AbstractCompilerVisitor
 		var native_mtype = mmodule.native_string_type
 		var nat = self.new_var(native_mtype)
 		self.add("{nat} = \"{string.escape_to_c}\";")
-		var length = self.int_instance(string.bytelen)
-		self.add("{res} = {self.send(self.get_property("to_s_with_length", native_mtype), [nat, length]).as(not null)};")
+		var bytelen = self.int_instance(string.bytelen)
+		var unilen = self.int_instance(string.length)
+		self.add("{res} = {self.send(self.get_property("to_s_full", native_mtype), [nat, bytelen, unilen]).as(not null)};")
 		self.add("{name} = {res};")
 		self.add("\}")
 		return res

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -343,7 +343,7 @@ class NaiveInterpreter
 	fun string_instance(txt: String): Instance
 	do
 		var nat = native_string_instance(txt)
-		var res = self.send(self.force_get_primitive_method("to_s_with_length", nat.mtype), [nat, self.int_instance(txt.bytelen)])
+		var res = self.send(self.force_get_primitive_method("to_s_full", nat.mtype), [nat, self.int_instance(txt.bytelen), self.int_instance(txt.length)])
 		assert res != null
 		return res
 	end

--- a/src/rapid_type_analysis.nit
+++ b/src/rapid_type_analysis.nit
@@ -581,7 +581,7 @@ redef class AStringFormExpr
 	do
 		var native = v.analysis.mainmodule.native_string_type
 		v.add_type(native)
-		var prop = v.get_method(native, "to_s_with_length")
+		var prop = v.get_method(native, "to_s_full")
 		v.add_monomorphic_send(native, prop)
 	end
 end

--- a/tests/sav/error_needed_method_alt3.res
+++ b/tests/sav/error_needed_method_alt3.res
@@ -1,1 +1,1 @@
-alt/error_needed_method_alt3.nit:48,9--13: Fatal Error: `NativeString` must have a property named `to_s_with_length`.
+alt/error_needed_method_alt3.nit:48,9--13: Fatal Error: `NativeString` must have a property named `to_s_full`.

--- a/tests/sav/niti/error_needed_method_alt4.res
+++ b/tests/sav/niti/error_needed_method_alt4.res
@@ -1,1 +1,1 @@
-alt/error_needed_method_alt4.nit:49,10--14: Fatal Error: `NativeString` must have a property named `to_s_with_length`.
+alt/error_needed_method_alt4.nit:49,10--14: Fatal Error: `NativeString` must have a property named `to_s_full`.


### PR DESCRIPTION
This PR introduces some more bookkeeping to Texts variants, some more work is to be expected at compilation-time for the generation of FlatStrings with all the information, but this should improve execution speeds in clients.

`./chain_concat -m string --loops 1000000 --strlen 15 --ccts 20`

* Before:
4.42 4.48 4.51 4.5025 "20"
* After:
2.40 2.36 2.38 2.37 "20"

`time ./bin/nitc --semi-global src/nitc.nit -o bin/nitc` best of 10:

* Before
~~~
real  0m6.075s
user  0m4.624s
sys   0m0.826s
~~~

* After
~~~
real  0m6.172s
user  0m4.751s
sys   0m0.870s
~~~

Valgrind:

* Before; GIr: 14,768,723,784
* After; GIr: 14,775,119,149