### PR TITLE
github: save Github events ids.

### DIFF
--- a/lib/github/api.nit
+++ b/lib/github/api.nit
@@ -732,6 +732,12 @@ class Issue
 		super
 	end
 
+	# Issue id.
+	fun id: Int do return json["id"].as(Int)
+
+	# Set issue id.
+	fun id=(id: Int) do json["id"] = id
+
 	# Issue title.
 	fun title: String do return json["title"].as(String)
 

--- a/lib/github/events.nit
+++ b/lib/github/events.nit
@@ -38,6 +38,12 @@ class GithubEvent
 		self.json = json
 	end
 
+	# Event ID from Github.
+	fun id: String do return json["id"].as(String)
+
+	# Set id.
+	fun id=(id: String) do json["id"] = id
+
 	# Action performed by the event.
 	fun action: String do return json["action"].as(String)
 


### PR DESCRIPTION
Save event IDs so the future loader will know it will not have to process it again.

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>