### PR TITLE
Benitlux mailing list: nicer and differentiate between streets

### DIFF
--- a/contrib/benitlux/src/benitlux_daily.nit
+++ b/contrib/benitlux/src/benitlux_daily.nit
@@ -189,6 +189,8 @@ To unsubscribe, go to <a href="{{{unsub_link}}}">{{{unsub_link}}}</a>
 			var mail = new Mail("Benitlux <benitlux@xymus.net>", email_title, content)
 			mail.to.add email
 			mail.header["Content-Type"] = "text/html; charset=\"UTF-8\""
+			mail.header["List-Unsubscribe"] = unsub_link
+			mail.header["Precedence"] = "bulk"
 			mail.encrypt_with_base64
 
 			mail.send

--- a/contrib/benitlux/src/benitlux_daily.nit
+++ b/contrib/benitlux/src/benitlux_daily.nit
@@ -171,7 +171,7 @@ class Benitlux
 	# Generate email and fill the attributes `email_content` and `email_title`
 	fun generate_email(beer_events: BeerEvents)
 	do
-		email_title = beer_events.to_email_title
+		email_title = "Benitlux {street.capitalized}{beer_events.to_email_title}"
 		email_content = beer_events.to_email_content
 	end
 

--- a/contrib/benitlux/src/benitlux_model.nit
+++ b/contrib/benitlux/src/benitlux_model.nit
@@ -71,16 +71,14 @@ class BeerEvents
 	# Get a pretty and short version of `self`
 	fun to_email_title: String
 	do
-		var title = "Benelux Beer Menu"
-
 		# New beers
 		var new_beers_name = new Array[String]
 		for beer in self.new_beers do new_beers_name.add beer.name
 
 		if not new_beers_name.is_empty then
-			title += " (+ {new_beers_name.join(", ")})"
+			return " (+ {new_beers_name.join(", ")})"
 		end
 
-		return title
+		return ""
 	end
 end


### PR DESCRIPTION
This is an ongoing effort to please GMail and the likes, so Benitlux emails are no longer sent to the spam folder. Which is vital to keep @R4PaSs happy, hydrated and productive.

This PR adds headers to the email to make it clear that it is a mailing list and to guide the assisted unsubscribe option. Specifying the street name will help differentiate between the emails from the two mailing lists. (One of which is not exposed on the website, it is available on request only.)

I've also added DKIM (to the existing SPF) as server identification, it should help a lot too.