### PR TITLE
More keepgoing

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -3894,11 +3894,7 @@ end
 # Here we load an process all modules passed on the command line
 var mmodules = modelbuilder.parse(arguments)
 
-if mmodules.is_empty then
-	toolcontext.check_errors
-	toolcontext.errors_info
-	if toolcontext.error_count > 0 then exit(1) else exit(0)
-end
+if mmodules.is_empty then toolcontext.quit
 
 modelbuilder.run_phases
 

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -104,7 +104,7 @@ redef class ModelBuilder
 
 		if toolcontext.opt_only_parse.value then
 			self.toolcontext.info("*** ONLY PARSE...", 1)
-			exit(0)
+			self.toolcontext.quit
 		end
 
 		return mmodules.to_a
@@ -199,7 +199,7 @@ redef class ModelBuilder
 
 		if toolcontext.opt_only_parse.value then
 			self.toolcontext.info("*** ONLY PARSE...", 1)
-			exit(0)
+			self.toolcontext.quit
 		end
 
 		return mmodules.to_a

--- a/src/modelbuilder.nit
+++ b/src/modelbuilder.nit
@@ -100,7 +100,7 @@ redef class ModelBuilder
 
 		if toolcontext.opt_only_metamodel.value then
 			self.toolcontext.info("*** ONLY METAMODEL", 1)
-			exit(0)
+			toolcontext.quit
 		end
 	end
 

--- a/src/modelize/modelize_class.nit
+++ b/src/modelize/modelize_class.nit
@@ -301,7 +301,6 @@ redef class ModelBuilder
 	# REQUIRE: classes of imported modules are already build. (let `phase` do the job)
 	private fun build_classes(nmodule: AModule)
 	do
-		var errcount = toolcontext.error_count
 		# Force building recursively
 		if nmodule.build_classes_is_done then return
 		nmodule.build_classes_is_done = true
@@ -311,8 +310,6 @@ redef class ModelBuilder
 			var nimp = mmodule2node(imp)
 			if nimp != null then build_classes(nimp)
 		end
-
-		if errcount != toolcontext.error_count then return
 
 		# Create all classes
 		# process AStdClassdef before so that non-AStdClassdef classes can be attached to existing ones, if any
@@ -325,8 +322,6 @@ redef class ModelBuilder
 			self.build_a_mclass(nmodule, nclassdef)
 		end
 
-		if errcount != toolcontext.error_count then return
-
 		# Create all classdefs
 		for nclassdef in nmodule.n_classdefs do
 			if not nclassdef isa AStdClassdef then continue
@@ -337,28 +332,20 @@ redef class ModelBuilder
 			self.build_a_mclassdef(nmodule, nclassdef)
 		end
 
-		if errcount != toolcontext.error_count then return
-
 		# Create inheritance on all classdefs
 		for nclassdef in nmodule.n_classdefs do
 			self.collect_a_mclassdef_inheritance(nmodule, nclassdef)
 		end
-
-		if errcount != toolcontext.error_count then return
 
 		# Create the mclassdef hierarchy
 		for mclassdef in mmodule.mclassdefs do
 			mclassdef.add_in_hierarchy
 		end
 
-		if errcount != toolcontext.error_count then return
-
 		# Check inheritance
 		for nclassdef in nmodule.n_classdefs do
 			self.check_supertypes(nmodule, nclassdef)
 		end
-
-		if errcount != toolcontext.error_count then return
 
 		# Check unchecked ntypes
 		for nclassdef in nmodule.n_classdefs do
@@ -383,8 +370,6 @@ redef class ModelBuilder
 			end
 		end
 
-		if errcount != toolcontext.error_count then return
-
 		# Check clash of ancestors
 		for nclassdef in nmodule.n_classdefs do
 			var mclassdef = nclassdef.mclassdef
@@ -405,13 +390,11 @@ redef class ModelBuilder
 			end
 		end
 
-		if errcount != toolcontext.error_count then return
-
 		# TODO: Check that the super-class is not intrusive
 
 		# Check that the superclasses are not already known (by transitivity)
 		for nclassdef in nmodule.n_classdefs do
-			if not nclassdef isa AStdClassdef then continue
+			if not nclassdef isa AStdClassdef or nclassdef.is_broken then continue
 			var mclassdef = nclassdef.mclassdef
 			if mclassdef == null then continue
 

--- a/src/nit.nit
+++ b/src/nit.nit
@@ -70,7 +70,7 @@ end
 
 modelbuilder.run_phases
 
-if toolcontext.opt_only_metamodel.value then exit(0)
+if toolcontext.opt_only_metamodel.value then toolcontext.quit
 
 var mainmodule = toolcontext.make_main_module(mmodules)
 

--- a/src/nitvm.nit
+++ b/src/nitvm.nit
@@ -45,7 +45,7 @@ var mmodules = modelbuilder.parse([progname])
 mmodules.add_all modelbuilder.parse(opt_mixins.value)
 modelbuilder.run_phases
 
-if toolcontext.opt_only_metamodel.value then exit(0)
+if toolcontext.opt_only_metamodel.value then toolcontext.quit
 
 var mainmodule: nullable MModule
 

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -1134,6 +1134,7 @@ redef class AForExpr
 			var mtype = v.visit_expr(g.n_expr)
 			if mtype == null then return
 			g.do_type_iterator(v, mtype)
+			if g.is_broken then is_broken = true
 		end
 
 		v.visit_stmt(n_block)

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -117,6 +117,7 @@ private class TypeVisitor
 			#node.debug("Unsafe typing: expected {sup}, got {sub}")
 			return sup
 		end
+		if sup isa MBottomType then return null # Skip error
 		if sub.need_anchor then
 			var u = anchor_to(sub)
 			self.modelbuilder.error(node, "Type Error: expected `{sup}`, got `{sub}: {u}`.")

--- a/src/toolcontext.nit
+++ b/src/toolcontext.nit
@@ -169,6 +169,16 @@ class ToolContext
 		return tags.has("all") or tags.has(tag)
 	end
 
+	# Output all current stacked messages, total and exit the program
+	#
+	# If there is no error, exit with 0, else exit with 1.
+	fun quit
+	do
+		check_errors
+		errors_info
+		if error_count > 0 then exit(1) else exit(0)
+	end
+
 	# Output all current stacked messages
 	#
 	# Return true if no errors occurred.

--- a/tests/error_array_ambig.nit
+++ b/tests/error_array_ambig.nit
@@ -15,3 +15,4 @@
 # limitations under the License.
 
 var i = [4, '4']
+i.first.output

--- a/tests/error_attr_2def.nit
+++ b/tests/error_attr_2def.nit
@@ -18,3 +18,6 @@ class A
 	var toto: Int
 	var toto: Object
 end
+
+var a = new A
+a.toto.output

--- a/tests/error_attr_assign.nit
+++ b/tests/error_attr_assign.nit
@@ -21,3 +21,6 @@ class A
 		_toto = 't'
 	end
 end
+
+var a = new A(1)
+a.m

--- a/tests/error_cons_arity.nit
+++ b/tests/error_cons_arity.nit
@@ -18,3 +18,6 @@ class C[E]
 end
 class C[E: Object, F: Object]
 end
+
+var c = new C
+c.output

--- a/tests/error_cons_arity2.nit
+++ b/tests/error_cons_arity2.nit
@@ -19,3 +19,6 @@ end
 
 class A[E: Object]
 end
+
+var a = new A
+a.output

--- a/tests/error_constraint.nit
+++ b/tests/error_constraint.nit
@@ -19,3 +19,6 @@ class A
 end
 class A[E: Object]
 end
+
+var a = new A
+a.output

--- a/tests/error_decl_type_var.nit
+++ b/tests/error_decl_type_var.nit
@@ -15,3 +15,4 @@
 # limitations under the License.
 
 var i: Int = '4'
+i.output

--- a/tests/error_for_coll.nit
+++ b/tests/error_for_coll.nit
@@ -15,4 +15,5 @@
 # limitations under the License.
 
 for i in 5 do
+	i.output
 end

--- a/tests/error_formal.nit
+++ b/tests/error_formal.nit
@@ -17,3 +17,6 @@
 class A[T]
 	var k: T[Int]
 end
+
+var a = new A[Object]
+a.output

--- a/tests/error_formal_name.nit
+++ b/tests/error_formal_name.nit
@@ -17,3 +17,5 @@ import kernel
 class G[Foo]
 	type Bar: Object
 end
+
+var g = new G[Object]

--- a/tests/error_fun_ret.nit
+++ b/tests/error_fun_ret.nit
@@ -17,3 +17,5 @@
 fun toto: Int
 do
 end
+
+toto.output

--- a/tests/error_fun_ret2.nit
+++ b/tests/error_fun_ret2.nit
@@ -20,3 +20,5 @@ do
 		return 0
 	end
 end
+
+toto.output

--- a/tests/error_fun_ret3.nit
+++ b/tests/error_fun_ret3.nit
@@ -21,3 +21,5 @@ do
 		return 1
 	end
 end
+
+toto.output

--- a/tests/error_fun_ret4.nit
+++ b/tests/error_fun_ret4.nit
@@ -21,3 +21,5 @@ do
 		return 1
 	end
 end
+
+toto.output

--- a/tests/error_fun_ret5.nit
+++ b/tests/error_fun_ret5.nit
@@ -20,3 +20,5 @@ do
 		return 1
 	end
 end
+
+toto.output

--- a/tests/error_gen_f_inh_clash.nit
+++ b/tests/error_gen_f_inh_clash.nit
@@ -20,3 +20,6 @@ class G3
 	super G1
 	super G2
 end
+
+var g = new G3
+g.output

--- a/tests/error_if_bool.nit
+++ b/tests/error_if_bool.nit
@@ -15,4 +15,5 @@
 # limitations under the License.
 
 if 5 then
+	1.output
 end

--- a/tests/error_inh_clash.nit
+++ b/tests/error_inh_clash.nit
@@ -18,3 +18,6 @@ class A
 	super Array[Int]
 	super Array[Char]
 end
+
+var a = new A
+a.output

--- a/tests/error_inh_clash2.nit
+++ b/tests/error_inh_clash2.nit
@@ -24,3 +24,6 @@ class C
 	super A
 	super B
 end
+
+var c = new C
+c.output

--- a/tests/error_inh_clash3.nit
+++ b/tests/error_inh_clash3.nit
@@ -24,3 +24,6 @@ class C
 	super A[Int]
 	super B[Char]
 end
+
+var c = new C
+c.output

--- a/tests/error_inh_clash4.nit
+++ b/tests/error_inh_clash4.nit
@@ -16,3 +16,6 @@ class A[E, F]
 	super Array[E]
 	super List[F]
 end
+
+var a = new A[Int, Int]
+a.output

--- a/tests/error_inh_loop.nit
+++ b/tests/error_inh_loop.nit
@@ -27,3 +27,6 @@ end
 class C
 	super A
 end
+
+var a = new A
+a.output

--- a/tests/error_kern_attr_any.nit
+++ b/tests/error_kern_attr_any.nit
@@ -17,3 +17,5 @@
 redef class Object
 	var toto: Bool
 end
+
+toto.output

--- a/tests/error_kern_attr_int.nit
+++ b/tests/error_kern_attr_int.nit
@@ -17,3 +17,5 @@
 redef class Int
 	var toto: Object
 end
+
+1.toto.output

--- a/tests/error_left_bool.nit
+++ b/tests/error_left_bool.nit
@@ -15,4 +15,5 @@
 # limitations under the License.
 
 if 5 and true then
+	1.output
 end

--- a/tests/error_loop_bool_while.nit
+++ b/tests/error_loop_bool_while.nit
@@ -15,4 +15,5 @@
 # limitations under the License.
 
 while 5 do
+	1.output
 end

--- a/tests/error_meth_2def.nit
+++ b/tests/error_meth_2def.nit
@@ -18,3 +18,6 @@ class A
 	fun toto(a: Int) do end
 	fun toto(a: Char) do end
 end
+
+var a = new A
+a.toto(1)

--- a/tests/error_meth_2def2.nit
+++ b/tests/error_meth_2def2.nit
@@ -18,3 +18,6 @@ class A
 	fun toto(a: Int) do end
 	fun toto(a: Int): Int do return 0 end
 end
+
+var a = new A
+a.toto(1).output

--- a/tests/error_redef3.nit
+++ b/tests/error_redef3.nit
@@ -15,3 +15,5 @@
 class A end
 class A end
 
+var a = new A
+a.output

--- a/tests/error_redef4.nit
+++ b/tests/error_redef4.nit
@@ -17,3 +17,5 @@ import error_redef4_base
 redef class A end
 redef class A end
 
+var a = new A
+a.output

--- a/tests/error_redef_class.nit
+++ b/tests/error_redef_class.nit
@@ -15,3 +15,6 @@
 import kernel
 
 redef class Fail end
+
+var f = new Fail
+f.output

--- a/tests/error_ref_attr.nit
+++ b/tests/error_ref_attr.nit
@@ -19,3 +19,6 @@ import module_simple
 redef class C
 	redef var a: Int
 end
+
+var c = new C(new B)
+c.a.output

--- a/tests/error_ref_fun.nit
+++ b/tests/error_ref_fun.nit
@@ -19,3 +19,6 @@ import module_simple
 redef class C
 	redef fun s do end
 end
+
+var c = new C(new B)
+c.s.output

--- a/tests/error_ref_param.nit
+++ b/tests/error_ref_param.nit
@@ -19,3 +19,6 @@ import module_simple
 redef class C
 	redef fun r(x: C) do end
 end
+
+var c = new C(new B)
+c.r

--- a/tests/error_ref_proc.nit
+++ b/tests/error_ref_proc.nit
@@ -19,3 +19,6 @@ import module_simple
 redef class C
 	redef fun r(x: B): B do return self end
 end
+
+var c = new C(new B)
+c.r

--- a/tests/error_ref_ret.nit
+++ b/tests/error_ref_ret.nit
@@ -19,3 +19,6 @@ import module_simple
 redef class C
 	redef fun s: Int do return 1 end
 end
+
+var c = new C(new B)
+c.s.output

--- a/tests/error_ret_fun.nit
+++ b/tests/error_ret_fun.nit
@@ -18,3 +18,5 @@ fun toto: Int
 do
 	return
 end
+
+toto.output

--- a/tests/error_ret_type.nit
+++ b/tests/error_ret_type.nit
@@ -18,3 +18,5 @@ fun toto: Int
 do
 	return '4'
 end
+
+(toto+1).output

--- a/tests/error_right_bool.nit
+++ b/tests/error_right_bool.nit
@@ -15,4 +15,5 @@
 # limitations under the License.
 
 if true or 6 then
+	1.output
 end

--- a/tests/error_signature.nit
+++ b/tests/error_signature.nit
@@ -27,3 +27,12 @@ class C
 	super A
 	redef fun foo: Int do return 3
 end
+
+var a = new A
+a.foo.output
+
+var b = new B
+b.foo
+
+var c = new C
+c.foo

--- a/tests/error_spe_attr.nit
+++ b/tests/error_spe_attr.nit
@@ -21,3 +21,6 @@ class B
 	super A
 	redef var a: Object = 2
 end
+
+var b = new B
+b.a.output

--- a/tests/error_spe_fun.nit
+++ b/tests/error_spe_fun.nit
@@ -22,3 +22,6 @@ class B
 	super A
 redef fun toto do end
 end
+
+var b = new B
+b.toto.output

--- a/tests/error_spe_param.nit
+++ b/tests/error_spe_param.nit
@@ -23,3 +23,6 @@ class B
 	super A
 redef fun toto(c: Object) do end
 end
+
+var b = new B
+b.toto(true)

--- a/tests/error_spe_param2.nit
+++ b/tests/error_spe_param2.nit
@@ -23,3 +23,6 @@ class B
 	super A
 redef fun toto(c: Char) do end
 end
+
+var b = new B
+b.toto(true)

--- a/tests/error_spe_proc.nit
+++ b/tests/error_spe_proc.nit
@@ -20,5 +20,8 @@ end
 
 class B
 	super A
-redef fun toto: Int do return 2end
+redef fun toto: Int do return 2 end
 end
+
+var b = new B
+b.toto.output

--- a/tests/error_spe_ret.nit
+++ b/tests/error_spe_ret.nit
@@ -22,3 +22,6 @@ class B
 	super A
 redef fun toto: Char do return 'a' end
 end
+
+var b = new B
+b.toto.output

--- a/tests/error_super_none.nit
+++ b/tests/error_super_none.nit
@@ -21,3 +21,6 @@ class A
 		super
 	end
 end
+
+var a = new A
+a.foo

--- a/tests/error_type_not_ok.nit
+++ b/tests/error_type_not_ok.nit
@@ -21,3 +21,5 @@ class A
 	super Fail
 end
 
+var a = new A
+a.output

--- a/tests/error_type_not_ok2.nit
+++ b/tests/error_type_not_ok2.nit
@@ -21,3 +21,5 @@ class B
 	super Array[Fail]
 end
 
+var b = new B
+b.output

--- a/tests/error_type_not_ok3.nit
+++ b/tests/error_type_not_ok3.nit
@@ -22,3 +22,8 @@ end
 
 class D[T: Array[Fail]]
 end
+
+var c = new C[Int]
+c.output
+var d = new D[Int]
+d.output

--- a/tests/error_type_not_ok4.nit
+++ b/tests/error_type_not_ok4.nit
@@ -33,3 +33,13 @@ class G
 	fun md: Array[Fail] do return 0
 end
 
+var e = new E
+e.output
+var f = new F
+f.output
+var g = new G
+g.a.output
+g.ma(1)
+g.mb(1)
+g.mc(1).output
+g.md(1).output

--- a/tests/error_unk_class.nit
+++ b/tests/error_unk_class.nit
@@ -15,3 +15,4 @@
 # limitations under the License.
 
 var i = new Canard
+i.output


### PR DESCRIPTION
Another small serie about robustness.

Now all files in tests (including alts), except one, do not make `nipick` crash.
This should improve the quality of error messages in vim.