### PR TITLE
Modelize check visibility

### DIFF
--- a/lib/android/audio.nit
+++ b/lib/android/audio.nit
@@ -646,7 +646,7 @@ redef class App
 	var default_soundpool: SoundPool is lazy do return new SoundPool
 
 	# Get the native audio manager
-	fun audio_manager: NativeAudioManager import native_activity in "Java" `{
+	private fun audio_manager: NativeAudioManager import native_activity in "Java" `{
 		return (AudioManager)App_native_activity(self).getSystemService(Context.AUDIO_SERVICE);
 	`}
 

--- a/lib/core/collection/array.nit
+++ b/lib/core/collection/array.nit
@@ -130,7 +130,7 @@ abstract class AbstractArrayRead[E]
 		end
 	end
 
-	redef fun iterator: ArrayIterator[E] do
+	redef fun iterator: IndexedIterator[E] do
 		var res = _free_iterator
 		if res == null then return new ArrayIterator[E](self)
 		res._index = 0
@@ -653,7 +653,7 @@ private class ArraySetIterator[E]
 
 	redef fun item: E do return _iter.item
 
-	var iter: ArrayIterator[E]
+	var iter: Iterator[E]
 end
 
 

--- a/lib/core/collection/hash_collection.nit
+++ b/lib/core/collection/hash_collection.nit
@@ -238,7 +238,7 @@ class HashMap[K, V]
 		end
 	end
 
-	redef fun iterator: HashMapIterator[K, V] do return new HashMapIterator[K,V](self)
+	redef fun iterator do return new HashMapIterator[K,V](self)
 
 	redef fun length do return _the_length
 

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -68,7 +68,7 @@ abstract class Text
 	fun substring(from: Int, count: Int): SELFTYPE is abstract
 
 	# Iterates on the substrings of self if any
-	fun substrings: Iterator[FlatText] is abstract
+	private fun substrings: Iterator[FlatText] is abstract
 
 	# Is the current Text empty (== "")
 	#

--- a/src/ffi/cpp.nit
+++ b/src/ffi/cpp.nit
@@ -195,9 +195,9 @@ redef class NitniCallback
 	fun compile_callback_to_cpp(mmodule: MModule, mainmodule: MModule) do end
 end
 
-fun cpp_call_context: CppCallContext do return once new CppCallContext
-fun to_cpp_call_context: ToCppCallContext do return once new ToCppCallContext
-fun from_cpp_call_context: FromCppCallContext do return once new FromCppCallContext
+private fun cpp_call_context: CppCallContext do return once new CppCallContext
+private fun to_cpp_call_context: ToCppCallContext do return once new ToCppCallContext
+private fun from_cpp_call_context: FromCppCallContext do return once new FromCppCallContext
 
 redef class MExplicitCall
 	redef fun compile_callback_to_cpp(mmodule, mainmodule)

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -1060,7 +1060,7 @@ redef class AMethPropdef
 			end
 		end
 
-		if mysignature.arity > 0 then
+		if nsig != null then
 			# Check parameters visibility
 			for i in [0..mysignature.arity[ do
 				var nt = nsig.n_params[i].n_type

--- a/src/rapid_type_analysis.nit
+++ b/src/rapid_type_analysis.nit
@@ -25,7 +25,7 @@ module rapid_type_analysis
 
 import semantize
 
-private import csv # for live_types_to_csv
+import csv # for live_types_to_csv
 private import ordered_tree # for live_methods_to_tree
 
 private import more_collections

--- a/tests/base_prot_sig.nit
+++ b/tests/base_prot_sig.nit
@@ -18,6 +18,10 @@ class A
 	protected fun proA(a: A) do end
 	private fun priA(a: A) do end
 
+	fun pubA2: A do abort
+	protected fun proA2: A do abort
+	private fun priA2: A do abort
+
 	var vpubA: nullable A is writable, noinit
 	protected var vproA: nullable A is protected writable, noinit
 	private var vpriA: nullable A is noinit
@@ -29,6 +33,10 @@ class A
 	#alt1#fun pubB(a: B) do end
 	#alt2#protected fun proB(a: B) do end
 	private fun priB(a: B) do end
+
+	#alt1#fun pubB2: B do abort
+	#alt2#protected fun proB2: B do abort
+	private fun priB2: B do abort
 
 	#alt3#var vpubB: nullable B is writable, noinit
 	#alt4#protected var vproB: nullable B is protected writable, noinit

--- a/tests/sav/base_prot_sig_alt1.res
+++ b/tests/sav/base_prot_sig_alt1.res
@@ -1,1 +1,2 @@
-alt/base_prot_sig_alt1.nit:29,14: Error: the public property `pubB` cannot contain the private type `B`.
+alt/base_prot_sig_alt1.nit:33,14: Error: the public property `pubB` cannot contain the private type `B`.
+alt/base_prot_sig_alt1.nit:37,13: Error: the public property `pubB2` cannot contain the private type `B`.

--- a/tests/sav/base_prot_sig_alt2.res
+++ b/tests/sav/base_prot_sig_alt2.res
@@ -1,1 +1,2 @@
-alt/base_prot_sig_alt2.nit:30,24: Error: the protected property `proB` cannot contain the private type `B`.
+alt/base_prot_sig_alt2.nit:34,24: Error: the protected property `proB` cannot contain the private type `B`.
+alt/base_prot_sig_alt2.nit:38,23: Error: the protected property `proB2` cannot contain the private type `B`.

--- a/tests/sav/base_prot_sig_alt3.res
+++ b/tests/sav/base_prot_sig_alt3.res
@@ -1,2 +1,2 @@
-alt/base_prot_sig_alt3.nit:33,13--22: Error: the public property `vpubB` cannot contain the private type `B`.
-alt/base_prot_sig_alt3.nit:33,13--22: Error: the public property `vpubB=` cannot contain the private type `B`.
+alt/base_prot_sig_alt3.nit:41,13--22: Error: the public property `vpubB` cannot contain the private type `B`.
+alt/base_prot_sig_alt3.nit:41,13--22: Error: the public property `vpubB=` cannot contain the private type `B`.

--- a/tests/sav/base_prot_sig_alt4.res
+++ b/tests/sav/base_prot_sig_alt4.res
@@ -1,2 +1,2 @@
-alt/base_prot_sig_alt4.nit:34,23--32: Error: the protected property `vproB` cannot contain the private type `B`.
-alt/base_prot_sig_alt4.nit:34,23--32: Error: the protected property `vproB=` cannot contain the private type `B`.
+alt/base_prot_sig_alt4.nit:42,23--32: Error: the protected property `vproB` cannot contain the private type `B`.
+alt/base_prot_sig_alt4.nit:42,23--32: Error: the protected property `vproB=` cannot contain the private type `B`.

--- a/tests/sav/base_prot_sig_alt5.res
+++ b/tests/sav/base_prot_sig_alt5.res
@@ -1,2 +1,2 @@
-alt/base_prot_sig_alt5.nit:37,6--11: Error: the public property `vpubB2` cannot contain the private type `B`.
-alt/base_prot_sig_alt5.nit:37,6--11: Error: the public property `vpubB2=` cannot contain the private type `B`.
+alt/base_prot_sig_alt5.nit:45,6--11: Error: the public property `vpubB2` cannot contain the private type `B`.
+alt/base_prot_sig_alt5.nit:45,6--11: Error: the public property `vpubB2=` cannot contain the private type `B`.

--- a/tests/sav/base_prot_sig_alt6.res
+++ b/tests/sav/base_prot_sig_alt6.res
@@ -1,2 +1,2 @@
-alt/base_prot_sig_alt6.nit:38,16--21: Error: the protected property `vproB2` cannot contain the private type `B`.
-alt/base_prot_sig_alt6.nit:38,16--21: Error: the protected property `vproB2=` cannot contain the private type `B`.
+alt/base_prot_sig_alt6.nit:46,16--21: Error: the protected property `vproB2` cannot contain the private type `B`.
+alt/base_prot_sig_alt6.nit:46,16--21: Error: the protected property `vproB2=` cannot contain the private type `B`.

--- a/tests/sav/base_prot_sig_alt7.res
+++ b/tests/sav/base_prot_sig_alt7.res
@@ -1,10 +1,10 @@
-alt/base_prot_sig_alt7.nit:46,2--10: Error: `private` is the only legal visibility for properties in a private class.
-alt/base_prot_sig_alt7.nit:50,2--10: Error: `private` is the only legal visibility for properties in a private class.
-alt/base_prot_sig_alt7.nit:50,37--45: Error: `private` is the only legal visibility for properties in a private class.
 alt/base_prot_sig_alt7.nit:54,2--10: Error: `private` is the only legal visibility for properties in a private class.
-alt/base_prot_sig_alt7.nit:54,34--42: Error: `private` is the only legal visibility for properties in a private class.
 alt/base_prot_sig_alt7.nit:58,2--10: Error: `private` is the only legal visibility for properties in a private class.
+alt/base_prot_sig_alt7.nit:58,37--45: Error: `private` is the only legal visibility for properties in a private class.
 alt/base_prot_sig_alt7.nit:62,2--10: Error: `private` is the only legal visibility for properties in a private class.
-alt/base_prot_sig_alt7.nit:62,37--45: Error: `private` is the only legal visibility for properties in a private class.
+alt/base_prot_sig_alt7.nit:62,34--42: Error: `private` is the only legal visibility for properties in a private class.
 alt/base_prot_sig_alt7.nit:66,2--10: Error: `private` is the only legal visibility for properties in a private class.
-alt/base_prot_sig_alt7.nit:66,34--42: Error: `private` is the only legal visibility for properties in a private class.
+alt/base_prot_sig_alt7.nit:70,2--10: Error: `private` is the only legal visibility for properties in a private class.
+alt/base_prot_sig_alt7.nit:70,37--45: Error: `private` is the only legal visibility for properties in a private class.
+alt/base_prot_sig_alt7.nit:74,2--10: Error: `private` is the only legal visibility for properties in a private class.
+alt/base_prot_sig_alt7.nit:74,34--42: Error: `private` is the only legal visibility for properties in a private class.

--- a/tests/sav/nituml_args3.res
+++ b/tests/sav/nituml_args3.res
@@ -78,7 +78,7 @@ Task [
 Object -> Task [dir=back arrowtail=open style=dashed];
 
 A [
- label = "{A|- _vpubA: nullable A\l- _vproA: nullable A\l- _vpriA: nullable A\l- _vpubA2: A\l- _vproA2: A\l- _vpriA2: A\l- _vpriB: nullable B\l- _vpriB2: B\l|+ pubA(a: A)\l# proA(a: A)\l- priA(a: A)\l+ vpubA(): nullable A\l+ vpubA=(vpubA: nullable A)\l# vproA(): nullable A\l# vproA=(vproA: nullable A)\l- vpriA(): nullable A\l- vpriA=(vpriA: nullable A)\l+ vpubA2(): A\l+ vpubA2=(vpubA2: A)\l# vproA2(): A\l# vproA2=(vproA2: A)\l- vpriA2(): A\l- vpriA2=(vpriA2: A)\l- priB(a: B)\l- vpriB(): nullable B\l- vpriB=(vpriB: nullable B)\l- vpriB2(): B\l- vpriB2=(vpriB2: B)\l}"
+ label = "{A|- _vpubA: nullable A\l- _vproA: nullable A\l- _vpriA: nullable A\l- _vpubA2: A\l- _vproA2: A\l- _vpriA2: A\l- _vpriB: nullable B\l- _vpriB2: B\l|+ pubA(a: A)\l# proA(a: A)\l- priA(a: A)\l+ pubA2(): A\l# proA2(): A\l- priA2(): A\l+ vpubA(): nullable A\l+ vpubA=(vpubA: nullable A)\l# vproA(): nullable A\l# vproA=(vproA: nullable A)\l- vpriA(): nullable A\l- vpriA=(vpriA: nullable A)\l+ vpubA2(): A\l+ vpubA2=(vpubA2: A)\l# vproA2(): A\l# vproA2=(vproA2: A)\l- vpriA2(): A\l- vpriA2=(vpriA2: A)\l- priB(a: B)\l- priB2(): B\l- vpriB(): nullable B\l- vpriB=(vpriB: nullable B)\l- vpriB2(): B\l- vpriB2=(vpriB2: B)\l}"
 ]
 Object -> A [dir=back arrowtail=open style=dashed];
 

--- a/tests/sav/nituml_args4.res
+++ b/tests/sav/nituml_args4.res
@@ -78,7 +78,7 @@ Task [
 Object -> Task [dir=back arrowtail=open style=dashed];
 
 A [
- label = "{A||+ pubA(a: A)\l+ vpubA(): nullable A\l+ vpubA=(vpubA: nullable A)\l+ vpubA2(): A\l+ vpubA2=(vpubA2: A)\l}"
+ label = "{A||+ pubA(a: A)\l+ pubA2(): A\l+ vpubA(): nullable A\l+ vpubA=(vpubA: nullable A)\l+ vpubA2(): A\l+ vpubA2=(vpubA2: A)\l}"
 ]
 Object -> A [dir=back arrowtail=open style=dashed];
 


### PR DESCRIPTION
Forces modelize to check that the return types of methods are legal with regard to visibility.

Also fixes some code where such issues occur.