### PR TITLE
objcwrapper: generate valid Nit code for large Objective-C classes

### DIFF
--- a/contrib/objcwrapper/.gitignore
+++ b/contrib/objcwrapper/.gitignore
@@ -2,4 +2,6 @@ src/objc_lexer.nit
 src/objc_parser.nit
 src/objc_test_parser.nit
 tests/MyClass.nit
+tests/nsarray.nit
+tests/nsalert.nit
 objc.ast.dot

--- a/contrib/objcwrapper/Makefile
+++ b/contrib/objcwrapper/Makefile
@@ -1,4 +1,4 @@
-all: bin/objcwrapper
+all: bin/objcwrapper bin/header_static
 
 ../nitcc/src/nitcc:
 	make -C ../nitcc
@@ -23,7 +23,7 @@ check: bin/objc_test_parser bin/objcwrapper
 	../../bin/nitpick tests/MyClass.nit
 
 # Test on classes of libgnustep-base-dev
-check-gnustep: bin/objcwrapper
+check-gnustep: bin/objcwrapper bin/header_static
 	gcc -E /usr/include/GNUstep/Foundation/NSArray.h -I /usr/include/GNUstep/ -Wno-deprecated \
 	| ../header_keeper/bin/header_keeper /usr/include/GNUstep/Foundation/NSArray.h \
 	| bin/header_static > tests/NSArray.pre.h
@@ -31,7 +31,7 @@ check-gnustep: bin/objcwrapper
 	../../bin/nitpick tests/nsarray.nit
 
 # Test on classes of the Apple Foundation framework
-check-apple: bin/objcwrapper
+check-apple: bin/objcwrapper bin/header_static
 	gcc -E /System/Library/Frameworks/Foundation.framework/Versions/C/Headers/NSArray.h \
 	| ../header_keeper/bin/header_keeper /System/Library/Frameworks/Foundation.framework/Versions/C/Headers/NSArray.h \
 	| bin/header_static > tests/NSArray.pre.h
@@ -44,5 +44,5 @@ check-apple: bin/objcwrapper
 	bin/objcwrapper tests/NSAlert.pre.h -o tests/nsalert.nit
 	../../bin/nitpick tests/nsalert.nit
 
-bin/header_static:
+bin/header_static: $(shell ../../bin/nitls -M src/header_static.nit)
 	../../bin/nitc --dir bin src/header_static.nit

--- a/contrib/objcwrapper/Makefile
+++ b/contrib/objcwrapper/Makefile
@@ -23,20 +23,20 @@ check: bin/objc_test_parser bin/objcwrapper
 	../../bin/nitpick tests/MyClass.nit
 
 # Test on classes of libgnustep-base-dev
-check-gnustep:
+check-gnustep: bin/objcwrapper
 	gcc -E /usr/include/GNUstep/Foundation/NSArray.h -I /usr/include/GNUstep/ -Wno-deprecated \
 	| ../header_keeper/bin/header_keeper /usr/include/GNUstep/Foundation/NSArray.h \
 	| bin/header_static > tests/NSArray.pre.h
-	bin/objcwrapper tests/NSArray.pre.h
-	../../bin/nitpick NSArray.nit
+	bin/objcwrapper tests/NSArray.pre.h -o tests/nsarray.nit
+	../../bin/nitpick tests/nsarray.nit
 
 # Test on classes of the Apple Foundation framework
-check-apple:
+check-apple: bin/objcwrapper
 	gcc -E /System/Library/Frameworks/Foundation.framework/Versions/C/Headers/NSArray.h \
 	| ../header_keeper/bin/header_keeper /System/Library/Frameworks/Foundation.framework/Versions/C/Headers/NSArray.h \
 	| bin/header_static > tests/NSArray.pre.h
-	bin/objcwrapper tests/NSArray.pre.h
-	../../bin/nitpick NSArray.nit
+	bin/objcwrapper tests/NSArray.pre.h -o tests/nsarray.nit
+	../../bin/nitpick tests/nsarray.nit
 
 bin/header_static:
 	../../bin/nitc --dir bin src/header_static.nit

--- a/contrib/objcwrapper/Makefile
+++ b/contrib/objcwrapper/Makefile
@@ -38,5 +38,11 @@ check-apple: bin/objcwrapper
 	bin/objcwrapper tests/NSArray.pre.h -o tests/nsarray.nit
 	../../bin/nitpick tests/nsarray.nit
 
+	gcc -E /System/Library/Frameworks/AppKit.framework/Headers/NSAlert.h \
+	| ../header_keeper/bin/header_keeper NSAlert.h \
+	| bin/header_static > tests/NSAlert.pre.h
+	bin/objcwrapper tests/NSAlert.pre.h -o tests/nsalert.nit
+	../../bin/nitpick tests/nsalert.nit
+
 bin/header_static:
 	../../bin/nitc --dir bin src/header_static.nit

--- a/contrib/objcwrapper/README.md
+++ b/contrib/objcwrapper/README.md
@@ -1,0 +1,31 @@
+Generator of Nit extern classes to wrap Objective-C services.
+
+# Description
+
+_objcwrapper_ is a tool to help access Objective-C classes and methods from Nit.
+It generates Nit code composed of extern classes and extern methods from the Objective-C FFI.
+The code should be valid Nit, but it may need some tweaking by hand before use.
+
+_objcwrapper_ takes as input preprocessed Objective-C header files.
+This preprocessing is usually done by combinig (or piping) calls to:
+`gcc -E`, `header_keeper` and `header_static`.
+See the check rules in the Makefile for example preprocessing.
+
+# Usage
+
+1. Compile _objcwrapper_ with: `make`
+
+2. Compile the wrapper `NSArray.nit` from the preprocessed header `NSArray.h` with:
+
+	~~~
+	bin/objcwrapper -o NSArray.h NSArray.h
+	~~~
+
+3. Import the generated module as usual from any Nit program.
+   It is not recommended to modify the generated file directly,
+   but you can redef the generated classes from other modules.
+
+# See also
+
+_jwrapper_ is the inspiration for this tool.
+It generate wrappers to access Java services from Nit.

--- a/contrib/objcwrapper/grammar/objc.sablecc
+++ b/contrib/objcwrapper/grammar/objc.sablecc
@@ -197,7 +197,8 @@ Parser
         'long long int' |
         'float' |
         'double' |
-        'long double';
+        'long double' |
+        'size_t';
 
     classe =
         {class:} class |

--- a/contrib/objcwrapper/grammar/objc.sablecc
+++ b/contrib/objcwrapper/grammar/objc.sablecc
@@ -121,10 +121,12 @@ Parser
         {instance:} '-';
 
     parameter =
-        {named:} [left:]term ':' lpar parameter_type rpar attribute? [right:]term |
+        {named:} [left:]term ':' parameter_type_in_par? attribute? [right:]term |
         {single:} term |
         {comma:} comma '...' |
         {macro:} macro_name;
+
+    parameter_type_in_par = lpar parameter_type rpar;
 
     parameter_type =
         {normal:} type |

--- a/contrib/objcwrapper/src/header_static.nit
+++ b/contrib/objcwrapper/src/header_static.nit
@@ -49,7 +49,10 @@ fun header_static(input: Reader, output: Writer) do
 
 	while not input.eof do
 		var line = input.read_line
-		if line.to_s.has("static") then static_target = true
+
+		if line.has("typedef struct") then continue
+
+		if line.has("static") then static_target = true
 
 		if static_target then
 			if line.to_s.has("__attribute__") then static_attribute_target = true

--- a/contrib/objcwrapper/src/objc_generator.nit
+++ b/contrib/objcwrapper/src/objc_generator.nit
@@ -67,6 +67,11 @@ redef class Sys
 	end
 end
 
+redef class ObjcModel
+	redef fun knows_type(objc_type) do return super or
+		nit_to_java_types.keys.has(objc_type)
+end
+
 # Wrapper generator
 class CodeGenerator
 

--- a/contrib/objcwrapper/src/objc_generator.nit
+++ b/contrib/objcwrapper/src/objc_generator.nit
@@ -59,6 +59,10 @@ redef class Sys
 		types["NSUInteger"] = "Int"
 		types["BOOL"] = "Bool"
 		types["id"] = "NSObject"
+		types["constid"] = "NSObject"
+		types["SEL"] = "NSObject"
+		types["void"] = "Pointer"
+
 		return types
 	end
 end

--- a/contrib/objcwrapper/src/objc_generator.nit
+++ b/contrib/objcwrapper/src/objc_generator.nit
@@ -63,10 +63,17 @@ redef class Sys
 	end
 end
 
+# Wrapper generator
 class CodeGenerator
+
+	# `ObjcModel` to wrap
+	var model: ObjcModel
+
 	# Generate Nit code to wrap `classes`
-	fun generate(classes: Array[ObjcClass])
+	fun generate
 	do
+		var classes = model.classes
+
 		# Open specified path or stdin
 		var file
 		var path = opt_output.value

--- a/contrib/objcwrapper/src/objc_generator.nit
+++ b/contrib/objcwrapper/src/objc_generator.nit
@@ -133,6 +133,7 @@ extern class {{{classe.name}}} in "ObjC" `{ {{{classe.name}}} * `}
 
 		# Methods
 		for method in classe.methods do
+			if not model.knows_all_types(method) then method.is_commented = true
 
 			if not opt_init_as_methods.value and method.is_init then continue
 
@@ -162,6 +163,8 @@ end
 		for method in classe.methods do
 			if not method.is_init then continue
 
+			if not model.knows_all_types(method) then method.is_commented = true
+
 			write_method_signature(method, file)
 
 				write_objc_init_call(classe.name, method, file)
@@ -170,6 +173,8 @@ end
 
 	private fun write_attribute(attribute: ObjcAttribute, file: Writer)
 	do
+		if not model.knows_type(attribute.return_type) then attribute.is_commented = true
+
 		write_attribute_getter(attribute, file)
 		# TODO write_attribute_setter if there is no `readonly` annotation
 	end

--- a/contrib/objcwrapper/src/objc_generator.nit
+++ b/contrib/objcwrapper/src/objc_generator.nit
@@ -42,7 +42,7 @@ redef class Sys
 		"Wrap `init...` constructors as Nit methods instead of Nit constructors",
 		"--init-as-methods")
 
-	private var nit_to_java_types: Map[String, String] is lazy do
+	private var objc_to_nit_types: Map[String, String] is lazy do
 		var types = new HashMap[String, String]
 		types["char"] = "Byte"
 		types["short"] = "Int"
@@ -69,7 +69,7 @@ end
 
 redef class ObjcModel
 	redef fun knows_type(objc_type) do return super or
-		nit_to_java_types.keys.has(objc_type)
+		objc_to_nit_types.keys.has(objc_type)
 end
 
 # Wrapper generator
@@ -182,7 +182,7 @@ end
 	private fun write_attribute_getter(attribute: ObjcAttribute, file: Writer)
 	do
 		var nit_attr_name = attribute.name.to_snake_case
-		var nit_attr_type = attribute.return_type.to_nit_type
+		var nit_attr_type = attribute.return_type.objc_to_nit_type
 
 		var c = attribute.comment_str
 
@@ -197,7 +197,7 @@ end
 	private fun write_attribute_setter(attribute: ObjcAttribute, file: Writer)
 	do
 		var nit_attr_name = attribute.name.to_snake_case
-		var nit_attr_type = attribute.return_type.to_nit_type
+		var nit_attr_type = attribute.return_type.objc_to_nit_type
 
 		var c = attribute.comment_str
 
@@ -232,7 +232,7 @@ end
 		var params = new Array[String]
 		for param in method.params do
 			if param.is_single then break
-			params.add "{param.variable_name}: {param.return_type.to_nit_type}"
+			params.add "{param.variable_name}: {param.return_type.objc_to_nit_type}"
 		end
 
 		var params_with_par = ""
@@ -241,7 +241,7 @@ end
 		# Return
 		var ret = ""
 		if method.return_type != "void" and fun_keyword != "new" then
-			ret = ": {method.return_type.to_nit_type}"
+			ret = ": {method.return_type.objc_to_nit_type}"
 		end
 
 		file.write """
@@ -295,9 +295,9 @@ end
 
 redef class Text
 	# Nit equivalent to this type
-	private fun to_nit_type: String
+	private fun objc_to_nit_type: String
 	do
-		var types = sys.nit_to_java_types
+		var types = sys.objc_to_nit_types
 
 		if types.has_key(self) then
 			return types[self]

--- a/contrib/objcwrapper/src/objc_model.nit
+++ b/contrib/objcwrapper/src/objc_model.nit
@@ -48,6 +48,9 @@ class ObjcMethod
 
 	# Return type as a `String`
 	var return_type: String is noinit, writable
+
+	# Does this method look like a constructor/method?
+	fun is_init: Bool do return params.first.name.has_prefix("init")
 end
 
 # Attribute of an `ObjcClass`

--- a/contrib/objcwrapper/src/objc_model.nit
+++ b/contrib/objcwrapper/src/objc_model.nit
@@ -19,6 +19,33 @@ module objc_model
 class ObjcModel
 	# All analyzed classes
 	var classes = new Array[ObjcClass]
+
+	# Is `objc_type` known by this model?
+	fun knows_type(objc_type: Text): Bool
+	do
+		for c in classes do
+			if c.name == objc_type then return true
+		end
+
+		return imported_types.has(objc_type)
+	end
+
+	# Are all types in the signature or `method` known by this model?
+	fun knows_all_types(method: ObjcMethod): Bool
+	do
+		for param in method.params do
+			if param.is_single then break
+			if not knows_type(param.return_type) then return false
+		end
+
+		var r = method.return_type
+		return r == "void" or r == "id" or knows_type(r)
+	end
+
+	# Objective-C types available in imported modules
+	#
+	# TODO seach in existing wrappers
+	private var imported_types: Array[String] = ["NSObject", "NSString"]
 end
 
 # Objective-C class

--- a/contrib/objcwrapper/src/objc_visitor.nit
+++ b/contrib/objcwrapper/src/objc_visitor.nit
@@ -167,7 +167,12 @@ redef class Nparameter_named
 		var param = new Param
 		param.variable_name = n_right.collect_text
 		param.name = n_left.collect_text
-		param.return_type = n_parameter_type.to_type
+
+		var n_type = n_parameter_type_in_par
+		param.return_type = if n_type != null then
+			n_type.n_parameter_type.to_type
+		else  "NSObject"
+
 		return param
 	end
 end

--- a/contrib/objcwrapper/src/objcwrapper.nit
+++ b/contrib/objcwrapper/src/objcwrapper.nit
@@ -41,7 +41,6 @@ Options:"""
 end
 
 var v = new ObjcVisitor
-var g = new CodeGenerator
 
 for arg in opts.rest do
 	# Read input
@@ -64,4 +63,5 @@ for arg in opts.rest do
 	v.enter_visit root
 end
 
-g.generate v.model.classes
+var g = new CodeGenerator(v.model)
+g.generate

--- a/contrib/objcwrapper/src/objcwrapper.nit
+++ b/contrib/objcwrapper/src/objcwrapper.nit
@@ -27,7 +27,7 @@ import objc_parser
 var opt_help = new OptionBool("Show this help message", "-h", "--help")
 
 var opts = new OptionContext
-opts.add_option(opt_help, opt_output)
+opts.add_option(opt_help, opt_output, opt_init_as_methods)
 opts.parse(args)
 
 if opts.errors.not_empty or opts.rest.is_empty or opt_help.value then


### PR DESCRIPTION
This PR continues the good work of #1661 by improving further the code generator of _objcwrapper_. The main change is the revamp of the code generator module, the detection of unknown types so they are not used in active methods, and improvements to the gammar and preprocessor to accept some GNUStep classes.

The generated code now passes nitpick but there is some problems with the generated Objective-C. Some types are not correctly reproduced. So it is not usable as of yet, but it is not too far.

The main limiting factors at this points are functions pointers used as parameters, the class hierarchy that is not duplicated and the Objective-C FFI not working on GNU/Linux.