### PR TITLE
lib/ini: give to the user `null` on undefined keys

### DIFF
--- a/contrib/nitiwiki/src/wiki_base.nit
+++ b/contrib/nitiwiki/src/wiki_base.nit
@@ -616,8 +616,7 @@ class WikiConfig
 
 	# Returns the config value at `key` or return `default` if no key was found.
 	private fun value_or_default(key: String, default: String): String do
-		if not has_key(key) then return default
-		return self[key]
+		return self[key] or else default
 	end
 
 	# Site name displayed.

--- a/lib/ini.nit
+++ b/lib/ini.nit
@@ -41,41 +41,32 @@ class ConfigTree
 
 	# Get the config value for `key`
 	#
-	# REQUIRE: `has_key(key)`
-	#
 	#     var config = new ConfigTree("config.ini")
 	#     assert config["goo"] == "goo"
 	#     assert config["foo.bar"] == "foobar"
 	#     assert config["foo.baz"] == "foobaz"
-	fun [](key: String): String do
-		if not has_key(key) then
-			print "error: config key `{key}` not found"
-			abort
-		end
-		var node = get_node(key).as(not null)
-		if node.value == null then
-			print "error: config key `{key}` has no value"
-			abort
-		end
-		return node.value.as(not null)
+	#     assert config["fail.fail"] == null
+	fun [](key: String): nullable String do
+		var node = get_node(key)
+		if node == null then return null
+		return node.value
 	end
 
 	# Get the config values under `key`
-	#
-	# REQUIRE: `has_key(key)`
 	#
 	#     var config = new ConfigTree("config.ini")
 	#     var values = config.at("foo")
 	#     assert values.has_key("bar")
 	#     assert values.has_key("baz")
 	#     assert not values.has_key("goo")
-	fun at(key: String): Map[String, String] do
-		if not has_key(key) then
-			print "error: config key `{key}` not found"
-			abort
-		end
+	#
+	# Return null if the key does not exists.
+	#
+	#     assert config.at("fail.fail") == null
+	fun at(key: String): nullable Map[String, String] do
+		var node = get_node(key)
+		if node == null then return null
 		var map = new HashMap[String, String]
-		var node = get_node(key).as(not null)
 		for k, child in node.children do
 			if child.value == null then continue
 			map[k] = child.value.to_s
@@ -278,7 +269,7 @@ class ConfigTree
 	private fun get_node(key: String): nullable ConfigNode do
 		var parts = key.split(".").reversed
 		var node = get_root(parts.pop)
-		while not parts.is_empty do
+		while node != null and not parts.is_empty do
 			node = node.get_child(parts.pop)
 		end
 		return node

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -446,8 +446,7 @@ redef class ModelBuilder
 		var mgroup
 		if parent == null then
 			# no parent, thus new project
-			var namekey = "project.name"
-			if ini != null and ini.has_key(namekey) then pn = ini[namekey]
+			if ini != null then pn = ini["project.name"] or else pn
 			var mproject = new MProject(pn, model)
 			mgroup = new MGroup(pn, mproject, null) # same name for the root group
 			mproject.root = mgroup


### PR DESCRIPTION
Since the absence of a key is an ini file is an expected thing, I think it is better that the library return `null` instead of aborting.

This simplifies the library (and remove all aborts and cast on null).
This also simplify clients: a single call and use of advanced nullable features of Nit.