### PR TITLE
String block optimisations

### DIFF
--- a/lib/core/bytes.nit
+++ b/lib/core/bytes.nit
@@ -262,7 +262,7 @@ class Bytes
 			i += 1
 			oi += 2
 		end
-		return new FlatString.full(ns, elen, 0, elen - 1, elen)
+		return new FlatString.full(ns, elen, 0, elen)
 	end
 
 	#     var b = new Bytes.with_capacity(1)
@@ -609,7 +609,7 @@ redef class Text
 			bytes[i].add_digest_at(outns, oi)
 			oi += 2
 		end
-		return new FlatString.with_infos(outns, ln * 2, 0, ln * 2 - 1)
+		return new FlatString.with_infos(outns, ln * 2, 0)
 	end
 
 	# Return a `Bytes` instance where Nit escape sequences are transformed.

--- a/lib/core/file.nit
+++ b/lib/core/file.nit
@@ -1271,7 +1271,7 @@ redef class FlatString
 
 	redef fun file_extension do
 		var its = _items
-		var p = _last_byte
+		var p = last_byte
 		var c = its[p]
 		var st = _first_byte
 		while p >= st and c != '.'.ascii do
@@ -1279,12 +1279,12 @@ redef class FlatString
 			c = its[p]
 		end
 		if p <= st then return null
-		var ls = _last_byte
-		return new FlatString.with_infos(its, ls - p, p + 1, ls)
+		var ls = last_byte
+		return new FlatString.with_infos(its, ls - p, p + 1)
 	end
 
 	redef fun basename(extension) do
-		var l = _last_byte
+		var l = last_byte
 		var its = _items
 		var min = _first_byte
 		var sl = '/'.ascii
@@ -1292,7 +1292,7 @@ redef class FlatString
 		if l == min then return "/"
 		var ns = l
 		while ns >= min and its[ns] != sl do ns -= 1
-		var bname = new FlatString.with_infos(its, l - ns, ns + 1, l)
+		var bname = new FlatString.with_infos(its, l - ns, ns + 1)
 
 		return if extension != null then bname.strip_extension(extension) else bname
 	end

--- a/lib/core/re.nit
+++ b/lib/core/re.nit
@@ -382,7 +382,7 @@ class Regex
 			var bfrom = native_match.rm_so + bytefrom
 			var bto = native_match.rm_eo - 1 + bytefrom
 			var cpos = cstr.byte_to_char_index_cached(bfrom, charfrom, bytefrom)
-			var len = cstr.utf8_length(bfrom, bto)
+			var len = cstr.utf8_length(bfrom, bto - bfrom + 1)
 			var match = new Match(rets, cpos, len)
 			var subs = match.subs
 
@@ -395,7 +395,7 @@ class Regex
 				var sub_bfrom = native_match[i].rm_so + bytefrom
 				var sub_bto = native_match[i].rm_eo - 1 + bytefrom
 				var sub_cpos = cstr.byte_to_char_index_cached(sub_bfrom, cpos, bfrom)
-				var sub_len = cstr.utf8_length(sub_bfrom, sub_bto)
+				var sub_len = cstr.utf8_length(sub_bfrom, sub_bto - sub_bfrom + 1)
 				subs.add(new Match(rets, sub_cpos, sub_len))
 			end
 
@@ -442,7 +442,7 @@ class Regex
 			var bfrom = native_match.rm_so + bytesub
 			var bto = native_match.rm_eo - 1 + bytesub
 			var cstart = cstr.byte_to_char_index_cached(bfrom, charsub, bytesub)
-			var len = cstr.utf8_length(bfrom, bto)
+			var len = cstr.utf8_length(bfrom, bto - bfrom + 1)
 			var match = new Match(rets, cstart, len)
 			matches.add match
 			var subs = match.subs
@@ -456,7 +456,7 @@ class Regex
 				var sub_bfrom = native_match[i].rm_so + bytesub
 				var sub_bto = native_match[i].rm_eo - 1 + bytesub
 				var sub_cstart = cstr.byte_to_char_index_cached(sub_bfrom, cstart, bfrom)
-				var sub_len = cstr.utf8_length(sub_bfrom, sub_bto)
+				var sub_len = cstr.utf8_length(sub_bfrom, sub_bto - sub_bfrom + 1)
 				subs.add(new Match(rets, sub_cstart, sub_len))
 			end
 

--- a/lib/core/stream.nit
+++ b/lib/core/stream.nit
@@ -207,12 +207,12 @@ abstract class Reader
 			# if this is the best size or not
 			var chunksz = 129
 			if chunksz > remsp then
-				rets += new FlatString.with_infos(sits, remsp, pos, pos + remsp - 1)
+				rets += new FlatString.with_infos(sits, remsp, pos)
 				break
 			end
 			var st = sits.find_beginning_of_char_at(pos + chunksz - 1)
 			var bytelen = st - pos
-			rets += new FlatString.with_infos(sits, bytelen, pos, st - 1)
+			rets += new FlatString.with_infos(sits, bytelen, pos)
 			pos = st
 			remsp -= bytelen
 		end

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -852,7 +852,7 @@ abstract class Text
 			l += 1
 		end
 
-		return buf.to_s_with_length(l)
+		return buf.to_s_unsafe(l)
 	end
 
 	# Escape the characters `<`, `>`, `&`, `"`, `'` and `/` as HTML/XML entity references.
@@ -1062,7 +1062,7 @@ abstract class Text
 	#
 	#	var ns = new NativeString(8)
 	#	"Text is String".copy_to_native(ns, 8, 2, 0)
-	#	assert ns.to_s_with_length(8) == "xt is St"
+	#	assert ns.to_s_unsafe(8) == "xt is St"
 	#
 	fun copy_to_native(dest: NativeString, n, src_offset, dest_offset: Int) do
 		var mypos = src_offset
@@ -1541,7 +1541,7 @@ redef class Byte
 		var ns = new NativeString(nslen + 1)
 		ns[nslen] = 0u8
 		native_byte_to_s(ns, nslen + 1)
-		return ns.to_s_with_length(nslen)
+		return ns.to_s_unsafe(nslen)
 	end
 end
 
@@ -1702,7 +1702,7 @@ redef class Char
 		var ln = u8char_len
 		var ns = new NativeString(ln + 1)
 		u8char_tos(ns, ln)
-		return ns.to_s_with_length(ln)
+		return ns.to_s_unsafe(ln)
 	end
 
 	# Returns `self` escaped to UTF-16
@@ -2000,6 +2000,12 @@ redef class NativeString
 
 	# Returns `self` as a String of `length`.
 	fun to_s_with_length(length: Int): String is abstract
+
+	# Returns a new instance of `String` with self as `_items`
+	#
+	# /!\: Does not clean the items for compliance with UTF-8,
+	# Use only if you know what you are doing
+	fun to_s_unsafe(len: nullable Int): String is abstract
 
 	# Returns `self` as a String with `bytelen` and `length` set
 	#

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -274,7 +274,7 @@ redef class FlatText
 			end
 			pos += 1
 		end
-		return nns.to_s_with_length(nlen)
+		return nns.to_s_unsafe(nlen)
 	end
 
 	redef fun [](index) do return _items.char_at(char_to_byte_index(index))
@@ -1079,6 +1079,11 @@ redef class NativeString
 
 	redef fun to_s_full(bytelen, unilen) do
 		return new FlatString.full(self, bytelen, 0, unilen)
+	end
+
+	redef fun to_s_unsafe(len) do
+		if len == null then len = cstring_length
+		return new FlatString.with_infos(self, len, 0)
 	end
 
 	# Returns `self` as a new String.

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -1101,8 +1101,23 @@ redef class NativeString
 		var end_length = len
 		var pos = 0
 		var chr_ln = 0
-		while pos < len do
+		var rem = len
+		while rem > 0 do
+			while rem >= 4 do
+				var i = fetch_4_chars(pos)
+				if i & 0x80808080 != 0 then break
+				pos += 4
+				chr_ln += 4
+				rem -= 4
+			end
+			if rem == 0 then break
 			var b = self[pos]
+			if b & 0x80u8 == 0x00u8 then
+				pos += 1
+				chr_ln += 1
+				rem -= 1
+				continue
+			end
 			var nxst = length_of_char_at(pos)
 			var ok_st: Bool
 			if nxst == 1 then
@@ -1119,6 +1134,7 @@ redef class NativeString
 				replacements.add pos
 				end_length += 2
 				pos += 1
+				rem -= 1
 				chr_ln += 1
 				continue
 			end
@@ -1141,9 +1157,12 @@ redef class NativeString
 				end_length += 2
 				pos += 1
 				chr_ln += 1
+				rem -= 1
 				continue
 			end
-			pos += c.u8char_len
+			var clen = c.u8char_len
+			pos += clen
+			rem -= clen
 			chr_ln += 1
 		end
 		var ret = self

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -458,7 +458,7 @@ class FlatString
 		self._bytelen = bytelen
 		_first_byte = from
 		_bytepos = from
-		_length = _items.utf8_length(_first_byte, last_byte)
+		_length = _items.utf8_length(_first_byte, bytelen)
 	end
 
 	# Low-level creation of a new string with all the data.

--- a/lib/core/text/native.nit
+++ b/lib/core/text/native.nit
@@ -248,14 +248,23 @@ extern class NativeString `{ char* `}
 		return endpos
 	end
 
-	# Number of UTF-8 characters in `self` between positions `from` and `to`
-	fun utf8_length(from, to: Int): Int do
+	# Number of UTF-8 characters in `self` starting at `from`, for a length of `bytelen`
+	fun utf8_length(from, bytelen: Int): Int do
 		var st = from
-		var lst = to
 		var ln = 0
-		while st <= lst do
-			st += length_of_char_at(st)
+		while bytelen > 0 do
+			while bytelen >= 4 do
+				var i = fetch_4_chars(st)
+				if i & 0x80808080 != 0 then break
+				bytelen -= 4
+				st += 4
+				ln += 4
+			end
+			if bytelen == 0 then break
+			var cln = length_of_char_at(st)
+			st += cln
 			ln += 1
+			bytelen -= cln
 		end
 		return ln
 	end

--- a/lib/core/text/native.nit
+++ b/lib/core/text/native.nit
@@ -84,6 +84,10 @@ extern class NativeString `{ char* `}
 	# Copy `self` to `dest`.
 	fun copy_to(dest: NativeString, length: Int, from: Int, to: Int) is intern
 
+	redef fun ==(o) is intern do return is_same_instance(o)
+
+	redef fun !=(o) is intern do return not is_same_instance(o)
+
 	# Position of the first nul character.
 	fun cstring_length: Int
 	do

--- a/lib/core/text/native.nit
+++ b/lib/core/text/native.nit
@@ -238,6 +238,7 @@ extern class NativeString `{ char* `}
 	fun find_beginning_of_char_at(pos: Int): Int do
 		var endpos = pos
 		var c = self[pos]
+		if c & 0x80u8 == 0x00u8 then return pos
 		while c & 0xC0u8 == 0x80u8 do
 			pos -= 1
 			c = self[pos]

--- a/lib/core/text/native.nit
+++ b/lib/core/text/native.nit
@@ -253,7 +253,7 @@ extern class NativeString `{ char* `}
 	end
 
 	# Number of UTF-8 characters in `self` starting at `from`, for a length of `bytelen`
-	fun utf8_length(from, bytelen: Int): Int do
+	fun utf8_length(from, bytelen: Int): Int is intern do
 		var st = from
 		var ln = 0
 		while bytelen > 0 do

--- a/lib/core/text/ropes.nit
+++ b/lib/core/text/ropes.nit
@@ -115,6 +115,8 @@ private class Concat
 		_bytelen = l.bytelen + r.bytelen
 	end
 
+	redef fun is_empty do return _bytelen == 0
+
 	redef fun output do
 		_left.output
 		_right.output

--- a/lib/core/text/ropes.nit
+++ b/lib/core/text/ropes.nit
@@ -154,11 +154,11 @@ private class Concat
 		var lft = _left
 		var llen = lft.length
 		if from < llen then
-			if from + len < llen then return lft.substring(from,len)
+			if from + count < llen then return lft.substring(from, count)
 			var lsublen = llen - from
-			return lft.substring_from(from) + _right.substring(0, len - lsublen)
+			return lft.substring_from(from) + _right.substring(0, count - lsublen)
 		else
-			return _right.substring(from - llen, len)
+			return _right.substring(from - llen, count)
 		end
 	end
 
@@ -479,7 +479,7 @@ class RopeBuffer
 	# the final String and re-allocates a new larger Buffer.
 	private fun dump_buffer do
 		written = false
-		var nstr = new FlatString.with_infos(ns, rpos - dumped, dumped, rpos - 1)
+		var nstr = new FlatString.with_infos(ns, rpos - dumped, dumped)
 		str += nstr
 		var bs = buf_size
 		bs = bs * 2
@@ -492,14 +492,14 @@ class RopeBuffer
 	# Similar to dump_buffer, but does not reallocate a new NativeString
 	private fun persist_buffer do
 		if rpos == dumped then return
-		var nstr = new FlatString.with_infos(ns, rpos - dumped, dumped, rpos - 1)
+		var nstr = new FlatString.with_infos(ns, rpos - dumped, dumped)
 		str += nstr
 		dumped = rpos
 	end
 
 	redef fun output do
 		str.output
-		new FlatString.with_infos(ns, rpos - dumped, dumped, rpos - 1).output
+		new FlatString.with_infos(ns, rpos - dumped, dumped).output
 	end
 
 	# Enlarge is useless here since the `Buffer`
@@ -521,7 +521,7 @@ class RopeBuffer
 	redef fun reverse do
 		# Flush the buffer in order to only have to reverse `str`.
 		if rpos > 0 and dumped != rpos then
-			str += new FlatString.with_infos(ns, rpos - dumped, dumped, rpos - 1)
+			str += new FlatString.with_infos(ns, rpos - dumped, dumped)
 			dumped = rpos
 		end
 		str = str.reversed
@@ -564,7 +564,7 @@ redef class FlatString
 			var ns = new NativeString(nlen + 1)
 			mits.copy_to(ns, mlen, mifrom, 0)
 			sits.copy_to(ns, slen, sifrom, mlen)
-			return new FlatString.full(ns, nlen, 0, nlen - 1, length + s.length)
+			return new FlatString.full(ns, nlen, 0, length + s.length)
 		else if s isa Concat then
 			var sl = s._left
 			var sllen = sl.bytelen
@@ -625,7 +625,7 @@ private class RopeByteReverseIterator
 		if not subs.is_ok then return
 		var s = subs.item
 		ns = s._items
-		pns = s._last_byte
+		pns = s.last_byte
 	end
 end
 
@@ -834,7 +834,7 @@ private class RopeBufSubstringIterator
 
 	init from(str: RopeBuffer) do
 		iter = str.str.substrings
-		nsstr = new FlatString.with_infos(str.ns, str.rpos - str.dumped, str.dumped, str.rpos - 1)
+		nsstr = new FlatString.with_infos(str.ns, str.rpos - str.dumped, str.dumped)
 		if str.length == 0 then nsstr_done = true
 	end
 

--- a/lib/core/text/ropes.nit
+++ b/lib/core/text/ropes.nit
@@ -425,12 +425,12 @@ class RopeBuffer
 				var rem = count - subpos
 				var nns = new NativeString(rem)
 				ns.copy_to(nns, rem, dumped, 0)
-				return new RopeBuffer.from(l + nns.to_s_with_length(rem))
+				return new RopeBuffer.from(l + nns.to_s_unsafe(rem))
 			end
 		else
 			var nns = new NativeString(count)
 			ns.copy_to(nns, count, dumped, 0)
-			return new RopeBuffer.from(nns.to_s_with_length(count))
+			return new RopeBuffer.from(nns.to_s_unsafe(count))
 		end
 	end
 

--- a/lib/text_stat.nit
+++ b/lib/text_stat.nit
@@ -319,25 +319,20 @@ redef class FlatString
 		return super
 	end
 
-	redef fun last_byte=(v) do
-		sys.last_byte_call += 1
-		super
-	end
-
 	init do
 		sys.flatstr_allocations += 1
 	end
 
-	redef init with_infos(items, bytelen, from, to)
+	redef init with_infos(items, bytelen, from)
 	do
 		self.items = items
 		self.bytelen = bytelen
 		sys.str_bytelen.inc bytelen
 		first_byte = from
-		last_byte = to
+		length = items.utf8_length(from, bytelen)
 	end
 
-	redef init full(items, bytelen, from, to, length)
+	redef init full(items, bytelen, from, length)
 	do
 		self.items = items
 		self.length = length
@@ -345,7 +340,6 @@ redef class FlatString
 		sys.str_bytelen.inc bytelen
 		sys.str_full_created += 1
 		first_byte = from
-		last_byte = to
 	end
 
 	private var length_cache: nullable Int = null

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -980,6 +980,10 @@ redef class AMethPropdef
 				return v.bool_instance(recvval >= args[1].to_i)
 			else if pname == "<=>" then
 				return v.int_instance(recvval <=> args[1].to_i)
+			else if pname == "&" then
+				return v.int_instance(recvval & args[1].to_i)
+			else if pname == "|" then
+				return v.int_instance(recvval | args[1].to_i)
 			else if pname == "to_f" then
 				return v.float_instance(recvval.to_f)
 			else if pname == "to_b" then
@@ -1028,6 +1032,10 @@ redef class AMethPropdef
 				return v.bool_instance(recvval >= args[1].to_b)
 			else if pname == "<=>" then
 				return v.int_instance(recvval <=> args[1].to_b)
+			else if pname == "&" then
+				return v.byte_instance(recvval & args[1].to_b)
+			else if pname == "|" then
+				return v.byte_instance(recvval | args[1].to_b)
 			else if pname == "to_f" then
 				return v.float_instance(recvval.to_f)
 			else if pname == "to_i" then
@@ -1160,6 +1168,12 @@ redef class AMethPropdef
 			else if pname == "fast_cstring" then
 				var ns = recvval.fast_cstring(args[1].to_i)
 				return v.native_string_instance(ns.to_s)
+			else if pname == "fetch_4_chars" then
+				return v.int_instance(args[0].val.as(NativeString).fetch_4_chars(args[1].to_i))
+			else if pname == "fetch_4_hchars" then
+				return v.int_instance(args[0].val.as(NativeString).fetch_4_hchars(args[1].to_i))
+			else if pname == "utf8_length" then
+				return v.int_instance(args[0].val.as(NativeString).utf8_length(args[1].to_i, args[2].to_i))
 			end
 		else if pname == "calloc_string" then
 			return v.native_string_instance_len(args[1].to_i)

--- a/tests/sav/nitcg/test_text_stat.res
+++ b/tests/sav/nitcg/test_text_stat.res
@@ -3,56 +3,55 @@ Usage of Strings:
 
 Allocations, by type:
 		
-	-FlatString = 32
+	-FlatString = 29
 	-FlatBuffer = 2
 	-Concat = 0
 	-RopeBuffer = 0
 
 Calls to length, by type:
-	FlatString = 36 (cache misses 8, 22.22%)
-	FlatBuffer = 4
+	FlatString = 23 (cache misses 5, 21.73%)
 Indexed accesses, by type:
-	FlatString = 17
+	FlatString = 13
 Calls to bytelen for each type:
-	FlatString = 70
+	FlatString = 61
 Calls to position for each type:
-	FlatString = 35
+	FlatString = 27
 Calls to bytepos for each type:
-	FlatString = 18
-Calls to first_byte on FlatString 227
-Calls to last_byte on FlatString 103
-FlatStrings allocated with length 82 (86.458%)
+	FlatString = 14
+Calls to first_byte on FlatString 216
+Calls to last_byte on FlatString 19
+FlatStrings allocated with length 78 (86.813%)
 Length of travel for index distribution:
-* null = 20 => occurences 83.333%, cumulative 83.333% 
-* 1 = 8 => occurences 21.053%, cumulative 73.684% 
+* null = 16 => occurences 80.0%, cumulative 80.0% 
+* 1 = 14 => occurences 35.0%, cumulative 75.0% 
 Byte length of the FlatStrings created:
-* null = 6 => occurences 4.286%, cumulative 4.286% 
-* 1 = 25 => occurences 16.234%, cumulative 20.13% 
-* 2 = 31 => occurences 18.452%, cumulative 36.905% 
-* 3 = 30 => occurences 16.393%, cumulative 50.273% 
-* 4 = 4 => occurences 2.02%, cumulative 48.485% 
-* 5 = 19 => occurences 8.92%, cumulative 53.991% 
-* 6 = 26 => occurences 11.404%, cumulative 61.842% 
-* 9 = 1 => occurences 0.412%, cumulative 58.436% 
-* 10 = 10 => occurences 3.876%, cumulative 58.915% 
-* 11 = 2 => occurences 0.733%, cumulative 56.41% 
-* 12 = 1 => occurences 0.348%, cumulative 54.007% 
-* 13 = 1 => occurences 0.333%, cumulative 52.0% 
-* 14 = 1 => occurences 0.319%, cumulative 50.16% 
-* 15 = 6 => occurences 1.84%, cumulative 50.0% 
-* 16 = 7 => occurences 2.053%, cumulative 49.853% 
-* 17 = 1 => occurences 0.281%, cumulative 48.034% 
-* 25 = 2 => occurences 0.542%, cumulative 46.883% 
-* 26 = 1 => occurences 0.261%, cumulative 45.431% 
-* 31 = 2 => occurences 0.505%, cumulative 44.444% 
-* 32 = 1 => occurences 0.244%, cumulative 43.171% 
-* 33 = 1 => occurences 0.236%, cumulative 42.08% 
-* 34 = 2 => occurences 0.459%, cumulative 41.284% 
-* 36 = 1 => occurences 0.222%, cumulative 40.222% 
-* 37 = 1 => occurences 0.216%, cumulative 39.309% 
-* 39 = 1 => occurences 0.21%, cumulative 38.445% 
-* 40 = 1 => occurences 0.204%, cumulative 37.628% 
-* 43 = 1 => occurences 0.199%, cumulative 36.853% 
-* 46 = 1 => occurences 0.194%, cumulative 36.117% 
-* 51 = 15 => occurences 2.841%, cumulative 38.068% 
-* 55 = 1 => occurences 0.184%, cumulative 37.201% 
+* null = 6 => occurences 4.444%, cumulative 4.444% 
+* 1 = 21 => occurences 14.094%, cumulative 18.121% 
+* 2 = 33 => occurences 20.245%, cumulative 36.81% 
+* 3 = 29 => occurences 16.292%, cumulative 50.0% 
+* 4 = 9 => occurences 4.663%, cumulative 50.777% 
+* 5 = 20 => occurences 9.615%, cumulative 56.731% 
+* 6 = 21 => occurences 9.417%, cumulative 62.332% 
+* 9 = 1 => occurences 0.42%, cumulative 58.824% 
+* 10 = 9 => occurences 3.557%, cumulative 58.893% 
+* 11 = 2 => occurences 0.746%, cumulative 56.343% 
+* 12 = 1 => occurences 0.355%, cumulative 53.901% 
+* 13 = 1 => occurences 0.339%, cumulative 51.864% 
+* 14 = 1 => occurences 0.325%, cumulative 50.0% 
+* 15 = 5 => occurences 1.558%, cumulative 49.533% 
+* 16 = 7 => occurences 2.083%, cumulative 49.405% 
+* 17 = 1 => occurences 0.285%, cumulative 47.578% 
+* 25 = 2 => occurences 0.549%, cumulative 46.429% 
+* 26 = 1 => occurences 0.265%, cumulative 44.974% 
+* 31 = 2 => occurences 0.512%, cumulative 43.99% 
+* 32 = 1 => occurences 0.247%, cumulative 42.716% 
+* 33 = 1 => occurences 0.239%, cumulative 41.627% 
+* 34 = 2 => occurences 0.464%, cumulative 40.835% 
+* 35 = 1 => occurences 0.225%, cumulative 39.775% 
+* 37 = 1 => occurences 0.218%, cumulative 38.865% 
+* 39 = 1 => occurences 0.212%, cumulative 38.004% 
+* 40 = 1 => occurences 0.207%, cumulative 37.19% 
+* 43 = 1 => occurences 0.201%, cumulative 36.419% 
+* 46 = 1 => occurences 0.196%, cumulative 35.686% 
+* 48 = 1 => occurences 0.191%, cumulative 34.99% 
+* 51 = 21 => occurences 3.918%, cumulative 38.06% 

--- a/tests/sav/test_text_stat.res
+++ b/tests/sav/test_text_stat.res
@@ -3,56 +3,54 @@ Usage of Strings:
 
 Allocations, by type:
 		
-	-FlatString = 32
+	-FlatString = 29
 	-FlatBuffer = 2
 	-Concat = 0
 	-RopeBuffer = 0
 
 Calls to length, by type:
-	FlatString = 36 (cache misses 8, 22.22%)
-	FlatBuffer = 4
+	FlatString = 23 (cache misses 5, 21.73%)
 Indexed accesses, by type:
-	FlatString = 17
+	FlatString = 13
 Calls to bytelen for each type:
-	FlatString = 70
+	FlatString = 61
 Calls to position for each type:
-	FlatString = 35
+	FlatString = 27
 Calls to bytepos for each type:
-	FlatString = 18
-Calls to first_byte on FlatString 227
-Calls to last_byte on FlatString 103
-FlatStrings allocated with length 82 (86.458%)
+	FlatString = 14
+Calls to first_byte on FlatString 216
+Calls to last_byte on FlatString 19
+FlatStrings allocated with length 78 (86.813%)
 Length of travel for index distribution:
-* 0 = 20 => occurences 83.333%, cumulative 83.333% 
-* 1 = 8 => occurences 21.053%, cumulative 73.684% 
+* 0 = 16 => occurences 80.0%, cumulative 80.0% 
+* 1 = 14 => occurences 35.0%, cumulative 75.0% 
 Byte length of the FlatStrings created:
-* 0 = 6 => occurences 4.317%, cumulative 4.317% 
-* 1 = 25 => occurences 16.34%, cumulative 20.261% 
-* 2 = 31 => occurences 18.563%, cumulative 37.126% 
-* 3 = 30 => occurences 16.484%, cumulative 50.549% 
-* 4 = 3 => occurences 1.523%, cumulative 48.223% 
-* 5 = 20 => occurences 9.434%, cumulative 54.245% 
-* 6 = 26 => occurences 11.454%, cumulative 62.115% 
-* 9 = 1 => occurences 0.413%, cumulative 58.678% 
-* 10 = 10 => occurences 3.891%, cumulative 59.144% 
-* 11 = 2 => occurences 0.735%, cumulative 56.618% 
-* 12 = 1 => occurences 0.35%, cumulative 54.196% 
-* 13 = 1 => occurences 0.334%, cumulative 52.174% 
-* 14 = 1 => occurences 0.321%, cumulative 50.321% 
-* 15 = 6 => occurences 1.846%, cumulative 50.154% 
-* 16 = 7 => occurences 2.059%, cumulative 50.0% 
-* 17 = 1 => occurences 0.282%, cumulative 48.169% 
-* 25 = 2 => occurences 0.543%, cumulative 47.011% 
-* 26 = 1 => occurences 0.262%, cumulative 45.55% 
-* 31 = 2 => occurences 0.506%, cumulative 44.557% 
-* 32 = 1 => occurences 0.244%, cumulative 43.276% 
-* 33 = 1 => occurences 0.237%, cumulative 42.18% 
-* 34 = 2 => occurences 0.46%, cumulative 41.379% 
-* 36 = 1 => occurences 0.223%, cumulative 40.312% 
-* 37 = 1 => occurences 0.216%, cumulative 39.394% 
-* 39 = 1 => occurences 0.211%, cumulative 38.526% 
-* 40 = 1 => occurences 0.205%, cumulative 37.705% 
-* 43 = 1 => occurences 0.2%, cumulative 36.926% 
-* 46 = 1 => occurences 0.195%, cumulative 36.187% 
-* 51 = 16 => occurences 3.036%, cumulative 38.33% 
-* 52 = 5 => occurences 0.923%, cumulative 38.192% 
+* 0 = 6 => occurences 4.478%, cumulative 4.478% 
+* 1 = 21 => occurences 14.189%, cumulative 18.243% 
+* 2 = 33 => occurences 20.37%, cumulative 37.037% 
+* 3 = 29 => occurences 16.384%, cumulative 50.282% 
+* 4 = 7 => occurences 3.646%, cumulative 50.0% 
+* 5 = 20 => occurences 9.662%, cumulative 56.039% 
+* 6 = 21 => occurences 9.459%, cumulative 61.712% 
+* 9 = 1 => occurences 0.422%, cumulative 58.228% 
+* 10 = 9 => occurences 3.571%, cumulative 58.333% 
+* 11 = 2 => occurences 0.749%, cumulative 55.805% 
+* 12 = 1 => occurences 0.356%, cumulative 53.381% 
+* 13 = 1 => occurences 0.34%, cumulative 51.361% 
+* 14 = 1 => occurences 0.326%, cumulative 49.511% 
+* 15 = 5 => occurences 1.563%, cumulative 49.063% 
+* 16 = 7 => occurences 2.09%, cumulative 48.955% 
+* 17 = 1 => occurences 0.286%, cumulative 47.143% 
+* 25 = 2 => occurences 0.551%, cumulative 46.006% 
+* 26 = 1 => occurences 0.265%, cumulative 44.562% 
+* 31 = 2 => occurences 0.513%, cumulative 43.59% 
+* 32 = 1 => occurences 0.248%, cumulative 42.327% 
+* 33 = 1 => occurences 0.24%, cumulative 41.247% 
+* 34 = 2 => occurences 0.465%, cumulative 40.465% 
+* 35 = 1 => occurences 0.225%, cumulative 39.414% 
+* 37 = 1 => occurences 0.219%, cumulative 38.512% 
+* 39 = 1 => occurences 0.213%, cumulative 37.66% 
+* 40 = 1 => occurences 0.207%, cumulative 36.853% 
+* 43 = 1 => occurences 0.202%, cumulative 36.089% 
+* 46 = 1 => occurences 0.196%, cumulative 35.363% 
+* 48 = 3 => occurences 0.575%, cumulative 35.057% 


### PR DESCRIPTION
This stack of commits is a batch of brand-new optimisations on `String`, especially regarding the manipulation of UTF-8 characters.

As a baseline, last Tuesday @privat tried the JSON parser on a 30MiB json file, the execution took approximately 10 seconds for ~38 GIr with Valgrind, now and with his Nitcc upgrades, the total runtime is less than 2 seconds for ~11 GIr with Valgrind.