### PR TITLE
Optimized use of escape_to_c

### DIFF
--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -599,8 +599,6 @@ abstract class Text
 				b.append("\\n")
 			else if c == '\t' then
 				b.append("\\t")
-			else if c == '\0' then
-				b.append("\\000")
 			else if c == '"' then
 				b.append("\\\"")
 			else if c == '\'' then


### PR DESCRIPTION
All is in the title, @privat noticed me this morning that text::escape_to_c was taking around 4% of the time in nitc, taking the runtime to 15.183 GIr according to Valgrind.

By shortcutting all Unicode-related services since the C-side escaping is done on ASCII-sequences only and UTF-8 cannot contain invalid C sequences, the gain is substantial, one run of nitc is now done in 14.580 GIr, a gain of 600+ MIr (around 4%, what a coincidence !).