### PR TITLE
lib/serialization: fix deserialization constructor calling the default init

### DIFF
--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -191,7 +191,7 @@ interface Serializable
 	# Create an instance of this class from the `deserializer`
 	#
 	# This constructor is refined by subclasses to correctly build their instances.
-	init from_deserializer(deserializer: Deserializer) do end
+	init from_deserializer(deserializer: Deserializer) is nosuper do end
 end
 
 redef interface Object

--- a/tests/sav/nitce/test_binary_deserialization_alt1.res
+++ b/tests/sav/nitce/test_binary_deserialization_alt1.res
@@ -32,5 +32,5 @@ Deserialization Error: Doesn't know how to deserialize class "HashSet", Deserial
 # Src:
 <G: hs: -1, 0; s: one, two; hm: one. 1, two. 2; am: three. 3, four. 4>
 # Dst:
-<G: hs: -1, 0; s: one, two; hm: one. 1, two. 2; am: three. 3, four. 4>
+<G: hs: ; s: ; hm: ; am: >
 

--- a/tests/sav/nitce/test_json_deserialization_alt1.res
+++ b/tests/sav/nitce/test_json_deserialization_alt1.res
@@ -70,5 +70,5 @@ null
 {"__kind": "obj", "__id": 0, "__class": "G", "hs": {"__kind": "obj", "__id": 1, "__class": "HashSet", "__items": [-1, 0]}, "s": {"__kind": "obj", "__id": 2, "__class": "ArraySet", "__items": ["one", "two"]}, "hm": {"__kind": "obj", "__id": 3, "__class": "HashMap", "__length": 2, "__keys": ["one", "two"], "__values": [1, 2]}, "am": {"__kind": "obj", "__id": 4, "__class": "ArrayMap", "__length": 2, "__keys": ["three", "four"], "__values": ["3", "4"]}}
 
 # Back in Nit:
-<G: hs: -1, 0; s: one, two; hm: one. 1, two. 2; am: three. 3, four. 4>
+<G: hs: ; s: ; hm: ; am: >
 


### PR DESCRIPTION
Restore previous behavior of the deserialization init which should not call the default init. This caused problems on default inits that accessed not yet deserialized attributes.

This also fixes WBTW troubles with game saving and multiplayer.