### PR TITLE
app::ui: intro Label and apply many other fixes

### DIFF
--- a/lib/android/ui/native_ui.nit
+++ b/lib/android/ui/native_ui.nit
@@ -62,6 +62,8 @@ extern class NativeViewGroup in "Java" `{ android.view.ViewGroup `}
 
 	fun add_view(view: NativeView) in "Java" `{ self.addView(view); `}
 
+	fun remove_view(view: NativeView) in "Java" `{ self.removeView(view); `}
+
 	fun add_view_with_weight(view: NativeView, weight: Float)
 	in "Java" `{
 		self.addView(view, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT, (float)weight));

--- a/lib/android/ui/native_ui.nit
+++ b/lib/android/ui/native_ui.nit
@@ -41,17 +41,7 @@ redef extern class NativeActivity
 
 	# Set the main layout of this activity
 	fun content_view=(layout: NativeViewGroup) in "Java" `{
-		final ViewGroup final_layout = layout;
-		final Activity final_self = self;
-
-		self.runOnUiThread(new Runnable() {
-			@Override
-			public void run()  {
-				final_self.setContentView(final_layout);
-
-				final_layout.requestFocus();
-			}
-		});
+		self.setContentView(layout);
 	`}
 end
 
@@ -63,17 +53,7 @@ extern class NativeView in "Java" `{ android.view.View `}
 	fun minimum_height=(val: Int) in "Java" `{ self.setMinimumHeight((int)val); `}
 
 	fun enabled: Bool in "Java" `{ return self.isEnabled(); `}
-	fun enabled=(value: Bool) in "Java" `{
-		final View final_self = self;
-		final boolean final_value = value;
-
-		((Activity)self.getContext()).runOnUiThread(new Runnable() {
-			@Override
-			public void run()  {
-				final_self.setEnabled(final_value);
-			}
-		});
-	`}
+	fun enabled=(value: Bool) in "Java" `{ self.setEnabled(value); `}
 end
 
 # A collection of `NativeView`
@@ -158,18 +138,7 @@ extern class NativeTextView in "Java" `{ android.widget.TextView `}
 
 	fun text: JavaString in "Java" `{ return self.getText().toString(); `}
 
-	fun text=(value: JavaString) in "Java" `{
-
-		final TextView final_self = self;
-		final String final_value = value;
-
-		((Activity)self.getContext()).runOnUiThread(new Runnable() {
-			@Override
-			public void run()  {
-				final_self.setText(final_value);
-			}
-		});
-	`}
+	fun text=(value: JavaString) in "Java" `{ self.setText(value); `}
 
 	fun gravity_center in "Java" `{
 		self.setGravity(Gravity.CENTER);

--- a/lib/android/ui/native_ui.nit
+++ b/lib/android/ui/native_ui.nit
@@ -104,6 +104,12 @@ extern class NativeLinearLayout in "Java" `{ android.widget.LinearLayout `}
 			LinearLayout.LayoutParams.WRAP_CONTENT);
 		self.addView(view, params);
 	`}
+
+	redef fun new_global_ref import sys, Sys.jni_env `{
+		Sys sys = NativeLinearLayout_sys(self);
+		JNIEnv *env = Sys_jni_env(sys);
+		return (*env)->NewGlobalRef(env, self);
+	`}
 end
 
 # A `NativeViewGroup` organized as a grid
@@ -117,6 +123,12 @@ extern class NativeGridLayout in "Java" `{ android.widget.GridLayout `}
 	fun column_count=(val: Int) in "Java" `{ self.setColumnCount((int)val); `}
 
 	redef fun add_view(view) in "Java" `{ self.addView(view); `}
+
+	redef fun new_global_ref import sys, Sys.jni_env `{
+		Sys sys = NativeGridLayout_sys(self);
+		JNIEnv *env = Sys_jni_env(sys);
+		return (*env)->NewGlobalRef(env, self);
+	`}
 end
 
 extern class NativePopupWindow in "Java" `{ android.widget.PopupWindow `}
@@ -131,6 +143,12 @@ extern class NativePopupWindow in "Java" `{ android.widget.PopupWindow `}
 	`}
 
 	fun content_view=(layout: NativeViewGroup) in "Java" `{ self.setContentView(layout); `}
+
+	redef fun new_global_ref import sys, Sys.jni_env `{
+		Sys sys = NativePopupWindow_sys(self);
+		JNIEnv *env = Sys_jni_env(sys);
+		return (*env)->NewGlobalRef(env, self);
+	`}
 end
 
 extern class NativeTextView in "Java" `{ android.widget.TextView `}
@@ -163,6 +181,12 @@ extern class NativeTextView in "Java" `{ android.widget.TextView `}
 	fun text_size=(dpi: Float) in "Java" `{
 		self.setTextSize(android.util.TypedValue.COMPLEX_UNIT_DIP, (float)dpi);
 	`}
+
+	redef fun new_global_ref import sys, Sys.jni_env `{
+		Sys sys = NativeTextView_sys(self);
+		JNIEnv *env = Sys_jni_env(sys);
+		return (*env)->NewGlobalRef(env, self);
+	`}
 end
 
 extern class NativeEditText in "Java" `{ android.widget.EditText `}
@@ -176,7 +200,7 @@ extern class NativeEditText in "Java" `{ android.widget.EditText `}
 
 	fun input_type_text in "Java" `{ self.setInputType(android.text.InputType.TYPE_CLASS_TEXT); `}
 
-	redef fun new_global_ref: SELF import sys, Sys.jni_env `{
+	redef fun new_global_ref import sys, Sys.jni_env `{
 		Sys sys = NativeEditText_sys(self);
 		JNIEnv *env = Sys_jni_env(sys);
 		return (*env)->NewGlobalRef(env, self);
@@ -188,7 +212,7 @@ extern class NativeButton in "Java" `{ android.widget.Button `}
 
 	redef type SELF: NativeButton
 
-	redef fun new_global_ref: SELF import sys, Sys.jni_env `{
+	redef fun new_global_ref import sys, Sys.jni_env `{
 		Sys sys = NativeButton_sys(self);
 		JNIEnv *env = Sys_jni_env(sys);
 		return (*env)->NewGlobalRef(env, self);

--- a/lib/android/ui/ui.nit
+++ b/lib/android/ui/ui.nit
@@ -37,7 +37,7 @@ redef class Control
 end
 
 redef class Window
-	redef var native = app.native_activity
+	redef var native = app.native_activity.new_global_ref
 
 	redef type NATIVE: NativeActivity
 
@@ -75,6 +75,7 @@ end
 redef class HorizontalLayout
 	redef var native do
 		var layout = new NativeLinearLayout(app.native_activity)
+		layout = layout.new_global_ref
 		layout.set_horizontal
 		return layout
 	end
@@ -83,6 +84,7 @@ end
 redef class VerticalLayout
 	redef var native do
 		var layout = new NativeLinearLayout(app.native_activity)
+		layout = layout.new_global_ref
 		layout.set_vertical
 		return layout
 	end

--- a/lib/android/ui/ui.nit
+++ b/lib/android/ui/ui.nit
@@ -114,6 +114,11 @@ redef class TextView
 	end
 end
 
+redef class Label
+	redef type NATIVE: NativeTextView
+	redef var native do return (new NativeTextView(app.native_activity)).new_global_ref
+end
+
 redef class TextInput
 	redef type NATIVE: NativeEditText
 	redef var native = (new NativeEditText(app.native_activity)).new_global_ref

--- a/lib/android/ui/ui.nit
+++ b/lib/android/ui/ui.nit
@@ -70,6 +70,12 @@ redef class Layout
 		# FIXME abstract the use either homogeneous or weight to balance views size in a layout
 		native.add_view_with_weight(item.native, 1.0)
 	end
+
+	redef fun remove(item)
+	do
+		super
+		if item isa View then native.remove_view item.native
+	end
 end
 
 redef class HorizontalLayout

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -146,7 +146,7 @@ abstract class View
 	# Is this control enabled so the user can interact with it?
 	#
 	# By default, or if set to `null`, the control is enabled.
-	var enabled: nullable Bool is writable #, abstract FIXME with #1311
+	var enabled: nullable Bool is writable, abstract, autoinit
 end
 
 # A control with some `text`
@@ -156,7 +156,7 @@ abstract class TextView
 	# Main `Text` of this control
 	#
 	# By default, or if set to `null`, no text is shown.
-	var text: nullable Text is writable #, abstract FIXME with #1311
+	var text: nullable Text is writable, abstract, autoinit
 end
 
 # A control for the user to enter custom `text`

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -169,6 +169,11 @@ class Button
 	super TextView
 end
 
+# A text label
+class Label
+	super TextView
+end
+
 # A `Button` press event
 class ButtonPressEvent
 	super AppEvent

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -112,10 +112,10 @@ class CompositeControl
 	protected fun add(item: Control) do items.add item
 
 	# Remove `item` from `self`
-	protected fun remove(item: Control) do if has(item) then items.remove item
+	fun remove(item: Control) do if has(item) then items.remove item
 
 	# Is `item` in `self`?
-	protected fun has(item: Control): Bool do return items.has(item)
+	fun has(item: Control): Bool do return items.has(item)
 
 	redef fun on_create do for i in items do i.on_create
 

--- a/lib/linux/ui.nit
+++ b/lib/linux/ui.nit
@@ -134,6 +134,14 @@ redef class Button
 	init do native.signal_connect("clicked", self, null)
 end
 
+redef class Label
+	redef type NATIVE: GtkLabel
+	redef var native = new GtkLabel("")
+
+	redef fun text do return native.text
+	redef fun text=(value) do native.text = (value or else "").to_s
+end
+
 redef class TextInput
 	redef type NATIVE: GtkEntry
 	redef var native = new GtkEntry

--- a/lib/linux/ui.nit
+++ b/lib/linux/ui.nit
@@ -83,12 +83,19 @@ redef class Window
 end
 
 redef class View
+	init do native.show
+
 	redef fun enabled do return native.sensitive
 	redef fun enabled=(enabled) do native.sensitive = enabled or else true
 end
 
 redef class Layout
 	redef type NATIVE: GtkBox
+	redef fun remove(view)
+	do
+		super
+		native.remove view.native
+	end
 end
 
 redef class HorizontalLayout


### PR DESCRIPTION
Most features are self-explanatory, but here it is anyway. `Label` defines a simple non-editable text field. And the newly public `remove` method remove views from other views (such as `Layouts`).

Other fixes clean up the relation with the Java GC and multi-threads behavior.