### PR TITLE
glesv2: more services from OpenGL ES 2.0 to prepare for gamnit

### DIFF
--- a/lib/android/native_app_glue.nit
+++ b/lib/android/native_app_glue.nit
@@ -368,4 +368,13 @@ end
 
 # Android NDK's structure to control the native window for drawing
 extern class ANativeWindow `{ ANativeWindow* `}
+	# Change the format and size of the window buffers
+	#
+	# All arguments can be set to 0 to use the default devices values.
+	# `width` and `height` must both be set to 0 or have significant values.
+	#
+	# `format` is a value specified by EGL.
+	fun set_buffers_geometry(width, height, format: Int): Bool `{
+		return ANativeWindow_setBuffersGeometry(self, (int32_t)width, (int32_t)height, (int32_t)format);
+	`}
 end

--- a/lib/c.nit
+++ b/lib/c.nit
@@ -93,8 +93,8 @@ class CIntArray
 		super size
 	end
 
-	# Build from an `Array[Int]`
-	new from(array: Array[Int])
+	# Create from an `SequenceRead[Int]`
+	new from(array: SequenceRead[Int])
 	do
 		var carray = new CIntArray(array.length)
 		for i in array.length.times do
@@ -129,7 +129,7 @@ class CByteArray
 		super size
 	end
 
-	# Build from a `SequenceRead[Byte]`
+	# Create from a `SequenceRead[Byte]`
 	new from(array: SequenceRead[Byte])
 	do
 		var carray = new CByteArray(array.length)
@@ -166,8 +166,8 @@ class CNativeStringArray
 		super size
 	end
 
-	# Build from an `Array[NativeString]`
-	new from(array: Array[NativeString])
+	# Create from an `SequenceRead[NativeString]`
+	new from(array: SequenceRead[NativeString])
 	do
 		var carray = new CNativeStringArray(array.length)
 		for i in array.length.times do

--- a/lib/egl.nit
+++ b/lib/egl.nit
@@ -454,3 +454,6 @@ end
 fun egl_bind_opengl_api: Bool `{ return eglBindAPI(EGL_OPENGL_API); `}
 fun egl_bind_opengl_es_api: Bool `{ return eglBindAPI(EGL_OPENGL_ES_API); `}
 fun egl_bind_openvg_api: Bool `{ return eglBindAPI(EGL_OPENVG_API); `}
+
+# Handle to the default display to use with EGL
+fun egl_default_display: Pointer `{ return EGL_DEFAULT_DISPLAY; `}

--- a/lib/glesv2/examples/opengles2_hello_triangle.nit
+++ b/lib/glesv2/examples/opengles2_hello_triangle.nit
@@ -168,7 +168,7 @@ for i in [0..10000[ do
 	gl.clear((new GLBuffer).color)
 	program.use
 	vertex_array.enable
-	vertex_array.draw_arrays_triangles
+	glDrawArrays(new GLDrawMode.triangles, 0, 3)
 	egl_display.swap_buffers(surface)
 end
 

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -330,6 +330,11 @@ fun glDisableVertexAttribArray(index: Int) `{ glDisableVertexAttribArray(index);
 # Render primitives from array data
 fun glDrawArrays(mode: GLDrawMode, from, count: Int) `{ glDrawArrays(mode, from, count); `}
 
+# Define an array of generic vertex attribute data
+fun glVertexAttribPointer(index, size: Int, typ: GLDataType, normalized: Bool, stride: Int, array: NativeGLfloatArray) `{
+	glVertexAttribPointer(index, size, typ, normalized, stride, array);
+`}
+
 # Specify the value of a generic vertex attribute
 fun glVertexAttrib1f(index: Int, x: Float) `{ glVertexAttrib1f(index, x); `}
 

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -330,6 +330,32 @@ fun glDisableVertexAttribArray(index: Int) `{ glDisableVertexAttribArray(index);
 # Render primitives from array data
 fun glDrawArrays(mode: GLDrawMode, from, count: Int) `{ glDrawArrays(mode, from, count); `}
 
+# Specify the value of a generic vertex attribute
+fun glVertexAttrib1f(index: Int, x: Float) `{ glVertexAttrib1f(index, x); `}
+
+# Specify the value of a generic vertex attribute
+fun glVertexAttrib2f(index: Int, x, y: Float) `{ glVertexAttrib2f(index, x, y); `}
+
+# Specify the value of a generic vertex attribute
+fun glVertexAttrib3f(index: Int, x, y, z: Float) `{ glVertexAttrib3f(index, x, y, z); `}
+
+# Specify the value of a generic vertex attribute
+fun glVertexAttrib4f(index: Int, x, y, z, w: Float) `{ glVertexAttrib4f(index, x, y, z, w); `}
+
+# Specify the value of a uniform variable for the current program object
+fun glUniform1i(index, x: Int) `{ glUniform1i(index, x); `}
+
+# Specify the value of a uniform variable for the current program object
+fun glUniform2i(index, x, y: Int) `{ glUniform2i(index, x, y); `}
+
+# Specify the value of a uniform variable for the current program object
+fun glUniform3i(index, x, y, z: Int) `{ glUniform3i(index, x, y, z); `}
+
+# Specify the value of a uniform variable for the current program object
+fun glUniform4i(index, x, y, z, w: Int) `{ glUniform4i(index, x, y, z, w); `}
+
+# TODO glUniform*f
+
 # Low level array of `Float`
 class GLfloatArray
 	super CArray[Float]

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -532,7 +532,7 @@ class GLES
 	#
 	# Foreign: glReadPixel
 	fun read_pixels(x, y, width, height: Int, format: GLPixelFormat, typ: GLPixelType, data: Pointer) `{
-		glReadPixels(x, y, width, height, GL_RGBA, GL_UNSIGNED_BYTE, data);
+		glReadPixels(x, y, width, height, format, typ, data);
 	`}
 
 	# Set the texture minifying function

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -429,6 +429,12 @@ fun gl_UNPACK_ALIGNEMENT: GLPack `{ return GL_UNPACK_ALIGNMENT; `}
 # TODO GL_PACK_ROW_LENGTH, GL_PACK_IMAGE_HEIGHT, GL_PACK_SKIP_PIXELS, GL_PACK_SKIP_ROWS, GL_PACK_SKIP_IMAGES
 # GL_UNPACK_ROW_LENGTH, GL_UNPACK_IMAGE_HEIGHT, GL_UNPACK_SKIP_PIXELS, GL_UNPACK_SKIP_ROWS, GL_UNPACK_SKIP_IMAGES
 
+# Specify a two-dimensional texture image
+fun glTexImage2D(target: GLTextureTarget, level, internalformat, width, height, border: Int,
+                 format: GLPixelFormat, typ: GLPixelType, data: NativeCByteArray) `{
+	glTexImage2D(target, level, internalformat, width, height, border, format, typ, data);
+`}
+
 # Texture minifying and magnifying function
 extern class GLTextureFilter
 	super GLEnum

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -314,14 +314,21 @@ class VertexArray
 		glVertexAttribPointer(index, count, GL_FLOAT, GL_FALSE, 0, array);
 	`}
 
-	fun enable do enable_intern(index)
-	private fun enable_intern(index: Int) `{ glEnableVertexAttribArray(index); `}
+	# Enable this vertex attribute array
+	fun enable do glEnableVertexAttribArray(index)
 
-	fun draw_arrays_triangles do draw_arrays_triangles_intern(index, count)
-	private fun draw_arrays_triangles_intern(index, count: Int) `{
-		glDrawArrays(GL_TRIANGLES, index, count);
-	`}
+	# Disable this vertex attribute array
+	fun disable do glDisableVertexAttribArray(index)
 end
+
+# Enable the generic vertex attribute array at `index`
+fun glEnableVertexAttribArray(index: Int) `{ glEnableVertexAttribArray(index); `}
+
+# Disable the generic vertex attribute array at `index`
+fun glDisableVertexAttribArray(index: Int) `{ glDisableVertexAttribArray(index); `}
+
+# Render primitives from array data
+fun glDrawArrays(mode: GLDrawMode, from, count: Int) `{ glDrawArrays(mode, from, count); `}
 
 # Low level array of `Float`
 class GLfloatArray

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -375,29 +375,17 @@ do
 	end
 end
 
-# Texture minifying function
-#
-# Used by: `GLES::tex_parameter_min_filter`
-extern class GLTextureMinFilter
+# Texture minifying and magnifying function
+extern class GLTextureFilter
 	super GLEnum
-
-	new nearest `{ return GL_NEAREST; `}
-	new linear `{ return GL_LINEAR; `}
 end
 
-# Texture magnification function
-#
-# Used by: `GLES::tex_parameter_mag_filter`
-extern class GLTextureMagFilter
-	super GLEnum
-
-	new nearest `{ return GL_NEAREST; `}
-	new linear `{ return GL_LINEAR; `}
-	new nearest_mipmap_nearest `{ return GL_NEAREST_MIPMAP_NEAREST; `}
-	new linear_mipmap_nearest `{ return GL_LINEAR_MIPMAP_NEAREST; `}
-	new nearest_mipmap_linear `{ return GL_NEAREST_MIPMAP_LINEAR; `}
-	new linear_mipmap_linear `{ return GL_LINEAR_MIPMAP_LINEAR; `}
-end
+fun gl_NEAREST: GLTextureFilter `{ return GL_NEAREST; `}
+fun gl_LINEAR: GLTextureFilter `{ return GL_LINEAR; `}
+fun gl_NEAREST_MIPMAP_NEAREST: GLTextureFilter `{ return GL_NEAREST_MIPMAP_NEAREST; `}
+fun gl_LINEAR_MIPMAP_NEAREST: GLTextureFilter `{ return GL_LINEAR_MIPMAP_NEAREST; `}
+fun gl_NEAREST_MIPMAP_NINEAR: GLTextureFilter `{ return GL_NEAREST_MIPMAP_LINEAR; `}
+fun gl_LINEAR_MIPMAP_LINEAR: GLTextureFilter `{ return GL_LINEAR_MIPMAP_LINEAR; `}
 
 # Wrap parameter of a texture
 #
@@ -550,14 +538,14 @@ class GLES
 	# Set the texture minifying function
 	#
 	# Foreign: glTexParameter with GL_TEXTURE_MIN_FILTER
-	fun tex_parameter_min_filter(target: GLTextureTarget, value: GLTextureMinFilter) `{
+	fun tex_parameter_min_filter(target: GLTextureTarget, value: GLTextureFilter) `{
 		glTexParameteri(target, GL_TEXTURE_MIN_FILTER, value);
 	`}
 
 	# Set the texture magnification function
 	#
 	# Foreign: glTexParameter with GL_TEXTURE_MAG_FILTER
-	fun tex_parameter_mag_filter(target: GLTextureTarget, value: GLTextureMagFilter) `{
+	fun tex_parameter_mag_filter(target: GLTextureTarget, value: GLTextureFilter) `{
 		glTexParameteri(target, GL_TEXTURE_MAG_FILTER, value);
 	`}
 

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -406,6 +406,12 @@ do
 	end
 end
 
+# Does `name` corresponds to a texture?
+fun glIsTexture(name: Int): Bool `{ return glIsTexture(name); `}
+
+# Bind the named `texture` to a `target`
+fun glBindTexture(target: GLTextureTarget, texture: Int) `{ glBindTexture(target, texture); `}
+
 # Texture minifying and magnifying function
 extern class GLTextureFilter
 	super GLEnum

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -459,14 +459,18 @@ extern class GLTextureWrap
 end
 
 # Target texture
-#
-# Used by: `tex_parameter_*`
 extern class GLTextureTarget
 	super GLEnum
-
-	new flat `{ return GL_TEXTURE_2D; `}
-	new cube_map `{ return GL_TEXTURE_CUBE_MAP; `}
 end
+
+# Two-dimensional texture
+fun gl_TEXTURE_2D: GLTextureTarget `{ return GL_TEXTURE_2D; `}
+
+# Cube map texture
+fun gl_TEXTURE_CUBE_MAP: GLTextureTarget `{ return GL_TEXTURE_CUBE_MAP; `}
+
+# TODO GL_TEXTURE_CUBE_MAP_POSITIVE_X, GL_TEXTURE_CUBE_MAP_NEGATIVE_X, GL_TEXTURE_CUBE_MAP_POSITIVE_Y,
+# GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, GL_TEXTURE_CUBE_MAP_POSITIVE_Z, GL_TEXTURE_CUBE_MAP_NEGATIVE_Z
 
 # A server-side capability
 class GLCap

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -458,6 +458,27 @@ class GLCap
 	redef fun hash do return val
 	redef fun ==(o) do return o != null and is_same_type(o) and o.hash == self.hash
 end
+
+# Attach a renderbuffer object to a framebuffer object
+fun glFramebufferRenderbuffer(target: GLFramebufferTarget, attachment: GLAttachment,
+                              renderbuffertarget: GLRenderbufferTarget, renderbuffer: Int) `{
+	glFramebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer);
+`}
+
+# Renderbuffer attachment point to a framebuffer
+extern class GLAttachment
+	super GLEnum
+end
+
+# First color attachment point
+fun gl_COLOR_ATTACHMENT0: GLAttachment `{ return GL_COLOR_ATTACHMENT0; `}
+
+# Depth attachment point
+fun gl_DEPTH_ATTACHMENT: GLAttachment `{ return GL_DEPTH_ATTACHMENT; `}
+
+# Stencil attachment
+fun gl_STENCIL_ATTACHMENT: GLAttachment `{ return GL_STENCIL_ATTACHMENT; `}
+
 redef class Sys
 	private var gles = new GLES is lazy
 end

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -471,6 +471,31 @@ fun glFramebufferRenderbuffer(target: GLFramebufferTarget, attachment: GLAttachm
 	glFramebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer);
 `}
 
+# Establish data storage, `format` and dimensions of the `target` renderbuffer object's image
+fun glRenderbufferStorage(target: GLRenderbufferTarget, format: GLRenderbufferFormat, width, height: Int) `{
+	glRenderbufferStorage(GL_RENDERBUFFER, format, width, height);
+`}
+
+# Format for a renderbuffer
+extern class GLRenderbufferFormat
+	super GLEnum
+end
+
+# 4 red, 4 green, 4 blue, 4 alpha bits format
+fun gl_RGBA4: GLRenderbufferFormat `{ return GL_RGBA4; `}
+
+# 5 red, 6 green, 5 blue bits format
+fun gl_RGB565: GLRenderbufferFormat `{ return GL_RGB565; `}
+
+# 5 red, 5 green, 5 blue, 1 alpha bits format
+fun gl_RGB_A1: GLRenderbufferFormat `{ return GL_RGB5_A1; `}
+
+# 16 depth bits format
+fun gl_DEPTH_COMPNENT16: GLRenderbufferFormat `{ return GL_DEPTH_COMPONENT16; `}
+
+# 8 stencil bits format
+fun gl_STENCIL_INDEX8: GLRenderbufferFormat `{ return GL_STENCIL_INDEX8; `}
+
 # Renderbuffer attachment point to a framebuffer
 extern class GLAttachment
 	super GLEnum

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -668,6 +668,20 @@ fun glHint(target: GLHintTarget, mode: GLHintMode) `{
 # Generate and fill set of mipmaps for the texture object `target`
 fun glGenerateMipmap(target: GLTextureTarget) `{ glGenerateMipmap(target); `}
 
+# Bind the named `buffer` object
+fun glBindBuffer(target: GLArrayBuffer, buffer: Int) `{ glBindBuffer(target, buffer); `}
+
+# Target to which bind the buffer with `glBindBuffer`
+extern class GLArrayBuffer
+	super GLEnum
+end
+
+# Array buffer target
+fun gl_ARRAY_BUFFER: GLArrayBuffer `{ return GL_ARRAY_BUFFER; `}
+
+# Element array buffer
+fun gl_ELEMENT_ARRAY_BUFFER: GLArrayBuffer `{ return GL_ELEMENT_ARRAY_BUFFER; `}
+
 # Completeness status of a framebuffer object
 fun glCheckFramebufferStatus(target: GLFramebufferTarget): GLFramebufferStatus `{
 	return glCheckFramebufferStatus(target);

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -665,6 +665,9 @@ fun glHint(target: GLHintTarget, mode: GLHintMode) `{
 	glHint(target, mode);
 `}
 
+# Generate and fill set of mipmaps for the texture object `target`
+fun glGenerateMipmap(target: GLTextureTarget) `{ glGenerateMipmap(target); `}
+
 # Completeness status of a framebuffer object
 fun glCheckFramebufferStatus(target: GLFramebufferTarget): GLFramebufferStatus `{
 	return glCheckFramebufferStatus(target);

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -791,6 +791,12 @@ fun gl_NICEST: GLHintMode `{ return GL_NICEST; `}
 # No preference
 fun gl_DONT_CARE: GLHintMode `{ return GL_DONT_CARE; `}
 
+# Attach a level of a texture object as a logical buffer to the currently bound framebuffer object
+fun glFramebufferTexture2D(target: GLFramebufferTarget, attachment: GLAttachment,
+                           texture_target: GLTextureTarget,  texture, level: Int) `{
+	glFramebufferTexture2D(target, attachment, texture_target, texture, level);
+`}
+
 # Entry point to OpenGL server-side capabilities
 class GLCapabilities
 

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -412,6 +412,23 @@ fun glIsTexture(name: Int): Bool `{ return glIsTexture(name); `}
 # Bind the named `texture` to a `target`
 fun glBindTexture(target: GLTextureTarget, texture: Int) `{ glBindTexture(target, texture); `}
 
+# Set pixel storage modes
+fun glPixelStorei(parameter: GLPack, val: Int) `{ glPixelStorei(parameter, val); `}
+
+# Symbolic name of the parameter to be set with `glPixelStorei`
+extern class GLPack
+	super GLEnum
+end
+
+# Parameter to specify the alignment requirements for the start of each pixel row in memory
+fun gl_PACK_ALIGNEMENT: GLPack `{ return GL_PACK_ALIGNMENT; `}
+
+# Parameter to specify the alignment requirements for the start of each pixel row in memory
+fun gl_UNPACK_ALIGNEMENT: GLPack `{ return GL_UNPACK_ALIGNMENT; `}
+
+# TODO GL_PACK_ROW_LENGTH, GL_PACK_IMAGE_HEIGHT, GL_PACK_SKIP_PIXELS, GL_PACK_SKIP_ROWS, GL_PACK_SKIP_IMAGES
+# GL_UNPACK_ROW_LENGTH, GL_UNPACK_IMAGE_HEIGHT, GL_UNPACK_SKIP_PIXELS, GL_UNPACK_SKIP_ROWS, GL_UNPACK_SKIP_IMAGES
+
 # Texture minifying and magnifying function
 extern class GLTextureFilter
 	super GLEnum

--- a/tests/sav/Darwin/todo
+++ b/tests/sav/Darwin/todo
@@ -1,4 +1,5 @@
 fatal error: 'endian.h' file not found
 Error: package `glesv1_cm` unknown by `pkg-config`, make sure the development package is be installed
 Error: package `glesv2` unknown by `pkg-config`, make sure the development package is be installed
+Error: package `egl` unknown by `pkg-config`, make sure the development package is be installed
 fatal error: 'libintl.h' file not found


### PR DESCRIPTION
This PR adds a few services to the low-level graphics modules to prepare for gamnit.

This is the 2nd PR to use a new style for the glesv2 module. The old code has not yet been fully updated, so the style may vary in the same module. The new style try to stay as close as possible to the names and signatures used by the OpenGL ES 2.0 C API and by webgl.

As usual with this module, for more documentation please refer to the official doc at https://www.khronos.org/opengles/sdk/docs/man/.