### PR TITLE
contrib/inkscape_tools: use Tinks! art instead of Dino's to test args

### DIFF
--- a/contrib/inkscape_tools/.gitignore
+++ b/contrib/inkscape_tools/.gitignore
@@ -2,4 +2,4 @@ tests/app/assets/
 tests/app/bin/
 tests/app/res2/
 tests/app/src/drawing.nit
-tests/dino/
+tests/tinks/

--- a/contrib/inkscape_tools/Makefile
+++ b/contrib/inkscape_tools/Makefile
@@ -2,13 +2,13 @@ all:
 	mkdir -p bin
 	../../bin/nitc --dir bin src/svg_to_png_and_nit.nit src/svg_to_icons.nit
 
-check: test-dino test-app
+check: test-tinks test-app
 
 test-app: bin/svg_to_png_and_nit
 	make -C tests/app
 
-test-dino: bin/svg_to_png_and_nit
-	mkdir -p tests/dino/images
-	bin/svg_to_png_and_nit --assets tests/dino/ --src tests/dino/ ../../examples/mnit_dino/art/drawing.svg
+test-tinks: bin/svg_to_png_and_nit
+	mkdir -p tests/tinks/images
+	bin/svg_to_png_and_nit --assets tests/tinks/ --src tests/tinks/ ../tinks/art/drawing.svg
 
 .PHONY: bin/svg_to_png_and_nit


### PR DESCRIPTION
Fix #1657, it was actually the test that was broken as the SVG source file is designed for the bash script that preceded inkscape_tools and not inkscape_tools itself (see examples/mnit_dino/tools/). This PR use Tinks! art instead of Dino's. It was already tested by the Tinks! project but here we use it to test the program arguments.