### PR TITLE
nitcorn server for nitiwiki

### DIFF
--- a/contrib/nitiwiki/Makefile
+++ b/contrib/nitiwiki/Makefile
@@ -1,8 +1,11 @@
-all: nitiwiki
+all: nitiwiki bin/nitiwiki_server
 
 nitiwiki:
 	mkdir -p bin
 	../../bin/nitc src/nitiwiki.nit -o bin/nitiwiki
+
+bin/nitiwiki_server: $(shell ../../bin/nitls -M src/wiki_edit.nit)
+	../../bin/nitc -o $@ src/wiki_edit.nit
 
 check: nitiwiki
 	cd tests; make

--- a/contrib/nitiwiki/README.md
+++ b/contrib/nitiwiki/README.md
@@ -250,7 +250,7 @@ Every template can access to:
 * `SUBTITLE`: Wiki description
 * `LOGO`: Wiki logo image path
 
-Additionnal macros can be used in specialized templates.
+Additional macros can be used in specialized templates.
 
 ### Main template
 
@@ -363,3 +363,17 @@ from git:
 Be sure to set `wiki.rsync_dir` in order to correctly push your changes.
 When using `--rsync`, keep in mind that the rendered output must be configured
 to work on the web server.
+
+### Serve and edit with nitiwiki_server
+
+nitiwiki_server is a lightweight web server to publish the generated files
+and accept modifications from a web form.
+
+The binary available in `bin/nitiwiki_server` is configured for simple usage or demo.
+The source of the server, at `src/wiki_edit`, can be tweaked for more advanced use.
+It is also possible to import the source and add an instance of `EditAction` to a custom nitcorn server.
+
+To launch the server, change directory to the root of the wiki and run `nitiwiki_server`.
+It uses `config.ini` from the local directory and listen on localhost:8080.
+The template should define the macro `%EDIT%` and `config.ini` should define `wiki.edit=/edit/`.
+To limit who can edit the wiki, list the md5 sum of accepted passwords (one per line) in the local file `passwords`.

--- a/contrib/nitiwiki/src/wiki_edit.nit
+++ b/contrib/nitiwiki/src/wiki_edit.nit
@@ -1,0 +1,76 @@
+import nitcorn
+import markdown
+
+fun html_document(body: String): String do
+    return """
+        <!DOCTYPE html>
+        <head>
+            <meta charset="utf-8">
+            <title>Nitiwiki Edit</title>
+        </head>
+        <body>
+          """ + body + """
+        </body>
+        </html>"""
+end
+
+class EditMarkdownAction
+    super Action
+
+    redef fun answer(http_request, turi)
+    do
+        var response = new HttpResponse(200)
+        var file_path = turi.substring(1, turi.length)
+        var md_file = new FileReader.open(file_path)
+        response.body = html_document("""
+            <form method="POST" action="/preview">
+              You may edit the file. When you are done, click on "Submit".<br/>
+              <textarea name="content" rows="30" cols="80" style="font-family: Courier">""" + md_file.read_all + """</textarea><br/>
+              <input type="submit" name="action" value="Preview">
+              <input type="submit" name="action" value="Submit">
+              <input type="hidden" name="filepath" value="""" + file_path + """">
+            </form>""")
+        md_file.close
+        return response
+    end
+end
+
+class PreviewMarkdown2HTMLAction
+    super Action
+
+    redef fun answer(http_request, turi)
+    do
+        var response = new HttpResponse(200)
+        var content = http_request.post_args["content"]
+        var action = http_request.post_args["action"]
+        var file_path = http_request.post_args["filepath"]
+        if action == "Preview" then
+            response.body = html_document("""
+                <p>
+                """ + content.md_to_html.to_s + """
+                </p>
+            """)
+        else if action == "Submit" then
+            var md_file = new FileWriter.open(file_path)
+            md_file.write(content)
+            response.body = html_document("""
+                <p>Updated file!</p>
+            """)
+            md_file.close
+        end
+        return response
+    end
+end
+
+var vh = new VirtualHost("localhost:8080")
+
+# Serve Markdown editing
+vh.routes.add new Route("/edit", new EditMarkdownAction)
+vh.routes.add new Route("/preview", new PreviewMarkdown2HTMLAction)
+
+# Serve everything else with a standard `FileServer`
+vh.routes.add new Route(null, new FileServer("/var/www/"))
+
+var factory = new HttpFactory.and_libevent
+factory.config.virtual_hosts.add vh
+factory.run

--- a/contrib/nitiwiki/src/wiki_edit.nit
+++ b/contrib/nitiwiki/src/wiki_edit.nit
@@ -94,7 +94,10 @@ class EditAction
 		var file_path = turi.strip_leading_slash
 		file_path = wiki_root / file_path
 
-		if not file_path.simplify_path.has_prefix(source_dir) then
+		var abs_file_path = file_path.to_absolute_path
+		var abs_source_dir = source_dir.to_absolute_path
+
+		if not abs_file_path.has_prefix(abs_source_dir) then
 			# Attempting to access a file outside the source directory
 			var entity = new WikiEditForm(wiki, turi.strip_leading_slash,
 				"Access denied: ", "", "<p>Target outside of the source directory</p>")
@@ -165,6 +168,11 @@ redef class String
 	do
 		if has_prefix("/") then return substring_from(1)
 		return self
+	end
+
+	private fun to_absolute_path: String
+	do
+		return (getcwd / self).simplify_path
 	end
 end
 

--- a/contrib/nitiwiki/src/wiki_edit.nit
+++ b/contrib/nitiwiki/src/wiki_edit.nit
@@ -1,75 +1,191 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Web server to server generated files and modify the wiki from a web form
+module wiki_edit
+
 import nitcorn
 import markdown
+import md5
 
-fun html_document(body: String): String do
-    return """
-        <!DOCTYPE html>
-        <head>
-            <meta charset="utf-8">
-            <title>Nitiwiki Edit</title>
-        </head>
-        <body>
-          """ + body + """
-        </body>
-        </html>"""
+intrude import wiki_html
+
+# Page for editing markdown source
+class WikiEditForm
+	super WikiArticle
+
+	# Part of the title before the name of the page
+	var title_prefix: String
+
+	# Markdown content, for previews
+	redef var md
+
+	# Custom HTML code, for forms and links
+	var html: String
+
+	init do content = (md or else "").md_to_html.to_s + html
+
+	redef fun dir_href do return "edit" / href
+
+	redef fun tpl_article
+	do
+		var s = super
+		s.title = title_prefix + title
+		return s
+	end
+
+	# Fill and return a new `HttpResponse` with this page content
+	fun to_http_response: HttpResponse
+	do
+		var resp = new HttpResponse(200)
+		resp.body = tpl_page.write_to_string
+		return resp
+	end
 end
 
-class EditMarkdownAction
-    super Action
+# Action to serve edit forms, show previews and apply changes
+class EditAction
+	super Action
 
-    redef fun answer(http_request, turi)
-    do
-        var response = new HttpResponse(200)
-        var file_path = turi.substring(1, turi.length)
-        var md_file = new FileReader.open(file_path)
-        response.body = html_document("""
-            <form method="POST" action="/preview">
-              You may edit the file. When you are done, click on "Submit".<br/>
-              <textarea name="content" rows="30" cols="80" style="font-family: Courier">""" + md_file.read_all + """</textarea><br/>
-              <input type="submit" name="action" value="Preview">
-              <input type="submit" name="action" value="Submit">
-              <input type="hidden" name="filepath" value="""" + file_path + """">
-            </form>""")
-        md_file.close
-        return response
-    end
+	# Full public URL for the root of this wiki
+	var root_url: String
+
+	# Path to the wiki config
+	var config_file_path: String
+
+	# Configuration of the Wiki, loaded once
+	var wiki_config = new WikiConfig(config_file_path) is lazy
+
+	# Path to the root of the wiki
+	private var wiki_root: String = config_file_path.dirname is lazy
+
+	# Path to the source files
+	private var source_dir: String = (wiki_root / wiki_config.source_dir).simplify_path + "/" is lazy
+
+	# List of acceptable password to apply modifications
+	#
+	# If `null`, no password checks are applied and all modifications are accepted.
+	var passwords: nullable Collection[String]
+
+	# Reload the wiki instance with the latest changes
+	fun wiki: Nitiwiki
+	do
+		var wiki = new Nitiwiki(wiki_config)
+		wiki.parse
+		return wiki
+	end
+
+	redef fun answer(http_request, turi)
+	do
+		var action = http_request.string_arg("action")
+		var markdown = http_request.post_args.get_or_default("content", "")
+
+		var file_path = turi.strip_leading_slash
+		file_path = wiki_root / file_path
+
+		if not file_path.simplify_path.has_prefix(source_dir) then
+			# Attempting to access a file outside the source directory
+			var entity = new WikiEditForm(wiki, turi.strip_leading_slash,
+				"Access denied: ", "", "<p>Target outside of the source directory</p>")
+			return entity.to_http_response
+		end
+
+		if action == "Submit" then
+			var passwords = passwords
+			var password = http_request.post_args.get_or_null("password")
+			if passwords != null and (password == null or not passwords.has(password.md5)) then
+				# Deny modification
+				var entity = new WikiEditForm(wiki, turi.strip_leading_slash,
+					"Changes rejected: ", "", "<p>Password invalid</p>")
+				return entity.to_http_response
+			end
+
+			# Save markdown source
+			markdown = markdown.replace('\r', "")
+			markdown.write_to_file file_path
+
+			# Update HTML files
+			var wiki = wiki
+			wiki.render
+
+			var link
+			if turi.has_prefix("/pages/") then
+				link = root_url / turi.substring_from(7)
+			else link = root_url / turi
+			link = link.strip_extension(".md") + ".html"
+
+			# Show confirmation
+			var body = """
+<p>Your edits were recorded and the file is updated: <a href="{{{link}}}">{{{link}}}</a></p>
+"""
+			var entity = new WikiEditForm(wiki, turi.strip_leading_slash, "Changes saved: ", "", body)
+			return entity.to_http_response
+		else
+			# Show edit form, and preview when requested
+
+			# When not in a preview, use the local content of the file
+			if action != "Preview" then markdown = file_path.to_path.read_all
+
+			var form = """
+<form method="POST" action="/edit{{{turi}}}">
+	You may edit the file. When you are done, click on "Submit".<br/>
+	<textarea name="content" rows="30" cols="80">{{{markdown.html_escape}}}</textarea><br/>
+"""
+			if passwords != null then form += """
+	Password: <input type="password" name="password"><br/>
+"""
+			form += """
+	<input type="submit" name="action" value="Preview">
+	<input type="submit" name="action" value="Submit">
+</form>
+"""
+
+			# Show processed markdown only on preview
+			if action != "Preview" then markdown = ""
+
+			var entity = new WikiEditForm(wiki, turi.strip_leading_slash, "Edit source: ", markdown, form)
+			return entity.to_http_response
+		end
+	end
 end
 
-class PreviewMarkdown2HTMLAction
-    super Action
-
-    redef fun answer(http_request, turi)
-    do
-        var response = new HttpResponse(200)
-        var content = http_request.post_args["content"]
-        var action = http_request.post_args["action"]
-        var file_path = http_request.post_args["filepath"]
-        if action == "Preview" then
-            response.body = html_document("""
-                <p>
-                """ + content.md_to_html.to_s + """
-                </p>
-            """)
-        else if action == "Submit" then
-            var md_file = new FileWriter.open(file_path)
-            md_file.write(content)
-            response.body = html_document("""
-                <p>Updated file!</p>
-            """)
-            md_file.close
-        end
-        return response
-    end
+redef class String
+	private fun strip_leading_slash: String
+	do
+		if has_prefix("/") then return substring_from(1)
+		return self
+	end
 end
 
-var vh = new VirtualHost("localhost:8080")
+var config_file_path = "config.ini"
+var iface = "localhost:8080"
+var password_file_path = "passwords"
 
-# Serve Markdown editing
-vh.routes.add new Route("/edit", new EditMarkdownAction)
-vh.routes.add new Route("/preview", new PreviewMarkdown2HTMLAction)
+# Load passwords for file
+var passwords = if password_file_path.file_exists then
+		password_file_path.to_path.read_lines
+	else null
 
-# Serve everything else with a standard `FileServer`
-vh.routes.add new Route(null, new FileServer("/var/www/"))
+var vh = new VirtualHost(iface)
+
+# Serve Markdown editing form
+var action = new EditAction("http://" + iface, config_file_path, passwords)
+vh.routes.add new Route("/edit", action)
+
+# Serve the static (and generated) content
+var path_to_public_files = config_file_path.dirname / action.wiki_config.out_dir
+vh.routes.add new Route(null, new FileServer(path_to_public_files))
 
 var factory = new HttpFactory.and_libevent
 factory.config.virtual_hosts.add vh

--- a/contrib/pep8analysis/www/index.html
+++ b/contrib/pep8analysis/www/index.html
@@ -133,11 +133,10 @@
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav">
         <li><a href="http://xymus.net/ens/">Enseignement</a></li>
-        <li class="active"><a href="http://pep8.xymus.net/">Pep/8 Analysis</a></li>
+        <li><a href="http://xymus.net/opportunity/">Opportunité</a></li>
         <li><a href="http://tnitter.xymus.net/">Tnitter</a></li>
+        <li class="active"><a href="http://pep8.xymus.net/">Pep/8 Analysis</a></li>
         <li><a href="http://benitlux.xymus.net/">Benitlux</a></li>
-		<li><a href="http://xymus.net/opportunity/">Opportunité</a></li>
-        <li><a href="http://nitlanguage.org/">Nit</a></li>
       </ul>
 
       <ul class="nav navbar-nav pull-right">

--- a/lib/core/file.nit
+++ b/lib/core/file.nit
@@ -959,10 +959,13 @@ redef class String
 	end
 
 	# Return the canonicalized absolute pathname (see POSIX function `realpath`)
+	#
+	# Require: `file_exists`
 	fun realpath: String do
 		var cs = to_cstring.file_realpath
+		assert file_exists
 		var res = cs.to_s_with_copy
-		# cs.free_malloc # FIXME memory leak
+		cs.free
 		return res
 	end
 

--- a/lib/markdown/markdown.nit
+++ b/lib/markdown/markdown.nit
@@ -168,6 +168,7 @@ class MarkdownProcessor
 				var c = input[i]
 				if c == '\n' then
 					eol = true
+				else if c == '\r' then
 				else if c == '\t' then
 					var np = pos + (4 - (pos & 3))
 					while pos < np do

--- a/lib/nitcorn/examples/src/xymus_net.nit
+++ b/lib/nitcorn/examples/src/xymus_net.nit
@@ -58,11 +58,10 @@ class MasterHeader
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav">
         <li{{{actives.get_or_default("ens", "")}}}><a href="http://xymus.net/ens/">Enseignement</a></li>
-        <li><a href="http://pep8.xymus.net/">Pep/8 Analysis</a></li>
-        <li{{{actives.get_or_default("tnitter", "")}}}><a href="http://tnitter.xymus.net/">Tnitter</a></li>
-        <li{{{actives.get_or_default("benitlux", "")}}}><a href="http://benitlux.xymus.net/">Benitlux</a></li>
         <li{{{actives.get_or_default("opportunity", "")}}}><a href="http://xymus.net/opportunity/">Opportunité</a></li>
-        <li><a href="http://nitlanguage.org/">Nit</a></li>
+        <li{{{actives.get_or_default("tnitter", "")}}}><a href="http://tnitter.xymus.net/">Tnitter</a></li>
+        <li><a href="http://pep8.xymus.net/">Pep/8 Analysis</a></li>
+        <li{{{actives.get_or_default("benitlux", "")}}}><a href="http://benitlux.xymus.net/">Benitlux</a></li>
       </ul>
 
       <ul class="nav navbar-nav pull-right">

--- a/lib/nitcorn/examples/src/xymus_net.nit
+++ b/lib/nitcorn/examples/src/xymus_net.nit
@@ -24,6 +24,7 @@ import privileges
 import tnitter
 import benitlux::benitlux_controller
 import opportunity::opportunity_controller
+import nitiwiki::wiki_edit
 
 # Header for the whole site
 class MasterHeader
@@ -169,7 +170,6 @@ tnitter_vh.routes.add new Route("/rest/", new TnitterREST)
 tnitter_vh.routes.add new Route("/push/", new TnitterPush)
 tnitter_vh.routes.add new Route(null, tnitter)
 
-
 # Pep/8 Analysis is only a file server. It is available at `pep8.xymus.net`
 # and through the global/default file server at `xymus.net/pep8/`
 #
@@ -187,10 +187,16 @@ default_vh.routes.add new Route("/benitlux/", benitlux_sub)
 benitlux_vh.routes.add new Route("/rest/", benitlux_rest)
 benitlux_vh.routes.add new Route(null, benitlux_sub)
 
+# Opportunity service
 var opportunity = new OpportunityWelcome
 var opportunity_rest = new OpportunityRESTAction
 default_vh.routes.add new Route("/opportunity/rest/", opportunity_rest)
 default_vh.routes.add new Route("/opportunity/", opportunity)
+
+# Nitiwiki modification form
+var passwords = "nitiwiki_passwords".to_path.read_lines
+assert passwords.not_empty
+default_vh.routes.add new Route("/edit", new EditAction("http://xymus.net/", "/home/xymus/projects/wiki/config.ini", passwords))
 
 # We use a special file server for the path `xymus.net/ens` only to display
 # a different header.


### PR DESCRIPTION
This PR contains the initial work of @ablondin and integrates it further with nitiwiki.

Intro a simple nitcorn server to publish the static files generated by nitiwiki and allow modifications from a web form. It is already applied on http://xymus.net/ to manage the main page.

The server reads the `config.ini` of the target to find the path to the public files. It writes the new markdown to the source folder and regenerates the wiki on each modification. The modification forms apply the template of the current wiki. (with some imperfections)

I've added a basic password authentication system using a list of hashed passwords in a simple text file. It should be enough for simple deployment of the server and this file can be ignored by git.

Limitations:
* Not integrated with all configuration of a nitiwiki server.
* Creating new files is supported by manually changing the path in the URI, but creating parent folders of a file is not supported.
* Some paths configuration may cause problems, the `edit/` page must be at the root of the server and other similar restrictions were not fully tested.
* There's no integration with git.

Closes #1832