### PR TITLE
Cleanup and synchronize options in manpages

### DIFF
--- a/misc/jenkins/check_manpages.sh
+++ b/misc/jenkins/check_manpages.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check that options are documented in the manpages of the tool.
+# Usage: check_manpages from to
+
+set -e
+
+ret=0
+for bin in bin/nit*; do
+
+	name=`basename $bin`
+
+	manc=share/man/nitc.md
+	man=share/man/$name.md
+
+	if ! test -f $man; then
+		echo "No manpage for binary $bin. Add one in $man"
+		echo ""
+		ret=1
+		continue
+	fi
+
+	$bin --help | grep '^  ' | sed 's/    */;/;s/  //' > check_manpages-option_list.out
+	while IFS=';' read opt cmt; do
+		# Generate first lines for the man page from --help
+		printf "%s\n" "$opt" | sed 's/, /`, `/g;s/^/### `/;s/$/`/' > check_manpages-from_help.out
+		echo "$cmt." >> check_manpages-from_help.out
+
+		# Generate grep pattern to search in the existing manpage
+		printf "%s\n" "$opt" | sed 's/, /`\\|`/g;s/^/###.*\\(`/;s/$/`\\)/' > check_manpages-grep_pattern.out
+
+		# Search pattern
+		if ! grep -A 1 -f check_manpages-grep_pattern.out $man > check_manpages-from_man.out; then
+			if ! grep -A 1 -f check_manpages-grep_pattern.out $manc > check_manpages-from_man.out; then
+				# Motif not found :(
+				echo "$opt: missing in the manpage $man. Here what is expected:"
+				echo ""
+				cat check_manpages-from_help.out
+				echo ""
+				ret=1
+				continue
+			fi
+
+			# found in `nitc.md`, check more only if dealing with nitc
+			[ "$man" = "$manc" ] || continue
+		fi
+
+		# Test what is expected
+		if ! diff -q <(sed 's/\s*(.*)//' check_manpages-from_help.out) <(sed  's/\s*(.*)//' check_manpages-from_man.out) > /dev/null; then
+			echo "$opt: mismatch documentation in the manpage $man. Here the word diff:"
+			echo ""
+			wdiff check_manpages-from_help.out check_manpages-from_man.out | colordiff
+			echo ""
+			ret=1
+			continue
+		fi
+	done < check_manpages-option_list.out
+done
+
+exit "$ret"

--- a/share/man/nit.md
+++ b/share/man/nit.md
@@ -84,24 +84,24 @@ This option helps the user to have a simplified but humanly readable overview of
 ## DEBUGGER OPTIONS
 
 ### `-d`
-Launches the target program with the debugger attached to it
+Launches the target program with the debugger attached to it.
 
 ### `-c`
-Launches the target program with the interpreter, such as when the program fails, the debugging prompt is summoned
+Launches the target program with the interpreter, such as when the program fails, the debugging prompt is summoned.
 
 ### `--socket`
-Launches the target program with raw output on the network via sockets
+Launches the target program with raw output on the network via sockets.
 
 ### `--websocket`
-Launches the target program with output on the network via websockets
+Launches the target program with output on the network via websockets.
 
 ### `--port`
-Sets the debug port (Defaults to 22125) - Must be contained between 0 and 65535
+Sets the debug port (Defaults to 22125) - Must be contained between 0 and 65535.
 
 ## OTHER OPTIONS
 
 ### `--vm`
-Run the virtual machine instead of the naive interpreter (experimental)
+Run the virtual machine instead of the naive interpreter (experimental).
 
 The virtual machine is currently under heavy development and, unless you are developing the vm, there is no reason to use this option yet.
 

--- a/share/man/nitc.md
+++ b/share/man/nitc.md
@@ -45,7 +45,6 @@ See the documentation of these specific modules for details.
 ## MESSAGES
 
 ### `-W`, `--warn`
-
 Show additional warnings (advices).
 
 By default, only important warnings are displayed.
@@ -68,7 +67,6 @@ A warning is considered an advice when:
 in order to let people fix them before promoting the advice to an important warning.
 
 ### `-w`, `--warning`
-
 Show/hide a specific warning.
 
 Each type of warning can be individually displayed or hidden.
@@ -144,14 +142,14 @@ The path added with `-I` are searched before those added by the environment vari
 May be used more than once.
 
 ### `-o`, `--output`
-Output executable name.
+Filename of the generated executable.
 
 Indicates the path and name of the produced executable.
 
 Note: it is better to use `--dir` if only the directory is important.
 This way, the platform extension will be correctly set.
 
-### `-o` is not usable if multiple programs are compiled at once.
+`-o` is not usable if multiple programs are compiled at once.
 
 ### `--dir`
 Output directory.
@@ -188,7 +186,7 @@ The final binary will be generated in the same directory.
 
 Note that, to be useful, the compilation directory is not destroyed when `--no-cc` is used.
 
-### `-m`
+### `-m`, `--mixin`
 Additional module to mix-in.
 
 Additional modules are imported and refine the main module of the program.
@@ -316,7 +314,7 @@ This makes the compiled program faster since less indirections are required to g
 It also produces executables that are a little bit smaller since static memory does not have to store the colors.
 
 ### `--substitute-monomorph`
-Replace monomorphic trampolines with direct call.
+Replace monomorphic trampolines with direct calls.
 
 Late-binding is implemented with *trampolines*, that are small functions that just select and jump the to right implementations.
 If, at link-time, is it known that the target will always by the same implementation then all calls to the trampoline are replaced by
@@ -410,7 +408,7 @@ Disable advanced gcc directives for optimization.
 ### `--trampoline-call`
 Use an indirection when calling.
 
-Just add the trampolines of `--substitute-monomorph` without doing any aditionnal optimizations.
+Just add the trampolines of `--substitute-monomorph` without doing any additionnal optimizations.
 
 ### `--no-tag-primitives`
 Use only boxes for primitive types.
@@ -436,7 +434,9 @@ Do not check, and produce errors, on visibility issues.
 Do not generate main entry point.
 
 ### `--no-stacktrace`
-The compiled program will not display stack traces on runtime errors.
+Disable the generation of stack traces.
+
+With this option, the compiled program will not display stack traces on runtime errors.
 
 Because stack traces rely on libunwind, this option might be useful in order to generate more portable binaries
 since libunwind might be non available on the runtime system (or available with an ABI incompatible version).

--- a/share/man/nitc.md
+++ b/share/man/nitc.md
@@ -285,6 +285,13 @@ Need `--rta`.
 Allow the separate compiler to direct call monomorphic sites (semi-global).
 Need `--rta`.
 
+### `--direct-call-monomorph0`
+Allow the separate compiler to direct call monomorphic sites (semi-global).
+Need `--rta`.
+
+The difference with the non-zero option is internal:
+with this option, the monomorphism is looked-at on the mmethod level and not at the callsite level.
+
 ### `--skip-dead-methods`
 Do not compile dead methods (semi-global).
 Need `--rta`.
@@ -319,6 +326,19 @@ Note that using trampolines as indirection slows down the executable.
 However, it is expected that the gain of monomorphic direct-calls overcompensates the additional indirections in polymorphic trampoline-calls.
 
 Note: automatically enable option `--trampoline-call`.
+
+## POTENTIAL OPTIMIZATIONS
+
+These optimisation are not enabled by default as they are counter-effective in most cases.
+
+### `--guard-call`
+Guard VFT calls with a direct call.
+
+### `--type-poset`
+Build a poset of types to create more condensed tables.
+
+The drawback is that more time and memory are used by the compilation process.
+
 
 ## DANGEROUS OPTIMIZATIONS
 
@@ -392,6 +412,9 @@ Use an indirection when calling.
 
 Just add the trampolines of `--substitute-monomorph` without doing any aditionnal optimizations.
 
+### `--no-tag-primitives`
+Use only boxes for primitive types.
+
 ## INTERNAL OPTIONS
 
 These options can be used to control the fine behavior of the tool.
@@ -462,6 +485,12 @@ Continue after errors, whatever the consequences.
 
 The tool does not stop after some errors but continue until it produces incorrect result, crashes, erases the hard drive, or just continue forever in an infinite loop.
 This option is used to test the robustness of the tools by allowing phases to progress on incorrect data.
+
+### `--sloppy`
+Force lazy semantic analysis of the source-code.
+
+Analysis of methods is thus done only when required.
+This option breaks the behavior of most of the tools since errors in methods are undetected until the method is required in some processing.
 
 # ENVIRONMENT VARIABLES
 

--- a/share/man/nitdbg_client.md
+++ b/share/man/nitdbg_client.md
@@ -15,12 +15,12 @@ See the interpreter command `nit(1)` for details about remote debugging.
 # OPTIONS
 
 ### `--host`
-Sets the host to debug from, use IPV4 only. (Defaults to 127.0.0.1).
+Sets the host to debug from, use IPV4 only (Defaults to 127.0.0.1).
 
 ### `--port`
 Sets the debug port (Defaults to 22125).
 
-Must be contained between 0 and 65535
+Must be contained between 0 and 65535.
 
 # SEE ALSO
 

--- a/share/man/nitdoc.md
+++ b/share/man/nitdoc.md
@@ -109,7 +109,10 @@ Piwik site ID.
 ## TESTING
 
 ### `--test`
-Only print the pages structure. Nothing is generated.
+Print test data (metrics and structure).
+
+### `--no-render`
+Do not render HTML files.
 
 # SEE ALSO
 

--- a/share/man/nitdoc.md
+++ b/share/man/nitdoc.md
@@ -34,7 +34,7 @@ See `nitunit(1)` for details.
 # OPTIONS
 
 ### `-d`, `--dir`
-output directory.
+Output directory.
 
 Where the HTML files are generated.
 
@@ -52,59 +52,59 @@ For instance, the [standard library] use the following value to link to files in
 
 Here, the `git rev-parse HEAD` is used to link to the current snapshot revision of the file.
 
-### `--no-attribute`
+### `--no-attributes`
 Ignore the attributes.
 
 Note: In Nit, attributes are private. Therefore, this option is only useful
 when combined with `--private`.
 
 ### `--no-dot`
-do not generate graphs with graphviz.
+Do not generate graphs with graphviz.
 
 ### `--private`
-also generate private API.
+Also generate private API.
 
 ## CUSTOMIZATION
 
 ### `--sharedir`
-directory containing nitdoc assets.
+Directory containing nitdoc assets.
 
 By default `$NIT_DIR/share/nitdoc/` is used.
 
 ### `--shareurl`
-use shareurl instead of copy shared files.
+Use shareurl instead of copy shared files.
 
 By default, assets from the sharedir a copied into the output directory and referred with a relative path in the generated files.
 With this option, the assets are not copied and the given URL of path is used in the generated files to locate assets.
 
 ### `--custom-title`
-custom title for homepage.
+Custom title for homepage.
 
 ### `--custom-footer-text`
-custom footer text.
+Custom footer text.
 
 ### `--custom-overview-text`
-custom intro text for homepage
+Custom intro text for homepage.
 
 ### `--custom-brand`
-custom link to external site
+Custom link to external site.
 
 ## SERVICES
 
 ### `--github-upstream`
-Git branch where edited commits will be pulled into (ex: user:repo:branch)
+Git branch where edited commits will be pulled into (ex: user:repo:branch).
 
 ### `--github-base-sha1`
-Git sha1 of base commit used to create pull request
+Git sha1 of base commit used to create pull request.
 
 ### `--github-gitdir`
-Git working directory used to resolve path name (ex: /home/me/myproject/)
+Git working directory used to resolve path name (ex: /home/me/myproject/).
 
 ### `--piwik-tracker`
-Piwik tracker URL (ex: `"nitlanguage.org/piwik/"`)
+Piwik tracker URL (ex: `nitlanguage.org/piwik/`).
 
 ### `--piwik-site-id`
-Piwik site ID
+Piwik site ID.
 
 ## TESTING
 

--- a/share/man/nitlight.md
+++ b/share/man/nitlight.md
@@ -40,7 +40,7 @@ Start the source file at this line (default: 1).
 The generated HTML will only contains lines bellow the specified one.
 
 ### `--last-line`
-End the source file at this line (default: to the end)
+End the source file at this line (default: to the end).
 
 The generated HTML will only contains lines above the specified one.
 

--- a/share/man/nitls.md
+++ b/share/man/nitls.md
@@ -70,7 +70,7 @@ Process directories recursively.
 All `.nit` files found in the specified directory and subdirectories are considered.
 
 ### `-d`, `--depends`
-List dependencies of given modules
+List dependencies of given modules.
 
 All imported modules are also considered.
 

--- a/share/man/nitls.md
+++ b/share/man/nitls.md
@@ -86,7 +86,7 @@ Without this option, an error message is displayed and nitls terminates on such 
 
 ## PRESENTATION OPTIONS
 
-### `-p`, `--path`
+### `-p`, `--path-only`
 List only path (instead of name + path).
 
 Paths are displayed uncolored.

--- a/share/man/nitmetrics.md
+++ b/share/man/nitmetrics.md
@@ -57,6 +57,9 @@ Detects the definition-site variance constraints on formal parameters.
 
 Infers the possible variance annotations of formal types in Nit programs by identifying the existing constraints on the usage of those formal type.
 
+### `--detect-covariance`
+Detect the static covariance usages.
+
 ## OUTPUT
 
 ### `--csv`

--- a/share/man/nitmetrics.md
+++ b/share/man/nitmetrics.md
@@ -11,49 +11,49 @@ nitmetrics [*options*]... FILE...
 ## METRICS
 
 ### `--all`
-Compute all metrics
+Compute all metrics.
 
 ### `--mmodules`
-Compute metrics about mmodules
+Compute metrics about mmodules.
 
 ### `--mclasses`
-Compute metrics about mclasses
+Compute metrics about mclasses.
 
 ### `--mendel`
-Compute mendel metrics
+Compute mendel metrics.
 
 ### `--inheritance`
-Compute metrics about inheritance usage
+Compute metrics about inheritance usage.
 
 ### `--refinement`
-Compute metrics about refinement usage
+Compute metrics about refinement usage.
 
 ### `--self`
-Compute metrics about the usage of explicit and implicit self
+Compute metrics about the usage of explicit and implicit self.
 
 ### `--ast`
-Compute metrics about the usage of nodes and identifiers in the AST
+Compute metrics about the usage of nodes and identifiers in the AST.
 
 ### `--nullables`
-Compute metrics on nullables send
+Compute metrics on nullables send.
 
 ### `--static-types`
-Compute explicit static types metrics
+Compute explicit static types metrics.
 
 ### `--tables`
-Compute tables metrics
+Compute tables metrics.
 
 ### `--rta`
-Compute RTA metrics
+Compute RTA metrics.
 
 ### `--generate_hyperdoc`
-Generate Hyperdoc
+Generate Hyperdoc.
 
 ### `--poset`
-Complete metrics on posets
+Complete metrics on posets.
 
 ### `--detect-variance-constraints`
-Detects the definition-site variance constraints on formal parameters.
+Detect the definition-site variance constraints on formal parameters.
 
 Infers the possible variance annotations of formal types in Nit programs by identifying the existing constraints on the usage of those formal type.
 

--- a/share/man/nitpick.md
+++ b/share/man/nitpick.md
@@ -14,7 +14,10 @@ It is currently used with the vim syntactic plugin.
 
 # OPTIONS
 
-Only common options of the Nit tools are understood.
+### `--vim-autocomplete`
+Generate metadata files used by the Vim plugin for autocompletion.
+
+This option is not expected to be called directly by users.
 
 # SEE ALSO
 

--- a/share/man/nitpretty.md
+++ b/share/man/nitpretty.md
@@ -39,6 +39,12 @@ By default empty lines are kept as they were typed in the file.
 When enabling this option, `nitpretty` will decide where to break lines and
 will put empty lines to separate properties and code blocks.
 
+### `--line-width`
+Maximum length of lines (use 0 to disable automatic line breaks).
+
+### `--no-inline`
+Disable automatic one-liners.
+
 # SPECIFICATION
 
 The specification of the pretty printing is described here.

--- a/share/man/nitpretty.md
+++ b/share/man/nitpretty.md
@@ -9,31 +9,31 @@ nitpretty [*options*]... FILE
 # OPTIONS
 
 ### `--dir`
-Working directory (default is '.nitpretty')
+Working directory (default is '.nitpretty').
 
 ### `-o`, `--output`
-Output name (default is pretty.nit)
+Output name (default is pretty.nit).
 
 ### `--diff`
-Show diff between source and output
+Show diff between source and output.
 
 ### `--meld`
-Show diff between source and output using meld
+Show diff between source and output using meld.
 
 ### `--check`
-Check format of Nit source files
+Check format of Nit source files.
 
 This option creates a temporary pretty printed file then checks if the output
 of the diff command on the source file and the pretty printed one is empty.
 
 ### `--break-strings`
-Break too long string literals
+Break too long string literals.
 
 ### `--inline-do`
-Force do keyword on the same line as the method signature
+Force do keyword on the same line as the method signature.
 
 ### `--skip-empty`
-Force formatting of empty lines
+Force formatting of empty lines.
 
 By default empty lines are kept as they were typed in the file.
 When enabling this option, `nitpretty` will decide where to break lines and

--- a/share/man/nitserial.md
+++ b/share/man/nitserial.md
@@ -14,6 +14,9 @@ Output file (can also be 'stdout')
 ### `--dir`
 Output directory
 
+### `-d`, `--depth`
+Depth of the visit and generation <module, group, package>.
+
 # SEE ALSO
 
 The Nit language documentation and the source code of its tools and libraries may be downloaded from <http://nitlanguage.org>

--- a/share/man/nitserial.md
+++ b/share/man/nitserial.md
@@ -9,10 +9,10 @@ nitserial [*options*]... FILE
 # OPTIONS
 
 ### `-o`, `--output`
-Output file (can also be 'stdout')
+Output file (can also be 'stdout').
 
 ### `--dir`
-Output directory
+Output directory.
 
 ### `-d`, `--depth`
 Depth of the visit and generation <module, group, package>.

--- a/share/man/nitunit.md
+++ b/share/man/nitunit.md
@@ -226,12 +226,12 @@ By default, only the modules indicated on the command line are tested.
 With the `--full` option, all imported modules (even those in standard) are also precessed.
 
 ### `-o`, `--output`
-Output name (default is 'nitunit.xml')
+Output name (default is 'nitunit.xml').
 
 ### `nitunit` produces a XML file comatible with JUnit.
 
 ### `--dir`
-Working directory (default is '.nitunit')
+Working directory (default is '.nitunit').
 
 In order to execute the tests, nit files are generated then compiled and executed in the giver working directory.
 
@@ -239,7 +239,9 @@ In order to execute the tests, nit files are generated then compiled and execute
 Does not compile and run tests.
 
 ### `-p`, `--pattern`
-Only run test case with name that match pattern. Examples: `TestFoo`, `TestFoo*`, `TestFoo::test_foo`, `TestFoo::test_foo*`, `test_foo`, `test_foo*`
+Only run test case with name that match pattern.
+
+Examples: `TestFoo`, `TestFoo*`, `TestFoo::test_foo`, `TestFoo::test_foo*`, `test_foo`, `test_foo*`
 
 ### `-t`, `--target-file`
 Specify test suite location.
@@ -247,7 +249,7 @@ Specify test suite location.
 ## SUITE GENERATION
 
 ### `--gen-suite`
-Generate test suite skeleton for a module
+Generate test suite skeleton for a module.
 
 ### `-f`, `--force`
 Force test generation even if file exists.

--- a/share/man/nitx.md
+++ b/share/man/nitx.md
@@ -49,6 +49,12 @@ exit the tool.
 ### `-q`
 execute a query, display results in console then quit.
 
+### `--no-attributes`
+Ignore the attributes.
+
+### `--private`
+Also generate private API.
+
 # SEE ALSO
 
 The Nit language documentation and the source code of its tools and libraries may be downloaded from <http://nitlanguage.org>

--- a/share/man/nitx.md
+++ b/share/man/nitx.md
@@ -46,10 +46,10 @@ exit the tool.
 
 # OPTIONS
 
-### `-q`, `--query`
-Nitx query to perform.
+### `-c`, `--command`
+Nitx command to perform.
 
-Execute a query, display results in the console, then quit.
+Execute a command, display results in the console, then quit.
 
 ### `--no-attributes`
 Ignore the attributes.

--- a/share/man/nitx.md
+++ b/share/man/nitx.md
@@ -46,8 +46,10 @@ exit the tool.
 
 # OPTIONS
 
-### `-q`
-execute a query, display results in console then quit.
+### `-q`, `--query`
+Nitx query to perform.
+
+Execute a query, display results in the console, then quit.
 
 ### `--no-attributes`
 Ignore the attributes.

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -28,15 +28,15 @@ import counter
 # Add compiling options
 redef class ToolContext
 	# --output
-	var opt_output = new OptionString("Output file", "-o", "--output")
+	var opt_output = new OptionString("Filename of the generated executable", "-o", "--output")
 	# --dir
 	var opt_dir = new OptionString("Output directory", "--dir")
 	# --no-cc
-	var opt_no_cc = new OptionBool("Do not invoke C compiler", "--no-cc")
+	var opt_no_cc = new OptionBool("Do not invoke the C compiler", "--no-cc")
 	# --no-main
 	var opt_no_main = new OptionBool("Do not generate main entry point", "--no-main")
 	# --make-flags
-	var opt_make_flags = new OptionString("Additional options to make", "--make-flags")
+	var opt_make_flags = new OptionString("Additional options to the `make` command", "--make-flags")
 	# --max-c-lines
 	var opt_max_c_lines = new OptionInt("Maximum number of lines in generated C files. Use 0 for unlimited", 10000, "--max-c-lines")
 	# --group-c-files
@@ -50,7 +50,7 @@ redef class ToolContext
 	# --no-check-attr-isset
 	var opt_no_check_attr_isset = new OptionBool("Disable isset tests before each attribute access (dangerous)", "--no-check-attr-isset")
 	# --no-check-assert
-	var opt_no_check_assert = new OptionBool("Disable the evaluation of explicit 'assert' and 'as' (dangerous)", "--no-check-assert")
+	var opt_no_check_assert = new OptionBool("Disable the evaluation of explicit `assert` and `as` (dangerous)", "--no-check-assert")
 	# --no-check-autocast
 	var opt_no_check_autocast = new OptionBool("Disable implicit casts on unsafe expression usage (dangerous)", "--no-check-autocast")
 	# --no-check-null
@@ -66,11 +66,11 @@ redef class ToolContext
 	# --no-stacktrace
 	var opt_no_stacktrace = new OptionBool("Disable the generation of stack traces", "--no-stacktrace")
 	# --no-gcc-directives
-	var opt_no_gcc_directive = new OptionArray("Disable a advanced gcc directives for optimization", "--no-gcc-directive")
+	var opt_no_gcc_directive = new OptionArray("Disable advanced gcc directives for optimization", "--no-gcc-directive")
 	# --release
 	var opt_release = new OptionBool("Compile in release mode and finalize application", "--release")
 	# -g
-	var opt_debug = new OptionBool("Compile in debug mode (no C-side optimization)", "--debug", "-g")
+	var opt_debug = new OptionBool("Compile in debug mode (no C-side optimization)", "-g", "--debug")
 
 	redef init
 	do

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -26,20 +26,20 @@ redef class ToolContext
 	# --no-inline-intern
 	var opt_no_inline_intern = new OptionBool("Do not inline call to intern methods", "--no-inline-intern")
 	# --no-union-attribute
-	var opt_no_union_attribute = new OptionBool("Put primitive attibutes in a box instead of an union", "--no-union-attribute")
+	var opt_no_union_attribute = new OptionBool("Put primitive attributes in a box instead of an union", "--no-union-attribute")
 	# --no-shortcut-equate
 	var opt_no_shortcut_equate = new OptionBool("Always call == in a polymorphic way", "--no-shortcut-equal")
 	# --no-tag-primitives
 	var opt_no_tag_primitives = new OptionBool("Use only boxes for primitive types", "--no-tag-primitives")
 
 	# --colors-are-symbols
-	var opt_colors_are_symbols = new OptionBool("Store colors as symbols (link-boost)", "--colors-are-symbols")
+	var opt_colors_are_symbols = new OptionBool("Store colors as symbols instead of static data (link-boost)", "--colors-are-symbols")
 	# --trampoline-call
 	var opt_trampoline_call = new OptionBool("Use an indirection when calling", "--trampoline-call")
 	# --guard-call
 	var opt_guard_call = new OptionBool("Guard VFT calls with a direct call", "--guard-call")
 	# --substitute-monomorph
-	var opt_substitute_monomorph = new OptionBool("Replace monomorph trampoline with direct call (link-boost)", "--substitute-monomorph")
+	var opt_substitute_monomorph = new OptionBool("Replace monomorphic trampolines with direct calls (link-boost)", "--substitute-monomorph")
 	# --link-boost
 	var opt_link_boost = new OptionBool("Enable all link-boost optimizations", "--link-boost")
 
@@ -48,9 +48,9 @@ redef class ToolContext
 	# --inline-some-methods
 	var opt_inline_some_methods = new OptionBool("Allow the separate compiler to inline some methods (semi-global)", "--inline-some-methods")
 	# --direct-call-monomorph
-	var opt_direct_call_monomorph = new OptionBool("Allow the separate compiler to direct call monomorph sites (semi-global)", "--direct-call-monomorph")
+	var opt_direct_call_monomorph = new OptionBool("Allow the separate compiler to direct call monomorphic sites (semi-global)", "--direct-call-monomorph")
 	# --direct-call-monomorph0
-	var opt_direct_call_monomorph0 = new OptionBool("Allow the separate compiler to direct call monomorph sites (semi-global)", "--direct-call-monomorph0")
+	var opt_direct_call_monomorph0 = new OptionBool("Allow the separate compiler to direct call monomorphic sites (semi-global)", "--direct-call-monomorph0")
 	# --skip-dead-methods
 	var opt_skip_dead_methods = new OptionBool("Do not compile dead methods (semi-global)", "--skip-dead-methods")
 	# --semi-global
@@ -60,7 +60,7 @@ redef class ToolContext
 	# --tables-metrics
 	var opt_tables_metrics = new OptionBool("Enable static size measuring of tables used for vft, typing and resolution", "--tables-metrics")
 	# --type-poset
-	var opt_type_poset = new OptionBool("Build a poset of types to create more condensed tables.", "--type-poset")
+	var opt_type_poset = new OptionBool("Build a poset of types to create more condensed tables", "--type-poset")
 
 	redef init
 	do

--- a/src/doc/doc_base.nit
+++ b/src/doc/doc_base.nit
@@ -221,7 +221,7 @@ end
 redef class ToolContext
 
 	# Directory where the Nitdoc is rendered.
-	var opt_dir = new OptionString("output directory", "-d", "--dir")
+	var opt_dir = new OptionString("Output directory", "-d", "--dir")
 
 	# Shortcut for `opt_dir.value` with default "doc".
 	var output_dir: String is lazy do return opt_dir.value or else "doc"

--- a/src/doc/doc_phases/doc_extract.nit
+++ b/src/doc/doc_phases/doc_extract.nit
@@ -25,10 +25,10 @@ import doc_base
 redef class ToolContext
 
 	# Do not generate documentation for attributes.
-	var opt_no_attributes = new OptionBool("ignore the attributes", "--no-attributes")
+	var opt_no_attributes = new OptionBool("Ignore the attributes", "--no-attributes")
 
 	# Do not generate documentation for private properties.
-	var opt_private = new OptionBool("also generate private API", "--private")
+	var opt_private = new OptionBool("Also generate private API", "--private")
 
 	redef init do
 		super

--- a/src/doc/doc_phases/doc_graphs.nit
+++ b/src/doc/doc_phases/doc_graphs.nit
@@ -22,7 +22,7 @@ import html_templates::html_model # FIXME maybe this phase should depend on `htm
 redef class ToolContext
 
 	# Do not generate `graphviz` diagrams.
-	var opt_nodot = new OptionBool("do not generate graphes with graphviz", "--no-dot")
+	var opt_nodot = new OptionBool("Do not generate graphs with graphviz", "--no-dot")
 
 	redef init do
 		super

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -71,7 +71,7 @@ redef class ToolContext
 	var opt_github_gitdir = new OptionString("Git working directory used to resolve path name (ex: /home/me/mypackage/)", "--github-gitdir")
 
 	# Do not produce HTML files
-	var opt_no_render = new OptionBool("do not render HTML files", "--no-render")
+	var opt_no_render = new OptionBool("Do not render HTML files", "--no-render")
 
 	redef init do
 		super

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -28,35 +28,35 @@ import html_templates
 redef class ToolContext
 
 	# File pattern used to link documentation to source code.
-	var opt_source = new OptionString("link for source (%f for filename, " +
+	var opt_source = new OptionString("Format to link source code (%f for filename, " +
 		"%l for first line, %L for last line)", "--source")
 
 	# Directory where the CSS and JS is stored.
-	var opt_sharedir = new OptionString("directory containing nitdoc assets", "--sharedir")
+	var opt_sharedir = new OptionString("Directory containing nitdoc assets", "--sharedir")
 
 	# Use a shareurl instead of copy shared files.
 	#
 	# This is usefull if you don't want to store the Nitdoc templates with your
 	# documentation.
-	var opt_shareurl = new OptionString("use shareurl instead of copy shared files", "--shareurl")
+	var opt_shareurl = new OptionString("Use shareurl instead of copy shared files", "--shareurl")
 
 	# Use a custom title for the homepage.
-	var opt_custom_title = new OptionString("custom title for homepage", "--custom-title")
+	var opt_custom_title = new OptionString("Custom title for homepage", "--custom-title")
 
 	# Display a custom brand or logo in the documentation top menu.
-	var opt_custom_brand = new OptionString("custom link to external site", "--custom-brand")
+	var opt_custom_brand = new OptionString("Custom link to external site", "--custom-brand")
 
 	# Display a custom introduction text before the packages overview.
-	var opt_custom_intro = new OptionString("custom intro text for homepage", "--custom-overview-text")
+	var opt_custom_intro = new OptionString("Custom intro text for homepage", "--custom-overview-text")
 	# Display a custom footer on each documentation page.
 	#
 	# Generally used to display the documentation or product version.
-	var opt_custom_footer = new OptionString("custom footer text", "--custom-footer-text")
+	var opt_custom_footer = new OptionString("Custom footer text", "--custom-footer-text")
 
 	# Piwik tracker URL.
 	#
 	# If you want to monitor your visitors.
-	var opt_piwik_tracker = new OptionString("Piwik tracker URL (ex: nitlanguage.org/piwik/)", "--piwik-tracker")
+	var opt_piwik_tracker = new OptionString("Piwik tracker URL (ex: `nitlanguage.org/piwik/`)", "--piwik-tracker")
 
 	# Piwik tracker site id.
 	var opt_piwik_site_id = new OptionString("Piwik site ID", "--piwik-site-id")

--- a/src/doc/doc_phases/doc_test.nit
+++ b/src/doc/doc_phases/doc_test.nit
@@ -23,7 +23,7 @@ import counter
 redef class ToolContext
 
 	# File pattern used to link documentation to source code.
-	var opt_test = new OptionBool("print test data", "--test")
+	var opt_test = new OptionBool("Print test data (metrics and structure)", "--test")
 
 	redef init do
 		super

--- a/src/doc/vim_autocomplete.nit
+++ b/src/doc/vim_autocomplete.nit
@@ -45,6 +45,7 @@ redef class ToolContext
 	do
 		super
 		option_context.add_option opt_vim_autocomplete
+		opt_vim_autocomplete.hidden = true
 	end
 end
 

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -25,7 +25,7 @@ import primitive_types
 
 redef class ToolContext
 	# --discover-call-trace
-	var opt_discover_call_trace = new OptionBool("Trace calls of the first invocation of a method", "--discover-call-trace")
+	var opt_discover_call_trace = new OptionBool("Trace calls of the first invocation of methods", "--discover-call-trace")
 
 	redef init
 	do

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -42,13 +42,13 @@ import ini
 
 redef class ToolContext
 	# Option --path
-	var opt_path = new OptionArray("Set include path for loaders (may be used more than once)", "-I", "--path")
+	var opt_path = new OptionArray("Add an additional include path (may be used more than once)", "-I", "--path")
 
 	# Option --only-metamodel
 	var opt_only_metamodel = new OptionBool("Stop after meta-model processing", "--only-metamodel")
 
 	# Option --only-parse
-	var opt_only_parse = new OptionBool("Only proceed to parse step of loaders", "--only-parse")
+	var opt_only_parse = new OptionBool("Only proceed to parse files", "--only-parse")
 
 	redef init
 	do

--- a/src/metrics/metrics_base.nit
+++ b/src/metrics/metrics_base.nit
@@ -51,7 +51,7 @@ redef class ToolContext
 	# --rta
 	var opt_rta = new OptionBool("Compute RTA metrics", "--rta")
 	# --generate-csv
-	var opt_csv = new OptionBool("Export metrics in CSV format", "--csv")
+	var opt_csv = new OptionBool("Also export metrics in CSV format", "--csv")
 	# --generate_hyperdoc
 	var opt_generate_hyperdoc = new OptionBool("Generate Hyperdoc", "--generate_hyperdoc")
 	# --poset

--- a/src/mixin.nit
+++ b/src/mixin.nit
@@ -21,7 +21,7 @@ import modelbuilder
 
 redef class ToolContext
 	# --mixin
-	var opt_mixins = new OptionArray("Additionals module to min-in", "-m", "--mixin")
+	var opt_mixins = new OptionArray("Additional module to mix-in", "-m", "--mixin")
 	# --define
 	var opt_defines = new OptionArray("Define a specific property", "-D", "--define")
 

--- a/src/modelbuilder.nit
+++ b/src/modelbuilder.nit
@@ -25,7 +25,7 @@ private import more_collections
 
 redef class ToolContext
 	# Option --ignore-visibility
-	var opt_ignore_visibility = new OptionBool("Do not check, and produce errors, on visibility issues.", "--ignore-visibility")
+	var opt_ignore_visibility = new OptionBool("Do not check, and produce errors, on visibility issues", "--ignore-visibility")
 
 	redef init
 	do

--- a/src/nit.nit
+++ b/src/nit.nit
@@ -26,8 +26,9 @@ import vm
 var toolcontext = new ToolContext
 toolcontext.option_context.options_before_rest = true
 toolcontext.tooldescription = "Usage: nit [OPTION]... <file.nit>...\nInterprets and debugs Nit programs."
-# Add an option "-o" to enable compatibilit with the tests.sh script
-var opt = new OptionString("compatibility (does noting)", "-o")
+# Add an option "-o" to enable compatibility with the tests.sh script
+var opt = new OptionString("Does nothing. Used for compatibility.", "-o")
+opt.hidden = true
 toolcontext.option_context.add_option(opt)
 var opt_eval = new OptionBool("Specifies the program from command-line", "-e")
 var opt_loop = new OptionBool("Repeatedly run the program for each line in file-name arguments", "-n")

--- a/src/nitdbg_client.nit
+++ b/src/nitdbg_client.nit
@@ -25,7 +25,7 @@ import toolcontext
 redef class ToolContext
 
 	var opt_host_address: OptionString = new OptionString("Sets the host to debug from, use IPV4 only (Defaults to 127.0.0.1)", "--host")
-	var opt_debug_port: OptionInt = new OptionInt("Sets the debug port (Defaults to 22125) - Must be contained between 0 and 65535", 22125, "--port")
+	var opt_debug_port: OptionInt = new OptionInt("Sets the debug port (Defaults to 22125)", 22125, "--port")
 
 	redef init
 	do

--- a/src/nitlight.nit
+++ b/src/nitlight.nit
@@ -23,7 +23,7 @@ var toolcontext = new ToolContext
 toolcontext.keep_going = true
 
 var opt_fragment = new OptionBool("Omit document header and footer", "-f", "--fragment")
-var opt_line_id_prefix = new OptionString("Prefix of the id of each line <span> element", "--line-id-prefix")
+var opt_line_id_prefix = new OptionString("Prefix of the id of each line `<span>` element", "--line-id-prefix")
 var opt_first_line = new OptionInt("Start the source file at this line (default: 1)", 0, "--first-line")
 var opt_last_line = new OptionInt("End the source file at this line (default: to the end)", 0, "--last-line")
 var opt_dir = new OptionString("Output html files in a specific directory (required if more than one module)", "-d", "--dir")

--- a/src/nitls.nit
+++ b/src/nitls.nit
@@ -90,12 +90,12 @@ end
 var tc = new ToolContext
 
 var opt_keep = new OptionBool("Ignore errors and files that are not a Nit source file", "-k", "--keep")
-var opt_recursive = new OptionBool("Process directories recussively", "-r", "--recursive")
+var opt_recursive = new OptionBool("Process directories recursively", "-r", "--recursive")
 var opt_tree = new OptionBool("List source files in their groups and packages", "-t", "--tree")
-var opt_source = new OptionBool("List source files", "-s", "--source")
-var opt_package = new OptionBool("List packages paths (default)", "-P", "--package")
+var opt_source = new OptionBool("List source files in a flat list", "-s", "--source")
+var opt_package = new OptionBool("List packages in a flat list (default)", "-P", "--package")
 var opt_depends = new OptionBool("List dependencies of given modules", "-d", "--depends")
-var opt_make = new OptionBool("List dependencies suitable for a rule in a Makefile. Alias for -d, -p and -s", "-M")
+var opt_make = new OptionBool("List dependencies suitable for a rule in a Makefile (alias for -d, -p and -s)", "-M")
 var opt_paths = new OptionBool("List only path (instead of name + path)", "-p", "--path-only")
 
 tc.option_context.add_option(opt_keep, opt_recursive, opt_tree, opt_source, opt_package, opt_depends, opt_paths, opt_make)

--- a/src/nitls.nit
+++ b/src/nitls.nit
@@ -96,7 +96,7 @@ var opt_source = new OptionBool("List source files", "-s", "--source")
 var opt_package = new OptionBool("List packages paths (default)", "-P", "--package")
 var opt_depends = new OptionBool("List dependencies of given modules", "-d", "--depends")
 var opt_make = new OptionBool("List dependencies suitable for a rule in a Makefile. Alias for -d, -p and -s", "-M")
-var opt_paths = new OptionBool("List only path (instead of name + path)", "-p", "--path")
+var opt_paths = new OptionBool("List only path (instead of name + path)", "-p", "--path-only")
 
 tc.option_context.add_option(opt_keep, opt_recursive, opt_tree, opt_source, opt_package, opt_depends, opt_paths, opt_make)
 tc.tooldescription = "Usage: nitls [OPTION]... <file.nit|directory>...\nLists the packages and/or paths of Nit sources files."

--- a/src/nitx.nit
+++ b/src/nitx.nit
@@ -32,9 +32,9 @@ redef class ToolContext
 	var docx: Phase = new NitxPhase(self, null)
 
 	# Used to shortcut the prompt and display directly the result in console.
-	var opt_query = new OptionString("Nitx query to perform", "-q", "--query")
+	var opt_command = new OptionString("Nitx command to perform", "-c", "--command")
 
-	init do option_context.add_option opt_query
+	init do option_context.add_option opt_command
 end
 
 # Nitx phase explores the model and prepares the console rendering.
@@ -58,7 +58,7 @@ private class NitxPhase
 
 		# start nitx
 		var nitx = new Nitx(toolcontext, doc)
-		var q = toolcontext.opt_query.value
+		var q = toolcontext.opt_command.value
 		if q != null then # shortcut prompt
 			print ""
 			nitx.do_query(q)

--- a/src/phase.nit
+++ b/src/phase.nit
@@ -28,10 +28,10 @@ redef class ToolContext
 	var phases = new POSet[Phase]
 
 	# --disable-phase
-	var opt_disable_phase = new OptionArray("DEBUG: Disable a specific phase; use `list` to get the list.", "--disable-phase")
+	var opt_disable_phase = new OptionArray("Disable a specific phase; use `list` to get the list (debug)", "--disable-phase")
 
-	# --disable-phase
-	var opt_sloppy = new OptionBool("DEBUG: force lazy semantic analysis of the source-code", "--sloppy")
+	# --sloppy
+	var opt_sloppy = new OptionBool("Force lazy semantic analysis of the source-code (debug)", "--sloppy")
 
 	redef init
 	do

--- a/src/testing/testing_gen.nit
+++ b/src/testing/testing_gen.nit
@@ -177,5 +177,5 @@ redef class ToolContext
 	var opt_gen_unit = new OptionBool("Generate test suite skeleton for a module", "--gen-suite")
 	var opt_gen_force = new OptionBool("Force test generation even if file exists", "-f", "--force")
 	var opt_gen_private = new OptionBool("Also generate test case for private methods", "--private")
-	var opt_gen_show = new OptionBool("Only display skeleton, do not write file", "--only-show")
+	var opt_gen_show = new OptionBool("Only display the skeleton, do not write any file", "--only-show")
 end

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -21,9 +21,9 @@ private import annotation
 
 redef class ToolContext
 	# -- target-file
-	var opt_file = new OptionString("Specify test suite location.", "-t", "--target-file")
+	var opt_file = new OptionString("Specify test suite location", "-t", "--target-file")
 	# --pattern
-	var opt_pattern = new OptionString("Only run test case with name that match pattern. Examples: 'TestFoo', 'TestFoo*', 'TestFoo::test_foo', 'TestFoo::test_foo*', 'test_foo', 'test_foo*'", "-p", "--pattern")
+	var opt_pattern = new OptionString("Only run test case with name that match pattern", "-p", "--pattern")
 end
 
 # Used to test nitunit test files.

--- a/src/toolcontext.nit
+++ b/src/toolcontext.nit
@@ -333,7 +333,7 @@ class ToolContext
 	var option_context = new OptionContext
 
 	# Option --warn
-	var opt_warn = new OptionCount("Show more warnings", "-W", "--warn")
+	var opt_warn = new OptionCount("Show additional warnings (advices)", "-W", "--warn")
 
 	# Option --warning
 	var opt_warning = new OptionArray("Show/hide a specific warning", "-w", "--warning")
@@ -360,10 +360,10 @@ class ToolContext
 	var opt_set_dummy_tool = new OptionBool("Set toolname and version to DUMMY. Useful for testing", "--set-dummy-tool")
 
 	# Option --verbose
-	var opt_verbose = new OptionCount("Verbose", "-v", "--verbose")
+	var opt_verbose = new OptionCount("Additional messages from the tool", "-v", "--verbose")
 
 	# Option --stop-on-first-error
-	var opt_stop_on_first_error = new OptionBool("Stop on first error", "--stop-on-first-error")
+	var opt_stop_on_first_error = new OptionBool("Just display the first encountered error then stop", "--stop-on-first-error")
 
 	# Option --keep-going
 	var opt_keep_going = new OptionBool("Continue after errors, whatever the consequences", "--keep-going")
@@ -440,26 +440,23 @@ class ToolContext
 
 		if opt_stub_man.value then
 			print """
-% {{{toolname.to_upper}}}(1)
-
 # NAME
 
 {{{tooldescription.split("\n")[1]}}}
 
 # SYNOPSYS
 
-{{{toolname}}} [*options*]...
-
 # OPTIONS
 """
 			for o in option_context.options do
 				var first = true
+				printn "### "
 				for n in o.names do
 					if first then first = false else printn ", "
 					printn "`{n}`"
 				end
 				print ""
-				print ":   {o.helptext}"
+				print "{o.helptext}."
 				print ""
 			end
 			print """

--- a/tests/nitx.args
+++ b/tests/nitx.args
@@ -1,3 +1,3 @@
-base_simple3.nit -q A
-base_simple3.nit -q foo
-base_simple3.nit -q base_simple3
+base_simple3.nit -c A
+base_simple3.nit -c foo
+base_simple3.nit -c base_simple3

--- a/tests/sav/test_toolcontext_args2.res
+++ b/tests/sav/test_toolcontext_args2.res
@@ -1,9 +1,9 @@
 Usage: test_toolcontext [OPTION]...
 Test for ToolContext, try --bash-completion.
-  -W, --warn              Show more warnings
+  -W, --warn              Show additional warnings (advices)
   -w, --warning           Show/hide a specific warning
   -q, --quiet             Do not show warnings
-  --stop-on-first-error   Stop on first error
+  --stop-on-first-error   Just display the first encountered error then stop
   --keep-going            Continue after errors, whatever the consequences
   --no-color              Do not use color to display errors and warnings
   --log                   Generate various log files
@@ -11,7 +11,7 @@ Test for ToolContext, try --bash-completion.
   --nit-dir               Base directory of the Nit installation
   -h, -?, --help          Show Help (This screen)
   --version               Show version and exit
-  -v, --verbose           Verbose
+  -v, --verbose           Additional messages from the tool
   -a, --option-a          option a, do nothing
   -b, --option-b          option b, do nothing
   -c                      option c, do nothing


### PR DESCRIPTION
A tedious work to detect and fix undocumented options in the manpages of tools.
This also synchronizse the description of `--help` and the text in manpages (when there is a diversion, the best one if often selected).

Cherry on the cake: a new script `check_manpage` can automatically check that new options of tools are documented in the man. Close #1772