### PR TITLE
lib/opts: accept non-conflicting parameters for OptionString and rename get_errors to errors

### DIFF
--- a/contrib/neo_doxygen/src/neo_doxygen.nit
+++ b/contrib/neo_doxygen/src/neo_doxygen.nit
@@ -199,7 +199,7 @@ class NeoDoxygenCommand
 		end
 		option_context.parse(args)
 
-		var errors = option_context.get_errors
+		var errors = option_context.errors
 		var rest = option_context.rest
 
 		if errors.is_empty and not opt_help.value and rest.length != 2 then

--- a/lib/opts.nit
+++ b/lib/opts.nit
@@ -281,7 +281,7 @@ class OptionContext
 	var rest = new Array[String]
 
 	# Errors found in the context after parsing
-	var errors = new Array[String]
+	var context_errors = new Array[String]
 
 	private var optmap = new HashMap[String, Option]
 
@@ -372,7 +372,7 @@ class OptionContext
 
 		for opt in options do
 			if opt.mandatory and not opt.read then
-				errors.add("Mandatory option {opt.names.join(", ")} not found.")
+				context_errors.add("Mandatory option {opt.names.join(", ")} not found.")
 			end
 		end
 	end
@@ -387,10 +387,10 @@ class OptionContext
 	end
 
 	# Options parsing errors.
-	fun get_errors: Array[String]
+	fun errors: Array[String]
 	do
 		var errors = new Array[String]
-		errors.add_all(errors)
+		errors.add_all context_errors
 		for o in options do
 			for e in o.errors do
 				errors.add(e)

--- a/src/toolcontext.nit
+++ b/src/toolcontext.nit
@@ -469,7 +469,7 @@ The Nit language documentation and the source code of its tools and libraries ma
 			exit 0
 		end
 
-		var errors = option_context.get_errors
+		var errors = option_context.errors
 		if not errors.is_empty then
 			for e in errors do print "Error: {e}"
 			print tooldescription

--- a/tests/sav/test_opts_args4.res
+++ b/tests/sav/test_opts_args4.res
@@ -1,6 +1,8 @@
 Arguments: 1
 -s
 Rest: 0
+Errors: 1
+Parameter expected for option -s.
 OptionBool: false
 OptionCount: 0
 OptionString: 

--- a/tests/sav/test_opts_args6.res
+++ b/tests/sav/test_opts_args6.res
@@ -1,6 +1,8 @@
 Arguments: 1
 -a
 Rest: 0
+Errors: 1
+Parameter expected for option -a.
 OptionBool: false
 OptionCount: 0
 OptionString: 

--- a/tests/sav/test_opts_args7.res
+++ b/tests/sav/test_opts_args7.res
@@ -2,6 +2,9 @@ Arguments: 2
 -e
 1
 Rest: 0
+Errors: 1
+Unrecognized value for option -e, --enum.
+Expected values are: zero, one, two, tree.
 OptionBool: false
 OptionCount: 0
 OptionString: 

--- a/tests/sav/test_opts_args9.res
+++ b/tests/sav/test_opts_args9.res
@@ -1,0 +1,10 @@
+Arguments: 2
+-s
+-z
+Rest: 0
+OptionBool: false
+OptionCount: 0
+OptionString: -z
+OptionInt: 10
+OptionArray: []
+OptionEnum: 1

--- a/tests/test_opts.args
+++ b/tests/test_opts.args
@@ -6,3 +6,4 @@ args --bool args -- args -c
 -a
 -e 1
 -bcc
+-s -z

--- a/tests/test_opts.nit
+++ b/tests/test_opts.nit
@@ -36,6 +36,12 @@ for x in ctx.rest do
 	print x
 end
 
+var errors = ctx.errors
+if errors.not_empty then
+	print "Errors: {errors.length}"
+	print ctx.errors.join("\n")
+end
+
 print "OptionBool: {ob.value}"
 print "OptionCount: {oc.value}"
 if os.value == null then os.value = ""


### PR DESCRIPTION
`OptionString` reads the next argument to be used as its parameter. However, to detect errors it did not read parameter beginning with `-`. This PR changes this behavior to only avoid parameters that are the name of a known option in the current `OptionContext`. This should report real errors and accept parameters beginning with `-`, such parameter are useful to forward options to subprograms.

Renaming `OptionContext::get_errors` to `errors` assign the short name to the most commonly used property. `errors` was previously reserved for errors local to the context only. From the Nit repo, only 2 projects correctly used `get_errors`, 8 wrongfully used `errors` and thus did not catch all errors.