### PR TITLE
Make stream and iterators withable

### DIFF
--- a/lib/core/collection/abstract_collection.nit
+++ b/lib/core/collection/abstract_collection.nit
@@ -228,6 +228,16 @@ interface Iterator[E]
 	# Iterate over `self`
 	fun iterator: Iterator[E] do return self
 
+	# Pre-iteration hook.
+	#
+	# Used to inform `self` that the iteration is starting.
+	# Specific iterators can use this to prepare some resources.
+	#
+	# Is automatically invoked at the beginning of `for` structures.
+	#
+	# Do nothing by default.
+	fun start do end
+
 	# Post-iteration hook.
 	#
 	# Used to inform `self` that the iteration is over.
@@ -707,6 +717,16 @@ interface MapIterator[K, V]
 
 	# Set a new `item` at `key`.
 	#fun item=(item: E) is abstract
+
+	# Pre-iteration hook.
+	#
+	# Used to inform `self` that the iteration is starting.
+	# Specific iterators can use this to prepare some resources.
+	#
+	# Is automatically invoked at the beginning of `for` structures.
+	#
+	# Do nothing by default.
+	fun start do end
 
 	# Post-iteration hook.
 	#

--- a/lib/core/stream.nit
+++ b/lib/core/stream.nit
@@ -39,6 +39,26 @@ abstract class Stream
 
 	# close the stream
 	fun close is abstract
+
+	# Pre-work hook.
+	#
+	# Used to inform `self` that operations will start.
+	# Specific streams can use this to prepare some resources.
+	#
+	# Is automatically invoked at the beginning of `with` structures.
+	#
+	# Do nothing by default.
+	fun start do end
+
+	# Post-work hook.
+	#
+	# Used to inform `self` that the operations are over.
+	# Specific streams can use this to free some resources.
+	#
+	# Is automatically invoked at the end of `woth` structures.
+	#
+	# call `close` by default.
+	fun finish do close
 end
 
 # A `Stream` that can be read from

--- a/misc/vim/syntax/nit.vim
+++ b/misc/vim/syntax/nit.vim
@@ -88,7 +88,7 @@ syn match  NITComment	"#.*" contains=NITTodo,@Spell
 " Keywords
 syn keyword NITKeyword	 abstract intern new
 syn keyword NITDefine	 private public protected intrude readable writable redef
-syn keyword NITControl   if while for assert and or in as isa once break continue return abort
+syn keyword NITControl   if while for with assert and or in as isa once break continue return abort
 syn keyword NITClass     nullable
 syn keyword NITInclude   special
 syn keyword NITTodo      FIXME NOTE TODO XXX contained

--- a/tests/sav/test_with.res
+++ b/tests/sav/test_with.res
@@ -1,0 +1,9 @@
+1
+2
+3
+4
+1
+one
+2
+two
+# Regression test for the Nit project

--- a/tests/test_with.nit
+++ b/tests/test_with.nit
@@ -1,0 +1,32 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+var a = [1,2,3,4]
+with i = a.iterator do while i.is_ok do
+	print i.item
+	i.next
+end
+
+var m = new HashMap[Int, String]
+m[1] = "one"
+m[2] = "two"
+with i = m.iterator do while i.is_ok do
+	print i.key
+	print i.item
+	i.next
+end
+
+with f = "README.md".to_path.open_ro do
+	print f.read_line
+end


### PR DESCRIPTION
As I wanted to use the `with` statement on Iterators in order to experiment with #1735, I realized that neither them not stream are usable with `with` since they lack the required methods.