### PR TITLE
Kill pseudo toplevel methods

### DIFF
--- a/contrib/wiringPi/lib/wiringPi.nit
+++ b/contrib/wiringPi/lib/wiringPi.nit
@@ -29,20 +29,21 @@ in "C Header" `{
 `}
 
 
-redef class Object
-	# This initialises wiringPi and assumes that the calling program is
-	# going to be using the wiringPi pin numbering scheme.
-	fun wiringPi_setup `{ wiringPiSetup(); `}
-	# Same as wiringPi_setup, however it allows the calling programs to
-	# use the Broadcom GPIO pin numbers directly with no re-mapping.
-	fun wiringPi_setup_gpio `{ wiringPiSetupGpio(); `}
-	# Identical to wiringPi_setup, however it allows the calling
-	# programs to use the physical pin numbers on the P1 connector only.
-	fun wiringPi_setup_phys `{ wiringPiSetupPhys(); `}
-	# This initialises wiringPi but uses the /sys/class/gpio interface
-	# rather than accessing the hardware directly.
-	fun wiringPi_setup_sys `{ wiringPiSetupSys(); `}
-end
+# Initializes wiringPi.
+# Assumes that the calling program is going to be using the wiringPi pin numbering scheme.
+fun wiringPi_setup `{ wiringPiSetup(); `}
+
+# Same as wiringPi_setup, but with GPIO.
+# It allows the calling programs to use the Broadcom GPIO pin numbers directly with no re-mapping.
+fun wiringPi_setup_gpio `{ wiringPiSetupGpio(); `}
+
+# Same as to wiringPi_setup, but with physical pin numbers.
+# It allows the calling programs to use the physical pin numbers on the P1 connector only.
+fun wiringPi_setup_phys `{ wiringPiSetupPhys(); `}
+
+# This initializes wiringPi, but with the /sys/class/gpio interface.
+# Use `/sys/class/gpio` rather than accessing the hardware directly.
+fun wiringPi_setup_sys `{ wiringPiSetupSys(); `}
 
 # A Raspberry Pi GPIO Pin
 extern class RPiPin `{ CRPiPin *`}

--- a/lib/bcm2835/bcm2835.nit
+++ b/lib/bcm2835/bcm2835.nit
@@ -25,11 +25,9 @@ in "C Header" `{
 	#include <bcm2835.h>
 `}
 
-redef class Object
-	protected fun bcm2835_init: Bool `{ return bcm2835_init(); `}
-	protected fun bcm2835_close `{ bcm2835_close(); `}
-	protected fun bcm2835_debug=(v: Bool) `{ bcm2835_set_debug(v); `}
-end
+fun bcm2835_init: Bool `{ return bcm2835_init(); `}
+fun bcm2835_close `{ bcm2835_close(); `}
+fun bcm2835_debug=(v: Bool) `{ bcm2835_set_debug(v); `}
 
 # A physical binary pin
 interface Pin

--- a/lib/core/time.nit
+++ b/lib/core/time.nit
@@ -21,10 +21,8 @@ in "C Header" `{
 	#include <time.h>
 `}
 
-redef class Object
-	# Unix time: the number of seconds elapsed since January 1, 1970
-	protected fun get_time: Int `{ return time(NULL); `}
-end
+# Unix time: the number of seconds elapsed since January 1, 1970
+fun get_time: Int `{ return time(NULL); `}
 
 redef class Sys
 	# Wait a specific number of second and nanoseconds

--- a/lib/egl.nit
+++ b/lib/egl.nit
@@ -103,6 +103,12 @@ extern class EGLDisplay `{ EGLDisplay `}
 		}
 	`}
 
+	private fun report_egl_error(cmsg: NativeString)
+	do
+		var msg = cmsg.to_s
+		print "libEGL error: {msg}"
+	end
+
 	# Can be used directly, but it is preferable to use a `EGLConfigAttribs`
 	fun config_attrib(config: EGLConfig, attribute: Int): Int `{
 		EGLint val;
@@ -440,14 +446,6 @@ class EGLConfigChooser
 	do
 		assert closed else print "EGLConfigChooser not closed."
 		return display.choose_configs(array)
-	end
-end
-
-redef class Object
-	private fun report_egl_error(cmsg: NativeString)
-	do
-		var msg = cmsg.to_s
-		print "libEGL error: {msg}"
 	end
 end
 

--- a/src/ffi/cpp.nit
+++ b/src/ffi/cpp.nit
@@ -195,11 +195,9 @@ redef class NitniCallback
 	fun compile_callback_to_cpp(mmodule: MModule, mainmodule: MModule) do end
 end
 
-redef class Object
-	private fun cpp_call_context: CppCallContext do return once new CppCallContext
-	private fun to_cpp_call_context: ToCppCallContext do return once new ToCppCallContext
-	private fun from_cpp_call_context: FromCppCallContext do return once new FromCppCallContext
-end
+fun cpp_call_context: CppCallContext do return once new CppCallContext
+fun to_cpp_call_context: ToCppCallContext do return once new ToCppCallContext
+fun from_cpp_call_context: FromCppCallContext do return once new FromCppCallContext
 
 redef class MExplicitCall
 	redef fun compile_callback_to_cpp(mmodule, mainmodule)

--- a/src/ffi/light_c.nit
+++ b/src/ffi/light_c.nit
@@ -91,13 +91,11 @@ class ForeignCType
 	redef var ctype: String
 end
 
-redef class Object
-	# Context when calling user C code from generated code
-	fun to_c_call_context: ToCCallContext do return once new ToCCallContext
+# Context when calling user C code from generated code
+fun to_c_call_context: ToCCallContext do return once new ToCCallContext
 
-	# Context when calling generated code from user C code
-	fun from_c_call_context: FromCCallContext do return once new FromCCallContext
-end
+# Context when calling generated code from user C code
+fun from_c_call_context: FromCCallContext do return once new FromCCallContext
 
 # Context when calling user C code from generated code
 class ToCCallContext

--- a/src/nitni/nitni_utilities.nit
+++ b/src/nitni/nitni_utilities.nit
@@ -140,12 +140,10 @@ class CallContext
 	fun cast_to(mtype: MType, name: String): String do return name
 end
 
-redef class Object
-	# Call context to use
-	protected fun internal_call_context: CallContext do return new CallContext
-	protected fun long_signature: SignatureLength do return once new SignatureLength(true)
-	protected fun short_signature: SignatureLength do return once new SignatureLength(false)
-end
+# Call context to use
+fun internal_call_context: CallContext do return new CallContext
+fun long_signature: SignatureLength do return once new SignatureLength(true)
+fun short_signature: SignatureLength do return once new SignatureLength(false)
 
 # Length of the signature of a C function (long version hase the module name as prefix)
 class SignatureLength


### PR DESCRIPTION
Move some methods from Object to the top-level (Sys) as they do not rely on `self` and are intended to be called from everywhere.

Beside documentation improvement, this should slightly reduce the size of tables as methods introduced in Object are inherited by all classes.