### PR TITLE
nitc: fix --typing-test-metrics by using correct tags in FFI

### DIFF
--- a/src/compiler/compiler_ffi/compiler_ffi.nit
+++ b/src/compiler/compiler_ffi/compiler_ffi.nit
@@ -280,7 +280,7 @@ redef class MExplicitCast
 
 			var from_var = nitni_visitor.var_from_c("from", from)
 			from_var = nitni_visitor.box_extern(from_var, from)
-			var recv_var = nitni_visitor.type_test(from_var, to, "FFI isa")
+			var recv_var = nitni_visitor.type_test(from_var, to, "isa")
 			nitni_visitor.add("return {recv_var};")
 
 			nitni_visitor.add("\}")
@@ -316,7 +316,7 @@ redef class MExplicitCast
 			from_var = nitni_visitor.box_extern(from_var, from)
 
 			## test type
-			var check = nitni_visitor.type_test(from_var, to, "FFI cast")
+			var check = nitni_visitor.type_test(from_var, to, "as")
 			nitni_visitor.add("if (!{check}) \{")
 			nitni_visitor.add_abort("FFI cast failed")
 			nitni_visitor.add("\}")


### PR DESCRIPTION
Just fix `--typing-test-metrics` that was broken.

A future PR (still wip) will ensure that the option will be no more broken