### PR TITLE
parser: do not allocate a reduction table for each parser

### DIFF
--- a/src/parser/parser.nit
+++ b/src/parser/parser.nit
@@ -10,7 +10,6 @@ redef class Parser
 	redef fun build_reduce_table
 	do
 		var reduce_table = new Array[ReduceAction].with_capacity(1091)
-		self.reduce_table = reduce_table
 		reduce_table.add new ReduceAction0(0)
 		reduce_table.add new ReduceAction1(0)
 		reduce_table.add new ReduceAction2(0)
@@ -1102,6 +1101,7 @@ redef class Parser
 		reduce_table.add new ReduceAction1088(220)
 		reduce_table.add new ReduceAction473(221)
 		reduce_table.add new ReduceAction492(221)
+		return reduce_table
 	end
 end
 

--- a/src/parser/parser_work.nit
+++ b/src/parser/parser_work.nit
@@ -40,7 +40,7 @@ class Parser
 
 	init
 	do
-		build_reduce_table
+		self.reduce_table = once build_reduce_table
 	end
 
 	# Do a transition in the automata
@@ -155,7 +155,7 @@ class Parser
 	end
 
 	private var reduce_table: Array[ReduceAction] is noinit
-	private fun build_reduce_table is abstract
+	private fun build_reduce_table: Array[ReduceAction] is abstract
 end
 
 redef class Prod

--- a/src/parser/xss/parser.xss
+++ b/src/parser/xss/parser.xss
@@ -21,10 +21,10 @@ redef class Parser
 	redef fun build_reduce_table
 	do
 		var reduce_table = new Array[ReduceAction].with_capacity(${count(rules/rule)})
-		self.reduce_table = reduce_table
 $ foreach {rules/rule}
 		reduce_table.add new ReduceAction@index(@leftside)
 $ end foreach
+		return reduce_table
 	end
 end
 


### PR DESCRIPTION
This optimize multiple Parser allocation, for instance nitunit or nitdoc that need to deal with each nitunit in the documentation.

usertime for `./nitdoc ../lib/core/`:

* before: 0m2.184s
* after: 0m1.788s (-18.1%)