### PR TITLE
Ini of projects

### DIFF
--- a/contrib/benitlux/project.ini
+++ b/contrib/benitlux/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=benitlux
+tags=network
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/benitlux/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/benitlux/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/brainfuck/project.ini
+++ b/contrib/brainfuck/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=brainfuck
+tags=language
+maintainer=Lucas Bajolet <r4pass@hotmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/brainfuck/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/brainfuck/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/crazy_moles/project.ini
+++ b/contrib/crazy_moles/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=crazy_moles
+tags=game
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/crazy_moles/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/crazy_moles/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/friendz/project.ini
+++ b/contrib/friendz/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=friendz
+tags=game
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/friendz/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/friendz/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/github_merge.ini
+++ b/contrib/github_merge.ini
@@ -1,0 +1,11 @@
+[project]
+name=github_merge
+tags=cli
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/github_merge.nit
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/github_merge.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/github_search_for_jni/project.ini
+++ b/contrib/github_search_for_jni/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=github_search_for_jni
+tags=cli
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/github_search_for_jni/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/github_search_for_jni/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/header_keeper/project.ini
+++ b/contrib/header_keeper/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=header_keeper
+tags=devel,cli
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/header_keeper/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/header_keeper/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/inkscape_tools/project.ini
+++ b/contrib/inkscape_tools/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=inkscape_tools
+tags=devel,cli
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/inkscape_tools/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/inkscape_tools/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/jwrapper/project.ini
+++ b/contrib/jwrapper/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=jwrapper
+tags=java,devel,cli
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/jwrapper/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/jwrapper/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/mnit_test/project.ini
+++ b/contrib/mnit_test/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=mnit_test
+tags=
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/mnit_simple/
+git=https://github.com/nitlang/nit.git
+git.directory=examples/mnit_simple/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/neo_doxygen/project.ini
+++ b/contrib/neo_doxygen/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=neo_doxygen
+tags=devel,cli
+maintainer=Jean-Christophe Beaupré <jcbrinfo@users.noreply.github.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/neo_doxygen/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/neo_doxygen/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/nitcc/project.ini
+++ b/contrib/nitcc/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=nitcc
+tags=devel,cli
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/nitcc/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/nitcc/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/nitester/project.ini
+++ b/contrib/nitester/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=nitester
+tags=devel,cli
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/nitester/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/nitester/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/nitiwiki/project.ini
+++ b/contrib/nitiwiki/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=nitiwiki
+tags=web,cli
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/nitiwiki/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/nitiwiki/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/nitrpg/project.ini
+++ b/contrib/nitrpg/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=nitrpg
+tags=devel,web,cli
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/nitrpg/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/nitrpg/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/objcwrapper/project.ini
+++ b/contrib/objcwrapper/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=objcwrapper
+tags=devel,cli
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/objcwrapper/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/objcwrapper/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/online_ide/project.ini
+++ b/contrib/online_ide/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=online_ide
+tags=devel,web
+maintainer=Johan Kayser <johan.kayser@viacesi.fr>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/online_ide/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/online_ide/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/opportunity/project.ini
+++ b/contrib/opportunity/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=opportunity
+tags=web
+maintainer=Lucas Bajolet <r4pass@hotmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/opportunity/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/opportunity/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/pep8analysis/project.ini
+++ b/contrib/pep8analysis/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=pep8analysis
+tags=educ,web,cli
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/pep8analysis/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/pep8analysis/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/physical_interface_for_mpd_on_rpi/project.ini
+++ b/contrib/physical_interface_for_mpd_on_rpi/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=physical_interface_for_mpd_on_rpi
+tags=embedded,cli
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/physical_interface_for_mpd_on_rpi/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/physical_interface_for_mpd_on_rpi/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/refund/project.ini
+++ b/contrib/refund/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=refund
+tags=example,cli
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/refund/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/refund/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/rss_downloader/project.ini
+++ b/contrib/rss_downloader/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=rss_downloader
+tags=network,cli
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/rss_downloader/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/rss_downloader/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/simplan/project.ini
+++ b/contrib/simplan/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=simplan
+tags=ai,example,cli
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/simplan/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/simplan/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/sort_downloads/project.ini
+++ b/contrib/sort_downloads/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=sort_downloads
+tags=cli
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/sort_downloads/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/sort_downloads/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/tinks/project.ini
+++ b/contrib/tinks/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=tinks
+tags=game
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/tinks/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/tinks/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/tnitter/project.ini
+++ b/contrib/tnitter/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=tnitter
+tags=web
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/tnitter/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/tnitter/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/wiringPi/project.ini
+++ b/contrib/wiringPi/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=wiringPi
+tags=embedded,wrapper
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/wiringPi/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/wiringPi/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/calculator/project.ini
+++ b/examples/calculator/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=calculator
+tags=example
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/calculator/
+git=https://github.com/nitlang/nit.git
+git.directory=examples/calculator/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/circular_list.ini
+++ b/examples/circular_list.ini
@@ -1,0 +1,11 @@
+[project]
+name=circular_list
+tags=algo,example
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/circular_list.nit
+git=https://github.com/nitlang/nit.git
+git.directory=examples/circular_list.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/clock.ini
+++ b/examples/clock.ini
@@ -1,0 +1,11 @@
+[project]
+name=clock
+tags=example
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/clock.nit
+git=https://github.com/nitlang/nit.git
+git.directory=examples/clock.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/clock_more.ini
+++ b/examples/clock_more.ini
@@ -1,0 +1,11 @@
+[project]
+name=clock_more
+tags=example
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/clock_more.nit
+git=https://github.com/nitlang/nit.git
+git.directory=examples/clock_more.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/draw_operation.ini
+++ b/examples/draw_operation.ini
@@ -1,0 +1,11 @@
+[project]
+name=draw_operation
+tags=
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/draw_operation.nit
+git=https://github.com/nitlang/nit.git
+git.directory=examples/draw_operation.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/extern_methods.ini
+++ b/examples/extern_methods.ini
@@ -1,0 +1,11 @@
+[project]
+name=extern_methods
+tags=wrapper,example
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/extern_methods.nit
+git=https://github.com/nitlang/nit.git
+git.directory=examples/extern_methods.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/fibonacci.ini
+++ b/examples/fibonacci.ini
@@ -1,0 +1,11 @@
+[project]
+name=fibonacci
+tags=example
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/fibonacci.nit
+git=https://github.com/nitlang/nit.git
+git.directory=examples/fibonacci.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/hello_world.ini
+++ b/examples/hello_world.ini
@@ -1,0 +1,11 @@
+[project]
+name=hello_world
+tags=example
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/hello_world.nit
+git=https://github.com/nitlang/nit.git
+git.directory=examples/hello_world.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/int_stack.ini
+++ b/examples/int_stack.ini
@@ -1,0 +1,11 @@
+[project]
+name=int_stack
+tags=example
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/int_stack.nit
+git=https://github.com/nitlang/nit.git
+git.directory=examples/int_stack.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/leapfrog/project.ini
+++ b/examples/leapfrog/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=leapfrog
+tags=game,terminal
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/leapfrog/
+git=https://github.com/nitlang/nit.git
+git.directory=examples/leapfrog/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/mnit_ballz/project.ini
+++ b/examples/mnit_ballz/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=mnit_ballz
+tags=game
+maintainer=Romain Chanoir <romain.chanoir@viacesi.fr>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/mnit_ballz/
+git=https://github.com/nitlang/nit.git
+git.directory=examples/mnit_ballz/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/mnit_dino/project.ini
+++ b/examples/mnit_dino/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=mnit_dino
+tags=game
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/mnit_dino/
+git=https://github.com/nitlang/nit.git
+git.directory=examples/mnit_dino/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/montecarlo.ini
+++ b/examples/montecarlo.ini
@@ -1,0 +1,11 @@
+[project]
+name=montecarlo
+tags=example
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/montecarlo.nit
+git=https://github.com/nitlang/nit.git
+git.directory=examples/montecarlo.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/print_arguments.ini
+++ b/examples/print_arguments.ini
@@ -1,0 +1,11 @@
+[project]
+name=print_arguments
+tags=example
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/print_arguments.nit
+git=https://github.com/nitlang/nit.git
+git.directory=examples/print_arguments.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/procedural_array.ini
+++ b/examples/procedural_array.ini
@@ -1,0 +1,11 @@
+[project]
+name=procedural_array
+tags=example
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/procedural_array.nit
+git=https://github.com/nitlang/nit.git
+git.directory=examples/procedural_array.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/rosettacode/project.ini
+++ b/examples/rosettacode/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=rosettacode
+tags=example
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/rosettacode/
+git=https://github.com/nitlang/nit.git
+git.directory=examples/rosettacode/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/examples/shoot/project.ini
+++ b/examples/shoot/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=shoot
+tags=game
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/examples/shoot/
+git=https://github.com/nitlang/nit.git
+git.directory=examples/shoot/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/a_star.ini
+++ b/lib/a_star.ini
@@ -1,0 +1,11 @@
+[project]
+name=a_star
+tags=algo,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/a_star.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/a_star.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/ai/project.ini
+++ b/lib/ai/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=ai
+tags=ai,algo,lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/ai/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/ai/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/android/project.ini
+++ b/lib/android/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=android
+tags=platform,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/android/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/android/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/app/project.ini
+++ b/lib/app/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=app
+tags=lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/app/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/app/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/array_debug.ini
+++ b/lib/array_debug.ini
@@ -1,0 +1,11 @@
+[project]
+name=array_debug
+tags=debug,lib
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/array_debug.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/array_debug.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/base64.ini
+++ b/lib/base64.ini
@@ -1,0 +1,11 @@
+[project]
+name=base64
+tags=encoding,lib
+maintainer=Lucas Bajolet <r4pass@hotmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/base64.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/base64.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/bcm2835/project.ini
+++ b/lib/bcm2835/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=bcm2835
+tags=embedded,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/bcm2835/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/bcm2835/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/binary/project.ini
+++ b/lib/binary/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=binary
+tags=io,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/binary/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/binary/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/bitmap/project.ini
+++ b/lib/bitmap/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=bitmap
+tags=lib
+maintainer=Lucas Bajolet <r4pass@hotmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/bitmap/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/bitmap/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/bucketed_game.ini
+++ b/lib/bucketed_game.ini
@@ -1,0 +1,11 @@
+[project]
+name=bucketed_game
+tags=game,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/bucketed_game.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/bucketed_game.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/buffered_ropes.ini
+++ b/lib/buffered_ropes.ini
@@ -1,0 +1,11 @@
+[project]
+name=buffered_ropes
+tags=algo,text,lib
+maintainer=Lucas Bajolet <r4pass@hotmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/buffered_ropes.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/buffered_ropes.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/c.ini
+++ b/lib/c.ini
@@ -1,0 +1,11 @@
+[project]
+name=c
+tags=language,wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/c.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/c.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/cartesian.ini
+++ b/lib/cartesian.ini
@@ -1,0 +1,11 @@
+[project]
+name=cartesian
+tags=algo,lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/cartesian.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/cartesian.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/cocoa/project.ini
+++ b/lib/cocoa/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=cocoa
+tags=wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/cocoa/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/cocoa/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/combinations.ini
+++ b/lib/combinations.ini
@@ -1,0 +1,11 @@
+[project]
+name=combinations
+tags=algo,lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/combinations.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/combinations.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/console.ini
+++ b/lib/console.ini
@@ -1,0 +1,11 @@
+[project]
+name=console
+tags=terminal,lib
+maintainer=Jean-Christophe Beaupré <jcbrinfo@users.noreply.github.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/console.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/console.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/core/project.ini
+++ b/lib/core/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=core
+tags=lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/core
+git=https://github.com/nitlang/nit.git
+git.directory=lib/core
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/counter.ini
+++ b/lib/counter.ini
@@ -1,0 +1,11 @@
+[project]
+name=counter
+tags=algo,lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/counter.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/counter.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/cpp.ini
+++ b/lib/cpp.ini
@@ -1,0 +1,11 @@
+[project]
+name=cpp
+tags=language,wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/cpp.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/cpp.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/crypto.ini
+++ b/lib/crypto.ini
@@ -1,0 +1,11 @@
+[project]
+name=crypto
+tags=crypto,algo,lib
+maintainer=Lucas Bajolet <r4pass@hotmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/crypto.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/crypto.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/csv/project.ini
+++ b/lib/csv/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=csv
+tags=format,lib
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/csv/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/csv/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/curl/project.ini
+++ b/lib/curl/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=curl
+tags=network,wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/curl/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/curl/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/curses/project.ini
+++ b/lib/curses/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=curses
+tags=ui,terminal,wrapper,lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/curses/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/curses/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/date.ini
+++ b/lib/date.ini
@@ -1,0 +1,11 @@
+[project]
+name=date
+tags=lib
+maintainer=Mehdi Ait Younes <overpex@gmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/date.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/date.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/deriving.ini
+++ b/lib/deriving.ini
@@ -1,0 +1,11 @@
+[project]
+name=deriving
+tags=lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/deriving.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/deriving.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/dom/project.ini
+++ b/lib/dom/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=dom
+tags=xml,lib
+maintainer=Lucas Bajolet <r4pass@hotmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/dom/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/dom/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/dummy_array.ini
+++ b/lib/dummy_array.ini
@@ -1,0 +1,11 @@
+[project]
+name=dummy_array
+tags=algo,lib
+maintainer=Floréal Morandat <morandat@lirmm.fr>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/dummy_array.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/dummy_array.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/egl.ini
+++ b/lib/egl.ini
@@ -1,0 +1,11 @@
+[project]
+name=egl
+tags=graphics,wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/egl.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/egl.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/emscripten/project.ini
+++ b/lib/emscripten/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=emscripten
+tags=platform,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/emscripten
+git=https://github.com/nitlang/nit.git
+git.directory=lib/emscripten
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/filter_stream.ini
+++ b/lib/filter_stream.ini
@@ -1,0 +1,11 @@
+[project]
+name=filter_stream
+tags=io,lib
+maintainer=Floréal Morandat <morandat@lirmm.fr>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/filter_stream.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/filter_stream.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/for_abuse.ini
+++ b/lib/for_abuse.ini
@@ -1,0 +1,11 @@
+[project]
+name=for_abuse
+tags=algo,lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/for_abuse.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/for_abuse.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/gamnit/project.ini
+++ b/lib/gamnit/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=gamnit
+tags=game,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/gamnit/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/gamnit/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/geometry/project.ini
+++ b/lib/geometry/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=geometry
+tags=algo,lib
+maintainer=Romain Chanoir <romain.chanoir@viacesi.fr>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/geometry/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/geometry/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/gettext/project.ini
+++ b/lib/gettext/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=gettext
+tags=i18n,lib
+maintainer=Lucas Bajolet <r4pass@hotmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/gettext
+git=https://github.com/nitlang/nit.git
+git.directory=lib/gettext
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/github/project.ini
+++ b/lib/github/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=github
+tags=web,lib
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/github/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/github/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/glesv2/project.ini
+++ b/lib/glesv2/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=glesv2
+tags=graphics,wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/glesv2/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/glesv2/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/graphs/project.ini
+++ b/lib/graphs/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=graphs
+tags=algo,lib
+maintainer=Alexandre Blondin Massé <alexandre.blondin.masse@gmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/graphs/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/graphs/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/gtk/project.ini
+++ b/lib/gtk/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=gtk
+tags=ui,wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/gtk/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/gtk/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/hash_debug.ini
+++ b/lib/hash_debug.ini
@@ -1,0 +1,11 @@
+[project]
+name=hash_debug
+tags=debug,lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/hash_debug.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/hash_debug.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/html/project.ini
+++ b/lib/html/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=html
+tags=format,lib
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/html/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/html/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/ini.ini
+++ b/lib/ini.ini
@@ -1,0 +1,11 @@
+[project]
+name=ini
+tags=format,lib
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/ini.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/ini.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/ios/project.ini
+++ b/lib/ios/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=ios
+tags=wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/ios/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/ios/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/java/project.ini
+++ b/lib/java/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=java
+tags=java,wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/java/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/java/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/json/project.ini
+++ b/lib/json/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=json
+tags=format,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/json/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/json/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/jvm.ini
+++ b/lib/jvm.ini
@@ -1,0 +1,11 @@
+[project]
+name=jvm
+tags=java,wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/jvm.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/jvm.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/libevent.ini
+++ b/lib/libevent.ini
@@ -1,0 +1,11 @@
+[project]
+name=libevent
+tags=wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/libevent.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/libevent.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/linux/project.ini
+++ b/lib/linux/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=linux
+tags=lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/linux/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/linux/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/markdown/project.ini
+++ b/lib/markdown/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=markdown
+tags=format,lib
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/markdown/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/markdown/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/md5.ini
+++ b/lib/md5.ini
@@ -1,0 +1,11 @@
+[project]
+name=md5
+tags=encoding,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/md5.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/md5.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/meta.ini
+++ b/lib/meta.ini
@@ -1,0 +1,11 @@
+[project]
+name=meta
+tags=lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/meta.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/meta.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/mnit/project.ini
+++ b/lib/mnit/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=mnit
+tags=lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/mnit/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/mnit/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/mongodb/project.ini
+++ b/lib/mongodb/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=mongodb
+tags=database,lib
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/mongodb/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/mongodb/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/more_collections.ini
+++ b/lib/more_collections.ini
@@ -1,0 +1,11 @@
+[project]
+name=more_collections
+tags=algo,lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/more_collections.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/more_collections.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/mpd.ini
+++ b/lib/mpd.ini
@@ -1,0 +1,11 @@
+[project]
+name=mpd
+tags=sound,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/mpd.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/mpd.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/mpi/project.ini
+++ b/lib/mpi/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=mpi
+tags=parallelism,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/mpi
+git=https://github.com/nitlang/nit.git
+git.directory=lib/mpi
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/neo4j/project.ini
+++ b/lib/neo4j/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=neo4j
+tags=database,lib
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/neo4j/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/neo4j/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/nitcc_runtime.ini
+++ b/lib/nitcc_runtime.ini
@@ -1,0 +1,11 @@
+[project]
+name=nitcc_runtime
+tags=lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/nitcc_runtime.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/nitcc_runtime.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/nitcorn/project.ini
+++ b/lib/nitcorn/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=nitcorn
+tags=network,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/nitcorn/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/nitcorn/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/niti_runtime.ini
+++ b/lib/niti_runtime.ini
@@ -1,0 +1,11 @@
+[project]
+name=niti_runtime
+tags=lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/niti_runtime.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/niti_runtime.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/noise.ini
+++ b/lib/noise.ini
@@ -1,0 +1,11 @@
+[project]
+name=noise
+tags=algo,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/noise.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/noise.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/opts.ini
+++ b/lib/opts.ini
@@ -1,0 +1,11 @@
+[project]
+name=opts
+tags=cli,lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/opts.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/opts.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/ordered_tree.ini
+++ b/lib/ordered_tree.ini
@@ -1,0 +1,11 @@
+[project]
+name=ordered_tree
+tags=algo,lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/ordered_tree.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/ordered_tree.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/parser_base.ini
+++ b/lib/parser_base.ini
@@ -1,0 +1,11 @@
+[project]
+name=parser_base
+tags=format,lib
+maintainer=Lucas Bajolet <r4pass@hotmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/parser_base.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/parser_base.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/perfect_hashing.ini
+++ b/lib/perfect_hashing.ini
@@ -1,0 +1,11 @@
+[project]
+name=perfect_hashing
+tags=algo,lib
+maintainer=Julien Pagès <julien.projet@gmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/perfect_hashing.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/perfect_hashing.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/performance_analysis.ini
+++ b/lib/performance_analysis.ini
@@ -1,0 +1,11 @@
+[project]
+name=performance_analysis
+tags=debug,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/performance_analysis.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/performance_analysis.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/pipeline.ini
+++ b/lib/pipeline.ini
@@ -1,0 +1,11 @@
+[project]
+name=pipeline
+tags=algo,lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/pipeline.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/pipeline.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/pnacl/project.ini
+++ b/lib/pnacl/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=pnacl
+tags=platform,lib
+maintainer=Johan Kayser <johan.kayser@viacesi.fr>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/pnacl
+git=https://github.com/nitlang/nit.git
+git.directory=lib/pnacl
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/poset.ini
+++ b/lib/poset.ini
@@ -1,0 +1,11 @@
+[project]
+name=poset
+tags=algo,lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/poset.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/poset.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/posix_ext.ini
+++ b/lib/posix_ext.ini
@@ -1,0 +1,11 @@
+[project]
+name=posix_ext
+tags=wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/posix_ext.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/posix_ext.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/privileges/project.ini
+++ b/lib/privileges/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=privileges
+tags=lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/privileges/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/privileges/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/progression.ini
+++ b/lib/progression.ini
@@ -1,0 +1,11 @@
+[project]
+name=progression
+tags=lib
+maintainer=Jean-Christophe Beaupré <jcbrinfo@users.noreply.github.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/progression.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/progression.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/pthreads/project.ini
+++ b/lib/pthreads/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=pthreads
+tags=parallelism,wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/pthreads/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/pthreads/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/realtime.ini
+++ b/lib/realtime.ini
@@ -1,0 +1,11 @@
+[project]
+name=realtime
+tags=lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/realtime.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/realtime.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/ropes_debug.ini
+++ b/lib/ropes_debug.ini
@@ -1,0 +1,11 @@
+[project]
+name=ropes_debug
+tags=debug,lib
+maintainer=Lucas Bajolet <r4pass@hotmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/ropes_debug.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/ropes_debug.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/sax/project.ini
+++ b/lib/sax/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=sax
+tags=xml,format,lib
+maintainer=Jean-Christophe Beaupré <jcbrinfo@users.noreply.github.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/sax/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/sax/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/saxophonit/project.ini
+++ b/lib/saxophonit/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=saxophonit
+tags=xml,format,lib
+maintainer=Jean-Christophe Beaupré <jcbrinfo@users.noreply.github.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/saxophonit/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/saxophonit/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/scene2d.ini
+++ b/lib/scene2d.ini
@@ -1,0 +1,11 @@
+[project]
+name=scene2d
+tags=game,lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/scene2d.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/scene2d.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/sdl.ini
+++ b/lib/sdl.ini
@@ -1,0 +1,11 @@
+[project]
+name=sdl
+tags=graphics,wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/sdl.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/sdl.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/sdl2/project.ini
+++ b/lib/sdl2/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=sdl2
+tags=graphics,wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/sdl2/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/sdl2/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/sendmail.ini
+++ b/lib/sendmail.ini
@@ -1,0 +1,11 @@
+[project]
+name=sendmail
+tags=network,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/sendmail.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/sendmail.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/serialization/project.ini
+++ b/lib/serialization/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=serialization
+tags=lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/serialization/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/serialization/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/sexp.ini
+++ b/lib/sexp.ini
@@ -1,0 +1,11 @@
+[project]
+name=sexp
+tags=format,lib
+maintainer=Lucas Bajolet <r4pass@hotmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/sexp.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/sexp.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/sha1.ini
+++ b/lib/sha1.ini
@@ -1,0 +1,11 @@
+[project]
+name=sha1
+tags=encoding,lib
+maintainer=Lucas Bajolet <r4pass@hotmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/sha1.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/sha1.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/signals.ini
+++ b/lib/signals.ini
@@ -1,0 +1,11 @@
+[project]
+name=signals
+tags=wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/signals.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/signals.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/socket/project.ini
+++ b/lib/socket/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=socket
+tags=network,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/socket/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/socket/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/sqlite3/project.ini
+++ b/lib/sqlite3/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=sqlite3
+tags=database,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/sqlite3/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/sqlite3/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/standard.ini
+++ b/lib/standard.ini
@@ -1,0 +1,11 @@
+[project]
+name=standard
+tags=lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/standard.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/standard.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/symbol.ini
+++ b/lib/symbol.ini
@@ -1,0 +1,11 @@
+[project]
+name=symbol
+tags=lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/symbol.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/symbol.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/template/project.ini
+++ b/lib/template/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=template
+tags=lib
+maintainer=Jean Privat <jean@pryen.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/template/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/template/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/test_suite.ini
+++ b/lib/test_suite.ini
@@ -1,0 +1,11 @@
+[project]
+name=test_suite
+tags=devel,lib
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/test_suite.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/test_suite.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/trees/project.ini
+++ b/lib/trees/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=trees
+tags=algo,lib
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/trees/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/trees/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/websocket/project.ini
+++ b/lib/websocket/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=websocket
+tags=network,lib
+maintainer=Lucas Bajolet <r4pass@hotmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/websocket/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/websocket/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/x11.ini
+++ b/lib/x11.ini
@@ -1,0 +1,11 @@
+[project]
+name=x11
+tags=ui,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/x11.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/x11.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/xdg_basedir/project.ini
+++ b/lib/xdg_basedir/project.ini
@@ -1,0 +1,11 @@
+[project]
+name=xdg_basedir
+tags=wrapper,lib
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/xdg_basedir/
+git=https://github.com/nitlang/nit.git
+git.directory=lib/xdg_basedir/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/src/project.ini
+++ b/src/project.ini
@@ -1,7 +1,7 @@
 [project]
 name=nitc
 tags=devel,cli
-author=Jean Privat <jean@pryen.org>
+maintainer=Jean Privat <jean@pryen.org>
 license=Apache-2.0
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/src


### PR DESCRIPTION
Now that projects can have metadata, let's just provide them.

Commits are grouped by maintainer and directory so that selfish maintainers can review only their.

Fell free to propose better tagging or metadata. See #1655 and http://nitlanguage.org/nep/project_metadata.html for current state of the discussion.

Note that the proof on concept of a catalog is available at http://nitlanguage.org/catalog