### PR TITLE
lib/html: implement the tag list as an hashset instead of a array.

### DIFF
--- a/lib/html/html.nit
+++ b/lib/html/html.nit
@@ -107,7 +107,12 @@ class HTMLTag
 	# `"div"` for `<div></div>`.
 	var tag: String
 	init do
-		self.is_void = (once ["area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr"]).has(tag)
+		self.is_void = (once void_list).has(tag)
+	end
+
+	private fun void_list: Set[String]
+	do
+		return new HashSet[String].from(["area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr"])
 	end
 
 	# Is the HTML element a void element?


### PR DESCRIPTION
This optimize clients of lib/html like highlight.

usertime for `./test_highlight ../lib/core/`:

* before: 0m2.416s
* after: 0m2.328s (-3.64%)

