### PR TITLE
nitcorn: intro an alternative to `answer` allowing more control and revamp the README file

### DIFF
--- a/lib/libevent.nit
+++ b/lib/libevent.nit
@@ -129,6 +129,7 @@ class Connection
 	# Close this connection if possible, otherwise mark it to be closed later
 	redef fun close
 	do
+		if closed then return
 		var success = native_buffer_event.destroy
 		close_requested = true
 		closed = success

--- a/lib/nitcorn/reactor.nit
+++ b/lib/nitcorn/reactor.nit
@@ -83,11 +83,15 @@ class HttpServer
 			else response = new HttpResponse(405)
 		else response = new HttpResponse(405)
 
-		# Send back a response
+		respond response
+		close
+	end
+
+	# Send back `response` to the client
+	fun respond(response: HttpResponse)
+	do
 		write response.to_s
 		for path in response.files do write_file path
-
-		close
 	end
 end
 


### PR DESCRIPTION
The new `prepare_respond_and_close` is an advanced alternative to `answer`. It allows mainly to delay answering to some requests. I may this to implement simple push notifications. It could also be used to do some parallel or IO intensive work, while processing other requests.

The new README should be more up to date and a better support to get to know the library. I'm not sure about including a code example, but I thought it could help. The file could still benefit from some work, but it's an improvement.