### PR TITLE
frontend: `missing-doc` advice is conditioned to the presence of doc on the module

### DIFF
--- a/src/frontend/no_warning.nit
+++ b/src/frontend/no_warning.nit
@@ -34,15 +34,17 @@ private class NoWarningPhase
 
 		var source = nmodule.location.file
 
-		# If no decl block then quit
 		var nmoduledecl = nmodule.n_moduledecl
-		if nmoduledecl == null then
+		if nmoduledecl == null or nmoduledecl.n_doc == null then
 			# Disable `missing-doc` if there is no `module` clause
 			# Rationale: the presence of a `module` clause is a good heuristic to
 			# discriminate quick and dirty prototypes from nice and clean modules
 			if source != null then toolcontext.warning_blacklist[source].add("missing-doc")
-			return
+
 		end
+
+		# If no decl block then quit
+		if nmoduledecl == null then return
 
 		var modelbuilder = toolcontext.modelbuilder
 

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -716,8 +716,6 @@ redef class ModelBuilder
 				var mdoc = ndoc.to_mdoc
 				mmodule.mdoc = mdoc
 				mdoc.original_mentity = mmodule
-			else
-				advice(decl, "missing-doc", "Documentation warning: Undocumented module `{mmodule}`")
 			end
 			# Is the module a test suite?
 			mmodule.is_test_suite = not decl.get_annotations("test_suite").is_empty


### PR DESCRIPTION
The `missing-doc` advice is now conditioned to the presence of a doc on the module.

The rationale is that if the module is documented, then the programmer does care and we show places where the documentation is missing, else the programmer does not care then we do not talk about documentation in order to not alienate him.