### PR TITLE
nitc/android: rely on Android's native stacktrace, drop MIPS support and temporarily disable the GC

### DIFF
--- a/clib/gc_chooser.c
+++ b/clib/gc_chooser.c
@@ -18,6 +18,9 @@
 #ifdef ANDROID
 	#include <android/log.h>
 	#define PRINT_ERROR(...) ((void)__android_log_print(ANDROID_LOG_WARN, "nit", __VA_ARGS__))
+
+	// FIXME bring back when the GC is fixed in Android
+	#undef WITH_LIBGC
 #else
 	#define PRINT_ERROR(...) ((void)fprintf(stderr, __VA_ARGS__))
 #endif

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -853,12 +853,14 @@ extern void nitni_global_ref_decr( struct nitni_ref *ref );
 			v.add_decl("int main(int argc, char** argv) \{")
 		end
 
+		v.add "#ifndef ANDROID"
 		v.add("signal(SIGABRT, sig_handler);")
 		v.add("signal(SIGFPE, sig_handler);")
 		v.add("signal(SIGILL, sig_handler);")
 		v.add("signal(SIGINT, sig_handler);")
 		v.add("signal(SIGTERM, sig_handler);")
 		v.add("signal(SIGSEGV, sig_handler);")
+		v.add "#endif"
 		v.add("signal(SIGPIPE, SIG_IGN);")
 
 		v.add("glob_argc = argc; glob_argv = argv;")

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -1053,7 +1053,7 @@ class SeparateCompiler
 		v.add_abort("type null")
 		v.add("\}")
 		v.add("if({t}->table_size < 0) \{")
-		v.add("PRINT_ERROR(\"Insantiation of a dead type: %s\\n\", {t}->name);")
+		v.add("PRINT_ERROR(\"Instantiation of a dead type: %s\\n\", {t}->name);")
 		v.add_abort("type dead")
 		v.add("\}")
 	end

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -36,7 +36,7 @@ class AndroidPlatform
 
 	redef fun name do return "android"
 
-	redef fun supports_libgc do return true
+	redef fun supports_libgc do return false
 
 	redef fun supports_libunwind do return false
 

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -141,7 +141,7 @@ class AndroidToolchain
 		## Generate Application.mk
 		dir = "{android_project_root}/jni/"
 		"""
-APP_ABI := armeabi armeabi-v7a x86 mips
+APP_ABI := armeabi armeabi-v7a x86
 APP_PLATFORM := android-{{{app_target_api}}}
 """.write_to_file "{dir}/Application.mk"
 


### PR DESCRIPTION
This PR tweaks basic Nit features on Android so it is more practical on the short-middle term.

It is better to not handle signals on Android so that it falls back on the Android stacktrace, which is pretty useful for debugging. We might want to handle the signals once we successfully integrate libunwind to the Android apps.

Dropping MIPS support saves some compilation time. The related commit can be reverted when supporting MIPS is useful.

This PR also deactivates the GC on Android as it is currently broken. Unexpected behaviors happen more frequently when using the Java FFI in a threaded app. There are possible solutions to this problem; newer versions of libgc are tweaked for Android, better compilation configs may help, and double checking the Android lib for objects that should be pinned for use from Java...