### PR TITLE
mailmap: add Mehdi Ait Younes and Hervé Matysiak

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -26,3 +26,7 @@ Clement de Figueiredo <clement.defigueiredo@gmail.com>
 Christophe Gigax <christophe.gigax@viacesi.fr>
 
 Julien Pagès <julien.projet@gmail.com>
+
+Mehdi Ait Younes <overpex@gmail.com>
+
+Hervé Matysiak <herve.matysiak@viacesi.fr>


### PR DESCRIPTION
Because the result of `git shortlog` was not OCD-compliant enough.