### PR TITLE
vim plugin: intro NitExecute to interpret the current file with `nit`

### DIFF
--- a/misc/README.md
+++ b/misc/README.md
@@ -102,7 +102,7 @@ The command `:Nitdoc` searches the documentation for the word under the cursor.
 The results are displayed in the preview window in order of relevance.
 You can search for any word by passing it as an argument, as in `:Nitdoc modulo`.
 The Nitdoc command uses the same metadata files as the omnifunc.
-You may want to map the function to a shortcut by adding the following code to `~/.vimrc`.
+You may want to map the command to a shortcut by adding the following code to `~/.vimrc`.
 
 ~~~
 " Map displaying Nitdoc to Ctrl-D
@@ -118,4 +118,19 @@ You may want to map the function to a shortcut by adding the following code to `
 ~~~
 " Map the NitGitGrep function to Ctrl-G
 map <C-g> :call NitGitGrep()<enter>
+~~~
+
+## Execute the current file
+
+The command `:NitExecute` calls `nit` to interpret the current file.
+
+If modified, the current buffer is saved to a temporary file before being executed.
+This may cause failures if the current buffer imports modules relative to the source package.
+In such cases, save the file before calling `:NitExecute`.
+
+You may want to map the command to a shortcut by adding the following code to `~/.vimrc`.
+
+~~~
+" Map the NitExecute function to Ctrl-F
+map <C-f> :NitExecute<enter>
 ~~~

--- a/misc/vim/plugin/nit.vim
+++ b/misc/vim/plugin/nit.vim
@@ -382,6 +382,19 @@ fun NitGitGrep()
 	redraw!
 endfun
 
+" Call `nit` on the current file
+fun NitExecute()
+	let path = expand('%')
+
+	if &modified
+		let path = tempname() . '.nit'
+		execute '%write '. path
+	endif
+
+	execute '!nit "' . path . '"'
+endfun
+command NitExecute call NitExecute()
+
 if !exists("g:nit_disable_omnifunc") || !g:nit_disable_omnifunc
 	" Activate the omnifunc on Nit files
 	autocmd FileType nit set omnifunc=NitOmnifunc


### PR DESCRIPTION
Adds the `:NitExecute` command (or `:NitE` as shortcut) to interpret the current file with `nit`.

This is very similar to the manual `:!nit %` but it saves modified buffers to a temp file to execute the content of the current buffer and not the last saved content.

This is completely up to you but I recommend mapping this to `ctrl-f` to fit between `ctrl-d -> Nitdoc` and `ctrl-g -> NitGitGrep`. Here are the required lines for `.vimrc`:

~~~
" Map the Nitdoc command to Ctrl-D
map <C-d> :Nitdoc<enter>

" Map the NitGitGrep function to Ctrl-G
map <C-g> :call NitGitGrep()<enter>

" Map the NitExecute function to Ctrl-F <------- The new one
map <C-f> :NitExecute<enter>
~~~