### PR TITLE
libevent & nitcorn: close connections on error and implement callbacks in Nit

### DIFF
--- a/lib/libevent.nit
+++ b/lib/libevent.nit
@@ -138,7 +138,7 @@ class Connection
 	# Callback method on a write event
 	fun write_callback
 	do
-		if close_requested and not closed then close
+		if close_requested then close
 	end
 
 	private fun read_callback_native(cstr: NativeString, len: Int)
@@ -149,7 +149,7 @@ class Connection
 	# Callback method when data is available to read
 	fun read_callback(content: String)
 	do
-		if close_requested and not closed then close
+		if close_requested then close
 	end
 
 	# Callback method on events

--- a/lib/libevent.nit
+++ b/lib/libevent.nit
@@ -158,18 +158,29 @@ class Connection
 	# Write a string to the connection
 	redef fun write(str)
 	do
+		if close_requested then return
 		native_buffer_event.write(str.to_cstring, str.bytelen)
 	end
 
-	redef fun write_byte(byte) do native_buffer_event.write_byte(byte)
+	redef fun write_byte(byte)
+	do
+		if close_requested then return
+		native_buffer_event.write_byte(byte)
+	end
 
-	redef fun write_bytes(bytes) do native_buffer_event.write(bytes.items, bytes.length)
+	redef fun write_bytes(bytes)
+	do
+		if close_requested then return
+		native_buffer_event.write(bytes.items, bytes.length)
+	end
 
 	# Write a file to the connection
 	#
 	# If `not path.file_exists`, the method returns.
 	fun write_file(path: String)
 	do
+		if close_requested then return
+
 		var file = new FileReader.open(path)
 		if file.last_error != null then
 			var error = new IOError("Failed to open file at '{path}'")

--- a/lib/nitcorn/http_request_buffer.nit
+++ b/lib/nitcorn/http_request_buffer.nit
@@ -31,11 +31,10 @@ class HTTPConnection
 	private var content_length = 0
 	private var current_length = 0
 
-	redef fun read_callback_native(cstr, len)
 	# FIXME will not work if the header/body delimiter falls between two watermarks windows.
+	redef fun read_callback(str)
 	do
 		# is this the start of a request?
-		var str = cstr.to_s_with_length(len)
 		if not in_request then parse_start
 
 		var body: String
@@ -45,10 +44,13 @@ class HTTPConnection
 		else
 			body = str
 		end
+
 		# parsing body
 		if in_body then parse_body(body)
 	end
 
+	# Callback when a full HTTP request is received
+	fun read_http_request(str: String) do end
 
 	# Prepare for a new request
 	private fun parse_start do
@@ -111,7 +113,7 @@ class HTTPConnection
 		for ch in current_header do res.append ch.write_to_string
 		res.append "\r\n\r\n"
 		for cb in current_body do res.append cb.write_to_string
-		read_callback(res.write_to_string)
+		read_http_request res.to_s
 		in_request = false
 	end
 end

--- a/lib/nitcorn/http_request_buffer.nit
+++ b/lib/nitcorn/http_request_buffer.nit
@@ -17,7 +17,11 @@ module http_request_buffer
 
 intrude import libevent
 
-redef class Connection
+# Connection rebuilding HTTP requests
+#
+# Subclass should refine `read_full_request` and avoid `read_callback`.
+class HTTPConnection
+	super Connection
 
 	private var in_request = false
 	private var in_header = false

--- a/lib/nitcorn/http_request_buffer.nit
+++ b/lib/nitcorn/http_request_buffer.nit
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Http request parsing for bufferized inputs.
-module http_request_parser
+module http_request_buffer
 
 intrude import libevent
 

--- a/lib/nitcorn/http_request_buffer.nit
+++ b/lib/nitcorn/http_request_buffer.nit
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Http request parsing for bufferized inputs.
+# Http request parsing for buffered inputs.
 module http_request_buffer
 
 intrude import libevent
@@ -31,14 +31,13 @@ class HTTPConnection
 	private var content_length = 0
 	private var current_length = 0
 
-	# FIXME will not work if the header/body delimiter fall between two watermarks windows.
 	redef fun read_callback_native(cstr, len)
+	# FIXME will not work if the header/body delimiter falls between two watermarks windows.
 	do
 		# is this the start of a request?
-		if not in_request then
-			parse_start
-		end
 		var str = cstr.to_s_with_length(len)
+		if not in_request then parse_start
+
 		var body: String
 		# parsing header
 		if in_header then
@@ -47,13 +46,11 @@ class HTTPConnection
 			body = str
 		end
 		# parsing body
-		if in_body then
-			parse_body(body)
-		end
+		if in_body then parse_body(body)
 	end
 
 
-	# We have a new request entering
+	# Prepare for a new request
 	private fun parse_start do
 		in_request = true
 		# reset values
@@ -68,7 +65,7 @@ class HTTPConnection
 
 	# We are receiving the header of a request
 	#
-	# Return parsed body foud in header window
+	# Return parsed body found in header window
 	private fun parse_header(str: String): String do
 		# split in CRLF
 		var parts = str.split("\r\n\r\n")

--- a/lib/nitcorn/reactor.nit
+++ b/lib/nitcorn/reactor.nit
@@ -35,7 +35,7 @@ class HttpServer
 
 	private var parser = new HttpRequestParser is lazy
 
-	redef fun read_callback(str)
+	redef fun read_http_request(str)
 	do
 		var request_object = parser.parse_http_request(str.to_s)
 		if request_object != null then delegate_answer request_object

--- a/lib/nitcorn/reactor.nit
+++ b/lib/nitcorn/reactor.nit
@@ -28,15 +28,10 @@ import http_response
 
 # A server handling a single connection
 class HttpServer
-	super Connection
+	super HTTPConnection
 
 	# The associated `HttpFactory`
 	var factory: HttpFactory
-
-	# Init the server using `HttpFactory`.
-	init(buf_ev: NativeBufferEvent, factory: HttpFactory) is old_style_init do
-		self.factory = factory
-	end
 
 	private var parser = new HttpRequestParser is lazy
 

--- a/lib/nitcorn/reactor.nit
+++ b/lib/nitcorn/reactor.nit
@@ -20,10 +20,10 @@
 module reactor
 
 import more_collections
-import http_request_parser
 
 import vararg_routes
 import http_request
+import http_request_buffer
 import http_response
 
 # A server handling a single connection


### PR DESCRIPTION
This PR moves the implementation of libevent callbacks from C to Nit to enable specialization and refinements of the callbacks, it should help for #1803. Also the event callback closes the connection on the Nit side on errors so servers do not attempt to write on broken connections, it should fix the current crash on http://xymus.net/ with Tnitter clients.

Also update the only user of `read_callback_native` for the new API. And seize this opportunity to rename the module, replace class refinement with specialization, clean up the doc and optimize a bit how it handle strings.