### PR TITLE
nitx: introduce NLP queries

### DIFF
--- a/share/man/nitx.md
+++ b/share/man/nitx.md
@@ -38,6 +38,9 @@ lookup documentation pages about 'name'.
 ### `code: name`
 lookup source code related to 'name'.
 
+### `keywords: query`
+lookup entities with a documentation that matches 'query'.
+
 ### `:h`
 display an help message about the commands.
 
@@ -56,6 +59,45 @@ Ignore the attributes.
 
 ### `--private`
 Also generate private API.
+
+### `--nlp`
+Use NLP phases (default is `no`).
+
+Because the NLP processing can be long for big projects, these phases
+are disabled by default.
+
+### `--cp`
+Java classpath for StanfordNLP jars.
+
+# FEATURES
+
+## NLP Queries
+
+Thanks to the nit `nlp` library, `nitx` is able to parse natural language queries
+and lookup entities with comments that matches.
+
+Usage:
+
+~~~raw
+./nitx --nlp --cp "/path/to/stanford_core_nlp/*" lib/
+>> keywords: shortest path in a graph
+# 9 result(s) for 'keywords: shortest path in a graph'
+
+ M a_star # A* pathfinding in graphs
+   a_star::a_star
+   module a_star
+   lib/a_star.nit:17,1--411,3
+
+ M graph # Provides an interface for services on a Neo4j graphs.
+   neo4j::graph::graph
+   module graph
+   lib/neo4j/graph/graph.nit:11,1--278,3
+
+ M json_graph_store # Provides JSON as a mean to store graphs.
+   neo4j::graph::json_graph_store
+   module json_graph_store
+   lib/neo4j/graph/json_graph_store.nit:11,1--321,3
+~~~
 
 # SEE ALSO
 

--- a/src/doc/doc_commands.nit
+++ b/src/doc/doc_commands.nit
@@ -57,6 +57,8 @@ interface DocCommand
 			return new CallCommand(command_string)
 		else if command_string.has_prefix("code:") then
 			return new CodeCommand(command_string)
+		else if command_string.has_prefix("keywords:") then
+			return new NLPCommand(command_string)
 		end
 		return new UnknownCommand(command_string)
 	end
@@ -151,5 +153,12 @@ end
 # * `./src/file.nit` to include source code from a file.
 # * `./src/file.nit:1,2--3,4` to select code between positions.
 class CodeCommand
+	super AbstractDocCommand
+end
+
+# A `DocCommand` that search mentities comments matching a natural language query.
+#
+# Syntax: `keywords: query in natural language`.
+class NLPCommand
 	super AbstractDocCommand
 end

--- a/src/doc/doc_phases/doc_nlp.nit
+++ b/src/doc/doc_phases/doc_nlp.nit
@@ -1,0 +1,138 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Apply NLP analysis to DocModel.
+#
+# Result of the analysis can then be used by other phases.
+#
+# NLP can be used to handle natural language queries, compare documents, valid
+# comments syntax, sky is the limit...
+module doc_nlp
+
+import doc_extract
+import doc_down
+import nlp
+import nlp::vsm
+import metrics::metrics_base
+
+redef class ToolContext
+
+	# Because the NLP processing can be long, we deactivate it by default.
+	var opt_nlp = new OptionBool("Use NLP phases (default is `no`)", "--nlp")
+
+	# Classpath to StanfordNLPJar
+	var opt_nlp_cp = new OptionString("Java classpath for StanfordNLP jars", "--cp")
+
+	redef init do
+		super
+		option_context.add_option(opt_nlp, opt_nlp_cp)
+	end
+
+	# Java NLP classpath to use.
+	#
+	# See `opt_nlp_cp`.
+	var nlp_cp: String is lazy do
+		var cp = opt_nlp_cp.value
+		if cp == null then cp = "*"
+		return cp
+	end
+end
+
+redef class DocModel
+	# NLProcessor instance used to process comments.
+	var nlp_processor: NLPProcessor is noinit
+end
+
+# NLP processing phase for comments.
+class NLPPhase
+	super DocPhase
+
+	# Populates the given DocModel with NLP documents.
+	redef fun apply do
+		if not ctx.opt_nlp.value then return
+
+		# Build nlp indexes
+		doc.nlp_processor = new NLPProcessor(ctx.nlp_cp)
+		# FIXME also index projects README files
+		var mentities = new Array[MEntity]
+		mentities.add_all doc.mmodules
+		mentities.add_all doc.mclasses
+		mentities.add_all doc.mproperties
+		build_nlp_documents(mentities)
+	end
+
+	# Build NLPDocuents from the comments of the `mentities`.
+	#
+	# See `MEntity::nlp_document`.
+	fun build_nlp_documents(mentities: Collection[MEntity]) do
+		var tmp_dir = ".nitdoc.nlp.tmp/"
+		tmp_dir.mkdir
+
+		# Process `mentities` comments.
+		var proc = doc.nlp_processor
+		var input_files = build_nlp_inputs(tmp_dir, mentities)
+		var map = proc.process_files(input_files.values, tmp_dir)
+
+		# Retrieve documents and associate them to their entities
+		for mentity, file in input_files do
+			mentity.nlp_document = map[file]
+		end
+
+		tmp_dir.rmdir
+	end
+
+	# Generate NLP input files for the NLP processor batch mode.
+	fun build_nlp_inputs(tmp_dir: String, mentities: Collection[MEntity]): Map[MEntity, String] do
+		var inputs = new HashMap[MEntity, String]
+		for mentity in mentities do
+			var file = tmp_dir / mentity.nitdoc_id
+
+			# Write the mentity comment into a single file
+			var fw = new FileWriter.open(file)
+			var mdoc = mentity.mdoc
+			if mdoc != null then
+				fw.write mdoc.comment
+			else
+				fw.write ""
+			end
+			fw.close
+
+			inputs[mentity] = file
+		end
+		return inputs
+	end
+end
+
+redef class MEntity
+	# NLPDocument associated with this mentity `comment`.
+	var nlp_document: nullable NLPDocument = null
+end
+
+# Cosine Similarity with other comments.
+class VectorSimilarityMetric
+	super FloatMetric
+
+	redef type ELM: NLPVector
+
+	redef fun name do return "cosine_similarity"
+	redef fun desc do return "Cosine similarity to other vectors"
+
+	# MVector compared with.
+	var vector: NLPVector
+
+	redef fun collect(vectors) do
+		var v = self.vector
+		for ov in vectors do values[ov] = v.cosine_similarity(ov)
+	end
+end

--- a/src/nitx.nit
+++ b/src/nitx.nit
@@ -46,6 +46,7 @@ private class NitxPhase
 
 		var phases = [
 			new ExtractionPhase(toolcontext, doc),
+			new NLPPhase(toolcontext, doc),
 			new MakePagePhase(toolcontext, doc),
 			new ConcernsPhase(toolcontext, doc),
 			new StructurePhase(toolcontext, doc),


### PR DESCRIPTION
This PR adds a new feature to the `nitx` documentation console tool.

Thanks to the nit `nlp` library, `nitx` is now able to parse natural language queries
and lookup entities with comments that matches.

Usage:

~~~raw
./nitx --nlp --cp "/path/to/stanford_core_nlp/*" lib/

>> keywords: shortest path in a graph

# 9 result(s) for 'keywords: shortest path in a graph'

 M a_star # A* pathfinding in graphs
   a_star::a_star
   module a_star
   lib/a_star.nit:17,1--411,3

 M graph # Provides an interface for services on a Neo4j graphs.
   neo4j::graph::graph
   module graph
   lib/neo4j/graph/graph.nit:11,1--278,3

 M json_graph_store # Provides JSON as a mean to store graphs.
   neo4j::graph::json_graph_store
   module json_graph_store
   lib/neo4j/graph/json_graph_store.nit:11,1--321,3

...
~~~

The entiere indexing process will be improved, this is just a proof of concept and a good client example for #1754.

Require #1754 and #1755