### PR TITLE
Clean up constructors in core/text

### DIFF
--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -533,11 +533,6 @@ private class FlatStringCharReverseIterator
 
 	var curr_pos: Int
 
-	init with_pos(tgt: FlatString, pos: Int)
-	do
-		init(tgt, pos)
-	end
-
 	redef fun is_ok do return curr_pos >= 0
 
 	redef fun item do return target[curr_pos]
@@ -553,14 +548,11 @@ private class FlatStringCharIterator
 
 	var target: FlatString
 
-	var max: Int
+	var max: Int is noautoinit
 
 	var curr_pos: Int
 
-	init with_pos(tgt: FlatString, pos: Int)
-	do
-		init(tgt, tgt.length - 1, pos)
-	end
+	init do max = target.length - 1
 
 	redef fun is_ok do return curr_pos <= max
 
@@ -579,9 +571,9 @@ private class FlatStringCharView
 
 	redef fun [](index) do return target[index]
 
-	redef fun iterator_from(start) do return new FlatStringCharIterator.with_pos(target, start)
+	redef fun iterator_from(start) do return new FlatStringCharIterator(target, start)
 
-	redef fun reverse_iterator_from(start) do return new FlatStringCharReverseIterator.with_pos(target, start)
+	redef fun reverse_iterator_from(start) do return new FlatStringCharReverseIterator(target, start)
 
 end
 
@@ -590,13 +582,15 @@ private class FlatStringByteReverseIterator
 
 	var target: FlatString
 
-	var target_items: NativeString
+	var target_items: NativeString is noautoinit
 
 	var curr_pos: Int
 
-	init with_pos(tgt: FlatString, pos: Int)
+	init
 	do
-		init(tgt, tgt._items, pos + tgt._first_byte)
+		var tgt = target
+		target_items = tgt._items
+		curr_pos += tgt._first_byte
 	end
 
 	redef fun is_ok do return curr_pos >= target._first_byte
@@ -614,13 +608,15 @@ private class FlatStringByteIterator
 
 	var target: FlatString
 
-	var target_items: NativeString
+	var target_items: NativeString is noautoinit
 
 	var curr_pos: Int
 
-	init with_pos(tgt: FlatString, pos: Int)
+	init
 	do
-		init(tgt, tgt._items, pos + tgt._first_byte)
+		var tgt = target
+		target_items = tgt._items
+		curr_pos += tgt._first_byte
 	end
 
 	redef fun is_ok do return curr_pos <= target._last_byte
@@ -649,9 +645,9 @@ private class FlatStringByteView
 		return target._items[ind]
 	end
 
-	redef fun iterator_from(start) do return new FlatStringByteIterator.with_pos(target, start)
+	redef fun iterator_from(start) do return new FlatStringByteIterator(target, start)
 
-	redef fun reverse_iterator_from(start) do return new FlatStringByteReverseIterator.with_pos(target, start)
+	redef fun reverse_iterator_from(start) do return new FlatStringByteReverseIterator(target, start)
 
 end
 
@@ -924,14 +920,11 @@ private class FlatBufferByteReverseIterator
 
 	var target: FlatBuffer
 
-	var target_items: NativeString
+	var target_items: NativeString is noautoinit
 
 	var curr_pos: Int
 
-	init with_pos(tgt: FlatBuffer, pos: Int)
-	do
-		init(tgt, tgt._items, pos)
-	end
+	init do target_items = target._items
 
 	redef fun index do return curr_pos
 
@@ -950,9 +943,9 @@ private class FlatBufferByteView
 
 	redef fun [](index) do return target._items[index]
 
-	redef fun iterator_from(pos) do return new FlatBufferByteIterator.with_pos(target, pos)
+	redef fun iterator_from(pos) do return new FlatBufferByteIterator(target, pos)
 
-	redef fun reverse_iterator_from(pos) do return new FlatBufferByteReverseIterator.with_pos(target, pos)
+	redef fun reverse_iterator_from(pos) do return new FlatBufferByteReverseIterator(target, pos)
 
 end
 
@@ -961,14 +954,11 @@ private class FlatBufferByteIterator
 
 	var target: FlatBuffer
 
-	var target_items: NativeString
+	var target_items: NativeString is noautoinit
 
 	var curr_pos: Int
 
-	init with_pos(tgt: FlatBuffer, pos: Int)
-	do
-		init(tgt, tgt._items, pos)
-	end
+	init do target_items = target._items
 
 	redef fun index do return curr_pos
 
@@ -986,11 +976,6 @@ private class FlatBufferCharReverseIterator
 	var target: FlatBuffer
 
 	var curr_pos: Int
-
-	init with_pos(tgt: FlatBuffer, pos: Int)
-	do
-		init(tgt, pos)
-	end
 
 	redef fun index do return curr_pos
 
@@ -1041,9 +1026,9 @@ private class FlatBufferCharView
 		for i in s do target.add i
 	end
 
-	redef fun iterator_from(pos) do return new FlatBufferCharIterator.with_pos(target, pos)
+	redef fun iterator_from(pos) do return new FlatBufferCharIterator(target, pos)
 
-	redef fun reverse_iterator_from(pos) do return new FlatBufferCharReverseIterator.with_pos(target, pos)
+	redef fun reverse_iterator_from(pos) do return new FlatBufferCharReverseIterator(target, pos)
 
 end
 
@@ -1052,14 +1037,11 @@ private class FlatBufferCharIterator
 
 	var target: FlatBuffer
 
-	var max: Int
+	var max: Int is noautoinit
 
 	var curr_pos: Int
 
-	init with_pos(tgt: FlatBuffer, pos: Int)
-	do
-		init(tgt, tgt.length - 1, pos)
-	end
+	init do max = target.length - 1
 
 	redef fun index do return curr_pos
 

--- a/lib/core/text/ropes.nit
+++ b/lib/core/text/ropes.nit
@@ -78,7 +78,7 @@ private class Concat
 
 	redef var bytelen is noinit
 
-	redef fun substrings do return new RopeSubstrings(self)
+	redef fun substrings do return new RopeSubstrings.from(self, 0)
 
 	redef fun empty do return ""
 
@@ -118,7 +118,7 @@ private class Concat
 		_right.output
 	end
 
-	redef fun iterator do return new RopeCharIterator(self)
+	redef fun iterator do return new RopeCharIterator.from(self, 0)
 
 	redef fun *(i) do
 		var x: String = self
@@ -315,7 +315,7 @@ class RopeBuffer
 	# mutable native string (`ns`)
 	private var buf_size: Int is noinit
 
-	redef fun substrings do return new RopeBufSubstringIterator(self)
+	redef fun substrings do return new RopeBufSubstringIterator.from(self)
 
 	# Builds an empty `RopeBuffer`
 	init do
@@ -593,22 +593,14 @@ private class RopeByteReverseIterator
 	super IndexedIterator[Byte]
 
 	# Current NativeString
-	var ns: NativeString
+	var ns: NativeString is noautoinit
 	# Current position in NativeString
-	var pns: Int
+	var pns: Int is noautoinit
 	# Position in the Rope (0-indexed)
-	var pos: Int
+	var pos: Int is noautoinit
 	# Iterator on the substrings, does the Postfix part of
 	# the Rope traversal.
-	var subs: IndexedIterator[FlatString]
-
-	init(root: Concat) is old_style_init do
-		pos = root._bytelen - 1
-		subs = new ReverseRopeSubstrings(root)
-		var s = subs.item
-		ns = s._items
-		pns = s._last_byte
-	end
+	var subs: IndexedIterator[FlatString] is noautoinit
 
 	init from(root: Concat, pos: Int) do
 		self.pos = pos
@@ -642,23 +634,15 @@ private class RopeByteIterator
 	super IndexedIterator[Byte]
 
 	# Position in current `String`
-	var pns: Int
+	var pns: Int is noautoinit
 	# Current `String` being iterated on
-	var ns: NativeString
+	var ns: NativeString is noautoinit
 	# Substrings of the Rope
-	var subs: IndexedIterator[FlatString]
+	var subs: IndexedIterator[FlatString] is noautoinit
 	# Maximum position to iterate on (e.g. Rope.length)
-	var max: Int
+	var max: Int is noautoinit
 	# Position (char) in the Rope (0-indexed)
-	var pos: Int
-
-	init(root: Concat) is old_style_init do
-		subs = new RopeSubstrings(root)
-		pns = 0
-		ns = subs.item._items
-		max = root.length - 1
-		pos = 0
-	end
+	var pos: Int is noautoinit
 
 	init from(root: Concat, pos: Int) do
 		subs = new RopeSubstrings.from(root, pos)
@@ -692,21 +676,14 @@ private class RopeCharReverseIterator
 	super IndexedIterator[Char]
 
 	# Current NativeString
-	var ns: String
+	var ns: String is noautoinit
 	# Current position in NativeString
-	var pns: Int
+	var pns: Int is noautoinit
 	# Position in the Rope (0-indexed)
-	var pos: Int
+	var pos: Int is noautoinit
 	# Iterator on the substrings, does the Postfix part of
 	# the Rope traversal.
-	var subs: IndexedIterator[String]
-
-	init(root: Concat) is old_style_init do
-		pos = root.length - 1
-		subs = new ReverseRopeSubstrings(root)
-		ns = subs.item
-		pns = ns.length - 1
-	end
+	var subs: IndexedIterator[String] is noautoinit
 
 	init from(root: Concat, pos: Int) do
 		self.pos = pos
@@ -738,23 +715,15 @@ private class RopeCharIterator
 	super IndexedIterator[Char]
 
 	# Position in current `String`
-	var pns: Int
+	var pns: Int is noautoinit
 	# Current `String` being iterated on
-	var str: String
+	var str: String is noautoinit
 	# Substrings of the Rope
-	var subs: IndexedIterator[String]
+	var subs: IndexedIterator[String] is noautoinit
 	# Maximum position to iterate on (e.g. Rope.length)
-	var max: Int
+	var max: Int is noautoinit
 	# Position (char) in the Rope (0-indexed)
-	var pos: Int
-
-	init(root: Concat) is old_style_init do
-		subs = new RopeSubstrings(root)
-		pns = 0
-		str = subs.item
-		max = root.length - 1
-		pos = 0
-	end
+	var pos: Int is noautoinit
 
 	init from(root: Concat, pos: Int) do
 		subs = new RopeSubstrings.from(root, pos)
@@ -793,22 +762,6 @@ private class ReverseRopeSubstrings
 
 	# Current leaf
 	var str: FlatString is noinit
-
-	init(root: Concat) is old_style_init do
-		var r = new RopeCharIteratorPiece(root, false, true, null)
-		pos = root.length - 1
-		var lnod: String = root
-		loop
-			if lnod isa Concat then
-				lnod = lnod._right
-				r = new RopeCharIteratorPiece(lnod, false, true, r)
-			else
-				str = lnod.as(FlatString)
-				iter = r
-				break
-			end
-		end
-	end
 
 	init from(root: Concat, pos: Int) do
 		var r = new RopeCharIteratorPiece(root, false, true, null)
@@ -873,13 +826,13 @@ private class RopeBufSubstringIterator
 	super Iterator[FlatText]
 
 	# Iterator on the substrings of the building string
-	var iter: Iterator[FlatText]
+	var iter: Iterator[FlatText] is noautoinit
 	# Makes a String out of the buffered part of the Ropebuffer
-	var nsstr: FlatString
+	var nsstr: FlatString is noautoinit
 	# Did we attain the buffered part ?
 	var nsstr_done = false
 
-	init(str: RopeBuffer) is old_style_init do
+	init from(str: RopeBuffer) do
 		iter = str.str.substrings
 		nsstr = new FlatString.with_infos(str.ns, str.rpos - str.dumped, str.dumped, str.rpos - 1)
 		if str.length == 0 then nsstr_done = true
@@ -915,24 +868,6 @@ private class RopeSubstrings
 
 	# Current leaf
 	var str: FlatString is noinit
-
-	init(root: Concat) is old_style_init do
-		var r = new RopeCharIteratorPiece(root, true, false, null)
-		pos = 0
-		max = root.length - 1
-		var rnod: String = root
-		loop
-			if rnod isa Concat then
-				rnod = rnod._left
-				r = new RopeCharIteratorPiece(rnod, true, false, r)
-			else
-				str = rnod.as(FlatString)
-				r.rdone = true
-				iter = r
-				break
-			end
-		end
-	end
 
 	init from(root: Concat, pos: Int) do
 		var r = new RopeCharIteratorPiece(root, true, false, null)
@@ -1043,15 +978,9 @@ class RopeBufferCharIterator
 	super IndexedIterator[Char]
 
 	# Subiterator.
-	var sit: IndexedIterator[Char]
+	var sit: IndexedIterator[Char] is noautoinit
 
 	redef fun index do return sit.index
-
-	# Init the iterator from a RopeBuffer.
-	init(t: RopeBuffer) is old_style_init do
-		t.persist_buffer
-		sit = t.str.chars.iterator
-	end
 
 	# Init the iterator from a RopeBuffer starting from `pos`.
 	init from(t: RopeBuffer, pos: Int) do
@@ -1074,15 +1003,9 @@ class RopeBufferCharReverseIterator
 	super IndexedIterator[Char]
 
 	# Subiterator.
-	var sit: IndexedIterator[Char]
+	var sit: IndexedIterator[Char] is noautoinit
 
 	redef fun index do return sit.index
-
-	# Init the iterator from a RopeBuffer.
-	init(tgt: RopeBuffer) is old_style_init do
-		tgt.persist_buffer
-		sit = tgt.str.chars.reverse_iterator
-	end
 
 	# Init the iterator from a RopeBuffer starting from `pos`.
 	init from(tgt: RopeBuffer, pos: Int) do
@@ -1124,27 +1047,18 @@ class RopeBufferByteIterator
 	super IndexedIterator[Byte]
 
 	# Subiterator.
-	var sit: IndexedIterator[Byte]
+	var sit: IndexedIterator[Byte] is noautoinit
 
 	# Native string iterated over.
-	var ns: NativeString
+	var ns: NativeString is noautoinit
 
 	# Current position in `ns`.
-	var pns: Int
+	var pns: Int is noautoinit
 
 	# Maximum position iterable.
-	var maxpos: Int
+	var maxpos: Int is noautoinit
 
-	redef var index
-
-	# Init the iterator from a RopeBuffer.
-	init(t: RopeBuffer) is old_style_init do
-		ns = t.ns
-		maxpos = t._bytelen
-		sit = t.str.bytes.iterator
-		pns = t.dumped
-		index = 0
-	end
+	redef var index is noautoinit
 
 	# Init the iterator from a RopeBuffer starting from `pos`.
 	init from(t: RopeBuffer, pos: Int) do
@@ -1177,23 +1091,15 @@ class RopeBufferByteReverseIterator
 	super IndexedIterator[Byte]
 
 	# Subiterator.
-	var sit: IndexedIterator[Byte]
+	var sit: IndexedIterator[Byte] is noautoinit
 
 	# Native string iterated over.
-	var ns: NativeString
+	var ns: NativeString is noautoinit
 
 	# Current position in `ns`.
-	var pns: Int
+	var pns: Int is noautoinit
 
-	redef var index
-
-	# Init the iterator from a RopeBuffer.
-	init(tgt: RopeBuffer) is old_style_init do
-		sit = tgt.str.bytes.reverse_iterator
-		pns = tgt.rpos - 1
-		index = tgt._bytelen - 1
-		ns = tgt.ns
-	end
+	redef var index is noautoinit
 
 	# Init the iterator from a RopeBuffer starting from `pos`.
 	init from(tgt: RopeBuffer, pos: Int) do


### PR DESCRIPTION
Remove useless named init when automatic-constructor are sufficient, and remove old_style_init when named init are sufficient.

This lib cleanup is part of an ongoing cleanup of constructors, see #1800