### PR TITLE
loader: print error if bad files given to `scan_full` or `parse_full`

### DIFF
--- a/src/loader.nit
+++ b/src/loader.nit
@@ -152,6 +152,11 @@ redef class ModelBuilder
 
 			var mmodule = identify_module(a)
 			if mmodule == null then
+				if a.file_exists then
+					toolcontext.error(null, "Error: `{a}` is not a Nit source file.")
+				else
+					toolcontext.error(null, "Error: cannot find module `{a}`.")
+				end
 				continue
 			end
 

--- a/tests/sav/test_test_phase_args2.res
+++ b/tests/sav/test_test_phase_args2.res
@@ -1,0 +1,3 @@
+Error: cannot find module `fail.nit`.
+Error: `README.md` is not a Nit source file.
+Errors: 2. Warnings: 0.

--- a/tests/test_test_phase.args
+++ b/tests/test_test_phase.args
@@ -1,1 +1,2 @@
 base_simple3.nit
+fail.nit base_simple3.nit README.md


### PR DESCRIPTION
The last series (#1750 ) removed then silently.

A test is also added to avoid regression.