### PR TITLE
lib/mongodb: minor fixes

### DIFF
--- a/lib/mongodb/mongodb.nit
+++ b/lib/mongodb/mongodb.nit
@@ -604,10 +604,7 @@ class MongoCollection
 		assert is_alive # FIXME used to avoid segfault (so `self` isn't garbage collected to soon)
 		if c == null then return null
 		var cursor = new MongoCursor(c)
-		if cursor.is_ok then
-			cursor.next
-			return cursor.item
-		end
+		if cursor.is_ok then return cursor.item
 		return null
 	end
 

--- a/lib/mongodb/mongodb.nit
+++ b/lib/mongodb/mongodb.nit
@@ -600,8 +600,9 @@ class MongoCollection
 	# ~~~
 	fun find(query: JsonObject): nullable JsonObject do
 		assert is_alive
-		var c = native.find(query.to_bson.native)
-		assert is_alive # FIXME used to avoid segfault (so `self` isn't garbage collected to soon)
+		var q = new NativeBSON.from_json_string(query.to_json.to_cstring)
+		var c = native.find(q)
+		q.destroy
 		if c == null then return null
 		var cursor = new MongoCursor(c)
 		if cursor.is_ok then return cursor.item


### PR DESCRIPTION
This PR apply some fixes to the MongoDB library:
* avoids crash when `Collection::find` returns only one element
* fixes the SegFault workaround in `Collection::find`