### PR TITLE
Extends catalog with a *try it* and a *download apk* links

### DIFF
--- a/contrib/benitlux/package.ini
+++ b/contrib/benitlux/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=contrib/benitlux/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+tryit=http://benitlux.xymus.net/

--- a/contrib/crazy_moles/package.ini
+++ b/contrib/crazy_moles/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=contrib/crazy_moles/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+apk=http://nitlanguage.org/fdroid/apk/moles_android.apk

--- a/contrib/friendz/package.ini
+++ b/contrib/friendz/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=contrib/friendz/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+apk=http://nitlanguage.org/fdroid/apk/friendz_android.apk

--- a/contrib/mnit_test/package.ini
+++ b/contrib/mnit_test/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=examples/mnit_simple/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+apk=http://nitlanguage.org/fdroid/apk/test_all.apk

--- a/contrib/nitrpg/package.ini
+++ b/contrib/nitrpg/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=contrib/nitrpg/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+tryit=http://nitlanguage.org/rpg/games/nitlang/nit

--- a/contrib/online_ide/package.ini
+++ b/contrib/online_ide/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=contrib/online_ide/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+tryit=http://nitlanguage.org/online_ide/

--- a/contrib/opportunity/package.ini
+++ b/contrib/opportunity/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=contrib/opportunity/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+tryit=http://xymus.net/opportunity/

--- a/contrib/pep8analysis/package.ini
+++ b/contrib/pep8analysis/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=contrib/pep8analysis/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+tryit=http://pep8.xymus.net/

--- a/contrib/tinks/package.ini
+++ b/contrib/tinks/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=contrib/tinks/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+apk=http://nitlanguage.org/fdroid/apk/tinks.apk

--- a/contrib/tnitter/package.ini
+++ b/contrib/tnitter/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=contrib/tnitter/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+tryit=http://tnitter.xymus.net/

--- a/examples/calculator/package.ini
+++ b/examples/calculator/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=examples/calculator/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+apk=http://nitlanguage.org/fdroid/apk/calculator.apk

--- a/examples/mnit_ballz/package.ini
+++ b/examples/mnit_ballz/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=examples/mnit_ballz/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+apk=http://nitlanguage.org/fdroid/apk/ballz.apk

--- a/examples/mnit_dino/package.ini
+++ b/examples/mnit_dino/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=examples/mnit_dino/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+apk=http://nitlanguage.org/fdroid/apk/dino.apk

--- a/examples/shoot/package.ini
+++ b/examples/shoot/package.ini
@@ -9,3 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=examples/shoot/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
+apk=http://nitlanguage.org/fdroid/apk/shoot_android.apk

--- a/src/nitcatalog.nit
+++ b/src/nitcatalog.nit
@@ -365,28 +365,25 @@ class Catalog
 
 		res.add "<h3>Tags</h3>\n"
 		var tags = mpackage.metadata("package.tags")
-		var ts2 = new Array[String]
-		var cat = null
+		var ts = new Array[String]
 		if tags != null then
-			var ts = tags.split(",")
-			for t in ts do
+			for t in tags.split(",") do
 				t = t.trim
 				if t == "" then continue
-				if cat == null then cat = t
-				tag2proj[t].add mpackage
-				t = t.html_escape
-				ts2.add "<a href=\"../index.html#tag_{t}\">{t}</a>"
+				ts.add t
 			end
-			res.add_list(ts2, ", ", ", ")
 		end
-		if ts2.is_empty then
-			var t = "none"
-			cat = t
+		if ts.is_empty then ts.add "none"
+		var ts2 = new Array[String]
+		for t in ts do
 			tag2proj[t].add mpackage
-			res.add "<a href=\"../index.html#tag_{t}\">{t}</a>"
+			t = t.html_escape
+			ts2.add "<a href=\"../index.html#tag_{t}\">{t}</a>"
 		end
-		if cat != null then cat2proj[cat].add mpackage
-		score += ts2.length.score
+		res.add_list(ts2, ", ", ", ")
+		var cat = ts.first
+		cat2proj[cat].add mpackage
+		score += ts.length.score
 
 		if deps.has(mpackage) then
 			var reqs = deps[mpackage].greaters.to_a

--- a/src/nitcatalog.nit
+++ b/src/nitcatalog.nit
@@ -319,6 +319,12 @@ class Catalog
 			var e = tryit.html_escape
 			res.add "<li><a href=\"{e}\">Try<span style=\"color:white\">n</span>it!</a></li>\n"
 		end
+		var apk = mpackage.metadata("upstream.apk")
+		if apk != null then
+			score += 1.0
+			var e = apk.html_escape
+			res.add "<li><a href=\"{e}\">Android apk</a></li>\n"
+		end
 
 		res.add """</ul>\n<ul class="box">\n"""
 
@@ -384,6 +390,7 @@ class Catalog
 		end
 		if ts.is_empty then ts.add "none"
 		if tryit != null then ts.add "tryit"
+		if apk != null then ts.add "apk"
 		var ts2 = new Array[String]
 		for t in ts do
 			tag2proj[t].add mpackage

--- a/src/nitcatalog.nit
+++ b/src/nitcatalog.nit
@@ -313,6 +313,15 @@ class Catalog
 <div class="sidebar">
 <ul class="box">
 """
+		var tryit = mpackage.metadata("upstream.tryit")
+		if tryit != null then
+			score += 1.0
+			var e = tryit.html_escape
+			res.add "<li><a href=\"{e}\">Try<span style=\"color:white\">n</span>it!</a></li>\n"
+		end
+
+		res.add """</ul>\n<ul class="box">\n"""
+
 		var homepage = mpackage.metadata("upstream.homepage")
 		if homepage != null then
 			score += 5.0
@@ -374,6 +383,7 @@ class Catalog
 			end
 		end
 		if ts.is_empty then ts.add "none"
+		if tryit != null then ts.add "tryit"
 		var ts2 = new Array[String]
 		for t in ts do
 			tag2proj[t].add mpackage


### PR DESCRIPTION
Two new package metadata are added

* `upstream.tryit` for an URL that points to a demo version or a live version of the main web service offered by the package.
* `upstream.apk` for an URL that points to a dry `apk`, or an install page on some store, for the main android application offered by the package.

Moreover, packages that have one them will be respectively tagged `tryit` and `apk`

A demo is available: http://info.uqam.ca/~privat/catalog/#tag_tryit and http://info.uqam.ca/~privat/catalog/#tag_apk