### PR TITLE
Loader refactor

### DIFF
--- a/contrib/online_ide/sources/nit/pnacl_nit.nit
+++ b/contrib/online_ide/sources/nit/pnacl_nit.nit
@@ -97,7 +97,7 @@ redef class ModelBuilder
 	redef fun module_absolute_path(path: String): String do return path
 
 	# We don't use paths as the interpreter, so we don't use location or lookpaths args (see the default implementation).
-	redef fun search_module_in_paths(location: nullable Location, name: String, lookpaths: Collection[String]): nullable ModulePath
+	redef fun search_module_in_paths(location: nullable Location, name: String, lookpaths: Collection[String]): nullable MModule
 	do
 		var candidate: nullable String = null
 		var try_file = "{name}.nit"
@@ -114,7 +114,7 @@ redef class ModelBuilder
 			end
 		end
 		if candidate == null then return null
-		return identify_file(candidate)
+		return identify_module(candidate)
 	end
 end
 

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -73,8 +73,6 @@ redef class ModelBuilder
 		for a in modules do
 			var nmodule = self.load_module(a)
 			if nmodule == null then continue # Skip error
-			# Load imported module
-			build_module_importation(nmodule)
 			var mmodule = nmodule.mmodule
 			if mmodule == null then continue # skip error
 			mmodules.add mmodule
@@ -1028,6 +1026,7 @@ redef class MModule
 		var nmodule = parse(modelbuilder)
 		if nmodule == null then return null
 
+		modelbuilder.build_module_importation(nmodule)
 		return nmodule
 	end
 end

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -130,6 +130,7 @@ redef class ModelBuilder
 			if stat != null and stat.is_dir then
 				self.toolcontext.info("look in directory {a}", 2)
 				var fs = a.files
+				alpha_comparator.sort(fs)
 				# Try each entry as a group or a module
 				for f in fs do
 					var af = a/f
@@ -539,7 +540,9 @@ redef class ModelBuilder
 		var p = mgroup.filepath
 		# a virtual group has nothing to scan
 		if p == null then return
-		for f in p.files do
+		var files = p.files
+		alpha_comparator.sort(files)
+		for f in files do
 			var fp = p/f
 			var g = identify_group(fp)
 			# Recursively scan for groups of the same package

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -199,8 +199,8 @@ redef class ModelBuilder
 	# Path can be added (or removed) by the client
 	var paths = new Array[String]
 
-	# Like (and used by) `get_mmodule_by_name` but just return the ModulePath
-	fun search_mmodule_by_name(anode: nullable ANode, mgroup: nullable MGroup, name: String): nullable ModulePath
+	# Like (and used by) `get_mmodule_by_name` but does not force the parsing of the MModule (cf. `identify_module`)
+	fun search_mmodule_by_name(anode: nullable ANode, mgroup: nullable MGroup, name: String): nullable MModule
 	do
 		# First, look in groups
 		var c = mgroup
@@ -208,7 +208,7 @@ redef class ModelBuilder
 			var r = c.mpackage.root
 			assert r != null
 			scan_group(r)
-			var res = r.mmodule_paths_by_name(name)
+			var res = r.mmodules_by_name(name)
 			if res.not_empty then return res.first
 		end
 
@@ -247,42 +247,32 @@ redef class ModelBuilder
 	# If no module exists or there is a name conflict, then an error on `anode` is displayed and null is returned.
 	fun get_mmodule_by_name(anode: nullable ANode, mgroup: nullable MGroup, name: String): nullable MModule
 	do
-		var path = search_mmodule_by_name(anode, mgroup, name)
-		if path == null then return null # Forward error
-		return load_module_path(path)
-	end
-
-	# Load and process importation of a given ModulePath.
-	#
-	# Basically chains `load_module` and `build_module_importation`.
-	fun load_module_path(path: ModulePath): nullable MModule
-	do
-		var res = self.load_module(path.filepath)
-		if res == null then return null # Forward error
-		# Load imported module
-		build_module_importation(res)
-		return res.mmodule
+		var mmodule = search_mmodule_by_name(anode, mgroup, name)
+		if mmodule == null then return null # Forward error
+		var ast = mmodule.load(self)
+		if ast == null then return null # Forward error
+		return mmodule
 	end
 
 	# Search a module `name` from path `lookpaths`.
-	# If found, the path of the file is returned
-	private fun search_module_in_paths(location: nullable Location, name: String, lookpaths: Collection[String]): nullable ModulePath
+	# If found, the module is returned.
+	private fun search_module_in_paths(location: nullable Location, name: String, lookpaths: Collection[String]): nullable MModule
 	do
-		var res = new ArraySet[ModulePath]
+		var res = new ArraySet[MModule]
 		for dirname in lookpaths do
 			# Try a single module file
-			var mp = identify_file((dirname/"{name}.nit").simplify_path)
+			var mp = identify_module((dirname/"{name}.nit").simplify_path)
 			if mp != null then res.add mp
 			# Try the default module of a group
 			var g = identify_group((dirname/name).simplify_path)
 			if g != null then
 				scan_group(g)
-				res.add_all g.mmodule_paths_by_name(name)
+				res.add_all g.mmodules_by_name(name)
 			end
 		end
 		if res.is_empty then return null
 		if res.length > 1 then
-			toolcontext.error(location, "Error: conflicting module files for `{name}`: `{res.join(",")}`")
+			toolcontext.error(location, "Error: conflicting module files for `{name}`: `{[for x in res do x.filepath or else x.full_name].join("`, `")}`")
 		end
 		return res.first
 	end
@@ -301,26 +291,36 @@ redef class ModelBuilder
 		return res
 	end
 
-	# Cache for `identify_file` by realpath
-	private var identified_files_by_path = new HashMap[String, nullable ModulePath]
+	# Cache for `identify_module` by relative and real paths
+	private var identified_modules_by_path = new HashMap[String, nullable MModule]
 
 	# All the currently identified modules.
-	# See `identify_file`.
-	var identified_files = new Array[ModulePath]
+	# See `identify_module`.
+	#
+	# An identified module exists in the model but might be not yet parsed (no AST), or not yet analysed (no importation).
+	var identified_modules = new Array[MModule]
+
+	# All the currently parsed modules.
+	#
+	# A parsed module exists in the model but might be not yet analysed (no importation).
+	var parsed_modules = new Array[MModule]
 
 	# Identify a source file and load the associated package and groups if required.
 	#
 	# This method does what the user expects when giving an argument to a Nit tool.
 	#
 	# * If `path` is an existing Nit source file (with the `.nit` extension),
-	#   then the associated ModulePath is returned
+	#   then the associated MModule is returned
 	# * If `path` is a directory (with a `/`),
-	#   then the ModulePath of its default module is returned (if any)
+	#   then the MModule of its default module is returned (if any)
 	# * If `path` is a simple identifier (eg. `digraph`),
 	#   then the main module of the package `digraph` is searched in `paths` and returned.
 	#
 	# Silently return `null` if `path` does not exists or cannot be identified.
-	fun identify_file(path: String): nullable ModulePath
+	#
+	# On success, it returns a module that is possibly not yet parsed (no AST), or not yet analysed (no importation).
+	# If the module was already identified, or loaded, it is returned.
+	fun identify_module(path: String): nullable MModule
 	do
 		# special case for not a nit file
 		if not path.has_suffix(".nit") then
@@ -352,9 +352,9 @@ redef class ModelBuilder
 		end
 
 		# Fast track, the path is already known
-		if identified_files_by_path.has_key(path) then return identified_files_by_path[path]
+		if identified_modules_by_path.has_key(path) then return identified_modules_by_path[path]
 		var rp = module_absolute_path(path)
-		if identified_files_by_path.has_key(rp) then return identified_files_by_path[rp]
+		if identified_modules_by_path.has_key(rp) then return identified_modules_by_path[rp]
 
 		var pn = path.basename(".nit")
 
@@ -378,12 +378,14 @@ redef class ModelBuilder
 			end
 		end
 
-		var res = new ModulePath(pn, path, mgroup)
-		mgroup.module_paths.add(res)
+		var src = new SourceFile.from_string(path, "")
+		var loc = new Location(src, 0, 0, 0, 0)
+		var res = new MModule(model, mgroup, pn, loc)
+		res.filepath = path
 
-		identified_files_by_path[rp] = res
-		identified_files_by_path[path] = res
-		identified_files.add(res)
+		identified_modules_by_path[rp] = res
+		identified_modules_by_path[path] = res
+		identified_modules.add(res)
 		return res
 	end
 
@@ -533,7 +535,7 @@ redef class ModelBuilder
 			var g = identify_group(fp)
 			# Recursively scan for groups of the same package
 			if g == null then
-				identify_file(fp)
+				identify_module(fp)
 			else if g.mpackage == mgroup.mpackage then
 				scan_group(g)
 			end
@@ -587,7 +589,7 @@ redef class ModelBuilder
 		var keep = new Array[String]
 		var res = new Array[String]
 		for a in args do
-			var l = identify_file(a)
+			var l = identify_module(a)
 			if l == null then
 				keep.add a
 			else
@@ -603,13 +605,12 @@ redef class ModelBuilder
 	# Display an error if there is a problem (IO / lexer / parser) and return null.
 	# Note: usually, you do not need this method, use `get_mmodule_by_name` instead.
 	#
-	# The MModule is created however, the importation is not performed,
-	# therefore you should call `build_module_importation`.
+	# The MModule is located, created, parsed and the importation is performed.
 	fun load_module(filename: String): nullable AModule
 	do
 		# Look for the module
-		var file = identify_file(filename)
-		if file == null then
+		var mmodule = identify_module(filename)
+		if mmodule == null then
 			if filename.file_exists then
 				toolcontext.error(null, "Error: `{filename}` is not a Nit source file.")
 			else
@@ -618,25 +619,8 @@ redef class ModelBuilder
 			return null
 		end
 
-		# Already known and loaded? then return it
-		var mmodule = file.mmodule
-		if mmodule != null then
-			return mmodule2nmodule[mmodule]
-		end
-
-		# Load it manually
-		var nmodule = load_module_ast(file.filepath)
-		if nmodule == null then return null # forward error
-
-		# build the mmodule and load imported modules
-		mmodule = build_a_mmodule(file.mgroup, file.name, nmodule)
-
-		if mmodule == null then return null # forward error
-
-		# Update the file information
-		file.mmodule = mmodule
-
-		return nmodule
+		# Load it
+		return mmodule.load(self)
 	end
 
 	# Injection of a new module without source.
@@ -665,22 +649,25 @@ redef class ModelBuilder
 	end
 
 	# Visit the AST and create the `MModule` object
-	private fun build_a_mmodule(mgroup: nullable MGroup, mod_name: String, nmodule: AModule): nullable MModule
+	private fun build_a_mmodule(mgroup: nullable MGroup, nmodule: AModule)
 	do
+		var mmodule = nmodule.mmodule
+		assert mmodule != null
+
 		# Check the module name
 		var decl = nmodule.n_moduledecl
 		if decl != null then
 			var decl_name = decl.n_name.n_id.text
-			if decl_name != mod_name then
-				error(decl.n_name, "Error: module name mismatch; declared {decl_name} file named {mod_name}.")
+			if decl_name != mmodule.name then
+				error(decl.n_name, "Error: module name mismatch; declared {decl_name} file named {mmodule.name}.")
 			end
 		end
 
 		# Check for conflicting module names in the package
 		if mgroup != null then
-			var others = model.get_mmodules_by_name(mod_name)
+			var others = model.get_mmodules_by_name(mmodule.name)
 			if others != null then for other in others do
-				if other.mgroup!= null and other.mgroup.mpackage == mgroup.mpackage then
+				if other != mmodule and mmodule2nmodule.has_key(mmodule) and other.mgroup!= null and other.mgroup.mpackage == mgroup.mpackage then
 					var node: ANode
 					if decl == null then node = nmodule else node = decl.n_name
 					error(node, "Error: a module named `{other.full_name}` already exists at {other.location}.")
@@ -689,9 +676,6 @@ redef class ModelBuilder
 			end
 		end
 
-		# Create the module
-		var mmodule = new MModule(model, mgroup, mod_name, nmodule.location)
-		nmodule.mmodule = mmodule
 		nmodules.add(nmodule)
 		self.mmodule2nmodule[mmodule] = nmodule
 
@@ -714,14 +698,12 @@ redef class ModelBuilder
 			# Is the module a test suite?
 			mmodule.is_test_suite = not decl.get_annotations("test_suite").is_empty
 		end
-
-		return mmodule
 	end
 
 	# Resolve the module identification for a given `AModuleName`.
 	#
 	# This method handles qualified names as used in `AModuleName`.
-	fun seach_module_by_amodule_name(n_name: AModuleName, mgroup: nullable MGroup): nullable ModulePath
+	fun seach_module_by_amodule_name(n_name: AModuleName, mgroup: nullable MGroup): nullable MModule
 	do
 		var mod_name = n_name.n_id.text
 
@@ -741,12 +723,12 @@ redef class ModelBuilder
 			assert r != null
 			scan_group(r)
 			# Get all modules with the final name
-			var res = r.mmodule_paths_by_name(mod_name)
+			var res = r.mmodules_by_name(mod_name)
 			# Filter out the name that does not match the qualifiers
 			res = [for x in res do if match_amodulename(n_name, x) then x]
 			if res.not_empty then
 				if res.length > 1 then
-					error(n_name, "Error: conflicting module files for `{mod_name}`: `{res.join(",")}`")
+					error(n_name, "Error: conflicting module files for `{mod_name}`: `{[for x in res do x.filepath or else x.full_name].join("`, `")}`")
 				end
 				return res.first
 			end
@@ -761,16 +743,16 @@ redef class ModelBuilder
 			return null
 		end
 
-		var res = new ArraySet[ModulePath]
+		var res = new ArraySet[MModule]
 		for r in roots do
 			# Then, for each root, collect modules that matches the qualifiers
 			scan_group(r)
-			var root_res = r.mmodule_paths_by_name(mod_name)
+			var root_res = r.mmodules_by_name(mod_name)
 			for x in root_res do if match_amodulename(n_name, x) then res.add x
 		end
 		if res.not_empty then
 			if res.length > 1 then
-				error(n_name, "Error: conflicting module files for `{mod_name}`: `{res.join(",")}`")
+				error(n_name, "Error: conflicting module files for `{mod_name}`: `{[for x in res do x.filepath or else x.full_name].join("`, `")}`")
 			end
 			return res.first
 		end
@@ -785,7 +767,7 @@ redef class ModelBuilder
 	# but not `baz/foo.nit` nor `foo/bar.nit`
 	#
 	# Is used by `seach_module_by_amodule_name` to validate qualified names.
-	private fun match_amodulename(n_name: AModuleName, m: ModulePath): Bool
+	private fun match_amodulename(n_name: AModuleName, m: MModule): Bool
 	do
 		var g: nullable MGroup = m.mgroup
 		for grp in n_name.n_path.reverse_iterator do
@@ -817,14 +799,14 @@ redef class ModelBuilder
 			end
 
 			# Load the imported module
-			var suppath = seach_module_by_amodule_name(aimport.n_name, mmodule.mgroup)
-			if suppath == null then
+			var sup = seach_module_by_amodule_name(aimport.n_name, mmodule.mgroup)
+			if sup == null then
 				mmodule.is_broken = true
 				nmodule.mmodule = null # invalidate the module
 				continue # Skip error
 			end
-			var sup = load_module_path(suppath)
-			if sup == null then
+			var ast = sup.load(self)
+			if ast == null then
 				mmodule.is_broken = true
 				nmodule.mmodule = null # invalidate the module
 				continue # Skip error
@@ -967,10 +949,6 @@ redef class ModelBuilder
 					var m
 					if rule_element isa MModule then
 						m = rule_element
-					else if rule_element isa ModulePath then
-						m = rule_element.mmodule
-						# Is loaded?
-						if m == null then continue label
 					else
 						abort
 					end
@@ -1018,22 +996,49 @@ redef class ModelBuilder
 	end
 end
 
-# File-system location of a module (file) that is identified but not always loaded.
-class ModulePath
-	# The name of the module
-	# (it's the basename of the filepath)
-	var name: String
+redef class MModule
+	# The path of the module source
+	var filepath: nullable String = null
 
-	# The human path of the module
-	var filepath: String
+	# Force the parsing of the module using `modelbuilder`.
+	#
+	# If the module was already parsed, the existing ASI is returned.
+	# Else the source file is loaded, and parsed and some
+	#
+	# The importation is not done by this
+	#
+	# REQUIRE: `filepath != null`
+	# ENSURE: `modelbuilder.parsed_modules.has(self)`
+	fun parse(modelbuilder: ModelBuilder): nullable AModule
+	do
+		# Already known and loaded? then return it
+		var nmodule = modelbuilder.mmodule2nmodule.get_or_null(self)
+		if nmodule != null then return nmodule
 
-	# The group (and the package) of the possible module
-	var mgroup: MGroup
+		var filepath = self.filepath
+		assert filepath != null
+		# Load it manually
+		nmodule = modelbuilder.load_module_ast(filepath)
+		if nmodule == null then return null # forward error
 
-	# The loaded module (if any)
-	var mmodule: nullable MModule = null
+		# build the mmodule
+		nmodule.mmodule = self
+		modelbuilder.build_a_mmodule(mgroup, nmodule)
 
-	redef fun to_s do return filepath
+		modelbuilder.parsed_modules.add self
+		return nmodule
+	end
+
+	# Parse and process importation of a given MModule.
+	#
+	# Basically chains `parse` and `build_module_importation`.
+	fun load(modelbuilder: ModelBuilder): nullable AModule
+	do
+		var nmodule = parse(modelbuilder)
+		if nmodule == null then return null
+
+		return nmodule
+	end
 end
 
 redef class MPackage
@@ -1046,9 +1051,6 @@ redef class MPackage
 end
 
 redef class MGroup
-	# Modules paths associated with the group
-	var module_paths = new Array[ModulePath]
-
 	# Is the group interesting for a final user?
 	#
 	# Groups are mandatory in the model but for simple packages they are not
@@ -1061,8 +1063,7 @@ redef class MGroup
 	# * it has a documentation
 	fun is_interesting: Bool
 	do
-		return module_paths.length > 1 or
-			mmodules.length > 1 or
+		return mmodules.length > 1 or
 			not in_nesting.direct_smallers.is_empty or
 			mdoc != null or
 			(mmodules.length == 1 and default_mmodule == null)
@@ -1077,11 +1078,11 @@ redef class MGroup
 	#
 	# If `self` is not scanned (see `ModelBuilder::scan_group`) the
 	# results might be partial.
-	fun mmodule_paths_by_name(name: String): Array[ModulePath]
+	fun mmodules_by_name(name: String): Array[MModule]
 	do
-		var res = new Array[ModulePath]
+		var res = new Array[MModule]
 		for g in in_nesting.smallers do
-			for mp in g.module_paths do
+			for mp in g.mmodules do
 				if mp.name == name then
 					res.add mp
 				end
@@ -1103,7 +1104,8 @@ end
 
 redef class AModule
 	# The associated MModule once build by a `ModelBuilder`
-	var mmodule: nullable MModule
+	var mmodule: nullable MModule = null
+
 	# Flag that indicate if the importation is already completed
 	var is_importation_done: Bool = false
 end

--- a/src/model/mmodule.nit
+++ b/src/model/mmodule.nit
@@ -22,7 +22,11 @@ import mpackage
 private import more_collections
 
 # The container class of a Nit object-oriented model.
+#
 # A model knows modules, classes and properties and can retrieve them.
+#
+# However, a model is not a program or a library as it can contains modules
+# found by the system (including broken ones) but not used.
 redef class Model
 	# All known modules
 	var mmodules = new Array[MModule]

--- a/src/model/model_viz.nit
+++ b/src/model/model_viz.nit
@@ -19,9 +19,8 @@ import model
 import ordered_tree
 
 # A simple specialisation of OrderedTree to display packages, groups and modules
-# FIXME do not use Object, but a better common interface of MModule and MGroup
 class MPackageTree
-	super OrderedTree[Object]
+	super OrderedTree[MConcern]
 
 	# The model where to look for information
 	var model: Model
@@ -58,11 +57,10 @@ class MPackageTree
 end
 
 # Compare modules and groups using the
-# FIXME do not use Object, but a better common interface of MModule and MGroup
 private class LinexComparator
 	super Comparator
 
-	redef type COMPARED: Object
+	redef type COMPARED: MConcern
 
 	var mins = new HashMap [MGroup, nullable MModule]
 	var maxs = new HashMap [MGroup, nullable MModule]
@@ -111,7 +109,7 @@ private class LinexComparator
 		var order = ma.model.mmodule_importation_hierarchy
 		return order.compare(ma, mb)
 	end
-	var tree: OrderedTree[Object]
+	var tree: OrderedTree[MConcern]
 end
 
 redef class Model

--- a/src/modelbuilder.nit
+++ b/src/modelbuilder.nit
@@ -89,7 +89,7 @@ redef class ModelBuilder
 	# Run phases on all loaded modules
 	fun run_phases
 	do
-		var mmodules = model.mmodules.to_a
+		var mmodules = parsed_modules.to_a
 		model.mmodule_importation_hierarchy.sort(mmodules)
 		var nmodules = new Array[AModule]
 		for mm in mmodules do

--- a/src/nitcatalog.nit
+++ b/src/nitcatalog.nit
@@ -245,7 +245,7 @@ class Catalog
 	end
 
 	# Recursively generate a level in the file tree of the *content* section
-	private fun gen_content_level(ot: OrderedTree[Object], os: Array[Object], res: Template)
+	private fun gen_content_level(ot: OrderedTree[MConcern], os: Array[Object], res: Template)
 	do
 		res.add "<ul>\n"
 		for o in os do
@@ -290,7 +290,7 @@ class Catalog
 		end
 
 		res.add "<h2>Content</h2>"
-		var ot = new OrderedTree[Object]
+		var ot = new OrderedTree[MConcern]
 		for g in mpackage.mgroups do
 			var pa = g.parent
 			if g.is_interesting then

--- a/src/nitcatalog.nit
+++ b/src/nitcatalog.nit
@@ -255,13 +255,10 @@ class Catalog
 				var mdoc = o.mdoc
 				if mdoc != null then d = ": {mdoc.html_synopsis.write_to_string}"
 				res.add "<strong>{o.name}</strong>{d} ({o.filepath.to_s})"
-			else if o isa ModulePath then
+			else if o isa MModule then
 				var d = ""
-				var m = o.mmodule
-				if m != null then
-					var mdoc = m.mdoc
-					if mdoc != null then d = ": {mdoc.html_synopsis.write_to_string}"
-				end
+				var mdoc = o.mdoc
+				if mdoc != null then d = ": {mdoc.html_synopsis.write_to_string}"
 				res.add "<strong>{o.name}</strong>{d} ({o.filepath.to_s})"
 			else
 				abort
@@ -300,7 +297,7 @@ class Catalog
 				ot.add(pa, g)
 				pa = g
 			end
-			for mp in g.module_paths do
+			for mp in g.mmodules do
 				ot.add(pa, mp)
 			end
 		end
@@ -464,7 +461,7 @@ class Catalog
 		var mmethods = 0
 		var loc = 0
 		for g in mpackage.mgroups do
-			mmodules += g.module_paths.length
+			mmodules += g.mmodules.length
 			for m in g.mmodules do
 				var am = modelbuilder.mmodule2node(m)
 				if am != null then
@@ -685,9 +682,11 @@ var modelbuilder = new ModelBuilder(model, tc)
 var catalog = new Catalog(modelbuilder)
 
 # Get files or groups
-for a in tc.option_context.rest do
-	modelbuilder.get_mgroup(a)
-	modelbuilder.identify_file(a)
+var args = tc.option_context.rest
+if opt_no_parse.value then
+	modelbuilder.scan_full(args)
+else
+	modelbuilder.parse_full(args)
 end
 
 # Scan packages and compute information
@@ -698,7 +697,6 @@ for p in model.mpackages do
 
 	# Load the module to process importation information
 	if opt_no_parse.value then continue
-	modelbuilder.parse_group(g)
 
 	catalog.deps.add_node(p)
 	for gg in p.mgroups do for m in gg.mmodules do

--- a/src/nitls.nit
+++ b/src/nitls.nit
@@ -22,7 +22,7 @@ import ordered_tree
 import console
 
 class ProjTree
-	super OrderedTree[Object]
+	super OrderedTree[MConcern]
 
 	var opt_paths = false
 	var tc: ToolContext

--- a/src/nitls.nit
+++ b/src/nitls.nit
@@ -87,24 +87,6 @@ class ProjTree
 	end
 end
 
-class AlphaEntityComparator
-	super Comparator
-	fun nameof(a: COMPARED): String
-	do
-		if a isa MGroup then
-			return a.name
-		else if a isa ModulePath then
-			return a.name
-		else
-			abort
-		end
-	end
-	redef fun compare(a,b)
-	do
-		return nameof(a) <=> nameof(b)
-	end
-end
-
 var tc = new ToolContext
 
 var opt_keep = new OptionBool("Ignore errors and files that are not a Nit source file", "-k", "--keep")
@@ -189,7 +171,6 @@ if opt_depends.value then
 end
 
 var ot = new ProjTree(tc)
-var sorter = new AlphaEntityComparator
 if opt_tree.value then
 	ot.opt_paths = opt_paths.value
 	var mgroups = new HashSet[MGroup]
@@ -205,12 +186,12 @@ if opt_tree.value then
 			ot.add(pa, g)
 		end
 	end
-	ot.sort_with(sorter)
+	ot.sort_with(alpha_comparator)
 	ot.write_to(stdout)
 end
 
 if opt_source.value then
-	sorter.sort(mmodules)
+	alpha_comparator.sort(mmodules)
 	for mp in mmodules do
 		if opt_paths.value then
 			print mp.filepath.as(not null)
@@ -228,7 +209,7 @@ if opt_package.value then
 		mpackages.add p
 	end
 
-	sorter.sort(mpackages)
+	alpha_comparator.sort(mpackages)
 	for p in mpackages do
 		var g = p.root.as(not null)
 		var path = g.filepath.as(not null)

--- a/src/nitunit.nit
+++ b/src/nitunit.nit
@@ -77,7 +77,7 @@ for a in args do
 end
 
 for a in module_files do
-	var g = modelbuilder.get_mgroup(a)
+	var g = modelbuilder.identify_group(a)
 	if g == null then continue
 	page.add modelbuilder.test_group(g)
 end

--- a/tests/nitls.args
+++ b/tests/nitls.args
@@ -3,3 +3,4 @@ base_simple3.nit project1
 -t -r base_simple3.nit project1
 -s base_simple3.nit project1
 -M base_simple3.nit base_simple_import.nit
+-td project1/module3.nit

--- a/tests/sav/base_import2_alt1.res
+++ b/tests/sav/base_import2_alt1.res
@@ -1,1 +1,1 @@
-alt/base_import2_alt1.nit:16,8--25: Error: conflicting module files for `module_0`: `./project1/module_0.nit,./project1/subdir/module_0.nit`
+alt/base_import2_alt1.nit:16,8--25: Error: conflicting module files for `module_0`: `./project1/module_0.nit`, `./project1/subdir/module_0.nit`

--- a/tests/sav/nitls_args6.res
+++ b/tests/sav/nitls_args6.res
@@ -1,0 +1,5 @@
+project1 ([33mproject1[m)
+|--[1mmodule1[m ([33mproject1/module1.nit[m)
+|--[1mmodule3[m ([33mproject1/module3.nit[m)[37m (module4)[m
+`--subdir ([33mproject1/subdir[m)
+   `--[1mmodule4[m ([33mproject1/subdir/module4.nit[m)[37m (module1)[m

--- a/tests/sav/nitmetrics_args1.res
+++ b/tests/sav/nitmetrics_args1.res
@@ -1,4 +1,92 @@
 *** METRICS ***
+--- AST Metrics ---
+## All nodes of the AST
+ population: 51
+ minimum value: 1
+ maximum value: 40
+ total value: 289
+ average value: 5.66
+ distribution:
+  <=1: sub-population=16 (31.37%); cumulated value=16 (5.53%)
+  <=2: sub-population=5 (9.80%); cumulated value=10 (3.46%)
+  <=4: sub-population=9 (17.64%); cumulated value=28 (9.68%)
+  <=8: sub-population=12 (23.52%); cumulated value=76 (26.29%)
+  <=16: sub-population=4 (7.84%); cumulated value=44 (15.22%)
+  <=32: sub-population=4 (7.84%); cumulated value=75 (25.95%)
+  <=64: sub-population=1 (1.96%); cumulated value=40 (13.84%)
+ list:
+  TId: 40 (13.84%)
+  APublicVisibility: 19 (6.57%)
+  AQid: 19 (6.57%)
+  AListExprs: 19 (6.57%)
+  ACallExpr: 18 (6.22%)
+  TClassid: 15 (5.19%)
+  TInteger: 10 (3.46%)
+  AIntegerExpr: 10 (3.46%)
+  AType: 9 (3.11%)
+  TKwend: 8 (2.76%)
+  ...
+  ACallAssignExpr: 1 (0.34%)
+  AAnnotations: 1 (0.34%)
+  TKwreturn: 1 (0.34%)
+  AReturnExpr: 1 (0.34%)
+  AInterfaceClasskind: 1 (0.34%)
+  TKwinterface: 1 (0.34%)
+  ANoImport: 1 (0.34%)
+  AMainMethPropdef: 1 (0.34%)
+  AMainClassdef: 1 (0.34%)
+  TKwimport: 1 (0.34%)
+## All identifiers of the AST
+ population: 20
+ minimum value: 1
+ maximum value: 11
+ total value: 55
+ average value: 2.75
+ distribution:
+  <=1: sub-population=3 (15.00%); cumulated value=3 (5.45%)
+  <=2: sub-population=12 (60.00%); cumulated value=24 (43.63%)
+  <=4: sub-population=3 (15.00%); cumulated value=10 (18.18%)
+  <=8: sub-population=1 (5.00%); cumulated value=7 (12.72%)
+  <=16: sub-population=1 (5.00%); cumulated value=11 (20.00%)
+ list:
+  output: 11 (20.00%)
+  Int: 7 (12.72%)
+  run: 4 (7.27%)
+  c: 3 (5.45%)
+  val: 3 (5.45%)
+  i: 2 (3.63%)
+  bar: 2 (3.63%)
+  foo: 2 (3.63%)
+  val2: 2 (3.63%)
+  val1: 2 (3.63%)
+  C: 2 (3.63%)
+  v: 2 (3.63%)
+  baz: 2 (3.63%)
+  a: 2 (3.63%)
+  A: 2 (3.63%)
+  B: 2 (3.63%)
+  b: 2 (3.63%)
+  intern: 1 (1.81%)
+  Object: 1 (1.81%)
+  Bool: 1 (1.81%)
+--- Detection of variance constraints on formal parameter types ---
+-- Generic classes --
+ list:
+  non generic: 7 (100.00%)
+  total classes: 7
+  total formal parameters: 0
+-- Including `private` properties --
+  covariants: 0 (na%)
+  contravariants: 0 (na%)
+  bivariants: 0 (na%)
+  invariants: 0 (na%)
+  total: 0
+-- Excluding `private` properties --
+  covariants: 0 (na%)
+  contravariants: 0 (na%)
+  bivariants: 0 (na%)
+  invariants: 0 (na%)
+  total: 0
 
 # MModules metrics
 
@@ -126,36 +214,6 @@
 	  min: base_simple3 (1)
 	  std: 0.0
 	  sum: 1
---- Metrics of refinement usage ---
-Number of modules: 1
-
-Number of classes: 7
-  Number of interface kind: 1 (14.28%)
-  Number of enum kind: 2 (28.57%)
-  Number of class kind: 4 (57.14%)
-
-Number of class definitions: 7
-Number of refined classes: 0 (0.00%)
-Average number of class refinments by classes: 0.00
-Average number of class refinments by refined classes: na
-
-Number of properties: 18
-  Number of MAttribute: 3 (16.66%)
-  Number of MMethod: 15 (83.33%)
-
-Number of property definitions: 20
-Number of redefined properties: 1 (5.55%)
-Average number of property redefinitions by property: 0.11
-Average number of property redefinitions by redefined property: 2.00
---- Explicit vs. Implicit Self ---
-Total number of self: 5
-Total number of implicit self: 4 (80.00%)
---- Construction of tables ---
-Number of runtime classes: 6 (excluding interfaces and abstract classes)
-Average number of composing class definition by runtime class: 2.00
-Total size of tables (classes and instances): 23 (not including stuff like info for subtyping or call-next-method)
-Average size of table by runtime class: 3.83
-Values never redefined: 17 (73.91%)
 --- Poset metrics ---
 ## Module importation hierarchy
 Number of nodes: 1
@@ -273,94 +331,38 @@ Distribution of direct smallers
  distribution:
   <=0: sub-population=6 (85.71%); cumulated value=0 (0.00%)
   <=8: sub-population=1 (14.28%); cumulated value=6 (100.00%)
---- AST Metrics ---
-## All nodes of the AST
- population: 51
- minimum value: 1
- maximum value: 40
- total value: 289
- average value: 5.66
- distribution:
-  <=1: sub-population=16 (31.37%); cumulated value=16 (5.53%)
-  <=2: sub-population=5 (9.80%); cumulated value=10 (3.46%)
-  <=4: sub-population=9 (17.64%); cumulated value=28 (9.68%)
-  <=8: sub-population=12 (23.52%); cumulated value=76 (26.29%)
-  <=16: sub-population=4 (7.84%); cumulated value=44 (15.22%)
-  <=32: sub-population=4 (7.84%); cumulated value=75 (25.95%)
-  <=64: sub-population=1 (1.96%); cumulated value=40 (13.84%)
- list:
-  TId: 40 (13.84%)
-  APublicVisibility: 19 (6.57%)
-  AQid: 19 (6.57%)
-  AListExprs: 19 (6.57%)
-  ACallExpr: 18 (6.22%)
-  TClassid: 15 (5.19%)
-  TInteger: 10 (3.46%)
-  AIntegerExpr: 10 (3.46%)
-  AType: 9 (3.11%)
-  TKwend: 8 (2.76%)
-  ...
-  ACallAssignExpr: 1 (0.34%)
-  AAnnotations: 1 (0.34%)
-  TKwreturn: 1 (0.34%)
-  AReturnExpr: 1 (0.34%)
-  AInterfaceClasskind: 1 (0.34%)
-  TKwinterface: 1 (0.34%)
-  ANoImport: 1 (0.34%)
-  AMainMethPropdef: 1 (0.34%)
-  AMainClassdef: 1 (0.34%)
-  TKwimport: 1 (0.34%)
-## All identifiers of the AST
- population: 20
- minimum value: 1
- maximum value: 11
- total value: 55
- average value: 2.75
- distribution:
-  <=1: sub-population=3 (15.00%); cumulated value=3 (5.45%)
-  <=2: sub-population=12 (60.00%); cumulated value=24 (43.63%)
-  <=4: sub-population=3 (15.00%); cumulated value=10 (18.18%)
-  <=8: sub-population=1 (5.00%); cumulated value=7 (12.72%)
-  <=16: sub-population=1 (5.00%); cumulated value=11 (20.00%)
- list:
-  output: 11 (20.00%)
-  Int: 7 (12.72%)
-  run: 4 (7.27%)
-  c: 3 (5.45%)
-  val: 3 (5.45%)
-  i: 2 (3.63%)
-  bar: 2 (3.63%)
-  foo: 2 (3.63%)
-  val2: 2 (3.63%)
-  val1: 2 (3.63%)
-  C: 2 (3.63%)
-  v: 2 (3.63%)
-  baz: 2 (3.63%)
-  a: 2 (3.63%)
-  A: 2 (3.63%)
-  B: 2 (3.63%)
-  b: 2 (3.63%)
-  intern: 1 (1.81%)
-  Object: 1 (1.81%)
-  Bool: 1 (1.81%)
---- Detection of variance constraints on formal parameter types ---
--- Generic classes --
- list:
-  non generic: 7 (100.00%)
-  total classes: 7
-  total formal parameters: 0
--- Including `private` properties --
-  covariants: 0 (na%)
-  contravariants: 0 (na%)
-  bivariants: 0 (na%)
-  invariants: 0 (na%)
-  total: 0
--- Excluding `private` properties --
-  covariants: 0 (na%)
-  contravariants: 0 (na%)
-  bivariants: 0 (na%)
-  invariants: 0 (na%)
-  total: 0
+--- Metrics of refinement usage ---
+Number of modules: 1
+
+Number of classes: 7
+  Number of interface kind: 1 (14.28%)
+  Number of enum kind: 2 (28.57%)
+  Number of class kind: 4 (57.14%)
+
+Number of class definitions: 7
+Number of refined classes: 0 (0.00%)
+Average number of class refinments by classes: 0.00
+Average number of class refinments by refined classes: na
+
+Number of properties: 18
+  Number of MAttribute: 3 (16.66%)
+  Number of MMethod: 15 (83.33%)
+
+Number of property definitions: 20
+Number of redefined properties: 1 (5.55%)
+Average number of property redefinitions by property: 0.11
+Average number of property redefinitions by redefined property: 2.00
+--- Explicit vs. Implicit Self ---
+Total number of self: 5
+Total number of implicit self: 4 (80.00%)
+--- Construction of tables ---
+Number of runtime classes: 6 (excluding interfaces and abstract classes)
+Average number of composing class definition by runtime class: 2.00
+Total size of tables (classes and instances): 23 (not including stuff like info for subtyping or call-next-method)
+Average size of table by runtime class: 3.83
+Values never redefined: 17 (73.91%)
+generating package_hierarchy.dot
+generating module_hierarchy.dot
 
 # MClasses metrics
 
@@ -488,8 +490,6 @@ Distribution of direct smallers
 	  min: Object (0)
 	  std: 0.926
 	  sum: 6
-generating package_hierarchy.dot
-generating module_hierarchy.dot
 
 # Inheritance metrics
 

--- a/tests/sav/nitx_args3.res
+++ b/tests/sav/nitx_args3.res
@@ -4,15 +4,15 @@
  [1m[32mP[m[m [1m[34mbase_simple3[m[m
    [1m[30mbase_simple3[m[m
    package base_simple3
-   [30mbase_simple3.nit:17,1--66,13[m
+   [30mbase_simple3.nit[m
 
  [1m[32mG[m[m [1m[34mbase_simple3[m[m
    [1m[30mbase_simple3[m[m
    group base_simple3
-   [30mbase_simple3.nit:17,1--66,13[m
+   [30mbase_simple3.nit[m
 
  [1m[32mM[m[m [1m[34mbase_simple3[m[m
    [1m[30mbase_simple3::base_simple3[m[m
    module base_simple3
-   [30mbase_simple3.nit:17,1--66,13[m
+   [30mbase_simple3.nit[m
 


### PR DESCRIPTION
A big refactorization of the loader

This include cleanup, renaming and documentation of the existing code.

The major change is the removal of `ModulePath` used to designate an identified module that is not yet loaded. This caused major issues since once the module was loaded, the MModule object has to be used instead.
Now, genuine `MModule` are used to also represent modules identified in the file system but not yet loaded.
This simplify the code of the loader, nitls and nitcatalog.

By the way, the option `-d` (and `-M`) of nitls that was broken by the previous changes in the loader is now fixed.

Another change is the introduction of `scan_full` that is a high-level method to be used by clients like nitls or nitcatalog that just need to identify packages, groups and modules in the filesystem without loading them.

By the way, nitcalatog works on directories of projects now. eg. `nitcatalog ../lib)

Note, because this PR introduces a lot of interrelated changes, It was hard to come up with nice commits. The alternative was to have a single big commit.