### PR TITLE
app: portable services to do requests over HTTP asynchronously

### DIFF
--- a/lib/android/http_request.nit
+++ b/lib/android/http_request.nit
@@ -1,0 +1,104 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Android implementation of `app:http_request`
+module http_request is
+	android_manifest """<uses-permission android:name="android.permission.INTERNET" />"""
+end
+
+intrude import app::http_request
+import ui
+
+in "Java" `{
+	import org.apache.http.client.methods.HttpGet;
+	import org.apache.http.impl.client.DefaultHttpClient;
+	import org.apache.http.HttpResponse;
+	import org.apache.http.HttpStatus;
+	import org.apache.http.StatusLine;
+	import java.io.ByteArrayOutputStream;
+`}
+
+redef class App
+	redef fun run_on_ui_thread(task) do app.native_activity.run_on_ui_thread task
+end
+
+redef class Text
+
+	redef fun http_get
+	do
+		jni_env.push_local_frame 8
+		var juri = self.to_java_string
+		var jrep = java_http_get(juri)
+
+		assert not jrep.is_java_null
+
+		var res
+		if jrep.is_exception then
+			jrep = jrep.as_exception
+			res = new HttpRequestResult(null, new IOError(jrep.message.to_s))
+		else if jrep.is_http_response then
+			jrep = jrep.as_http_response
+			res = new HttpRequestResult(jrep.content.to_s, null, jrep.status_code)
+		else abort
+
+		jni_env.pop_local_frame
+		return res
+	end
+end
+
+redef class AsyncHttpRequest
+
+	redef fun main
+	do
+		var res = super
+		jvm.detach_current_thread
+		return res
+	end
+end
+
+redef class JavaObject
+	private fun is_exception: Bool in "Java" `{ return self instanceof Exception; `}
+	private fun as_exception: JavaException in "Java" `{ return (Exception)self; `}
+
+	private fun is_http_response: Bool in "Java" `{ return self instanceof HttpResponse; `}
+	private fun as_http_response: JavaHttpResponse in "Java" `{ return (HttpResponse)self; `}
+end
+
+private fun java_http_get(uri: JavaString): JavaObject in "Java" `{
+	try {
+		DefaultHttpClient client = new DefaultHttpClient();
+		HttpGet get = new HttpGet(uri);
+		return client.execute(get);
+	} catch (Exception ex) {
+		return ex;
+	}
+`}
+
+private extern class JavaHttpResponse in "Java" `{ org.apache.http.HttpResponse `}
+	super JavaObject
+
+	fun status_code: Int in "Java" `{ return self.getStatusLine().getStatusCode(); `}
+
+	fun content: JavaString in "Java" `{
+		try {
+			ByteArrayOutputStream out = new ByteArrayOutputStream();
+			self.getEntity().writeTo(out);
+			out.close();
+			return out.toString();
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			return "";
+		}
+	`}
+end

--- a/lib/app/http_request.nit
+++ b/lib/app/http_request.nit
@@ -1,0 +1,161 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# HTTP request services: `AsyncHttpRequest` and `Text::http_get`
+module http_request
+
+import app_base
+import pthreads
+import json::serialization
+
+import linux::http_request is conditional(linux)
+import android::http_request is conditional(android)
+
+redef class App
+	# Platform specific service to execute `task` on the main/UI thread
+	fun run_on_ui_thread(task: Task) is abstract
+end
+
+# Thread executing an HTTP request and deserializing JSON asynchronously
+#
+# This class defines four methods acting on the main/UI thread,
+# they should be implemented as needed:
+# * before
+# * on_load
+# * on_fail
+# * after
+class AsyncHttpRequest
+	super Thread
+
+	# Root URI of the remote server
+	fun rest_server_uri: String is abstract
+
+	# Action, or path, for this request within the `rest_server_uri`
+	fun rest_action: String is abstract
+
+	# Should the response content be deserialized from JSON?
+	var deserialize_json = true is writable
+
+	redef fun start
+	do
+		before
+		super
+	end
+
+	redef fun main
+	do
+		var uri = rest_server_uri / rest_action
+
+		# Execute REST request
+		var rep = uri.http_get
+		if rep.is_error then
+			app.run_on_ui_thread new RestRunnableOnFail(self, rep.error)
+			return null
+		end
+
+		if not deserialize_json then
+			app.run_on_ui_thread new RestRunnableOnLoad(self, rep)
+			return null
+		end
+
+		# Deserialize
+		var deserializer = new JsonDeserializer(rep.value)
+		var res = deserializer.deserialize
+		if deserializer.errors.not_empty then
+			app.run_on_ui_thread new RestRunnableOnFail(self, deserializer.errors.first)
+		end
+
+		app.run_on_ui_thread new RestRunnableOnLoad(self, res)
+		return null
+	end
+
+	# Prepare the UI or other parts of the program before executing the REST request
+	fun before do end
+
+	# Invoked when the HTTP request returned valid data
+	#
+	# If `deserialize_json`, the default behavior, this method is invoked only if deserialization was successful.
+	# In this case, `result` may be any deserialized object.
+	#
+	# Otherwise, if `not deserialize_json`, `result` contains the content of the response as a `String`.
+	fun on_load(result: nullable Object) do end
+
+	# Invoked when the HTTP request has failed and no data was received or deserialization failed
+	fun on_fail(error: Error) do print_error "REST request '{rest_action}' failed with: {error}"
+
+	# Complete this request whether it was a success or not
+	fun after do end
+end
+
+redef class Text
+	# Execute an HTTP GET request synchronously at the URI `self`
+	#
+	# ~~~nitish
+	# var response = "http://example.org/".http_get
+	# if response.is_error then
+	#     print_error response.error
+	# else
+	#     print "HTTP status code: {response.code}"
+	#     print response.value
+	# end
+	# ~~~
+	private fun http_get: HttpRequestResult is abstract
+end
+
+# Result of a call to `Text::http_get`
+#
+# Users should first check if `is_error` to use `error`.
+# Otherwise they can use `value` to get the content of the response
+# and `code` for the HTTP status code.
+class HttpRequestResult
+	super MaybeError[String, Error]
+
+	# The HTTP status code, if any
+	var maybe_code: nullable Int
+
+	# The status code
+	# Require: `not is_error`
+	fun code: Int do return maybe_code.as(not null)
+end
+
+private abstract class HttpRequestTask
+	super Task
+
+	# `AsyncHttpRequest` to which send callbacks
+	var sender_thread: AsyncHttpRequest
+end
+
+private class RestRunnableOnLoad
+	super HttpRequestTask
+
+	var res: nullable Object
+
+	redef fun main
+	do
+		sender_thread.on_load(res)
+		sender_thread.after
+	end
+end
+
+private class RestRunnableOnFail
+	super HttpRequestTask
+
+	var error: Error
+
+	redef fun main
+	do
+		sender_thread.on_fail(error)
+		sender_thread.after
+	end
+end

--- a/lib/core/error.nit
+++ b/lib/core/error.nit
@@ -79,7 +79,7 @@ class MaybeError[V, E: Error]
 	# REQUIRE: `not is_error`
 	fun value: V do return maybe_value.as(V)
 
-	# The require
+	# The error
 	# REQUIRE: `is_error`
 	fun error: E do return maybe_error.as(E)
 

--- a/lib/gtk/v3_4/gdk.nit
+++ b/lib/gtk/v3_4/gdk.nit
@@ -18,26 +18,29 @@ module gdk is pkgconfig "gtk+-3.0"
 import gtk_core
 
 `{
-#ifdef GdkCallback_run
-	// Callback to GdkCallaback::run
-	gboolean nit_gdk_callback(gpointer user_data) {
-		GdkCallback_decr_ref(user_data);
-		return GdkCallback_run(user_data);
+#ifdef Task_gdk_main
+	// Callback to Task::gdk_main
+	gboolean nit_gdk_callback_task(gpointer user_data) {
+		Task_decr_ref(user_data);
+		return Task_gdk_main(user_data);
 	}
 #endif
 `}
 
-# Callback to pass to `gdk_threads_add_idle`
-class GdkCallback
+redef class Task
 
 	# Small unit of code executed by the GDK loop when idle
 	#
-	# Returns true if this object should be invoked again.
-	fun run: Bool do return false
+	# Returns `true` if this object should be invoked again.
+	fun gdk_main: Bool
+	do
+		main
+		return false
+	end
 end
 
 # Add a callback to execute whenever there are no higher priority events pending
-fun gdk_threads_add_idle(callback: GdkCallback): Int import GdkCallback.run `{
-	GdkCallback_incr_ref(callback);
-	return gdk_threads_add_idle(&nit_gdk_callback, callback);
+fun gdk_threads_add_idle(task: Task): Int import Task.gdk_main `{
+	Task_incr_ref(task);
+	return gdk_threads_add_idle(&nit_gdk_callback_task, task);
 `}

--- a/lib/java/base.nit
+++ b/lib/java/base.nit
@@ -193,3 +193,53 @@ redef extern class JavaObject
 		return to_java_string.to_s
 	end
 end
+
+# Java class: java.lang.Throwable
+extern class JavaThrowable in "Java" `{ java.lang.Throwable `}
+	super JavaObject
+
+	# Java implementation: java.lang.String java.lang.Throwable.getMessage()
+	fun message: JavaString in "Java" `{
+		return self.getMessage();
+	`}
+
+	# Java implementation: java.lang.String java.lang.Throwable.getLocalizedMessage()
+	fun localized_message: JavaString in "Java" `{
+		return self.getLocalizedMessage();
+	`}
+
+	# Java implementation:  java.lang.Throwable.printStackTrace()
+	fun print_stack_trace in "Java" `{
+		self.printStackTrace();
+	`}
+
+	# Java implementation: java.lang.Throwable java.lang.Throwable.getCause()
+	fun cause: JavaThrowable in "Java" `{
+		return self.getCause();
+	`}
+
+	redef fun new_global_ref import sys, Sys.jni_env `{
+		Sys sys = JavaThrowable_sys(self);
+		JNIEnv *env = Sys_jni_env(sys);
+		return (*env)->NewGlobalRef(env, self);
+	`}
+
+	redef fun pop_from_local_frame_with_env(jni_env) `{
+		return (*jni_env)->PopLocalFrame(jni_env, self);
+	`}
+end
+
+# Java class: java.lang.Exception
+extern class JavaException in "Java" `{ java.lang.Exception `}
+	super JavaThrowable
+
+	redef fun new_global_ref import sys, Sys.jni_env `{
+		Sys sys = JavaException_sys(self);
+		JNIEnv *env = Sys_jni_env(sys);
+		return (*env)->NewGlobalRef(env, self);
+	`}
+
+	redef fun pop_from_local_frame_with_env(jni_env) `{
+		return (*jni_env)->PopLocalFrame(jni_env, self);
+	`}
+end

--- a/lib/jvm.nit
+++ b/lib/jvm.nit
@@ -183,6 +183,14 @@ extern class JavaVM `{JavaVM *`}
 		}
 		return env;
 	`}
+
+	# Detach the calling thread from this JVM
+	fun detach_current_thread import jni_error `{
+		int res = (*self)->DetachCurrentThread(self);
+		if (res != JNI_OK) {
+			JavaVM_jni_error(NULL, "Could not detach current thread to Java VM", res);
+		}
+	`}
 end
 
 # Represents a jni JNIEnv, which is a thread in a JavaVM

--- a/lib/linux/http_request.nit
+++ b/lib/linux/http_request.nit
@@ -1,0 +1,39 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Implementation of `app::http_request` using GDK and Curl
+module http_request
+
+intrude import app::http_request
+private import curl
+private import gtk::gdk
+
+redef class App
+	redef fun run_on_ui_thread(task) do gdk_threads_add_idle task
+end
+
+redef class Text
+	redef fun http_get
+	do
+		var req = new CurlHTTPRequest(to_s)
+		var rep = req.execute
+		if rep isa CurlResponseSuccess then
+			return new HttpRequestResult(rep.body_str, null, rep.status_code)
+		else
+			assert rep isa CurlResponseFailed
+			var error = new IOError(rep.error_msg)
+			return new HttpRequestResult(null, error)
+		end
+	end
+end


### PR DESCRIPTION
This PR introduces a series of portable services to execute HTTP request asynchronously from graphical programs. These services should be independent and may be reorganized as needed by client programs.

The HTTP request services are very simple by design, it is not an attempt to define a true API to build the request. It is currently limited to GET calls to a simple URI, for example a simple use may look like:

~~~
print "http://xymus.net/rest/list?query=asdf".http_get.value
~~~

## The services

* `Text::http_get` makes an HTTP request and blocks until the response is received. It returns `HttpRequestResult`, a subclass of `MaybeError`, with a possible error, status code and response body content. This service is implemented independently on each platform, using GDK + Curl on GNU/Linux and Apache HTTP client services in Java on Android.

* `App::run_on_ui_thread` sends an instance of `Task` to be executed on the main UI thread when possible. This method may be moved "up" to `app::ui` as needed.

* `AsyncHttpRequest` combines the two previous features to execute an HTTP request asynchronously, deserialize the result from JSON (if needed) and execute custom behaviors on the main UI thread. Users of this service should subclass `AsyncHttpRequest` and implement as needed `before`, `on_load`, `on_error` and `after`. By default, all user code is executed on the main UI thread and as such users do not have to worry about threading logic.