### PR TITLE
misc/vim: update the vim plugin to use core instead of standard

### DIFF
--- a/misc/vim/plugin/nit.vim
+++ b/misc/vim/plugin/nit.vim
@@ -53,7 +53,7 @@ function NitComplete()
 		let g:acp_behaviorKeywordIgnores = ['new', 'var', 'in', 'do', 'els', 'end', 'ret', 'for', 'fun']
 
 		" Use nitls to compute all interesting files from the current directory and the standard library
-		for file in split(system('nitls -M standard .', '\n'))
+		for file in split(system('nitls -M core .', '\n'))
 			silent let &complete = &complete . ',s' . file
 			silent set complete?
 		endfor


### PR DESCRIPTION
The plugin was not updated with the new name for the `core` library, but it's never too late.