### PR TITLE
Use `as` casts to implicitly type class attributes

### DIFF
--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -1355,6 +1355,8 @@ redef class AAttrPropdef
 			if nexpr != null then
 				if nexpr isa ANewExpr then
 					mtype = modelbuilder.resolve_mtype_unchecked(mmodule, mclassdef, nexpr.n_type, true)
+				else if nexpr isa AAsCastExpr then
+					mtype = modelbuilder.resolve_mtype_unchecked(mmodule, mclassdef, nexpr.n_type, true)
 				else if nexpr isa AIntegerExpr then
 					var cla: nullable MClass = null
 					if nexpr.value isa Int then


### PR DESCRIPTION
Until now, implicit types for class attributes are defined by literal types or new calls. This PR extends the support to `as` casts. So when an expression setting an attribute ends with a cast such as `.as(String)`, we can safely define the type of the attribute as `String`.

~~~
class A
    # Before
    var s: String = data_store["s"].as(String)

    # After
    var s = data_store["s"].as(String)
end
~~~

I did not modify the error messages by choice, to avoid making more complex the already long error messages with a rare use case. Also since `as` casts are unsafe by definition, I would not recommend to abuse this feature.

This does not apply to `as(not null)`.