### PR TITLE
Bench strings update

### DIFF
--- a/benchmarks/bench_plot.sh
+++ b/benchmarks/bench_plot.sh
@@ -94,20 +94,20 @@ set title "$1 ; avg. on $count-1 runs"
 set ylabel "time (s)"
 $plots
 END
-plots=
+	plots=
 
-if test -n "$html"; then
-	echo "# gnuplot $1"
-	bn=`basename "$1" .gnu`
-	gnuplot -e "set term png; set output \"$bn.png\"" "$1"
-	echo gnuplot -e "set term png; set output \"$bn.png\"" "$1"
+	if test -n "$html"; then
+		echo "# gnuplot $1"
+		bn=`basename "$1" .gnu`
+		gnuplot -e "set term png; set output \"$bn.png\"" "$1"
+		echo gnuplot -e "set term png; set output \"$bn.png\"" "$1"
 
-	echo >>"$html" "<img src=\"$bn.png\"/>"
-fi
-if test -n "$DISPLAY"; then
-	echo "# gnuplot -p $1"
-	gnuplot -p "$1"
-fi
+		echo >>"$html" "<img src=\"$bn.png\"/>"
+	fi
+	if test -n "$DISPLAY"; then
+		echo "# gnuplot -p $1"
+		gnuplot -p "$1"
+	fi
 }
 
 # Create a new $res to be used in the next plot

--- a/benchmarks/bench_plot.sh
+++ b/benchmarks/bench_plot.sh
@@ -110,6 +110,57 @@ if test -n "$DISPLAY"; then
 fi
 }
 
+# Create a new $res to be used in the next plot
+#
+# $1 = resfile
+# $2 = title
+# $3 = description
+function prepare_res_lines()
+{
+	echo
+	echo "# [$2] $3 #"
+	if test -n "$html"; then
+		echo >>"$html" "<p>[$2] $3 <a href=\"$1\">data</a></p>"
+	fi
+	res=$1
+	if [ "$plots" = "" ]; then
+		plots="plot '$1' using 4 with lines ti '$2'"
+	else
+		plots="$plots, '$1' using 4 with lines ti '$2'"
+	fi
+	if [ "$dry_run" = "true" ]; then return; fi
+	echo "# [$2] $3 ; count=$count" > "$res"
+	echo "# first min max avg title" >> "$res"
+}
+
+# Plot the last $res as a line graph
+# $1: plot file (eg toto.gnu)
+function plot_lines()
+{
+	cat >"$1" <<END
+set auto x;
+set yrange [0:];
+set xtic nomirror rotate by -45 scale 0 font ',8';
+set title "$1 ; avg. on $count-1 runs"
+set ylabel "time (s)"
+$plots
+END
+	plots=
+
+	if test -n "$html"; then
+		echo "# gnuplot $1"
+		bn=`basename "$1" .gnu`
+		gnuplot -e "set term png; set output \"$bn.png\"" "$1"
+		echo gnuplot -e "set term png; set output \"$bn.png\"" "$1"
+
+		echo >>"$html" "<img src=\"$bn.png\"/>"
+	fi
+	if test -n "$DISPLAY"; then
+		echo "# gnuplot -p $1"
+		gnuplot -p "$1"
+	fi
+}
+
 ## GLOBAL VARIABLES ##
 
 # The current $res (set by prepare_res, used by bench_command)

--- a/benchmarks/strings/bench_strings.sh
+++ b/benchmarks/strings/bench_strings.sh
@@ -35,6 +35,8 @@ function usage()
 	echo "  -v: verbose mode"
 	echo "  -n count: number of execution for each bar (default: $count)"
 	echo "  -h: this help"
+	echo "  --head-only: do not try to pass benchmarks on variants"
+	echo "  --maxlen min_maxln inc_maxln max_maxln: start bench with different values of threshold between ropes and flats"
 	echo ""
 	echo "Benches : "
 	echo "  index: indexed access benchmark"
@@ -58,8 +60,9 @@ function bench_index()
 		usage
 		exit
 	fi
-	echo "Generating executable index_bench for variant $variant"
-	../../bin/nitc --global index_bench.nit
+	echo "Generating executable index_bench for variant $variant";
+
+	../../bin/nitc --global index_bench.nit -D maxlen=$curr_maxln
 
 	bench_indexed_variant "string" $1 $2 $3 $4
 	bench_indexed_variant "buffer" $1 $2 $3 $4
@@ -74,8 +77,8 @@ function bench_index()
 # $5: strlen max
 function bench_indexed_variant()
 {
-	tmp="${variant}_$1"
-	prepare_res index_$tmp.out $tmp $tmp
+	tmp="${variant}_${1}_${curr_maxln}.out"
+	prepare_res_lines index_$tmp $tmp $tmp
 	for i in `seq "$3" "$4" "$5"`; do
 		bench_command $i index_$tmp$i ./index_bench -m $1 --loops $2 --strlen $i
 	done
@@ -90,7 +93,7 @@ function bench_concat()
 	fi
 
 	echo "Generating executable chain_concat for variant $variant"
-	../../bin/nitc --global chain_concat.nit
+	../../bin/nitc chain_concat.nit -D maxlen=$curr_maxlen
 
 	bench_concat_variant "string" $1 $2 $3 $4 $5
 	bench_concat_variant "buffer" $1 $2 $3 $4 $5
@@ -107,7 +110,7 @@ function bench_concat()
 function bench_concat_variant()
 {
 	tmp="${variant}_$1"
-	prepare_res out/concat/concat_$tmp.out $tmp $tmp
+	prepare_res_lines out/concat/concat_$tmp.out $tmp $tmp
 	for i in `seq "$4" "$5" "$6"`; do
 		bench_command $i $tmp$i ./chain_concat -m $1 --loops $2 --strlen $3 --ccts $i
 	done
@@ -121,7 +124,7 @@ function bench_iteration()
 		exit
 	fi
 	echo "Generating executable iteration_bench for variant $variant"
-	../../bin/nitc --global iteration_bench.nit
+	../../bin/nitc --global iteration_bench.nit -D maxlen=$curr_maxlen
 
 	bench_iterate_variant "iterator" "string" $1 $2 $3 $4
 	bench_iterate_variant "index" "string" $1 $2 $3 $4
@@ -140,7 +143,7 @@ function bench_iteration()
 function bench_iterate_variant()
 {
 	tmp="${variant}_$1_$2"
-	prepare_res out/iteration/iteration_$tmp.out $tmp $tmp
+	prepare_res_lines out/iteration/iteration_$tmp.out $tmp $tmp
 	for i in `seq "$4" "$5" "$6"`; do
 		bench_command $i $tmp$i ./iteration_bench -m $2 --iter-mode $1 --loops $3 --strlen $i
 	done
@@ -154,7 +157,7 @@ function bench_substring()
 		exit
 	fi
 	echo "Generating executable substr_bench for variant $variant"
-	../../bin/nitc --global substr_bench.nit
+	../../bin/nitc --global substr_bench.nit -D maxlen=$curr_maxlen
 
 	bench_substring_variant "string" $1 $2 $3 $4
 	bench_substring_variant "buffer" $1 $2 $3 $4
@@ -170,7 +173,7 @@ function bench_substring()
 function bench_substring_variant()
 {
 	tmp="${variant}_$1"
-	prepare_res out/substring/substring_$tmp.out $tmp $tmp
+	prepare_res_lines out/substring/substring_$tmp.out $tmp $tmp
 	for i in `seq "$3" "$4" "$5"`; do
 		bench_command $i $tmp$i ./substr_bench -m $1 --loops $2 --strlen $i
 	done
@@ -178,7 +181,7 @@ function bench_substring_variant()
 
 function bench_compiler()
 {
-	prepare_res out/compiler/compiler_$variant.out compiler_$variant compiler_$variant
+	prepare_res_lines out/compiler/compiler_$variant.out compiler_$variant compiler_$variant
 
 	echo "Pre-compiling nitc"
 	# Do it twice before bench to have stable times when generating C
@@ -187,14 +190,14 @@ function bench_compiler()
 	../../bin/nitc ../../src/nitc.nit -o ../../bin/nitc
 	echo "nitc (2/2)"
 
-	bench_command nitc nitc_$variant ../../bin/nitc ../../src/nitc.nit
+	bench_command nitc nitc_$variant ../../bin/nitc ../../src/nitc.nit -D maxlen=$curr_maxlen
 
 	rm nitc
 }
 
 function bench_basic()
 {
-	../../bin/nitc ../../examples/hello_world.nit
+	../../bin/nitc ../../examples/hello_world.nit -D maxlen=$curr_maxlen
 	./hello_world
 	rm hello_world
 }
@@ -234,12 +237,19 @@ function prepare_compiler()
 
 function main()
 {
+	html="index.html"
+	head_only=false
+	bench_maxln=false
+	curr_maxln=64
+	echo >"$html" "<html><head></head><body>"
 	stop=false
 	while [ "$stop" = false ]; do
 		case "$1" in
+			--maxlen) bench_maxln=true; min_maxln=$2; inc_maxln=$3; max_maxln=$4; shift; shift; shift; shift;;
 			-v) verbose=true; shift;;
 			-h) usage; exit;;
 			-n) count="$2"; shift; shift;;
+			--head-only) head_only=true; shift;;
 			*) stop=true
 		esac
 	done
@@ -263,6 +273,21 @@ function main()
 	bench=$1
 	shift;
 
+	if [ "${bench_maxln}" = true ]; then
+		for i in `seq $min_maxln $inc_maxln $max_maxln`; do curr_maxln=$i; launch_benches "$@"; done;
+	else
+		launch_benches "$@";
+	fi
+
+	if [ "${need_plot}" = true ]; then
+		plot_lines out/$bench/$bench.gnu
+	fi
+
+	echo >> "$html" "</body></html>"
+}
+
+function launch_benches()
+{
 	head=`git rev-parse HEAD`
 	variant="HEAD"
 	need_plot=true
@@ -289,21 +314,19 @@ function main()
 	echo "---------------------------------------------------------"
 	bench_$bench "$@";
 
-	for i in lib_variants/regular/*; do
-		curr_rev=$i
-		variant=`basename "$i" | cut -f 1 -d '.'`
-		launch_bench "$@"
-	done
+	if [ ! $head_only ]; then
+		for i in lib_variants/regular/*; do
+			curr_rev=$i
+			variant=`basename "$i" | cut -f 1 -d '.'`
+			launch_bench "$@"
+		done
 
-	need_bootstrap=true
-	for i in lib_variants/need_bootstrap/*; do
-		curr_rev=$i
-		variant=`basename "$i" | cut -f 1 -d '.'`
-		launch_bench "$@"
-	done
-
-	if [ "${need_plot}" = true ]; then
-		plot out/$bench/$bench.gnu
+		need_bootstrap=true
+		for i in lib_variants/need_bootstrap/*; do
+			curr_rev=$i
+			variant=`basename "$i" | cut -f 1 -d '.'`
+			launch_bench "$@"
+		done
 	fi
 }
 


### PR DESCRIPTION
A few things happening here:

* Added some line-producing output to `bench_plot.sh`, use both functions to produce lines instead of histograms
* `bench_strings.sh` underwent a few transformations: now you can try with different values of `maxlen` (threshold at which a flat concatenation produces a new Concat node instead of a new FlatString), you can also work on HEAD only with a new option, also, all benches now produce lines instead of histograms