### PR TITLE
Better nitcc

### DIFF
--- a/contrib/nitcc/src/autom.nit
+++ b/contrib/nitcc/src/autom.nit
@@ -667,12 +667,10 @@ private class DFAGenerator
 		add("\tredef fun start_state do return dfastate_{names[automaton.start]}\n")
 		add("end\n")
 
-		add("redef class Object\n")
 		for s in automaton.states do
 			var n = names[s]
-			add("\tprivate fun dfastate_{n}: DFAState{n} do return once new DFAState{n}\n")
+			add("private fun dfastate_{n}: DFAState{n} do return once new DFAState{n}\n")
 		end
-		add("end\n")
 
 		add("class MyNToken\n")
 		add("\tsuper NToken\n")

--- a/contrib/nitcc/src/grammar.nit
+++ b/contrib/nitcc/src/grammar.nit
@@ -648,14 +648,12 @@ private class Generator
 		add "\tredef fun start_state do return state_{states.first.cname}"
 		add "end"
 		
-		add "redef class Object"
 		for s in states do
-			add "\tprivate fun state_{s.cname}: LRState{s.cname} do return once new LRState{s.cname}"
+			add "private fun state_{s.cname}: LRState{s.cname} do return once new LRState{s.cname}"
 		end
 		for p in gram.prods do
-			add "\tprivate fun goto_{p.cname}: Goto_{p.cname} do return once new Goto_{p.cname}"
+			add "private fun goto_{p.cname}: Goto_{p.cname} do return once new Goto_{p.cname}"
 		end
-		add "end"
 
 		add "redef class NToken"
 		for s in states do

--- a/contrib/nitcc/src/grammar.nit
+++ b/contrib/nitcc/src/grammar.nit
@@ -995,6 +995,8 @@ class LRState
 				abort
 			end
 		end
+		# Token to remove as reduction guard to solve S/R conflicts
+		var removed_reduces = new Array[Token]
 		for t, a in guarded_reduce do
 			if a.length > 1 then
 				print "REDUCE/REDUCE Conflict on state {self.number} {self.name} for token {t}:"
@@ -1031,13 +1033,16 @@ class LRState
 					print "Automatic Dangling on state {self.number} {self.name} for token {t}:"
 					print "\treduce: {ri}"
 					for r in ress do print r
-					guarded_reduce.keys.remove(t)
+					removed_reduces.add t
 				else
 					print "SHIFT/REDUCE Conflict on state {self.number} {self.name} for token {t}:"
 					print "\treduce: {ri}"
 					for i in guarded_shift[t] do print "\tshift:  {i}"
 				end
 			end
+		end
+		for t in removed_reduces do
+			guarded_reduce.keys.remove(t)
 		end
 	end
 

--- a/contrib/nitcc/src/grammar.nit
+++ b/contrib/nitcc/src/grammar.nit
@@ -1045,6 +1045,7 @@ class LRState
 		end
 		for t in removed_reduces do
 			guarded_reduce.keys.remove(t)
+			t.reduces.remove(self)
 		end
 	end
 

--- a/contrib/nitcc/src/grammar.nit
+++ b/contrib/nitcc/src/grammar.nit
@@ -653,6 +653,11 @@ private class Generator
 		end
 		for p in gram.prods do
 			add "private fun goto_{p.cname}: Goto_{p.cname} do return once new Goto_{p.cname}"
+			for a in p.alts do
+				add "private fun reduce_{a.cname}(parser: Parser) do"
+				gen_reduce_to_nit(a)
+				add "end"
+			end
 		end
 
 		add "redef class NToken"
@@ -664,7 +669,8 @@ private class Generator
 			if s.reduces.length != 1 then
 				add "\t\tparser.parse_error"
 			else
-				gen_reduce_to_nit(s.reduces.first)
+				add "\t\treduce_{s.reduces.first.cname}(parser)"
+				#gen_reduce_to_nit(s.reduces.first)
 			end
 			add "\tend"
 		end
@@ -687,7 +693,8 @@ private class Generator
 				if not s.need_guard then continue
 				if s.reduces.length <= 1 then continue
 				add "\tredef fun action_s{s.cname}(parser) do"
-				gen_reduce_to_nit(s.guarded_reduce[t].first.alt)
+				add "\t\treduce_{s.guarded_reduce[t].first.alt.cname}(parser)"
+				#gen_reduce_to_nit(s.guarded_reduce[t].first.alt)
 				add "\tend"
 			end
 			add "\tredef fun node_name do return \"{t.name.escape_to_nit}\""
@@ -783,7 +790,8 @@ private class Generator
 			if s.need_guard then
 				add "\t\tparser.peek_token.action_s{s.cname}(parser)"
 			else if s.reduces.length == 1 then
-				gen_reduce_to_nit(s.reduces.first)
+				add "\t\treduce_{s.reduces.first.cname}(parser)"
+				#gen_reduce_to_nit(s.reduces.first)
 			else
 				abort
 			end

--- a/contrib/nitcc/src/grammar.nit
+++ b/contrib/nitcc/src/grammar.nit
@@ -1038,6 +1038,7 @@ class LRState
 					print "SHIFT/REDUCE Conflict on state {self.number} {self.name} for token {t}:"
 					print "\treduce: {ri}"
 					for i in guarded_shift[t] do print "\tshift:  {i}"
+					removed_reduces.add t
 				end
 			end
 		end

--- a/contrib/nitcc/src/grammar.nit
+++ b/contrib/nitcc/src/grammar.nit
@@ -1009,6 +1009,7 @@ class LRState
 			if a.length > 1 then
 				print "REDUCE/REDUCE Conflict on state {self.number} {self.name} for token {t}:"
 				for i in a do print "\treduce: {i}"
+				conflicting_items.add_all a
 			end
 			if guarded_shift.has_key(t) then
 				var ri = a.first
@@ -1048,6 +1049,8 @@ class LRState
 					print "\treduce: {ri}"
 					for i in guarded_shift[t] do print "\tshift:  {i}"
 					removed_reduces.add t
+					conflicting_items.add_all a
+					conflicting_items.add_all guarded_shift[t]
 				end
 			end
 		end
@@ -1056,6 +1059,11 @@ class LRState
 			t.reduces.remove(self)
 		end
 	end
+
+	# Items within a reduce/reduce or a shift/reduce conflict.
+	#
+	# Is computed by `analysis`
+	var conflicting_items = new ArraySet[Item]
 
 	# Return `i` and all other items of the state that expands, directly or indirectly, to `i`
 	fun back_expand(i: Item): Set[Item]

--- a/contrib/nitcc/src/grammar.nit
+++ b/contrib/nitcc/src/grammar.nit
@@ -1001,7 +1001,8 @@ class LRState
 			if a.length > 1 then
 				print "REDUCE/REDUCE Conflict on state {self.number} {self.name} for token {t}:"
 				for i in a do print "\treduce: {i}"
-			else if guarded_shift.has_key(t) then
+			end
+			if guarded_shift.has_key(t) then
 				var ri = a.first
 				var confs = new Array[Item]
 				var ress = new Array[String]

--- a/contrib/nitcc/src/nitcc.nit
+++ b/contrib/nitcc/src/nitcc.nit
@@ -72,8 +72,8 @@ end
 var lr = gram.lr0
 
 var conflitcs = new ArraySet[Production]
-for s in lr.states do for t, a in s.guarded_reduce do if a.length > 1 or s.guarded_shift.has_key(t) then
-	for i in a do conflitcs.add(i.alt.prod)
+for s in lr.states do
+	for i in s.conflicting_items do conflitcs.add(i.alt.prod)
 end
 
 if not conflitcs.is_empty then

--- a/lib/json/json_lexer.nit
+++ b/lib/json/json_lexer.nit
@@ -6,43 +6,41 @@ class Lexer_json
 	super Lexer
 	redef fun start_state do return dfastate_0
 end
-redef class Object
-	private fun dfastate_0: DFAState0 do return once new DFAState0
-	private fun dfastate_1: DFAState1 do return once new DFAState1
-	private fun dfastate_2: DFAState2 do return once new DFAState2
-	private fun dfastate_3: DFAState3 do return once new DFAState3
-	private fun dfastate_4: DFAState4 do return once new DFAState4
-	private fun dfastate_5: DFAState5 do return once new DFAState5
-	private fun dfastate_6: DFAState6 do return once new DFAState6
-	private fun dfastate_7: DFAState7 do return once new DFAState7
-	private fun dfastate_8: DFAState8 do return once new DFAState8
-	private fun dfastate_9: DFAState9 do return once new DFAState9
-	private fun dfastate_10: DFAState10 do return once new DFAState10
-	private fun dfastate_11: DFAState11 do return once new DFAState11
-	private fun dfastate_12: DFAState12 do return once new DFAState12
-	private fun dfastate_13: DFAState13 do return once new DFAState13
-	private fun dfastate_14: DFAState14 do return once new DFAState14
-	private fun dfastate_15: DFAState15 do return once new DFAState15
-	private fun dfastate_16: DFAState16 do return once new DFAState16
-	private fun dfastate_17: DFAState17 do return once new DFAState17
-	private fun dfastate_18: DFAState18 do return once new DFAState18
-	private fun dfastate_19: DFAState19 do return once new DFAState19
-	private fun dfastate_20: DFAState20 do return once new DFAState20
-	private fun dfastate_21: DFAState21 do return once new DFAState21
-	private fun dfastate_22: DFAState22 do return once new DFAState22
-	private fun dfastate_23: DFAState23 do return once new DFAState23
-	private fun dfastate_24: DFAState24 do return once new DFAState24
-	private fun dfastate_25: DFAState25 do return once new DFAState25
-	private fun dfastate_26: DFAState26 do return once new DFAState26
-	private fun dfastate_27: DFAState27 do return once new DFAState27
-	private fun dfastate_28: DFAState28 do return once new DFAState28
-	private fun dfastate_29: DFAState29 do return once new DFAState29
-	private fun dfastate_30: DFAState30 do return once new DFAState30
-	private fun dfastate_31: DFAState31 do return once new DFAState31
-	private fun dfastate_32: DFAState32 do return once new DFAState32
-	private fun dfastate_33: DFAState33 do return once new DFAState33
-	private fun dfastate_34: DFAState34 do return once new DFAState34
-end
+private fun dfastate_0: DFAState0 do return once new DFAState0
+private fun dfastate_1: DFAState1 do return once new DFAState1
+private fun dfastate_2: DFAState2 do return once new DFAState2
+private fun dfastate_3: DFAState3 do return once new DFAState3
+private fun dfastate_4: DFAState4 do return once new DFAState4
+private fun dfastate_5: DFAState5 do return once new DFAState5
+private fun dfastate_6: DFAState6 do return once new DFAState6
+private fun dfastate_7: DFAState7 do return once new DFAState7
+private fun dfastate_8: DFAState8 do return once new DFAState8
+private fun dfastate_9: DFAState9 do return once new DFAState9
+private fun dfastate_10: DFAState10 do return once new DFAState10
+private fun dfastate_11: DFAState11 do return once new DFAState11
+private fun dfastate_12: DFAState12 do return once new DFAState12
+private fun dfastate_13: DFAState13 do return once new DFAState13
+private fun dfastate_14: DFAState14 do return once new DFAState14
+private fun dfastate_15: DFAState15 do return once new DFAState15
+private fun dfastate_16: DFAState16 do return once new DFAState16
+private fun dfastate_17: DFAState17 do return once new DFAState17
+private fun dfastate_18: DFAState18 do return once new DFAState18
+private fun dfastate_19: DFAState19 do return once new DFAState19
+private fun dfastate_20: DFAState20 do return once new DFAState20
+private fun dfastate_21: DFAState21 do return once new DFAState21
+private fun dfastate_22: DFAState22 do return once new DFAState22
+private fun dfastate_23: DFAState23 do return once new DFAState23
+private fun dfastate_24: DFAState24 do return once new DFAState24
+private fun dfastate_25: DFAState25 do return once new DFAState25
+private fun dfastate_26: DFAState26 do return once new DFAState26
+private fun dfastate_27: DFAState27 do return once new DFAState27
+private fun dfastate_28: DFAState28 do return once new DFAState28
+private fun dfastate_29: DFAState29 do return once new DFAState29
+private fun dfastate_30: DFAState30 do return once new DFAState30
+private fun dfastate_31: DFAState31 do return once new DFAState31
+private fun dfastate_32: DFAState32 do return once new DFAState32
+private fun dfastate_33: DFAState33 do return once new DFAState33
+private fun dfastate_34: DFAState34 do return once new DFAState34
 class MyNToken
 	super NToken
 end

--- a/lib/json/json_parser.nit
+++ b/lib/json/json_parser.nit
@@ -5,37 +5,168 @@ class Parser_json
 	super Parser
 	redef fun start_state do return state_Start
 end
-redef class Object
-	private fun state_Start: LRStateStart do return once new LRStateStart
-	private fun state_value: LRStatevalue do return once new LRStatevalue
-	private fun state_number: LRStatenumber do return once new LRStatenumber
-	private fun state_string: LRStatestring do return once new LRStatestring
-	private fun state__39dtrue_39d: LRState_39dtrue_39d do return once new LRState_39dtrue_39d
-	private fun state__39dfalse_39d: LRState_39dfalse_39d do return once new LRState_39dfalse_39d
-	private fun state__39dnull_39d: LRState_39dnull_39d do return once new LRState_39dnull_39d
-	private fun state__39d_123d_39d: LRState_39d_123d_39d do return once new LRState_39d_123d_39d
-	private fun state__39d_91d_39d: LRState_39d_91d_39d do return once new LRState_39d_91d_39d
-	private fun state_value_32dEof: LRStatevalue_32dEof do return once new LRStatevalue_32dEof
-	private fun state__39d_123d_39d_32dmembers: LRState_39d_123d_39d_32dmembers do return once new LRState_39d_123d_39d_32dmembers
-	private fun state__39d_123d_39d_32d_39d_125d_39d: LRState_39d_123d_39d_32d_39d_125d_39d do return once new LRState_39d_123d_39d_32d_39d_125d_39d
-	private fun state__39d_123d_39d_32dpair: LRState_39d_123d_39d_32dpair do return once new LRState_39d_123d_39d_32dpair
-	private fun state__39d_123d_39d_32dstring: LRState_39d_123d_39d_32dstring do return once new LRState_39d_123d_39d_32dstring
-	private fun state__39d_91d_39d_32delements: LRState_39d_91d_39d_32delements do return once new LRState_39d_91d_39d_32delements
-	private fun state__39d_91d_39d_32d_39d_93d_39d: LRState_39d_91d_39d_32d_39d_93d_39d do return once new LRState_39d_91d_39d_32d_39d_93d_39d
-	private fun state__39d_91d_39d_32dvalue: LRState_39d_91d_39d_32dvalue do return once new LRState_39d_91d_39d_32dvalue
-	private fun state__39d_123d_39d_32dmembers_32d_39d_125d_39d: LRState_39d_123d_39d_32dmembers_32d_39d_125d_39d do return once new LRState_39d_123d_39d_32dmembers_32d_39d_125d_39d
-	private fun state__39d_123d_39d_32dmembers_32d_39d_44d_39d: LRState_39d_123d_39d_32dmembers_32d_39d_44d_39d do return once new LRState_39d_123d_39d_32dmembers_32d_39d_44d_39d
-	private fun state__39d_123d_39d_32dstring_32d_39d_58d_39d: LRState_39d_123d_39d_32dstring_32d_39d_58d_39d do return once new LRState_39d_123d_39d_32dstring_32d_39d_58d_39d
-	private fun state__39d_91d_39d_32delements_32d_39d_93d_39d: LRState_39d_91d_39d_32delements_32d_39d_93d_39d do return once new LRState_39d_91d_39d_32delements_32d_39d_93d_39d
-	private fun state__39d_91d_39d_32delements_32d_39d_44d_39d: LRState_39d_91d_39d_32delements_32d_39d_44d_39d do return once new LRState_39d_91d_39d_32delements_32d_39d_44d_39d
-	private fun state__39d_123d_39d_32dmembers_32d_39d_44d_39d_32dpair: LRState_39d_123d_39d_32dmembers_32d_39d_44d_39d_32dpair do return once new LRState_39d_123d_39d_32dmembers_32d_39d_44d_39d_32dpair
-	private fun state__39d_123d_39d_32dstring_32d_39d_58d_39d_32dvalue: LRState_39d_123d_39d_32dstring_32d_39d_58d_39d_32dvalue do return once new LRState_39d_123d_39d_32dstring_32d_39d_58d_39d_32dvalue
-	private fun state__39d_91d_39d_32delements_32d_39d_44d_39d_32dvalue: LRState_39d_91d_39d_32delements_32d_39d_44d_39d_32dvalue do return once new LRState_39d_91d_39d_32delements_32d_39d_44d_39d_32dvalue
-	private fun goto_Nvalue: Goto_Nvalue do return once new Goto_Nvalue
-	private fun goto_Nmembers: Goto_Nmembers do return once new Goto_Nmembers
-	private fun goto_Npair: Goto_Npair do return once new Goto_Npair
-	private fun goto_Nelements: Goto_Nelements do return once new Goto_Nelements
-	private fun goto_N_start: Goto_N_start do return once new Goto_N_start
+private fun state_Start: LRStateStart do return once new LRStateStart
+private fun state_value: LRStatevalue do return once new LRStatevalue
+private fun state_number: LRStatenumber do return once new LRStatenumber
+private fun state_string: LRStatestring do return once new LRStatestring
+private fun state__39dtrue_39d: LRState_39dtrue_39d do return once new LRState_39dtrue_39d
+private fun state__39dfalse_39d: LRState_39dfalse_39d do return once new LRState_39dfalse_39d
+private fun state__39dnull_39d: LRState_39dnull_39d do return once new LRState_39dnull_39d
+private fun state__39d_123d_39d: LRState_39d_123d_39d do return once new LRState_39d_123d_39d
+private fun state__39d_91d_39d: LRState_39d_91d_39d do return once new LRState_39d_91d_39d
+private fun state_value_32dEof: LRStatevalue_32dEof do return once new LRStatevalue_32dEof
+private fun state__39d_123d_39d_32dmembers: LRState_39d_123d_39d_32dmembers do return once new LRState_39d_123d_39d_32dmembers
+private fun state__39d_123d_39d_32d_39d_125d_39d: LRState_39d_123d_39d_32d_39d_125d_39d do return once new LRState_39d_123d_39d_32d_39d_125d_39d
+private fun state__39d_123d_39d_32dpair: LRState_39d_123d_39d_32dpair do return once new LRState_39d_123d_39d_32dpair
+private fun state__39d_123d_39d_32dstring: LRState_39d_123d_39d_32dstring do return once new LRState_39d_123d_39d_32dstring
+private fun state__39d_91d_39d_32delements: LRState_39d_91d_39d_32delements do return once new LRState_39d_91d_39d_32delements
+private fun state__39d_91d_39d_32d_39d_93d_39d: LRState_39d_91d_39d_32d_39d_93d_39d do return once new LRState_39d_91d_39d_32d_39d_93d_39d
+private fun state__39d_91d_39d_32dvalue: LRState_39d_91d_39d_32dvalue do return once new LRState_39d_91d_39d_32dvalue
+private fun state__39d_123d_39d_32dmembers_32d_39d_125d_39d: LRState_39d_123d_39d_32dmembers_32d_39d_125d_39d do return once new LRState_39d_123d_39d_32dmembers_32d_39d_125d_39d
+private fun state__39d_123d_39d_32dmembers_32d_39d_44d_39d: LRState_39d_123d_39d_32dmembers_32d_39d_44d_39d do return once new LRState_39d_123d_39d_32dmembers_32d_39d_44d_39d
+private fun state__39d_123d_39d_32dstring_32d_39d_58d_39d: LRState_39d_123d_39d_32dstring_32d_39d_58d_39d do return once new LRState_39d_123d_39d_32dstring_32d_39d_58d_39d
+private fun state__39d_91d_39d_32delements_32d_39d_93d_39d: LRState_39d_91d_39d_32delements_32d_39d_93d_39d do return once new LRState_39d_91d_39d_32delements_32d_39d_93d_39d
+private fun state__39d_91d_39d_32delements_32d_39d_44d_39d: LRState_39d_91d_39d_32delements_32d_39d_44d_39d do return once new LRState_39d_91d_39d_32delements_32d_39d_44d_39d
+private fun state__39d_123d_39d_32dmembers_32d_39d_44d_39d_32dpair: LRState_39d_123d_39d_32dmembers_32d_39d_44d_39d_32dpair do return once new LRState_39d_123d_39d_32dmembers_32d_39d_44d_39d_32dpair
+private fun state__39d_123d_39d_32dstring_32d_39d_58d_39d_32dvalue: LRState_39d_123d_39d_32dstring_32d_39d_58d_39d_32dvalue do return once new LRState_39d_123d_39d_32dstring_32d_39d_58d_39d_32dvalue
+private fun state__39d_91d_39d_32delements_32d_39d_44d_39d_32dvalue: LRState_39d_91d_39d_32delements_32d_39d_44d_39d_32dvalue do return once new LRState_39d_91d_39d_32delements_32d_39d_44d_39d_32dvalue
+private fun goto_Nvalue: Goto_Nvalue do return once new Goto_Nvalue
+private fun reduce_Nvalue_number(parser: Parser) do
+		# REDUCE value::value_number=number
+		var n0 = parser.pop.as(Nnumber)
+		var p1 = new Nvalue_number(n0)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Nvalue)
+end
+private fun reduce_Nvalue_string(parser: Parser) do
+		# REDUCE value::value_string=string
+		var n0 = parser.pop.as(Nstring)
+		var p1 = new Nvalue_string(n0)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Nvalue)
+end
+private fun reduce_Nvalue_true(parser: Parser) do
+		# REDUCE value::value_true='true'
+		var n0 = parser.pop.as(N_39dtrue_39d)
+		var p1 = new Nvalue_true(n0)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Nvalue)
+end
+private fun reduce_Nvalue_false(parser: Parser) do
+		# REDUCE value::value_false='false'
+		var n0 = parser.pop.as(N_39dfalse_39d)
+		var p1 = new Nvalue_false(n0)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Nvalue)
+end
+private fun reduce_Nvalue_null(parser: Parser) do
+		# REDUCE value::value_null='null'
+		var n0 = parser.pop.as(N_39dnull_39d)
+		var p1 = new Nvalue_null(n0)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Nvalue)
+end
+private fun reduce_Nvalue_object_95d0(parser: Parser) do
+		# REDUCE value::value_object_0='{' members '}'
+		var n2 = parser.pop.as(N_39d_125d_39d)
+		var n1 = parser.pop.as(Nmembers)
+		var n0 = parser.pop.as(N_39d_123d_39d)
+		var p1 = new Nvalue_object(n0, n1, n2)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Nvalue)
+end
+private fun reduce_Nvalue_object_95d1(parser: Parser) do
+		# REDUCE value::value_object_1='{' '}'
+		var n1 = parser.pop.as(N_39d_125d_39d)
+		var n0 = parser.pop.as(N_39d_123d_39d)
+		var p1 = new Nvalue_object(n0, null, n1)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Nvalue)
+end
+private fun reduce_Nvalue_array_95d0(parser: Parser) do
+		# REDUCE value::value_array_0='[' elements ']'
+		var n2 = parser.pop.as(N_39d_93d_39d)
+		var n1 = parser.pop.as(Nelements)
+		var n0 = parser.pop.as(N_39d_91d_39d)
+		var p1 = new Nvalue_array(n0, n1, n2)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Nvalue)
+end
+private fun reduce_Nvalue_array_95d1(parser: Parser) do
+		# REDUCE value::value_array_1='[' ']'
+		var n1 = parser.pop.as(N_39d_93d_39d)
+		var n0 = parser.pop.as(N_39d_91d_39d)
+		var p1 = new Nvalue_array(n0, null, n1)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Nvalue)
+end
+private fun goto_Nmembers: Goto_Nmembers do return once new Goto_Nmembers
+private fun reduce_Nmembers_tail(parser: Parser) do
+		# REDUCE members::members_tail=members ',' pair
+		var n2 = parser.pop.as(Npair)
+		var n1 = parser.pop.as(N_39d_44d_39d)
+		var n0 = parser.pop.as(Nmembers)
+		var p1 = new Nmembers_tail(n0, n1, n2)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Nmembers)
+end
+private fun reduce_Nmembers_head(parser: Parser) do
+		# REDUCE members::members_head=pair
+		var n0 = parser.pop.as(Npair)
+		var p1 = new Nmembers_head(n0)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Nmembers)
+end
+private fun goto_Npair: Goto_Npair do return once new Goto_Npair
+private fun reduce_Npair(parser: Parser) do
+		# REDUCE pair::pair=string ':' value
+		var n2 = parser.pop.as(Nvalue)
+		var n1 = parser.pop.as(N_39d_58d_39d)
+		var n0 = parser.pop.as(Nstring)
+		var p1 = new Npair(n0, n1, n2)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Npair)
+end
+private fun goto_Nelements: Goto_Nelements do return once new Goto_Nelements
+private fun reduce_Nelements_tail(parser: Parser) do
+		# REDUCE elements::elements_tail=elements ',' value
+		var n2 = parser.pop.as(Nvalue)
+		var n1 = parser.pop.as(N_39d_44d_39d)
+		var n0 = parser.pop.as(Nelements)
+		var p1 = new Nelements_tail(n0, n1, n2)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Nelements)
+end
+private fun reduce_Nelements_head(parser: Parser) do
+		# REDUCE elements::elements_head=value
+		var n0 = parser.pop.as(Nvalue)
+		var p1 = new Nelements_head(n0)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.goto(goto_Nelements)
+end
+private fun goto_N_start: Goto_N_start do return once new Goto_N_start
+private fun reduce_NStart(parser: Parser) do
+		# REDUCE _start::Start=value Eof
+		var n1 = parser.pop.as(NEof)
+		var n0 = parser.pop.as(Nvalue)
+		var p1 = new NStart(n0, n1)
+		var prod = p1
+		parser.node_stack.push prod
+		parser.stop = true
 end
 redef class NToken
 	# guarded action for state Start
@@ -527,12 +658,7 @@ private class LRStatenumber
 	redef fun to_s do return "number"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE value::value_number=number
-		var n0 = parser.pop.as(Nnumber)
-		var p1 = new Nvalue_number(n0)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Nvalue)
+		reduce_Nvalue_number(parser)
 	end
 end
 # State string
@@ -541,12 +667,7 @@ private class LRStatestring
 	redef fun to_s do return "string"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE value::value_string=string
-		var n0 = parser.pop.as(Nstring)
-		var p1 = new Nvalue_string(n0)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Nvalue)
+		reduce_Nvalue_string(parser)
 	end
 end
 # State 'true'
@@ -555,12 +676,7 @@ private class LRState_39dtrue_39d
 	redef fun to_s do return "\'true\'"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE value::value_true='true'
-		var n0 = parser.pop.as(N_39dtrue_39d)
-		var p1 = new Nvalue_true(n0)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Nvalue)
+		reduce_Nvalue_true(parser)
 	end
 end
 # State 'false'
@@ -569,12 +685,7 @@ private class LRState_39dfalse_39d
 	redef fun to_s do return "\'false\'"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE value::value_false='false'
-		var n0 = parser.pop.as(N_39dfalse_39d)
-		var p1 = new Nvalue_false(n0)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Nvalue)
+		reduce_Nvalue_false(parser)
 	end
 end
 # State 'null'
@@ -583,12 +694,7 @@ private class LRState_39dnull_39d
 	redef fun to_s do return "\'null\'"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE value::value_null='null'
-		var n0 = parser.pop.as(N_39dnull_39d)
-		var p1 = new Nvalue_null(n0)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Nvalue)
+		reduce_Nvalue_null(parser)
 	end
 end
 # State '{'
@@ -621,13 +727,7 @@ private class LRStatevalue_32dEof
 	redef fun to_s do return "value Eof"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE _start::Start=value Eof
-		var n1 = parser.pop.as(NEof)
-		var n0 = parser.pop.as(Nvalue)
-		var p1 = new NStart(n0, n1)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.stop = true
+		reduce_NStart(parser)
 	end
 end
 # State '{' members
@@ -645,13 +745,7 @@ private class LRState_39d_123d_39d_32d_39d_125d_39d
 	redef fun to_s do return "\'\{\' \'\}\'"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE value::value_object_1='{' '}'
-		var n1 = parser.pop.as(N_39d_125d_39d)
-		var n0 = parser.pop.as(N_39d_123d_39d)
-		var p1 = new Nvalue_object(n0, null, n1)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Nvalue)
+		reduce_Nvalue_object_95d1(parser)
 	end
 end
 # State '{' pair
@@ -660,12 +754,7 @@ private class LRState_39d_123d_39d_32dpair
 	redef fun to_s do return "\'\{\' pair"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE members::members_head=pair
-		var n0 = parser.pop.as(Npair)
-		var p1 = new Nmembers_head(n0)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Nmembers)
+		reduce_Nmembers_head(parser)
 	end
 end
 # State '{' string
@@ -692,13 +781,7 @@ private class LRState_39d_91d_39d_32d_39d_93d_39d
 	redef fun to_s do return "\'[\' \']\'"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE value::value_array_1='[' ']'
-		var n1 = parser.pop.as(N_39d_93d_39d)
-		var n0 = parser.pop.as(N_39d_91d_39d)
-		var p1 = new Nvalue_array(n0, null, n1)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Nvalue)
+		reduce_Nvalue_array_95d1(parser)
 	end
 end
 # State '[' value
@@ -707,12 +790,7 @@ private class LRState_39d_91d_39d_32dvalue
 	redef fun to_s do return "\'[\' value"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE elements::elements_head=value
-		var n0 = parser.pop.as(Nvalue)
-		var p1 = new Nelements_head(n0)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Nelements)
+		reduce_Nelements_head(parser)
 	end
 end
 # State '{' members '}'
@@ -721,14 +799,7 @@ private class LRState_39d_123d_39d_32dmembers_32d_39d_125d_39d
 	redef fun to_s do return "\'\{\' members \'\}\'"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE value::value_object_0='{' members '}'
-		var n2 = parser.pop.as(N_39d_125d_39d)
-		var n1 = parser.pop.as(Nmembers)
-		var n0 = parser.pop.as(N_39d_123d_39d)
-		var p1 = new Nvalue_object(n0, n1, n2)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Nvalue)
+		reduce_Nvalue_object_95d0(parser)
 	end
 end
 # State '{' members ','
@@ -761,14 +832,7 @@ private class LRState_39d_91d_39d_32delements_32d_39d_93d_39d
 	redef fun to_s do return "\'[\' elements \']\'"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE value::value_array_0='[' elements ']'
-		var n2 = parser.pop.as(N_39d_93d_39d)
-		var n1 = parser.pop.as(Nelements)
-		var n0 = parser.pop.as(N_39d_91d_39d)
-		var p1 = new Nvalue_array(n0, n1, n2)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Nvalue)
+		reduce_Nvalue_array_95d0(parser)
 	end
 end
 # State '[' elements ','
@@ -789,14 +853,7 @@ private class LRState_39d_123d_39d_32dmembers_32d_39d_44d_39d_32dpair
 	redef fun to_s do return "\'\{\' members \',\' pair"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE members::members_tail=members ',' pair
-		var n2 = parser.pop.as(Npair)
-		var n1 = parser.pop.as(N_39d_44d_39d)
-		var n0 = parser.pop.as(Nmembers)
-		var p1 = new Nmembers_tail(n0, n1, n2)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Nmembers)
+		reduce_Nmembers_tail(parser)
 	end
 end
 # State '{' string ':' value
@@ -805,14 +862,7 @@ private class LRState_39d_123d_39d_32dstring_32d_39d_58d_39d_32dvalue
 	redef fun to_s do return "\'\{\' string \':\' value"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE pair::pair=string ':' value
-		var n2 = parser.pop.as(Nvalue)
-		var n1 = parser.pop.as(N_39d_58d_39d)
-		var n0 = parser.pop.as(Nstring)
-		var p1 = new Npair(n0, n1, n2)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Npair)
+		reduce_Npair(parser)
 	end
 end
 # State '[' elements ',' value
@@ -821,13 +871,6 @@ private class LRState_39d_91d_39d_32delements_32d_39d_44d_39d_32dvalue
 	redef fun to_s do return "\'[\' elements \',\' value"
 	redef fun error_msg do return ""
 	redef fun action(parser) do
-		# REDUCE elements::elements_tail=elements ',' value
-		var n2 = parser.pop.as(Nvalue)
-		var n1 = parser.pop.as(N_39d_44d_39d)
-		var n0 = parser.pop.as(Nelements)
-		var p1 = new Nelements_tail(n0, n1, n2)
-		var prod = p1
-		parser.node_stack.push prod
-		parser.goto(goto_Nelements)
+		reduce_Nelements_tail(parser)
 	end
 end


### PR DESCRIPTION
Some improvements and bugfixes for nitcc.

* Improve code size in C and in Nit
* Produce valid Nit code even in case of R/R, S/R or S/R/R conflicts. Close #1693

Before: compiling objc_test_parser on an old laptop
* 880.58 usertime
* 3GB memory
* produced executable: 50MB (31MB stripped)

after: same grammar, better nitcc
* 337.80usertime
* 788MB memory
* produced executable: 28MB (8,8MB stripped)