### PR TITLE
Improve ini

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,3 @@
+Nit compiler and tools
+
+See <http://nitlanguage.org/tools> for usage.

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -446,7 +446,8 @@ redef class ModelBuilder
 		var mgroup
 		if parent == null then
 			# no parent, thus new project
-			if ini != null and ini.has_key("name") then pn = ini["name"]
+			var namekey = "project.name"
+			if ini != null and ini.has_key(namekey) then pn = ini[namekey]
 			var mproject = new MProject(pn, model)
 			mgroup = new MGroup(pn, mproject, null) # same name for the root group
 			mproject.root = mgroup

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -353,6 +353,13 @@ redef class ModelBuilder
 			mgroup.filepath = path
 			mproject.root = mgroup
 			toolcontext.info("found singleton project `{pn}` at {path}", 2)
+
+			# Attach homonymous `ini` file to the project
+			var inipath = path.dirname / "{pn}.ini"
+			if inipath.file_exists then
+				var ini = new ConfigTree(inipath)
+				mproject.ini = ini
+			end
 		end
 
 		var res = new ModulePath(pn, path, mgroup)

--- a/src/project.ini
+++ b/src/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=nitc
+tags=devel,cli
+author=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/src
+git=https://github.com/nitlang/nit.git
+git.directory=src
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues


### PR DESCRIPTION
Small improvements and fixes for the ini files.

The most important change is how to associate ini file with singleton projects (no dir, only one nit file).
The proposal, from @xymus, is just to add a `.ini` file named like the `.nit`. so `lib/counter.ini` for the project `lib/counter.nit`.

I'm not sure that this feature should be official, consider it just as an easy path to update existing code.