### PR TITLE
mnit: Fix error on refined virtual types

### DIFF
--- a/lib/mnit/android/android_app.nit
+++ b/lib/mnit/android/android_app.nit
@@ -37,8 +37,6 @@ in "C" `{
 `}
 
 redef class App
-	redef type D: Opengles1Display
-
 	redef fun init_window
 	do
 		display = new Opengles1Display

--- a/lib/mnit/linux/linux_app.nit
+++ b/lib/mnit/linux/linux_app.nit
@@ -26,9 +26,6 @@ in "C" `{
 `}
 
 redef class App
-	redef type D: Opengles1Display
-	redef type I: Opengles1Image
-
 	redef fun setup
 	do
 		if "NIT_TESTING".environ == "true" then exit 0
@@ -39,8 +36,11 @@ redef class App
 
 	redef fun generate_input
 	do
+		var display = display
+		assert display isa Opengles1Display
+
 		for event in display.sdl_display.events do
-			input( event )
+			input event
 		end
 	end
 end

--- a/tests/sav/ballz_linux.res
+++ b/tests/sav/ballz_linux.res
@@ -1,2 +1,0 @@
-../lib/mnit/linux/linux_app.nit:29,16--31: Redef Error: a virtual type cannot be refined.
-../lib/mnit/linux/linux_app.nit:30,16--29: Redef Error: a virtual type cannot be refined.

--- a/tests/sav/dino_linux.res
+++ b/tests/sav/dino_linux.res
@@ -1,2 +1,0 @@
-../lib/mnit/linux/linux_app.nit:29,16--31: Redef Error: a virtual type cannot be refined.
-../lib/mnit/linux/linux_app.nit:30,16--29: Redef Error: a virtual type cannot be refined.

--- a/tests/sav/shoot_linux.res
+++ b/tests/sav/shoot_linux.res
@@ -1,2 +1,0 @@
-../lib/mnit/linux/linux_app.nit:29,16--31: Redef Error: a virtual type cannot be refined.
-../lib/mnit/linux/linux_app.nit:30,16--29: Redef Error: a virtual type cannot be refined.


### PR DESCRIPTION
Simple fix for the "Redef Error" in mnit clients: do not redef virtual types, instead assert the types in the users methods.