### PR TITLE
serialization: serialize the Error class and avoid  abstract classes with factories

### DIFF
--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -257,3 +257,25 @@ redef class Ref[E]
 		v.serialize_attribute("item", first)
 	end
 end
+
+redef class Error
+	super Serializable
+
+	redef init from_deserializer(v)
+	do
+		v.notify_of_creation self
+
+		var message = v.deserialize_attribute("message")
+		if not message isa String then message = ""
+		init message
+
+		var cause = v.deserialize_attribute("cause")
+		if cause isa nullable Error then self.cause = cause
+	end
+
+	redef fun core_serialize_to(v)
+	do
+		v.serialize_attribute("message", message)
+		v.serialize_attribute("cause", cause)
+	end
+end

--- a/src/nitserial.nit
+++ b/src/nitserial.nit
@@ -218,6 +218,7 @@ redef class Deserializer
 			if mtype isa MGenericType and
 			   mtype.is_subtype(m, null, serializable_type) and
 			   mtype.is_visible_from(mmodule) and
+			   mtype.mclass.kind == concrete_kind and
 			   not compiled_types.has(mtype) then
 
 				compiled_types.add mtype


### PR DESCRIPTION
This PR implements the serialization of the `Error` class manually, it is declared in `core` above the `serialization` module.

Also updates `nitserial` so that it does not attempt to instantiate abstract classes with factories.

@privat I have doubts about the use of `is_abstract` and `is_class`, is it appropriate?