### PR TITLE
json::serialization: intro services to easily serialize to and from Json

### DIFF
--- a/lib/json/serialization.nit
+++ b/lib/json/serialization.nit
@@ -448,6 +448,26 @@ class JsonDeserializer
 	end
 end
 
+redef class Text
+
+	# Deserialize a `nullable Object` from this JSON formatted string
+	#
+	# Warning: Deserialization errors are reported with `print_error` and
+	# may be returned as a partial object or as `null`.
+	#
+	# This method is not appropriate when errors need to be handled programmatically,
+	# manually use a `JsonDeserializer` in such cases.
+	fun from_json_string: nullable Object
+	do
+		var deserializer = new JsonDeserializer(self)
+		var res = deserializer.deserialize
+		if deserializer.errors.not_empty then
+			print_error "Deserialization Errors: {deserializer.errors.join(", ")}"
+		end
+		return res
+	end
+end
+
 redef class Serializable
 	private fun serialize_to_json(v: JsonSerializer)
 	do
@@ -462,6 +482,16 @@ redef class Serializable
 		end
 		core_serialize_to(v)
 		v.stream.write "\}"
+	end
+
+	# Serialize this object to a JSON string with metadata for deserialization
+	fun to_json_string: String
+	do
+		var stream = new StringWriter
+		var serializer = new JsonSerializer(stream)
+		serializer.serialize self
+		stream.close
+		return stream.to_s
 	end
 
 	# Serialize this object to plain JSON

--- a/lib/json/serialization.nit
+++ b/lib/json/serialization.nit
@@ -551,7 +551,7 @@ redef class SimpleCollection[E]
 		end
 	end
 
-	redef init from_deserializer(v: Deserializer)
+	redef init from_deserializer(v)
 	do
 		super
 		if v isa JsonDeserializer then
@@ -609,8 +609,7 @@ redef class Map[K, V]
 		end
 	end
 
-	# Instantiate a new `Array` from its serialized representation.
-	redef init from_deserializer(v: Deserializer)
+	redef init from_deserializer(v)
 	do
 		super
 


### PR DESCRIPTION
The services `to_json_string` and `from_json_string` should be useful for simple scripts. Both services report errors only on the console. This behavior is enough for simple scripts but more complex programs should still use `Serializer` and `Deserializer` services.

This methods may look a lot like `to_json` and `to_plain_json`. I plan to replace `to_json` with either `to_plain_json` to preserve the same behavior but with support for all serializable classes, or `to_json_string` to get JSON with metadata. Note that even if the output contains metadata, it is readable by external tools with a small overhead.

If you have a better idea for the names, please mention it. For my part, I consider these names temporary until we free the `to_json` names...