### PR TITLE
Robust Virtual Type

### DIFF
--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -1010,7 +1010,7 @@ abstract class MType
 	# The result is returned exactly as declared in the "type" property (verbatim).
 	# So it could be another formal type.
 	#
-	# In case of conflict, the method aborts.
+	# In case of conflicts or inconsistencies in the model, the method returns a `MBottomType`.
 	fun lookup_bound(mmodule: MModule, resolved_receiver: MType): MType do return self
 
 	# Resolve the formal type to its simplest equivalent form.
@@ -1024,6 +1024,8 @@ abstract class MType
 	#
 	# By default, return self.
 	# See the redefinitions for specific behavior in each kind of type.
+	#
+	# In case of conflicts or inconsistencies in the model, the method returns a `MBottomType`.
 	fun lookup_fixed(mmodule: MModule, resolved_receiver: MType): MType do return self
 
 	# Can the type be resolved?
@@ -1365,7 +1367,7 @@ class MVirtualType
 
 	redef fun lookup_bound(mmodule: MModule, resolved_receiver: MType): MType
 	do
-		return lookup_single_definition(mmodule, resolved_receiver).bound.as(not null)
+		return lookup_single_definition(mmodule, resolved_receiver).bound or else new MBottomType(model)
 	end
 
 	private fun lookup_single_definition(mmodule: MModule, resolved_receiver: MType): MVirtualTypeDef
@@ -1400,7 +1402,8 @@ class MVirtualType
 		assert resolved_receiver isa MClassType # It is the only remaining type
 
 		var prop = lookup_single_definition(mmodule, resolved_receiver)
-		var res = prop.bound.as(not null)
+		var res = prop.bound
+		if res == null then return new MBottomType(model)
 
 		# Recursively lookup the fixed result
 		res = res.lookup_fixed(mmodule, resolved_receiver)

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -809,19 +809,19 @@ abstract class MType
 		end
 		#print "4.is {sub} a {sup}? <- no more resolution"
 
+		if sub isa MBottomType then
+			return true
+		end
+
 		assert sub isa MClassType else print "{sub} <? {sub}" # It is the only remaining type
 
-		# A unfixed formal type can only accept itself
-		if sup isa MFormalType then
+		# Handle sup-type when the sub-type is class-based (other cases must have be identified before).
+		if sup isa MFormalType or sup isa MNullType or sup isa MBottomType then
+			# These types are not super-types of Class-based types.
 			return false
 		end
 
-		if sup isa MNullType then
-			# `sup` accepts only null
-			return false
-		end
-
-		assert sup isa MClassType # It is the only remaining type
+		assert sup isa MClassType else print "got {sup} {sub.inspect}" # It is the only remaining type
 
 		# Now both are MClassType, we need to dig
 

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -1582,22 +1582,23 @@ redef class ATypePropdef
 				modelbuilder.warning(n_id, "bad-type-name", "Warning: lowercase in the virtual type `{name}`.")
 				break
 			end
-			if not self.check_redef_keyword(modelbuilder, mclassdef, self.n_kwredef, false, mprop) then return
 		else
-			if not self.check_redef_keyword(modelbuilder, mclassdef, self.n_kwredef, true, mprop) then return
 			assert mprop isa MVirtualTypeProp
 			check_redef_property_visibility(modelbuilder, self.n_visibility, mprop)
 		end
-		mclassdef.mprop2npropdef[mprop] = self
 
 		var mpropdef = new MVirtualTypeDef(mclassdef, mprop, self.location)
 		self.mpropdef = mpropdef
-		modelbuilder.mpropdef2npropdef[mpropdef] = self
 		if mpropdef.is_intro then
 			modelbuilder.toolcontext.info("{mpropdef} introduces new type {mprop.full_name}", 4)
 		else
 			modelbuilder.toolcontext.info("{mpropdef} redefines type {mprop.full_name}", 4)
 		end
+		if not self.check_redef_keyword(modelbuilder, mclassdef, self.n_kwredef, not mpropdef.is_intro, mprop) then
+			mpropdef.is_broken =true
+		end
+		mclassdef.mprop2npropdef[mprop] = self
+		modelbuilder.mpropdef2npropdef[mpropdef] = self
 		set_doc(mpropdef, modelbuilder)
 
 		var atfixed = get_single_annotation("fixed", modelbuilder)

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -111,7 +111,7 @@ redef class ModelBuilder
 				if not check_virtual_types_circularity(npropdef, mpropdef.mproperty, mclassdef.bound_mtype, mclassdef.mmodule) then
 					# Invalidate the bound
 					mpropdef.is_broken = true
-					mpropdef.bound = mclassdef.mmodule.model.null_type
+					mpropdef.bound = new MBottomType(mclassdef.mmodule.model)
 				end
 			end
 			for npropdef in nclassdef2.n_propdefs do
@@ -385,6 +385,8 @@ redef class ModelBuilder
 		else if mtype isa MParameterType then
 			# nothing, always visible
 		else if mtype isa MNullType then
+			# nothing to do.
+		else if mtype isa MBottomType then
 			# nothing to do.
 		else
 			node.debug "Unexpected type {mtype}"
@@ -1643,7 +1645,7 @@ redef class ATypePropdef
 		# Check redefinitions
 		for p in mpropdef.mproperty.lookup_super_definitions(mmodule, anchor) do
 			var supbound = p.bound
-			if supbound == null then break # broken super bound, skip error
+			if supbound == null or supbound isa MBottomType or p.is_broken then break # broken super bound, skip error
 			if p.is_fixed then
 				modelbuilder.error(self, "Redef Error: virtual type `{mpropdef.mproperty}` is fixed in super-class `{p.mclassdef.mclass}`.")
 				break

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -447,8 +447,7 @@ redef class ModelBuilder
 				var vt = t.mproperty
 				# Because `vt` is possibly unchecked, we have to do the bound-lookup manually
 				var defs = vt.lookup_definitions(mmodule, recv)
-				# TODO something to manage correctly bound conflicts
-				assert not defs.is_empty
+				if defs.is_empty then return false
 				nexts = new Array[MType]
 				for d in defs do
 					var next = defs.first.bound

--- a/tests/error_redef_vt.nit
+++ b/tests/error_redef_vt.nit
@@ -1,0 +1,29 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import core::kernel
+
+class G[E: Object]
+end
+
+class A
+	redef type N1: A
+	redef type N2: FAIL
+	fun foo1: G[N1] do return new G[N1]
+	fun foo2: G[N2] do return new G[N2]
+end
+
+var a = new A
+a.foo1
+a.foo2

--- a/tests/sav/error_redef_vt.res
+++ b/tests/sav/error_redef_vt.res
@@ -1,0 +1,3 @@
+error_redef_vt.nit:21,2--17: Error: no property `A::N1` is inherited. Remove the `redef` keyword to define a new property.
+error_redef_vt.nit:22,17--20: Error: class `FAIL` not found in module `error_redef_vt`.
+error_redef_vt.nit:22,2--20: Error: no property `A::N2` is inherited. Remove the `redef` keyword to define a new property.

--- a/tests/sav/error_virtual_type2_alt1.res
+++ b/tests/sav/error_virtual_type2_alt1.res
@@ -1,5 +1,2 @@
 alt/error_virtual_type2_alt1.nit:22,2--24,14: Error: circularity of virtual type definition: GT -> T <-> T.
 alt/error_virtual_type2_alt1.nit:25,2--10: Error: circularity of virtual type definition: T <-> T.
-alt/error_virtual_type2_alt1.nit:38,23: Redef Error: expected `Comparable` for return type; got `T`.
-alt/error_virtual_type2_alt1.nit:40,17--27: Redef Error: expected `null` bound type; got `G[Discrete]`.
-alt/error_virtual_type2_alt1.nit:42,23: Redef Error: expected `Comparable` for return type; got `T`.

--- a/tests/sav/error_virtual_type2_alt2.res
+++ b/tests/sav/error_virtual_type2_alt2.res
@@ -1,5 +1,2 @@
 alt/error_virtual_type2_alt2.nit:22,2--24,14: Error: circularity of virtual type definition: GT -> T <-> nullable T.
 alt/error_virtual_type2_alt2.nit:25,2--26,19: Error: circularity of virtual type definition: T <-> nullable T.
-alt/error_virtual_type2_alt2.nit:38,23: Redef Error: expected `Comparable` for return type; got `T`.
-alt/error_virtual_type2_alt2.nit:40,17--27: Redef Error: expected `null` bound type; got `G[Discrete]`.
-alt/error_virtual_type2_alt2.nit:42,23: Redef Error: expected `Comparable` for return type; got `T`.

--- a/tests/sav/error_virtual_type2_alt3.res
+++ b/tests/sav/error_virtual_type2_alt3.res
@@ -1,5 +1,2 @@
 alt/error_virtual_type2_alt3.nit:22,2--24,14: Error: circularity of virtual type definition: GT -> G[T] <-> T.
 alt/error_virtual_type2_alt3.nit:25,2--27,13: Error: circularity of virtual type definition: T <-> G[T].
-alt/error_virtual_type2_alt3.nit:38,23: Redef Error: expected `Comparable` for return type; got `T`.
-alt/error_virtual_type2_alt3.nit:40,17--27: Redef Error: expected `null` bound type; got `G[Discrete]`.
-alt/error_virtual_type2_alt3.nit:42,23: Redef Error: expected `Comparable` for return type; got `T`.

--- a/tests/sav/error_virtual_type2_alt4.res
+++ b/tests/sav/error_virtual_type2_alt4.res
@@ -1,4 +1,1 @@
 alt/error_virtual_type2_alt4.nit:29,10--13: Error: class `FAIL` not found in module `error_virtual_type2_alt4`.
-alt/error_virtual_type2_alt4.nit:38,23: Redef Error: expected `Comparable` for return type; got `T`.
-alt/error_virtual_type2_alt4.nit:40,17--27: Redef Error: expected `null` bound type; got `G[Discrete]`.
-alt/error_virtual_type2_alt4.nit:42,23: Redef Error: expected `Comparable` for return type; got `T`.

--- a/tests/sav/error_virtual_type2_alt5.res
+++ b/tests/sav/error_virtual_type2_alt5.res
@@ -1,5 +1,2 @@
 alt/error_virtual_type2_alt5.nit:22,2--24,14: Error: circularity of virtual type definition: GT -> T <-> U.
 alt/error_virtual_type2_alt5.nit:25,2--30,10: Error: circularity of virtual type definition: T <-> U.
-alt/error_virtual_type2_alt5.nit:38,23: Redef Error: expected `Comparable` for return type; got `T`.
-alt/error_virtual_type2_alt5.nit:40,17--27: Redef Error: expected `null` bound type; got `G[Discrete]`.
-alt/error_virtual_type2_alt5.nit:42,23: Redef Error: expected `Comparable` for return type; got `T`.

--- a/tests/sav/error_virtual_type2_alt6.res
+++ b/tests/sav/error_virtual_type2_alt6.res
@@ -1,2 +1,3 @@
 alt/error_virtual_type2_alt6.nit:40,17--27: Redef Error: expected `G[T]` bound type; got `G[Discrete]`.
+alt/error_virtual_type2_alt6.nit:41,17--23: Redef Error: expected `G[T]` bound type; got `G[Bool]`.
 alt/error_virtual_type2_alt6.nit:41,2--23: Error: a property `GT` is already defined in class `B` at line 39.

--- a/tests/sav/error_virtual_type_alt3.res
+++ b/tests/sav/error_virtual_type_alt3.res
@@ -1,2 +1,1 @@
-alt/error_virtual_type_alt3.nit:25,12: Type Error: expected `Object`, got `T`.
 alt/error_virtual_type_alt3.nit:22,2--25,13: Error: circularity of virtual type definition: T <-> G[T].


### PR DESCRIPTION
Improve the handling of inconsistent model when virtual types are badly defined.

The changes are mainly done with 2 things:

* still register broken `type` definition in the property, so that properties have at least a definition
* use bottom type (also called the absurd type) to indicate inconsistency in the model (instead of aborting)

Reported-by: @Morriar 