### PR TITLE
src: fix null receiver error on useless-signature warning

### DIFF
--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -1536,7 +1536,7 @@ redef class AAttrPropdef
 			ntype = n_intro.n_type.mtype
 		end
 		# check
-		if ntype ==null or ntype != n_type.mtype then return
+		if ntype == null or ntype != n_type.mtype or mpropdef == null then return
 		modelbuilder.advice(n_type, "useless-signature", "Warning: useless type repetition on redefined attribute `{mpropdef.name}`")
 	end
 end


### PR DESCRIPTION
This caused most tools to crash on some useless types in redefined signatures. In my case, there was other problems in the same propdef, so it looks like it was not handling properly a "keep going" logic.