### PR TITLE
lib/github: clean code and add some services

### DIFF
--- a/lib/github/api.nit
+++ b/lib/github/api.nit
@@ -351,7 +351,7 @@ abstract class GithubEntity
 	redef fun to_s do return json.to_json
 
 	# Github page url.
-	fun html_url: String do return json["html_url"].to_s
+	fun html_url: String do return json["html_url"].as(String)
 end
 
 # A Github user
@@ -368,12 +368,12 @@ class User
 
 	# Init `self` from a `json` object.
 	init from_json(api: GithubAPI, json: JsonObject) do
-		init(api, json["login"].to_s)
+		init(api, json["login"].as(String))
 		self.json = json
 	end
 
 	# Avatar image url for this user.
-	fun avatar_url: String do return json["avatar_url"].to_s
+	fun avatar_url: String do return json["avatar_url"].as(String)
 end
 
 # A Github repository.
@@ -390,12 +390,12 @@ class Repo
 
 	# Init `self` from a `json` object.
 	init from_json(api: GithubAPI, json: JsonObject) do
-		init(api, json["full_name"].to_s)
+		init(api, json["full_name"].as(String))
 		self.json = json
 	end
 
 	# Repo short name on Github.
-	fun name: String do return json["name"].to_s
+	fun name: String do return json["name"].as(String)
 
 	# Get the repo owner.
 	fun owner: User do
@@ -410,7 +410,7 @@ class Repo
 		if not array isa JsonArray then return res
 		for obj in array do
 			if not obj isa JsonObject then continue
-			var name = obj["name"].to_s
+			var name = obj["name"].as(String)
 			res[name] = new Branch.from_json(api, self, obj)
 		end
 		return res
@@ -470,7 +470,7 @@ class Repo
 		if not array isa JsonArray then return res
 		for obj in array do
 			if not obj isa JsonObject then continue
-			var name = obj["name"].to_s
+			var name = obj["name"].as(String)
 			res[name] = new Label.from_json(api, self, obj)
 		end
 		return res
@@ -528,7 +528,7 @@ class Repo
 
 	# Repo default branch.
 	fun default_branch: Branch do
-		var name = json["default_branch"].to_s
+		var name = json["default_branch"].as(String)
 		var branch = api.load_branch(self, name)
 		assert branch isa Branch
 		return branch
@@ -564,7 +564,7 @@ class Branch
 	var name: String
 
 	redef init from_json(api, repo, json) do
-		self.name = json["name"].to_s
+		self.name = json["name"].as(String)
 		super
 	end
 
@@ -609,7 +609,7 @@ class Commit
 	var sha: String
 
 	redef init from_json(api, repo, json) do
-		self.sha = json["sha"].to_s
+		self.sha = json["sha"].as(String)
 		super
 	end
 
@@ -620,7 +620,7 @@ class Commit
 		if not parents isa JsonArray then return res
 		for obj in parents do
 			if not obj isa JsonObject then continue
-			res.add(api.load_commit(repo, obj["sha"].to_s).as(not null))
+			res.add(api.load_commit(repo, obj["sha"].as(String)).as(not null))
 		end
 		return res
 	end
@@ -645,14 +645,14 @@ class Commit
 	fun author_date: ISODate do
 		var commit = json["commit"].as(JsonObject)
 		var author = commit["author"].as(JsonObject)
-		return new ISODate.from_string(author["date"].to_s)
+		return new ISODate.from_string(author["date"].as(String))
 	end
 
 	# Commit date as ISODate.
 	fun commit_date: ISODate do
 		var commit = json["commit"].as(JsonObject)
 		var author = commit["committer"].as(JsonObject)
-		return new ISODate.from_string(author["date"].to_s)
+		return new ISODate.from_string(author["date"].as(String))
 	end
 
 	# List files staged in this commit.
@@ -667,7 +667,7 @@ class Commit
 	end
 
 	# Commit message.
-	fun message: String do return json["commit"].as(JsonObject)["message"].to_s
+	fun message: String do return json["commit"].as(JsonObject)["message"].as(String)
 end
 
 # A Github issue.
@@ -689,7 +689,7 @@ class Issue
 	end
 
 	# Issue title.
-	fun title: String do return json["title"].to_s
+	fun title: String do return json["title"].as(String)
 
 	# User that created this issue.
 	fun user: User do
@@ -702,14 +702,14 @@ class Issue
 		if not json.has_key("labels") then return res
 		for obj in json["labels"].as(JsonArray) do
 			if not obj isa JsonObject then continue
-			var name = obj["name"].to_s
+			var name = obj["name"].as(String)
 			res[name] = new Label.from_json(api, repo, obj)
 		end
 		return res
 	end
 
 	# State of the issue on Github.
-	fun state: String do return json["state"].to_s
+	fun state: String do return json["state"].as(String)
 
 	# Is the issue locked?
 	fun locked: Bool do return json["locked"].as(Bool)
@@ -750,31 +750,31 @@ class Issue
 	end
 
 	# Number of comments on this issue.
-	fun comments_count: Int do return json["comments"].to_s.to_i
+	fun comments_count: Int do return json["comments"].as(Int)
 
 	# Creation time in ISODate format.
 	fun created_at: ISODate do
-		return new ISODate.from_string(json["created_at"].to_s)
+		return new ISODate.from_string(json["created_at"].as(String))
 	end
 
 	# Last update time in ISODate format (if any).
 	fun updated_at: nullable ISODate do
 		var res = json["updated_at"]
 		if res == null then return null
-		return new ISODate.from_string(res.to_s)
+		return new ISODate.from_string(res.as(String))
 	end
 
 	# Close time in ISODate format (if any).
 	fun closed_at: nullable ISODate do
 		var res = json["closed_at"]
 		if res == null then return null
-		return new ISODate.from_string(res.to_s)
+		return new ISODate.from_string(res.as(String))
 	end
 
 	# TODO link to pull request
 
 	# Full description of the issue.
-	fun body: String  do return json["body"].to_s
+	fun body: String  do return json["body"].as(String)
 
 	# List of events on this issue.
 	fun events: Array[IssueEvent] do
@@ -819,10 +819,10 @@ class PullRequest
 	end
 
 	# Merge commit SHA.
-	fun merge_commit_sha: String do return json["merge_commit_sha"].to_s
+	fun merge_commit_sha: String do return json["merge_commit_sha"].as(String)
 
 	# Count of comments made on the pull request diff.
-	fun review_comments: Int do return json["review_comments"].to_s.to_i
+	fun review_comments: Int do return json["review_comments"].as(Int)
 
 	# Pull request head (can be a commit SHA or a branch name).
 	fun head: PullRef do
@@ -845,7 +845,7 @@ class PullRequest
 	# Mergeable state of this pull request.
 	#
 	# See <https://developer.github.com/v3/pulls/#list-pull-requests>.
-	fun mergeable_state: Int do return json["mergeable_state"].to_s.to_i
+	fun mergeable_state: Int do return json["mergeable_state"].as(Int)
 
 	# User that merged this pull request (if any).
 	fun merged_by: nullable User do
@@ -855,16 +855,16 @@ class PullRequest
 	end
 
 	# Count of commits in this pull request.
-	fun commits: Int do return json["commits"].to_s.to_i
+	fun commits: Int do return json["commits"].as(Int)
 
 	# Added line count.
-	fun additions: Int do return json["additions"].to_s.to_i
+	fun additions: Int do return json["additions"].as(Int)
 
 	# Deleted line count.
-	fun deletions: Int do return json["deletions"].to_s.to_i
+	fun deletions: Int do return json["deletions"].as(Int)
 
 	# Changed files count.
-	fun changed_files: Int do return json["changed_files"].to_s.to_i
+	fun changed_files: Int do return json["changed_files"].as(Int)
 end
 
 # A pull request reference (used for head and base).
@@ -877,13 +877,13 @@ class PullRef
 	var json: JsonObject
 
 	# Label pointed by `self`.
-	fun labl: String do return json["label"].to_s
+	fun labl: String do return json["label"].as(String)
 
 	# Reference pointed by `self`.
-	fun ref: String do return json["ref"].to_s
+	fun ref: String do return json["ref"].as(String)
 
 	# Commit SHA pointed by `self`.
-	fun sha: String do return json["sha"].to_s
+	fun sha: String do return json["sha"].as(String)
 
 	# User pointed by `self`.
 	fun user: User do
@@ -910,12 +910,12 @@ class Label
 	var name: String
 
 	redef init from_json(api, repo, json) do
-		self.name = json["name"].to_s
+		self.name = json["name"].as(String)
 		super
 	end
 
 	# Label color code.
-	fun color: String do return json["color"].to_s
+	fun color: String do return json["color"].as(String)
 end
 
 # A Github milestone.
@@ -937,23 +937,23 @@ class Milestone
 	end
 
 	# Milestone title.
-	fun title: String do return json["title"].to_s
+	fun title: String do return json["title"].as(String)
 
 	# Milestone long description.
-	fun description: String do return json["description"].to_s
+	fun description: String do return json["description"].as(String)
 
 	# Count of opened issues linked to this milestone.
-	fun open_issues: Int do return json["open_issues"].to_s.to_i
+	fun open_issues: Int do return json["open_issues"].as(Int)
 
 	# Count of closed issues linked to this milestone.
-	fun closed_issues: Int do return json["closed_issues"].to_s.to_i
+	fun closed_issues: Int do return json["closed_issues"].as(Int)
 
 	# Milestone state.
-	fun state: String do return json["state"].to_s
+	fun state: String do return json["state"].as(String)
 
 	# Creation time in ISODate format.
 	fun created_at: ISODate do
-		return new ISODate.from_string(json["created_at"].to_s)
+		return new ISODate.from_string(json["created_at"].as(String))
 	end
 
 	# User that created this milestone.
@@ -1008,17 +1008,17 @@ abstract class Comment
 
 	# Creation time in ISODate format.
 	fun created_at: ISODate do
-		return new ISODate.from_string(json["created_at"].to_s)
+		return new ISODate.from_string(json["created_at"].as(String))
 	end
 
 	# Last update time in ISODate format (if any).
 	fun updated_at: nullable ISODate do
 		if not json.has_key("updated_at") then return null
-		return new ISODate.from_string(json["updated_at"].to_s)
+		return new ISODate.from_string(json["updated_at"].as(String))
 	end
 
 	# Comment body text.
-	fun body: String do return json["body"].to_s
+	fun body: String do return json["body"].as(String)
 
 	# Does the comment contain an acknowledgement (+1)
 	fun is_ack: Bool
@@ -1035,7 +1035,7 @@ class CommitComment
 
 	# Commented commit.
 	fun commit: Commit do
-		return api.load_commit(repo, json["commit_id"].to_s).as(not null)
+		return api.load_commit(repo, json["commit_id"].as(String)).as(not null)
 	end
 
 	# Position of the comment on the line.
@@ -1055,7 +1055,7 @@ class CommitComment
 	end
 
 	# Path of the commented file.
-	fun path: String do return json["path"].to_s
+	fun path: String do return json["path"].as(String)
 end
 
 # Comments made on Github issue and pull request pages.
@@ -1075,7 +1075,7 @@ class IssueComment
 	end
 
 	# Link to the issue document on API.
-	fun issue_url: String do return json["issue_url"].to_s
+	fun issue_url: String do return json["issue_url"].as(String)
 end
 
 # Comments made on Github pull request diffs.
@@ -1095,25 +1095,25 @@ class ReviewComment
 	end
 
 	# Link to the pull request on API.
-	fun pull_request_url: String do return json["pull_request_url"].to_s
+	fun pull_request_url: String do return json["pull_request_url"].as(String)
 
 	# Diff hunk.
-	fun diff_hunk: String do return json["diff_hunk"].to_s
+	fun diff_hunk: String do return json["diff_hunk"].as(String)
 
 	# Path of commented file.
-	fun path: String do return json["path"].to_s
+	fun path: String do return json["path"].as(String)
 
 	# Position of the comment on the file.
-	fun position: Int do return json["position"].to_s.to_i
+	fun position: Int do return json["position"].as(Int)
 
 	# Original position in the diff.
-	fun original_position: Int do return json["original_position"].to_s.to_i
+	fun original_position: Int do return json["original_position"].as(Int)
 
 	# Commit referenced by this comment.
-	fun commit_id: String do return json["commit_id"].to_s
+	fun commit_id: String do return json["commit_id"].as(String)
 
 	# Original commit id.
-	fun original_commit_id: String do return json["original_commit_id"].to_s
+	fun original_commit_id: String do return json["original_commit_id"].as(String)
 end
 
 # An event that occurs on a Github `Issue`.
@@ -1146,11 +1146,11 @@ class IssueEvent
 
 	# Creation time in ISODate format.
 	fun created_at: ISODate do
-		return new ISODate.from_string(json["created_at"].to_s)
+		return new ISODate.from_string(json["created_at"].as(String))
 	end
 
 	# Event descriptor.
-	fun event: String do return json["event"].to_s
+	fun event: String do return json["event"].as(String)
 
 	# Commit linked to this event (if any).
 	fun commit_id: nullable String do
@@ -1195,10 +1195,10 @@ class RenameAction
 	var json: JsonObject
 
 	# Name before renaming.
-	fun from: String do return json["from"].to_s
+	fun from: String do return json["from"].as(String)
 
 	# Name after renaming.
-	fun to: String do return json["to"].to_s
+	fun to: String do return json["to"].as(String)
 end
 
 # Contributors list with additions, deletions, and commit counts.
@@ -1229,7 +1229,7 @@ class ContributorStats
 	end
 
 	# Total number of commit.
-	fun total: Int do return json["total"].to_s.to_i
+	fun total: Int do return json["total"].as(Int)
 
 	# Are of weeks of activity with detailed statistics.
 	fun weeks: JsonArray do return json["weeks"].as(JsonArray)
@@ -1247,5 +1247,5 @@ class GithubFile
 	var json: JsonObject
 
 	# File name.
-	fun filename: String do return json["filename"].to_s
+	fun filename: String do return json["filename"].as(String)
 end

--- a/lib/github/api.nit
+++ b/lib/github/api.nit
@@ -909,6 +909,9 @@ class Issue
 			json["closed_by"] = user.json
 		end
 	end
+
+	# Is this issue linked to a pull request?
+	fun is_pull_request: Bool do return json.has_key("pull_request")
 end
 
 # A Github pull request.

--- a/lib/github/api.nit
+++ b/lib/github/api.nit
@@ -352,6 +352,9 @@ abstract class GithubEntity
 
 	# Github page url.
 	fun html_url: String do return json["html_url"].as(String)
+
+	# Set page url.
+	fun html_url=(url: String) do json["html_url"] = url
 end
 
 # A Github user
@@ -374,6 +377,9 @@ class User
 
 	# Avatar image url for this user.
 	fun avatar_url: String do return json["avatar_url"].as(String)
+
+	# Set avatar url.
+	fun avatar_url=(url: String) do json["avatar_url"] = url
 end
 
 # A Github repository.
@@ -397,10 +403,14 @@ class Repo
 	# Repo short name on Github.
 	fun name: String do return json["name"].as(String)
 
+	# Set repo full name
+	fun name=(name: String) do json["name"] = name
+
 	# Get the repo owner.
-	fun owner: User do
-		return new User.from_json(api, json["owner"].as(JsonObject))
-	end
+	fun owner: User do return new User.from_json(api, json["owner"].as(JsonObject))
+
+	# Set repo owner
+	fun owner=(owner: User) do json["owner"] = owner.json
 
 	# List of branches associated with their names.
 	fun branches: Map[String, Branch] do
@@ -533,6 +543,9 @@ class Repo
 		assert branch isa Branch
 		return branch
 	end
+
+	# Set the default branch
+	fun default_branch=(branch: Branch) do json["default_branch"] = branch.json
 end
 
 # A `RepoEntity` is something contained in a `Repo`.
@@ -569,9 +582,10 @@ class Branch
 	end
 
 	# Get the last commit of `self`.
-	fun commit: Commit do
-		return new Commit.from_json(api, repo, json["commit"].as(JsonObject))
-	end
+	fun commit: Commit do return new Commit.from_json(api, repo, json["commit"].as(JsonObject))
+
+	# Set the last commit
+	fun commit=(commit: Commit) do json["commit"] = commit.json
 
 	# List all commits in `self`.
 	#
@@ -625,6 +639,13 @@ class Commit
 		return res
 	end
 
+	# Set parent commits.
+	fun parents=(parents: Array[Commit]) do
+		var res = new JsonArray
+		for parent in parents do res.add parent.json
+		json["parents"] = res
+	end
+
 	# Author of the commit.
 	fun author: nullable User do
 		var user = json.get_or_null("author")
@@ -632,11 +653,29 @@ class Commit
 		return null
 	end
 
+	# Set commit author.
+	fun author=(user: nullable User) do
+		if user == null then
+			json["author"] = null
+		else
+			json["author"] = user.json
+		end
+	end
+
 	# Committer of the commit.
 	fun committer: nullable User do
 		var user = json.get_or_null("author")
 		if user isa JsonObject then return new User.from_json(api, user)
 		return null
+	end
+
+	# Set commit committer.
+	fun committer=(user: nullable User) do
+		if user == null then
+			json["committer"] = null
+		else
+			json["committer"] = user.json
+		end
 	end
 
 	# Authoring date as ISODate.
@@ -664,6 +703,13 @@ class Commit
 		return res
 	end
 
+	# Set commit files.
+	fun files=(files: Array[GithubFile]) do
+		var res = new JsonArray
+		for file in files do res.add file.json
+		json["files"] = res
+	end
+
 	# Commit message.
 	fun message: String do return json["commit"].as(JsonObject)["message"].as(String)
 end
@@ -689,10 +735,14 @@ class Issue
 	# Issue title.
 	fun title: String do return json["title"].as(String)
 
+	# Set issue title
+	fun title=(title: String) do json["title"] = title
+
 	# User that created this issue.
-	fun user: User do
-		return new User.from_json(api, json["user"].as(JsonObject))
-	end
+	fun user: User do return new User.from_json(api, json["user"].as(JsonObject))
+
+	# Set issue creator.
+	fun user=(user: User) do json["user"] = user.json
 
 	# List of labels on this issue associated to their names.
 	fun labels: Map[String, Label] do
@@ -710,8 +760,14 @@ class Issue
 	# State of the issue on Github.
 	fun state: String do return json["state"].as(String)
 
+	# Set the state of this issue.
+	fun state=(state: String) do json["state"] = state
+
 	# Is the issue locked?
 	fun locked: Bool do return json["locked"].as(Bool)
+
+	# Set issue locked state.
+	fun locked=(locked: Bool) do json["locked"] = locked
 
 	# Assigned `User` (if any).
 	fun assignee: nullable User do
@@ -720,11 +776,29 @@ class Issue
 		return null
 	end
 
+	# Set issue assignee.
+	fun assignee=(user: nullable User) do
+		if user == null then
+			json["assignee"] = null
+		else
+			json["assignee"] = user.json
+		end
+	end
+
 	# `Milestone` (if any).
 	fun milestone: nullable Milestone do
 		var milestone = json.get_or_null("milestone")
 		if milestone isa JsonObject then return new Milestone.from_json(api, repo, milestone)
 		return null
+	end
+
+	# Set issue milestone.
+	fun milestone=(milestone: nullable Milestone) do
+		if milestone == null then
+			json["milestone"] = null
+		else
+			json["milestone"] = milestone.json
+		end
 	end
 
 	# List of comments made on this issue.
@@ -752,8 +826,15 @@ class Issue
 	fun comments_count: Int do return json["comments"].as(Int)
 
 	# Creation time in ISODate format.
-	fun created_at: ISODate do
-		return new ISODate.from_string(json["created_at"].as(String))
+	fun created_at: ISODate do return new ISODate.from_string(json["created_at"].as(String))
+
+	# Set issue creation time.
+	fun created_at=(created_at: nullable ISODate) do
+		if created_at == null then
+			json["created_at"] = null
+		else
+			json["created_at"] = created_at.to_s
+		end
 	end
 
 	# Last update time in ISODate format (if any).
@@ -763,6 +844,15 @@ class Issue
 		return null
 	end
 
+	# Set issue last update time.
+	fun updated_at=(updated_at: nullable ISODate) do
+		if updated_at == null then
+			json["updated_at"] = null
+		else
+			json["updated_at"] = updated_at.to_s
+		end
+	end
+
 	# Close time in ISODate format (if any).
 	fun closed_at: nullable ISODate do
 		var res = json.get_or_null("closed_at")
@@ -770,10 +860,22 @@ class Issue
 		return null
 	end
 
+	# Set issue close time.
+	fun closed_at=(closed_at: nullable ISODate) do
+		if closed_at == null then
+			json["closed_at"] = null
+		else
+			json["closed_at"] = closed_at.to_s
+		end
+	end
+
 	# TODO link to pull request
 
 	# Full description of the issue.
-	fun body: String  do return json["body"].as(String)
+	fun body: String do return json["body"].as(String)
+
+	# Set description body
+	fun body=(body: String) do json["body"] = body
 
 	# List of events on this issue.
 	fun events: Array[IssueEvent] do
@@ -798,6 +900,15 @@ class Issue
 		if closer isa JsonObject then return new User.from_json(api, closer)
 		return null
 	end
+
+	# Set user that closed the issue.
+	fun closed_by=(user: nullable User) do
+		if user == null then
+			json["closed_by"] = null
+		else
+			json["closed_by"] = user.json
+		end
+	end
 end
 
 # A Github pull request.
@@ -818,11 +929,26 @@ class PullRequest
 		return null
 	end
 
+	# Set pull request merge time.
+	fun merged_at=(merged_at: nullable ISODate) do
+		if merged_at == null then
+			json["merged_at"] = null
+		else
+			json["merged_at"] = merged_at.to_s
+		end
+	end
+
 	# Merge commit SHA.
 	fun merge_commit_sha: String do return json["merge_commit_sha"].as(String)
 
+	# Set merge_commit_sha
+	fun merge_commit_sha=(sha: String) do json["merge_commit_sha"] = sha
+
 	# Count of comments made on the pull request diff.
 	fun review_comments: Int do return json["review_comments"].as(Int)
+
+	# Set review_comments
+	fun review_comments=(count: Int) do json["review_comments"] = count
 
 	# Pull request head (can be a commit SHA or a branch name).
 	fun head: PullRef do
@@ -830,22 +956,37 @@ class PullRequest
 		return new PullRef(api, json)
 	end
 
+	# Set head
+	fun head=(head: PullRef) do json["head"] = head.json
+
 	# Pull request base (can be a commit SHA or a branch name).
 	fun base: PullRef do
 		var json = json["base"].as(JsonObject)
 		return new PullRef(api, json)
 	end
 
+	# Set base
+	fun base=(base: PullRef) do json["base"] = base.json
+
 	# Is this pull request merged?
 	fun merged: Bool do return json["merged"].as(Bool)
 
+	# Set merged
+	fun merged=(merged: Bool) do json["merged"] = merged
+
 	# Is this pull request mergeable?
 	fun mergeable: Bool do return json["mergeable"].as(Bool)
+
+	# Set mergeable
+	fun mergeable=(mergeable: Bool) do json["mergeable"] = mergeable
 
 	# Mergeable state of this pull request.
 	#
 	# See <https://developer.github.com/v3/pulls/#list-pull-requests>.
 	fun mergeable_state: Int do return json["mergeable_state"].as(Int)
+
+	# Set mergeable_state
+	fun mergeable_state=(mergeable_state: Int) do json["mergeable_state"] = mergeable_state
 
 	# User that merged this pull request (if any).
 	fun merged_by: nullable User do
@@ -854,17 +995,38 @@ class PullRequest
 		return null
 	end
 
+	# Set merged_by.
+	fun merged_by=(merged_by: nullable User) do
+		if merged_by == null then
+			json["merged_by"] = null
+		else
+			json["merged_by"] = merged_by.json
+		end
+	end
+
 	# Count of commits in this pull request.
 	fun commits: Int do return json["commits"].as(Int)
+
+	# Set commits
+	fun commits=(commits: Int) do json["commits"] = commits
 
 	# Added line count.
 	fun additions: Int do return json["additions"].as(Int)
 
+	# Set additions
+	fun additions=(additions: Int) do json["additions"] = additions
+
 	# Deleted line count.
 	fun deletions: Int do return json["deletions"].as(Int)
 
+	# Set deletions
+	fun deletions=(deletions: Int) do json["deletions"] = deletions
+
 	# Changed files count.
 	fun changed_files: Int do return json["changed_files"].as(Int)
+
+	# Set changed_files
+	fun changed_files=(changed_files: Int) do json["changed_files"] = changed_files
 end
 
 # A pull request reference (used for head and base).
@@ -879,21 +1041,36 @@ class PullRef
 	# Label pointed by `self`.
 	fun labl: String do return json["label"].as(String)
 
+	# Set labl
+	fun labl=(labl: String) do json["label"] = labl
+
 	# Reference pointed by `self`.
 	fun ref: String do return json["ref"].as(String)
 
+	# Set ref
+	fun ref=(ref: String) do json["ref"] = ref
+
 	# Commit SHA pointed by `self`.
 	fun sha: String do return json["sha"].as(String)
+
+	# Set sha
+	fun sha=(sha: String) do json["sha"] = sha
 
 	# User pointed by `self`.
 	fun user: User do
 		return new User.from_json(api, json["user"].as(JsonObject))
 	end
 
+	# Set user
+	fun user=(user: User) do json["user"] = user.json
+
 	# Repo pointed by `self`.
 	fun repo: Repo do
 		return new Repo.from_json(api, json["repo"].as(JsonObject))
 	end
+
+	# Set repo
+	fun repo=(repo: Repo) do json["repo"] = repo.json
 end
 
 # A Github label.
@@ -916,6 +1093,9 @@ class Label
 
 	# Label color code.
 	fun color: String do return json["color"].as(String)
+
+	# Set color
+	fun color=(color: String) do json["color"] = color
 end
 
 # A Github milestone.
@@ -939,33 +1119,63 @@ class Milestone
 	# Milestone title.
 	fun title: String do return json["title"].as(String)
 
+	# Set title
+	fun title=(title: String) do json["title"] = title
+
 	# Milestone long description.
 	fun description: String do return json["description"].as(String)
+
+	# Set description
+	fun description=(description: String) do json["description"] = description
 
 	# Count of opened issues linked to this milestone.
 	fun open_issues: Int do return json["open_issues"].as(Int)
 
+	# Set open_issues
+	fun open_issues=(open_issues: Int) do json["open_issues"] = open_issues
+
 	# Count of closed issues linked to this milestone.
 	fun closed_issues: Int do return json["closed_issues"].as(Int)
 
+	# Set closed_issues
+	fun closed_issues=(closed_issues: Int) do json["closed_issues"] = closed_issues
+
 	# Milestone state.
 	fun state: String do return json["state"].as(String)
+
+	# Set state
+	fun state=(state: String) do json["state"] = state
 
 	# Creation time in ISODate format.
 	fun created_at: ISODate do
 		return new ISODate.from_string(json["created_at"].as(String))
 	end
 
+	# Set created_at
+	fun created_at=(created_at: ISODate) do json["created_at"] = created_at.to_s
+
 	# User that created this milestone.
 	fun creator: User do
 		return new User.from_json(api, json["creator"].as(JsonObject))
 	end
+
+	# Set creator
+	fun creator=(creator: User) do json["creator"] = creator.json
 
 	# Due time in ISODate format (if any).
 	fun due_on: nullable ISODate do
 		var res = json.get_or_null("updated_at")
 		if res isa String then return new ISODate.from_string(res)
 		return null
+	end
+
+	# Set due_on.
+	fun due_on=(due_on: nullable ISODate) do
+		if due_on == null then
+			json["due_on"] = null
+		else
+			json["due_on"] = due_on.to_s
+		end
 	end
 
 	# Update time in ISODate format (if any).
@@ -975,11 +1185,29 @@ class Milestone
 		return null
 	end
 
+	# Set updated_at.
+	fun updated_at=(updated_at: nullable ISODate) do
+		if updated_at == null then
+			json["updated_at"] = null
+		else
+			json["updated_at"] = updated_at.to_s
+		end
+	end
+
 	# Close time in ISODate format (if any).
 	fun closed_at: nullable ISODate do
 		var res = json.get_or_null("closed_at")
 		if res isa String then return new ISODate.from_string(res)
 		return null
+	end
+
+	# Set closed_at.
+	fun closed_at=(closed_at: nullable ISODate) do
+		if closed_at == null then
+			json["closed_at"] = null
+		else
+			json["closed_at"] = closed_at.to_s
+		end
 	end
 end
 
@@ -1006,10 +1234,16 @@ abstract class Comment
 		return new User.from_json(api, json["user"].as(JsonObject))
 	end
 
+	# Set user
+	fun user=(user: User) do json["user"] = user.json
+
 	# Creation time in ISODate format.
 	fun created_at: ISODate do
 		return new ISODate.from_string(json["created_at"].as(String))
 	end
+
+	# Set created_at
+	fun created_at=(created_at: ISODate) do json["created_at"] = created_at.to_s
 
 	# Last update time in ISODate format (if any).
 	fun updated_at: nullable ISODate do
@@ -1018,8 +1252,20 @@ abstract class Comment
 		return null
 	end
 
+	# Set updated_at.
+	fun updated_at=(updated_at: nullable ISODate) do
+		if updated_at == null then
+			json["updated_at"] = null
+		else
+			json["updated_at"] = updated_at.to_s
+		end
+	end
+
 	# Comment body text.
 	fun body: String do return json["body"].as(String)
+
+	# Set body
+	fun body=(body: String) do json["body"] = body
 
 	# Does the comment contain an acknowledgement (+1)
 	fun is_ack: Bool
@@ -1039,12 +1285,18 @@ class CommitComment
 		return api.load_commit(repo, json["commit_id"].as(String)).as(not null)
 	end
 
+	# Set commit
+	fun commit=(commit: Commit) do json["commit_id"] = commit.json
+
 	# Position of the comment on the line.
 	fun position: nullable String do
 		var res = json.get_or_null("position")
 		if res isa String then return res
 		return null
 	end
+
+	# Set position.
+	fun position=(position: nullable String) do json["position"] = position
 
 	# Line of the comment.
 	fun line: nullable String do
@@ -1053,8 +1305,14 @@ class CommitComment
 		return null
 	end
 
+	# Set line.
+	fun line=(line: nullable String) do json["line"] = line
+
 	# Path of the commented file.
 	fun path: String do return json["path"].as(String)
+
+	# Set path.
+	fun path=(path: String) do json["path"] = path
 end
 
 # Comments made on Github issue and pull request pages.
@@ -1075,6 +1333,9 @@ class IssueComment
 
 	# Link to the issue document on API.
 	fun issue_url: String do return json["issue_url"].as(String)
+
+	# Set issue_url.
+	fun issue_url=(issue_url: String) do json["issue_url"] = issue_url
 end
 
 # Comments made on Github pull request diffs.
@@ -1096,23 +1357,44 @@ class ReviewComment
 	# Link to the pull request on API.
 	fun pull_request_url: String do return json["pull_request_url"].as(String)
 
+	# Set pull_request_url.
+	fun pull_request_url=(pull_request_url: String) do json["pull_request_url"] = pull_request_url
+
 	# Diff hunk.
 	fun diff_hunk: String do return json["diff_hunk"].as(String)
+
+	# Set diff_hunk.
+	fun diff_hunk=(diff_hunk: String) do json["diff_hunk"] = diff_hunk
 
 	# Path of commented file.
 	fun path: String do return json["path"].as(String)
 
+	# Set path.
+	fun path=(path: String) do json["path"] = path
+
 	# Position of the comment on the file.
 	fun position: Int do return json["position"].as(Int)
+
+	# Set position.
+	fun position=(position: Int) do json["position"] = position
 
 	# Original position in the diff.
 	fun original_position: Int do return json["original_position"].as(Int)
 
+	# Set original_position.
+	fun original_position=(original_position: Int) do json["original_position"] = original_position
+
 	# Commit referenced by this comment.
 	fun commit_id: String do return json["commit_id"].as(String)
 
+	# Set commit_id.
+	fun commit_id=(commit_id: String) do json["commit_id"] = commit_id
+
 	# Original commit id.
 	fun original_commit_id: String do return json["original_commit_id"].as(String)
+
+	# Set original_commit_id.
+	fun original_commit_id=(commit_id: String) do json["original_commit_id"] = commit_id
 end
 
 # An event that occurs on a Github `Issue`.
@@ -1138,18 +1420,30 @@ class IssueEvent
 		return new Issue.from_json(api, repo, json["issue"].as(JsonObject))
 	end
 
+	# Set issue.
+	fun issue=(issue: Issue) do json["issue"] = issue.json
+
 	# User that initiated the event.
 	fun actor: User do
 		return new User.from_json(api, json["actor"].as(JsonObject))
 	end
+
+	# Set actor.
+	fun actor=(actor: User) do json["actor"] = actor.json
 
 	# Creation time in ISODate format.
 	fun created_at: ISODate do
 		return new ISODate.from_string(json["created_at"].as(String))
 	end
 
+	# Set created_at.
+	fun created_at=(created_at: ISODate) do json["created_at"] = created_at.to_s
+
 	# Event descriptor.
 	fun event: String do return json["event"].as(String)
+
+	# Set event.
+	fun event=(event: String) do json["event"] = event
 
 	# Commit linked to this event (if any).
 	fun commit_id: nullable String do
@@ -1158,11 +1452,23 @@ class IssueEvent
 		return null
 	end
 
+	# Set commit_id.
+	fun commit_id=(commit_id: nullable String) do json["commit_id"] = commit_id
+
 	# Label linked to this event (if any).
 	fun labl: nullable Label do
 		var res = json.get_or_null("label")
 		if res isa JsonObject then return new Label.from_json(api, repo, res)
 		return null
+	end
+
+	# Set labl.
+	fun labl=(labl: nullable Label) do
+		if labl == null then
+			json["labl"] = null
+		else
+			json["labl"] = labl.json
+		end
 	end
 
 	# User linked to this event (if any).
@@ -1172,6 +1478,15 @@ class IssueEvent
 		return null
 	end
 
+	# Set assignee.
+	fun assignee=(assignee: nullable User) do
+		if assignee == null then
+			json["assignee"] = null
+		else
+			json["assignee"] = assignee.json
+		end
+	end
+
 	# Milestone linked to this event (if any).
 	fun milestone: nullable Milestone do
 		var res = json.get_or_null("milestone")
@@ -1179,11 +1494,29 @@ class IssueEvent
 		return null
 	end
 
+	# Set milestone.
+	fun milestone=(milestone: nullable User) do
+		if milestone == null then
+			json["milestone"] = null
+		else
+			json["milestone"] = milestone.json
+		end
+	end
+
 	# Rename linked to this event (if any).
 	fun rename: nullable RenameAction do
 		var res = json.get_or_null("rename")
 		if res isa JsonObject then return new RenameAction(res)
 		return null
+	end
+
+	# Set rename.
+	fun rename=(rename: nullable User) do
+		if rename == null then
+			json["rename"] = null
+		else
+			json["rename"] = rename.json
+		end
 	end
 end
 
@@ -1196,8 +1529,14 @@ class RenameAction
 	# Name before renaming.
 	fun from: String do return json["from"].as(String)
 
+	# Set from.
+	fun from=(from: String) do json["from"] = from
+
 	# Name after renaming.
 	fun to: String do return json["to"].as(String)
+
+	# Set to.
+	fun to=(to: String) do json["to"] = to
 end
 
 # Contributors list with additions, deletions, and commit counts.
@@ -1227,11 +1566,20 @@ class ContributorStats
 		return new User.from_json(api, json["author"].as(JsonObject))
 	end
 
+	# Set author.
+	fun author=(author: User) do json["author"] = author.json
+
 	# Total number of commit.
 	fun total: Int do return json["total"].as(Int)
 
+	# Set total.
+	fun total=(total: Int) do json["total"] = total
+
 	# Are of weeks of activity with detailed statistics.
 	fun weeks: JsonArray do return json["weeks"].as(JsonArray)
+
+	# Set weeks.
+	fun weeks=(weeks: JsonArray) do json["weeks"] = weeks
 
 	# ContributorStats can be compared on the total amount of commits.
 	redef fun <(o) do return total < o.total
@@ -1247,4 +1595,7 @@ class GithubFile
 
 	# File name.
 	fun filename: String do return json["filename"].as(String)
+
+	# Set filename.
+	fun filename=(filename: String) do json["filename"] = filename
 end

--- a/lib/github/api.nit
+++ b/lib/github/api.nit
@@ -616,7 +616,7 @@ class Commit
 	# Parent commits of `self`.
 	fun parents: Array[Commit] do
 		var res = new Array[Commit]
-		var parents = json["parents"]
+		var parents = json.get_or_null("parents")
 		if not parents isa JsonArray then return res
 		for obj in parents do
 			if not obj isa JsonObject then continue
@@ -627,18 +627,16 @@ class Commit
 
 	# Author of the commit.
 	fun author: nullable User do
-		if not json.has_key("author") then return null
-		var user = json["author"]
-		if not user isa JsonObject then return null
-		return new User.from_json(api, user)
+		var user = json.get_or_null("author")
+		if user isa JsonObject then return new User.from_json(api, user)
+		return null
 	end
 
 	# Committer of the commit.
 	fun committer: nullable User do
-		if not json.has_key("committer") then return null
-		var user = json["author"]
-		if not user isa JsonObject then return null
-		return new User.from_json(api, user)
+		var user = json.get_or_null("author")
+		if user isa JsonObject then return new User.from_json(api, user)
+		return null
 	end
 
 	# Authoring date as ISODate.
@@ -658,7 +656,7 @@ class Commit
 	# List files staged in this commit.
 	fun files: Array[GithubFile] do
 		var res = new Array[GithubFile]
-		var files = json["files"]
+		var files = json.get_or_null("files")
 		if not files isa JsonArray then return res
 		for obj in files do
 			res.add(new GithubFile(obj.as(JsonObject)))
@@ -699,8 +697,9 @@ class Issue
 	# List of labels on this issue associated to their names.
 	fun labels: Map[String, Label] do
 		var res = new HashMap[String, Label]
-		if not json.has_key("labels") then return res
-		for obj in json["labels"].as(JsonArray) do
+		var lbls = json.get_or_null("labels")
+		if not lbls isa JsonArray then return res
+		for obj in lbls do
 			if not obj isa JsonObject then continue
 			var name = obj["name"].as(String)
 			res[name] = new Label.from_json(api, repo, obj)
@@ -716,16 +715,16 @@ class Issue
 
 	# Assigned `User` (if any).
 	fun assignee: nullable User do
-		var assignee = json["assignee"]
-		if not assignee isa JsonObject then return null
-		return new User.from_json(api, assignee)
+		var assignee = json.get_or_null("assignee")
+		if assignee isa JsonObject then return new User.from_json(api, assignee)
+		return null
 	end
 
 	# `Milestone` (if any).
 	fun milestone: nullable Milestone do
-		var milestone = json["milestone"]
-		if not milestone isa JsonObject then return null
-		return new Milestone.from_json(api, repo, milestone)
+		var milestone = json.get_or_null("milestone")
+		if milestone isa JsonObject then return new Milestone.from_json(api, repo, milestone)
+		return null
 	end
 
 	# List of comments made on this issue.
@@ -759,16 +758,16 @@ class Issue
 
 	# Last update time in ISODate format (if any).
 	fun updated_at: nullable ISODate do
-		var res = json["updated_at"]
-		if res == null then return null
-		return new ISODate.from_string(res.as(String))
+		var res = json.get_or_null("updated_at")
+		if res isa String then return new ISODate.from_string(res)
+		return null
 	end
 
 	# Close time in ISODate format (if any).
 	fun closed_at: nullable ISODate do
-		var res = json["closed_at"]
-		if res == null then return null
-		return new ISODate.from_string(res.as(String))
+		var res = json.get_or_null("closed_at")
+		if res isa String then return new ISODate.from_string(res)
+		return null
 	end
 
 	# TODO link to pull request
@@ -780,7 +779,8 @@ class Issue
 	fun events: Array[IssueEvent] do
 		var res = new Array[IssueEvent]
 		var page = 1
-		var array = api.get("{key}/events?page={page}").as(JsonArray)
+		var array = api.get("{key}/events?page={page}")
+		if not array isa JsonArray then return res
 		while not array.is_empty do
 			for obj in array do
 				if not obj isa JsonObject then continue
@@ -794,9 +794,9 @@ class Issue
 
 	# User that closed this issue (if any).
 	fun closed_by: nullable User do
-		var closer = json["closed_by"]
-		if not closer isa JsonObject then return null
-		return new User.from_json(api, closer)
+		var closer = json.get_or_null("closed_by")
+		if closer isa JsonObject then return new User.from_json(api, closer)
+		return null
 	end
 end
 
@@ -813,9 +813,9 @@ class PullRequest
 
 	# Merge time in ISODate format (if any).
 	fun merged_at: nullable ISODate do
-		var res = json["merged_at"]
-		if res == null then return null
-		return new ISODate.from_string(res.to_s)
+		var res = json.get_or_null("merged_at")
+		if res isa String then return new ISODate.from_string(res)
+		return null
 	end
 
 	# Merge commit SHA.
@@ -849,9 +849,9 @@ class PullRequest
 
 	# User that merged this pull request (if any).
 	fun merged_by: nullable User do
-		var merger = json["merged_by"]
-		if not merger isa JsonObject then return null
-		return new User.from_json(api, merger)
+		var merger = json.get_or_null("merged_by")
+		if merger isa JsonObject then return new User.from_json(api, merger)
+		return null
 	end
 
 	# Count of commits in this pull request.
@@ -963,23 +963,23 @@ class Milestone
 
 	# Due time in ISODate format (if any).
 	fun due_on: nullable ISODate do
-		var res = json["updated_at"]
-		if res == null then return null
-		return new ISODate.from_string(res.to_s)
+		var res = json.get_or_null("updated_at")
+		if res isa String then return new ISODate.from_string(res)
+		return null
 	end
 
 	# Update time in ISODate format (if any).
 	fun updated_at: nullable ISODate do
-		var res = json["updated_at"]
-		if res == null then return null
-		return new ISODate.from_string(res.to_s)
+		var res = json.get_or_null("updated_at")
+		if res isa String then return new ISODate.from_string(res)
+		return null
 	end
 
 	# Close time in ISODate format (if any).
 	fun closed_at: nullable ISODate do
-		var res = json["closed_at"]
-		if res == null then return null
-		return new ISODate.from_string(res.to_s)
+		var res = json.get_or_null("closed_at")
+		if res isa String then return new ISODate.from_string(res)
+		return null
 	end
 end
 
@@ -1013,8 +1013,9 @@ abstract class Comment
 
 	# Last update time in ISODate format (if any).
 	fun updated_at: nullable ISODate do
-		if not json.has_key("updated_at") then return null
-		return new ISODate.from_string(json["updated_at"].as(String))
+		var res = json.get_or_null("updated_at")
+		if res isa String then return new ISODate.from_string(res)
+		return null
 	end
 
 	# Comment body text.
@@ -1040,18 +1041,16 @@ class CommitComment
 
 	# Position of the comment on the line.
 	fun position: nullable String do
-		if not json.has_key("position") then return null
-		var res = json["position"]
-		if res == null then return null
-		return res.to_s
+		var res = json.get_or_null("position")
+		if res isa String then return res
+		return null
 	end
 
 	# Line of the comment.
 	fun line: nullable String do
-		if not json.has_key("line") then return null
-		var res = json["line"]
-		if res == null then return null
-		return res.to_s
+		var res = json.get_or_null("line")
+		if res isa String then return res
+		return null
 	end
 
 	# Path of the commented file.
@@ -1154,37 +1153,37 @@ class IssueEvent
 
 	# Commit linked to this event (if any).
 	fun commit_id: nullable String do
-		var res = json["commit_id"]
-		if res == null then return null
-		return res.to_s
+		var res = json.get_or_null("commit_id")
+		if res isa String then return res
+		return null
 	end
 
 	# Label linked to this event (if any).
 	fun labl: nullable Label do
-		var res = json["label"]
-		if not res isa JsonObject then return null
-		return new Label.from_json(api, repo, res)
+		var res = json.get_or_null("label")
+		if res isa JsonObject then return new Label.from_json(api, repo, res)
+		return null
 	end
 
 	# User linked to this event (if any).
 	fun assignee: nullable User do
-		var res = json["assignee"]
-		if not res isa JsonObject then return null
-		return new User.from_json(api, res)
+		var res = json.get_or_null("assignee")
+		if res isa JsonObject then return new User.from_json(api, res)
+		return null
 	end
 
 	# Milestone linked to this event (if any).
 	fun milestone: nullable Milestone do
-		var res = json["milestone"]
-		if not res isa JsonObject then return null
-		return new Milestone.from_json(api, repo, res)
+		var res = json.get_or_null("milestone")
+		if res isa JsonObject then return new Milestone.from_json(api, repo, res)
+		return null
 	end
 
 	# Rename linked to this event (if any).
 	fun rename: nullable RenameAction do
-		var res = json["rename"]
-		if res == null then return null
-		return new RenameAction(res.as(JsonObject))
+		var res = json.get_or_null("rename")
+		if res isa JsonObject then return new RenameAction(res)
+		return null
 	end
 end
 

--- a/lib/github/events.nit
+++ b/lib/github/events.nit
@@ -41,10 +41,16 @@ class GithubEvent
 	# Action performed by the event.
 	fun action: String do return json["action"].as(String)
 
+	# Set action.
+	fun action=(action: String) do json["action"] = action
+
 	# Repo where this event occured.
 	fun repo: Repo do
 		return new Repo.from_json(api, json["repository"].as(JsonObject))
 	end
+
+	# Set repo.
+	fun repo=(repo: Repo) do json["repository"] = repo.json
 end
 
 # Triggered when a commit comment is created.
@@ -55,6 +61,9 @@ class CommitCommentEvent
 	fun comment: CommitComment do
 		return new CommitComment.from_json(api, repo, json["comment"].as(JsonObject))
 	end
+
+	# Set comment.
+	fun comment=(comment: CommitComment) do json["comment"] = comment.json
 end
 
 # Triggered when a repository, branch, or tag is created.
@@ -66,14 +75,26 @@ class CreateEvent
 	# Can be one of `repository`, `branch`, or `tag`.
 	fun ref_type: String do return json["ref_type"].as(String)
 
+	# Set ref_type.
+	fun ref_type=(ref_type: String) do json["ref_type"] = ref_type
+
 	# Git ref (or null if only a repository was created).
 	fun ref: String do return json["ref"].as(String)
+
+	# Set ref.
+	fun ref=(ref: String) do json["ref"] = ref
 
 	# Name of the repo's default branch (usually master).
 	fun master_branch: String do return json["master_branch"].as(String)
 
+	# Set master_branch.
+	fun master_branch=(master_branch: String) do json["master_branch"] = master_branch
+
 	# Repo's current description.
 	fun description: String do return json["description"].as(String)
+
+	# Set description.
+	fun description=(description: String) do json["description"] = description
 end
 
 # Triggered when a branch or a tag is deleted.
@@ -85,8 +106,14 @@ class DeleteEvent
 	# Can be one of `repository`, `branch`, or `tag`.
 	fun ref_type: String do return json["ref_type"].as(String)
 
+	# Set ref_type.
+	fun ref_type=(ref_type: String) do json["ref_type"] = ref_type
+
 	# Git ref (or null if only a repository was deleted).
 	fun ref: String do return json["ref"].as(String)
+
+	# Set ref.
+	fun ref=(ref: String) do json["ref"] = ref
 end
 
 # Triggered when a new snapshot is deployed.
@@ -98,14 +125,23 @@ class DeploymentEvent
 	# Commit SHA for which this deployment was created.
 	fun sha: String do return json["sha"].as(String)
 
+	# Set sha.
+	fun sha=(sha: String) do json["sha"] = sha
+
 	# Name of repository for this deployment, formatted as :owner/:repo.
 	fun name: String do return json["name"].as(String)
+
+	# Set name.
+	fun name=(name: String) do json["name"] = name
 
 	# Optional extra information for this deployment.
 	fun payload: nullable String do
 		var res = json.get_or_null("payload")
 		if res isa String then return res else return null
 	end
+
+	# Set payload.
+	fun payload=(payload: nullable String) do json["payload"] = payload
 
 	# Optional environment to deploy to.
 	# Default: "production"
@@ -114,11 +150,17 @@ class DeploymentEvent
 		if res isa String then return res else return null
 	end
 
+	# Set environment.
+	fun environment=(environment: nullable String) do json["environment"] = environment
+
 	# Optional human-readable description added to the deployment.
 	fun description: nullable String do
 		var res = json.get_or_null("description")
 		if res isa String then return res else return null
 	end
+
+	# Set description.
+	fun description=(description: nullable String) do json["description"] = description
 end
 
 # Triggered when a deployement's status changes.
@@ -136,14 +178,23 @@ class DeploymentStatusEvent
 		if res isa String then return res else return null
 	end
 
+	# Set target_url.
+	fun target_url=(target_url: nullable String) do json["target_url"] = target_url
+
 	# Deployment hash that this status is associated with.
 	fun deployment: String do return json["deployment"].as(String)
+
+	# Set deployment.
+	fun deployment=(deployment: String) do json["deployment"] = deployment
 
 	# Optional human-readable description added to the status.
 	fun description: nullable String do
 		var res = json.get_or_null("description")
 		if res isa String then return res else return null
 	end
+
+	# Set description.
+	fun description=(description: nullable String) do json["description"] = description
 end
 
 # Triggered when a user forks a repository.
@@ -152,6 +203,9 @@ class ForkEvent
 
 	# Created repository.
 	fun forkee: Repo do return new Repo.from_json(api, json["forkee"].as(JsonObject))
+
+	# Set forkee.
+	fun forkee=(forkee: Repo) do json["forkee"] = forkee.json
 end
 
 # Triggered when an issue comment is created.
@@ -163,10 +217,16 @@ class IssueCommentEvent
 		return new Issue.from_json(api, repo, json["issue"].as(JsonObject))
 	end
 
+	# Set issue.
+	fun issue=(issue: Issue) do json["issue"] = issue.json
+
 	# The `Comment` itself.
 	fun comment: IssueComment do
 		return new IssueComment.from_json(api, repo, json["comment"].as(JsonObject))
 	end
+
+	# Set comment.
+	fun comment=(comment: IssueComment) do json["comment"] = comment.json
 end
 
 # Triggered when an event occurs on an issue.
@@ -179,16 +239,37 @@ class IssuesEvent
 	# The `Issue` itself.
 	fun issue: Issue do return new Issue.from_json(api, repo, json["issue"].as(JsonObject))
 
+	# Set issue.
+	fun issue=(issue: Issue) do json["issue"] = issue.json
+
 	# Optional `Label` that was added or removed from the issue.
 	fun lbl: nullable Label do
 		var res = json.get_or_null("label")
 		if res isa JsonObject then return new Label.from_json(api, repo, res) else return null
 	end
 
+	# Set lbl.
+	fun lbl=(lbl: nullable Label) do
+		if lbl == null then
+			json["lbl"] = null
+		else
+			json["lbl"] = lbl.json
+		end
+	end
+
 	# Optional `User` that was assigned or unassigned from the issue.
 	fun assignee: nullable User do
 		var res = json.get_or_null("assignee")
 		if res isa JsonObject then return new User.from_json(api, res) else return null
+	end
+
+	# Set assignee.
+	fun assignee=(assignee: nullable User) do
+		if assignee == null then
+			json["assignee"] = null
+		else
+			json["assignee"] = assignee.json
+		end
 	end
 end
 
@@ -198,6 +279,9 @@ class MemberEvent
 
 	# `User` that was added.
 	fun member: User do return new User.from_json(api, json["member"].as(JsonObject))
+
+	# Set member.
+	fun member=(member: User) do json["member"] = member.json
 end
 
 # Triggered when an event occurs on a pull request.
@@ -210,10 +294,16 @@ class PullRequestEvent
 	# The pull request number.
 	fun number: Int do return json["number"].as(Int)
 
+	# Set number.
+	fun number=(number: Int) do json["number"] = number
+
 	# The `PullRequest` itself.
 	fun pull: PullRequest do
 		return new PullRequest.from_json(api, repo, json["pull_request"].as(JsonObject))
 	end
+
+	# Set pull.
+	fun pull=(pull: PullRequest) do json["pull_request"] = pull.json
 end
 
 # Triggered when a comment is created on a pull request diff.
@@ -225,10 +315,16 @@ class PullRequestReviewCommentEvent
 		return new ReviewComment.from_json(api, repo, json["comment"].as(JsonObject))
 	end
 
+	# Set comment.
+	fun comment=(comment: ReviewComment) do json["comment"] = comment.json
+
 	# `PullRequest` the `comment` belongs to.
 	fun pull: PullRequest do
 		return new PullRequest.from_json(api, repo, json["pull_request"].as(JsonObject))
 	end
+
+	# Set pull.
+	fun pull=(pull: PullRequest) do json["pull_request"] = pull.json
 end
 
 # Triggered when a repository branch is pushed to.
@@ -238,13 +334,22 @@ class PushEvent
 	# SHA of the HEAD commit on the repository.
 	fun head: String do return json["head"].as(String)
 
+	# Set head.
+	fun head=(head: String) do json["head"] = head
+
 	# Full Git ref that was pushed.
 	#
 	# Example: “refs/heads/master”
 	fun ref: String do return json["ref"].as(String)
 
+	# Set ref.
+	fun ref=(ref: String) do json["ref"] = ref
+
 	# Number of commits in the push.
 	fun size: Int do return json["size"].as(Int)
+
+	# Set size.
+	fun size=(size: Int) do json["size"] = size
 
 	# Array of pushed commits.
 	fun commits: Array[Commit] do
@@ -255,6 +360,13 @@ class PushEvent
 			res.add api.load_commit(repo, obj["sha"].as(String)).as(not null)
 		end
 		return res
+	end
+
+	# Set commits.
+	fun commits=(commits: Array[Commit]) do
+		var arr = new JsonArray
+		for commit in commits do arr.add commit.json
+		json["commits"] = arr
 	end
 end
 
@@ -267,10 +379,16 @@ class StatusEvent
 		return api.load_commit(repo, json["sha"].as(String)).as(not null)
 	end
 
+	# Set commit.
+	fun commit=(commit: Commit) do json["sha"] = commit.sha
+
 	# New state.
 	#
 	# Can be `pending`, `success`, `failure`, or `error`.
 	fun state: String do return json["state"].as(String)
+
+	# Set state.
+	fun state=(state: String) do json["state"] = state
 
 	# Optional human-readable description added to the status.
 	fun description: nullable String do
@@ -278,11 +396,17 @@ class StatusEvent
 		if res isa String then return res else return null
 	end
 
+	# Set description.
+	fun description=(description: nullable String) do json["description"] = description
+
 	# Optional link added to the status.
 	fun target_url: nullable String do
 		var res = json.get_or_null("target_url")
 		if res isa String then return res else return null
 	end
+
+	# Set target_url.
+	fun target_url=(target_url: nullable String) do json["target_url"] = target_url
 
 	# Array of branches containing the status' SHA.
 	#
@@ -298,5 +422,12 @@ class StatusEvent
 			res.add api.load_branch(repo, obj["name"].as(String)).as(not null)
 		end
 		return res
+	end
+
+	# Set branches.
+	fun branches=(branches: Array[Commit]) do
+		var arr = new JsonArray
+		for branch in branches do arr.add branch.json
+		json["branches"] = arr
 	end
 end

--- a/lib/github/events.nit
+++ b/lib/github/events.nit
@@ -103,21 +103,21 @@ class DeploymentEvent
 
 	# Optional extra information for this deployment.
 	fun payload: nullable String do
-		if not json.has_key("payload") then return null
-		return json["payload"].as(String)
+		var res = json.get_or_null("payload")
+		if res isa String then return res else return null
 	end
 
 	# Optional environment to deploy to.
 	# Default: "production"
 	fun environment: nullable String do
-		if not json.has_key("environment") then return null
-		return json["environment"].as(String)
+		var res = json.get_or_null("environment")
+		if res isa String then return res else return null
 	end
 
 	# Optional human-readable description added to the deployment.
 	fun description: nullable String do
-		if not json.has_key("description") then return null
-		return json["description"].as(String)
+		var res = json.get_or_null("description")
+		if res isa String then return res else return null
 	end
 end
 
@@ -132,8 +132,8 @@ class DeploymentStatusEvent
 
 	# Optional link added to the status.
 	fun target_url: nullable String do
-		if not json.has_key("target_url") then return null
-		return json["target_url"].as(String)
+		var res = json.get_or_null("target_url")
+		if res isa String then return res else return null
 	end
 
 	# Deployment hash that this status is associated with.
@@ -141,8 +141,8 @@ class DeploymentStatusEvent
 
 	# Optional human-readable description added to the status.
 	fun description: nullable String do
-		if not json.has_key("description") then return null
-		return json["description"].as(String)
+		var res = json.get_or_null("description")
+		if res isa String then return res else return null
 	end
 end
 
@@ -181,14 +181,14 @@ class IssuesEvent
 
 	# Optional `Label` that was added or removed from the issue.
 	fun lbl: nullable Label do
-		if not json.has_key("label") then return null
-		return new Label.from_json(api, repo, json["label"].as(JsonObject))
+		var res = json.get_or_null("label")
+		if res isa JsonObject then return new Label.from_json(api, repo, res) else return null
 	end
 
 	# Optional `User` that was assigned or unassigned from the issue.
 	fun assignee: nullable User do
-		if not json.has_key("assignee") then return null
-		return new User.from_json(api, json["assignee"].as(JsonObject))
+		var res = json.get_or_null("assignee")
+		if res isa JsonObject then return new User.from_json(api, res) else return null
 	end
 end
 
@@ -274,14 +274,14 @@ class StatusEvent
 
 	# Optional human-readable description added to the status.
 	fun description: nullable String do
-		if not json.has_key("description") then return null
-		return json["description"].as(String)
+		var res = json.get_or_null("description")
+		if res isa String then return res else return null
 	end
 
 	# Optional link added to the status.
 	fun target_url: nullable String do
-		if not json.has_key("target_url") then return null
-		return json["target_url"].as(String)
+		var res = json.get_or_null("target_url")
+		if res isa String then return res else return null
 	end
 
 	# Array of branches containing the status' SHA.

--- a/lib/github/events.nit
+++ b/lib/github/events.nit
@@ -39,7 +39,7 @@ class GithubEvent
 	end
 
 	# Action performed by the event.
-	fun action: String do return json["action"].to_s
+	fun action: String do return json["action"].as(String)
 
 	# Repo where this event occured.
 	fun repo: Repo do
@@ -64,16 +64,16 @@ class CreateEvent
 	# Oject type that was created.
 	#
 	# Can be one of `repository`, `branch`, or `tag`.
-	fun ref_type: String do return json["ref_type"].to_s
+	fun ref_type: String do return json["ref_type"].as(String)
 
 	# Git ref (or null if only a repository was created).
-	fun ref: String do return json["ref"].to_s
+	fun ref: String do return json["ref"].as(String)
 
 	# Name of the repo's default branch (usually master).
-	fun master_branch: String do return json["master_branch"].to_s
+	fun master_branch: String do return json["master_branch"].as(String)
 
 	# Repo's current description.
-	fun description: String do return json["description"].to_s
+	fun description: String do return json["description"].as(String)
 end
 
 # Triggered when a branch or a tag is deleted.
@@ -83,10 +83,10 @@ class DeleteEvent
 	# Object type that was deleted.
 	#
 	# Can be one of `repository`, `branch`, or `tag`.
-	fun ref_type: String do return json["ref_type"].to_s
+	fun ref_type: String do return json["ref_type"].as(String)
 
 	# Git ref (or null if only a repository was deleted).
-	fun ref: String do return json["ref"].to_s
+	fun ref: String do return json["ref"].as(String)
 end
 
 # Triggered when a new snapshot is deployed.
@@ -96,28 +96,28 @@ class DeploymentEvent
 	super GithubEvent
 
 	# Commit SHA for which this deployment was created.
-	fun sha: String do return json["sha"].to_s
+	fun sha: String do return json["sha"].as(String)
 
 	# Name of repository for this deployment, formatted as :owner/:repo.
-	fun name: String do return json["name"].to_s
+	fun name: String do return json["name"].as(String)
 
 	# Optional extra information for this deployment.
 	fun payload: nullable String do
 		if not json.has_key("payload") then return null
-		return json["payload"].to_s
+		return json["payload"].as(String)
 	end
 
 	# Optional environment to deploy to.
 	# Default: "production"
 	fun environment: nullable String do
 		if not json.has_key("environment") then return null
-		return json["environment"].to_s
+		return json["environment"].as(String)
 	end
 
 	# Optional human-readable description added to the deployment.
 	fun description: nullable String do
 		if not json.has_key("description") then return null
-		return json["description"].to_s
+		return json["description"].as(String)
 	end
 end
 
@@ -128,21 +128,21 @@ class DeploymentStatusEvent
 	# New deployment state.
 	#
 	# Can be `pending`, `success`, `failure`, or `error`.
-	fun state: String do return json["state"].to_s
+	fun state: String do return json["state"].as(String)
 
 	# Optional link added to the status.
 	fun target_url: nullable String do
 		if not json.has_key("target_url") then return null
-		return json["target_url"].to_s
+		return json["target_url"].as(String)
 	end
 
 	# Deployment hash that this status is associated with.
-	fun deployment: String do return json["deployment"].to_s
+	fun deployment: String do return json["deployment"].as(String)
 
 	# Optional human-readable description added to the status.
 	fun description: nullable String do
 		if not json.has_key("description") then return null
-		return json["description"].to_s
+		return json["description"].as(String)
 	end
 end
 
@@ -236,12 +236,12 @@ class PushEvent
 	super GithubEvent
 
 	# SHA of the HEAD commit on the repository.
-	fun head: String do return json["head"].to_s
+	fun head: String do return json["head"].as(String)
 
 	# Full Git ref that was pushed.
 	#
 	# Example: “refs/heads/master”
-	fun ref: String do return json["ref"].to_s
+	fun ref: String do return json["ref"].as(String)
 
 	# Number of commits in the push.
 	fun size: Int do return json["size"].as(Int)
@@ -252,7 +252,7 @@ class PushEvent
 		var arr = json["commits"].as(JsonArray)
 		for obj in arr do
 			if not obj isa JsonObject then continue
-			res.add api.load_commit(repo, obj["sha"].to_s).as(not null)
+			res.add api.load_commit(repo, obj["sha"].as(String)).as(not null)
 		end
 		return res
 	end
@@ -264,24 +264,24 @@ class StatusEvent
 
 	# The `Commit` itself.
 	fun commit: Commit do
-		return api.load_commit(repo, json["sha"].to_s).as(not null)
+		return api.load_commit(repo, json["sha"].as(String)).as(not null)
 	end
 
 	# New state.
 	#
 	# Can be `pending`, `success`, `failure`, or `error`.
-	fun state: String do return json["state"].to_s
+	fun state: String do return json["state"].as(String)
 
 	# Optional human-readable description added to the status.
 	fun description: nullable String do
 		if not json.has_key("description") then return null
-		return json["description"].to_s
+		return json["description"].as(String)
 	end
 
 	# Optional link added to the status.
 	fun target_url: nullable String do
 		if not json.has_key("target_url") then return null
-		return json["target_url"].to_s
+		return json["target_url"].as(String)
 	end
 
 	# Array of branches containing the status' SHA.
@@ -295,7 +295,7 @@ class StatusEvent
 		var arr = json["branches"].as(JsonArray)
 		for obj in arr do
 			if not obj isa JsonObject then continue
-			res.add api.load_branch(repo, obj["name"].to_s).as(not null)
+			res.add api.load_branch(repo, obj["name"].as(String)).as(not null)
 		end
 		return res
 	end


### PR DESCRIPTION
The first objective of this PR is to clean the `github::api` code and remove typing wranings.

It also add new services that can be useful for clients:
* `Issue::is_ull_request`
* Setters to modify GithubEntitties