### PR TITLE
examples/shoot: fix typo in shoot_linux synopsis

### DIFF
--- a/examples/shoot/src/shoot_linux.nit
+++ b/examples/shoot/src/shoot_linux.nit
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Linex version of the shoot program
+# Linux version of the shoot program
 module shoot_linux
 
 import shoot


### PR DESCRIPTION
Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>