### PR TITLE
nitc can inline redefinitions with -D

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -2022,6 +2022,7 @@ redef class MMethodDef
 	fun can_inline(v: VISITOR): Bool
 	do
 		if is_abstract then return true
+		if constant_value != null then return true
 		var modelbuilder = v.compiler.modelbuilder
 		var node = modelbuilder.mpropdef2node(self)
 		if node isa APropdef then

--- a/tests/nitc.args
+++ b/tests/nitc.args
@@ -7,3 +7,4 @@
 base_simple_import.nit base_simple.nit --dir out/ ; out/base_simple ; out/base_simple_import
 test_define.nit -D text=hello -D num=42 -D flag --dir out/ ; out/test_define
 --log --log-dir $WRITE test_prog -o out/test_prog.bin
+test_define.nit --semi-global -D text=hello -D num=42 -D flag --dir out/ ; out/test_define

--- a/tests/sav/nitc_args10.res
+++ b/tests/sav/nitc_args10.res
@@ -1,0 +1,3 @@
+hello
+42
+true


### PR DESCRIPTION
nitc with --global and --semi-global tries to inline things, but methods with an explicit `constant_value` (i.e. defined with `-D`) were not recognized when asked: ``can I inline this?''

The inlining itself does not require specific code.

Close #1793 