### PR TITLE
Clean UTF-8 string update

### DIFF
--- a/contrib/opportunity/src/opportunity_controller.nit
+++ b/contrib/opportunity/src/opportunity_controller.nit
@@ -16,7 +16,6 @@
 module opportunity_controller
 
 import nitcorn
-import sha1
 import templates
 import opportunity_model
 

--- a/contrib/opportunity/src/opportunity_model.nit
+++ b/contrib/opportunity/src/opportunity_model.nit
@@ -247,7 +247,7 @@ class Meetup
 	redef fun commit(db) do
 		if id == "" then
 			var time = get_time
-			var tmpid = (name + date + place + time.to_s).sha1_to_s
+			var tmpid = (name + date + place + time.to_s).sha1.hexdigest
 			if not db.execute("INSERT INTO meetups (id, name, date, place, answer_mode) VALUES({tmpid.to_sql_string}, {name.html_escape.to_sql_string}, {date.html_escape.to_sql_string}, {place.html_escape.to_sql_string}, {answer_mode});") then
 				print "Error recording entry Meetup {self}"
 				print db.error or else "Null error"

--- a/examples/rosettacode/sha_1.nit
+++ b/examples/rosettacode/sha_1.nit
@@ -9,4 +9,4 @@ module sha_1
 
 import sha1
 
-print "Rosetta Code".sha1_to_s
+print "Rosetta Code".sha1.hexdigest

--- a/lib/core/bytes.nit
+++ b/lib/core/bytes.nit
@@ -146,80 +146,13 @@ class Bytes
 	redef fun to_s do
 		persisted = true
 		var b = self
-		if not is_utf8 then
-			b = clean_utf8
-			persisted = false
-		end
-		return new FlatString.with_infos(b.items, b.length, 0, b.length -1)
+		var r = b.items.to_s_with_length(length)
+		if r != items then persisted = false
+		return r
 	end
 
 	redef fun iterator do return new BytesIterator.with_buffer(self)
 
-	# Is the byte collection valid UTF-8 ?
-	fun is_utf8: Bool do
-		var charst = once [0x80u8, 0u8, 0xE0u8, 0xC0u8, 0xF0u8, 0xE0u8, 0xF8u8, 0xF0u8]
-		var lobounds = once [0, 0x80, 0x800, 0x10000]
-		var hibounds = once [0x7F, 0x7FF, 0xFFFF, 0x10FFFF]
-		var pos = 0
-		var len = length
-		var mits = items
-		while pos < len do
-			var nxst = mits.length_of_char_at(pos)
-			var charst_index = (nxst - 1) * 2
-			if mits[pos] & charst[charst_index] == charst[charst_index + 1] then
-				var c = mits.char_at(pos)
-				var cp = c.ascii
-				if cp <= hibounds[nxst - 1] and cp >= lobounds[nxst - 1] then
-					if cp >= 0xD800 and cp <= 0xDFFF or
-					   cp == 0xFFFE or cp == 0xFFFF then return false
-				else
-					return false
-				end
-			else
-				return false
-			end
-			pos += nxst
-		end
-		return true
-	end
-
-	# Cleans the bytes of `self` to be UTF-8 compliant
-	private fun clean_utf8: Bytes do
-		var charst = once [0x80u8, 0u8, 0xE0u8, 0xC0u8, 0xF0u8, 0xE0u8, 0xF8u8, 0xF0u8]
-		var badchar = once [0xEFu8, 0xBFu8, 0xBDu8]
-		var lobounds = once [0, 0x80, 0x800, 0x10000]
-		var hibounds = once [0x7F, 0x7FF, 0xFFFF, 0x10FFFF]
-		var pos = 0
-		var len = length
-		var ret = new Bytes.with_capacity(len)
-		var mits = items
-		while pos < len do
-			var nxst = mits.length_of_char_at(pos)
-			var charst_index = (nxst - 1) * 2
-			if mits[pos] & charst[charst_index] == charst[charst_index + 1] then
-				var c = mits.char_at(pos)
-				var cp = c.ascii
-				if cp <= hibounds[nxst - 1] and cp >= lobounds[nxst - 1] then
-					if cp >= 0xD800 and cp <= 0xDFFF or
-					   cp == 0xFFFE or cp == 0xFFFF then
-						ret.append badchar
-						pos += 1
-					else
-						var pend = pos + nxst
-						for i in [pos .. pend[ do ret.add mits[i]
-						pos += nxst
-					end
-				else
-					ret.append badchar
-					pos += 1
-				end
-			else
-				ret.append badchar
-				pos += 1
-			end
-		end
-		return ret
-	end
 end
 
 private class BytesIterator

--- a/lib/core/stream.nit
+++ b/lib/core/stream.nit
@@ -173,12 +173,13 @@ abstract class Reader
 	# ~~~
 	fun read_all: String do
 		var s = read_all_bytes
-		if not s.is_utf8 then s = s.clean_utf8
 		var slen = s.length
 		if slen == 0 then return ""
 		var rets = ""
 		var pos = 0
-		var sits = s.items
+		var str = s.items.clean_utf8(slen)
+		slen = str.bytelen
+		var sits = str.items
 		var remsp = slen
 		while pos < slen do
 			# The 129 size was decided more or less arbitrarily

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -1185,7 +1185,7 @@ redef class Array[E]
 			end
 			i += 1
 		end
-		return ns.to_s_with_length(sl)
+		return new FlatString.with_infos(ns, sl, 0, sl - 1)
 	end
 end
 
@@ -1222,7 +1222,7 @@ redef class NativeArray[E]
 			end
 			i += 1
 		end
-		return ns.to_s_with_length(sl)
+		return new FlatString.with_infos(ns, sl, 0, sl - 1)
 	end
 end
 

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -985,8 +985,7 @@ redef class NativeString
 	redef fun to_s_with_length(length): FlatString
 	do
 		assert length >= 0
-		var str = new FlatString.with_infos(self, length, 0, length - 1)
-		return str
+		return clean_utf8(length)
 	end
 
 	redef fun to_s_full(bytelen, unilen) do
@@ -997,6 +996,8 @@ redef class NativeString
 	redef fun to_s_with_copy: FlatString
 	do
 		var length = cstring_length
+		var r = clean_utf8(length)
+		if r.items != self then return r
 		var new_self = new NativeString(length + 1)
 		copy_to(new_self, length, 0, 0)
 		var str = new FlatString.with_infos(new_self, length, 0, length - 1)

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -1005,6 +1005,81 @@ redef class NativeString
 		return str
 	end
 
+	# Cleans a NativeString if necessary
+	fun clean_utf8(len: Int): FlatString do
+		var replacements: nullable Array[Int] = null
+		var end_length = len
+		var pos = 0
+		var chr_ln = 0
+		while pos < len do
+			var b = self[pos]
+			var nxst = length_of_char_at(pos)
+			var ok_st: Bool
+			if nxst == 1 then
+				ok_st = b & 0x80u8 == 0u8
+			else if nxst == 2 then
+				ok_st = b & 0xE0u8 == 0xC0u8
+			else if nxst == 3 then
+				ok_st = b & 0xF0u8 == 0xE0u8
+			else
+				ok_st = b & 0xF8u8 == 0xF0u8
+			end
+			if not ok_st then
+				if replacements == null then replacements = new Array[Int]
+				replacements.add pos
+				end_length += 2
+				pos += 1
+				chr_ln += 1
+				continue
+			end
+			var ok_c: Bool
+			var c = char_at(pos)
+			var cp = c.ascii
+			if nxst == 1 then
+				ok_c = cp >= 0 and cp <= 0x7F
+			else if nxst == 2 then
+				ok_c = cp >= 0x80 and cp <= 0x7FF
+			else if nxst == 3 then
+				ok_c = cp >= 0x800 and cp <= 0xFFFF
+				ok_c = ok_c and not (cp >= 0xD800 and cp <= 0xDFFF) and cp != 0xFFFE and cp != 0xFFFF
+			else
+				ok_c = cp >= 0x10000 and cp <= 0x10FFFF
+			end
+			if not ok_c then
+				if replacements == null then replacements = new Array[Int]
+				replacements.add pos
+				end_length += 2
+				pos += 1
+				chr_ln += 1
+				continue
+			end
+			pos += c.u8char_len
+			chr_ln += 1
+		end
+		var ret = self
+		if end_length != len then
+			ret = new NativeString(end_length)
+			var old_repl = 0
+			var off = 0
+			var repls = replacements.as(not null)
+			var r = repls.items.as(not null)
+			var imax = repls.length
+			for i in [0 .. imax[ do
+				var repl_pos = r[i]
+				var chkln = repl_pos - old_repl
+				copy_to(ret, chkln, old_repl, off)
+				off += chkln
+				ret[off] = 0xEFu8
+				ret[off + 1] = 0xBFu8
+				ret[off + 2] = 0xBDu8
+				old_repl = repl_pos + 1
+				off += 3
+			end
+			copy_to(ret, len - old_repl, old_repl, off)
+		end
+		return new FlatString.full(ret, end_length, 0, end_length - 1, chr_ln)
+	end
+
 	# Sets the next bytes at position `pos` to the value of `c`, encoded in UTF-8
 	#
 	# Very unsafe, make sure to have room for this char prior to calling this function.

--- a/lib/websocket/websocket.nit
+++ b/lib/websocket/websocket.nit
@@ -114,7 +114,7 @@ class WebsocketConnection
 		resp_map["Connection:"] = "Upgrade"
 		var key = heads["Sec-WebSocket-Key"]
 		key += "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-		key = key.sha1.encode_base64
+		key = key.sha1.encode_base64.to_s
 		resp_map["Sec-WebSocket-Accept:"] = key
 		var resp = resp_map.join("\r\n", " ")
 		resp += "\r\n\r\n"

--- a/tests/sav/nitcg/test_text_stat.res
+++ b/tests/sav/nitcg/test_text_stat.res
@@ -21,7 +21,7 @@ Calls to bytepos for each type:
 	FlatString = 18
 Calls to first_byte on FlatString 153
 Calls to last_byte on FlatString 103
-FlatStrings allocated with length 81 (85.417%)
+FlatStrings allocated with length 82 (86.458%)
 Length of travel for index distribution:
 * null = 20 => occurences 83.333%, cumulative 83.333% 
 * 1 = 8 => occurences 21.053%, cumulative 73.684% 

--- a/tests/sav/nitserial_args1.res
+++ b/tests/sav/nitserial_args1.res
@@ -13,6 +13,7 @@ redef class Deserializer
 		if name == "Array[nullable Object]" then return new Array[nullable Object].from_deserializer(self)
 		if name == "Array[Serializable]" then return new Array[Serializable].from_deserializer(self)
 		if name == "Array[Object]" then return new Array[Object].from_deserializer(self)
+		if name == "Array[Int]" then return new Array[Int].from_deserializer(self)
 		if name == "Array[Match]" then return new Array[Match].from_deserializer(self)
 		if name == "Array[nullable Match]" then return new Array[nullable Match].from_deserializer(self)
 		return super

--- a/tests/sav/test_text_stat.res
+++ b/tests/sav/test_text_stat.res
@@ -21,7 +21,7 @@ Calls to bytepos for each type:
 	FlatString = 18
 Calls to first_byte on FlatString 153
 Calls to last_byte on FlatString 103
-FlatStrings allocated with length 81 (85.417%)
+FlatStrings allocated with length 82 (86.458%)
 Length of travel for index distribution:
 * 0 = 20 => occurences 83.333%, cumulative 83.333% 
 * 1 = 8 => occurences 21.053%, cumulative 73.684% 


### PR DESCRIPTION
Since quite some time now we've had the cleaning function for Bytes that ensured that what was coming from the exterior was clean and could be transformed safely to a String.

This is now generalized to any NativeString, and the clean function will be called each time a NativeString is `to_s`'d

At the same time, `clean_utf8` is now better performing (for `Files::read_all`, Ir per call is roughly 40% less than before), which limits the impacts of the new strategy.

Furthermore, the string produced by `NativeString::clean_utf8` has its length calculated which saves time on later operations on the string.

It also limits the number of calls by avoiding allocations if not necessary (if the string is already clean, which should happen a lot more often than not).

As for performances,

Valgrind `./bin/nitc src/nitc.nit`:
Before: 14.040 GIr
After: 13.859 GIr

Time, best of 10 for `./bin/nitc src/nitc.nit -o bin/nitc`:
Before: 0m4.989s
After: 0m4.933s

Time, best of 10 for `./bin/nitc --semi-global src/nitc.nit -o bin/nitc`:
Before: 0m4.696s
After: 0m4.691s

Pretty much equivalent in real time, and a bit better in Valgrind, not bad considering every String is now cleaner than ever !