### PR TITLE
File upgrade

### DIFF
--- a/lib/core/file.nit
+++ b/lib/core/file.nit
@@ -156,7 +156,7 @@ class FileReader
 	init open(path: String)
 	do
 		self.path = path
-		prepare_buffer(100)
+		prepare_buffer(4096)
 		_file = new NativeFile.io_open_read(path.to_cstring)
 		if _file.address_is_null then
 			last_error = new IOError("Cannot open `{path}`: {sys.errno.strerror}")

--- a/lib/core/stream.nit
+++ b/lib/core/stream.nit
@@ -564,7 +564,7 @@ abstract class BufferedReader
 	redef fun read_all_bytes
 	do
 		if last_error != null then return new Bytes.empty
-		var s = new Bytes.with_capacity(10)
+		var s = new Bytes.with_capacity(4096)
 		var b = _buffer
 		while not eof do
 			var j = _buffer_pos

--- a/lib/core/stream.nit
+++ b/lib/core/stream.nit
@@ -193,31 +193,40 @@ abstract class Reader
 	# ~~~
 	fun read_all: String do
 		var s = read_all_bytes
+		var sits = s.items
+		var tmp_clean: String
 		var slen = s.length
 		if slen == 0 then return ""
-		var rets = ""
 		var pos = 0
-		var str = s.items.clean_utf8(slen)
-		slen = str.bytelen
-		var sits = str.items
 		var remsp = slen
+		var arr = new Array[String].with_capacity(slen / 4096 + 1)
 		while pos < slen do
-			# The 129 size was decided more or less arbitrarily
-			# It will require some more benchmarking to compute
-			# if this is the best size or not
-			var chunksz = 129
+			# The 4096 size was decided more or less arbitrarily
+			# to be aligned on a page's size
+			var chunksz = 4096
 			if chunksz > remsp then
-				rets += new FlatString.with_infos(sits, remsp, pos)
+				var tmpns = sits.fast_cstring(pos)
+				tmp_clean = tmpns.clean_utf8(remsp)
+				if tmp_clean.items != tmpns then
+					arr.add(tmp_clean)
+				else
+					arr.add(new FlatString.full(sits, remsp, pos, tmp_clean.length))
+				end
 				break
 			end
 			var st = sits.find_beginning_of_char_at(pos + chunksz - 1)
 			var bytelen = st - pos
-			rets += new FlatString.with_infos(sits, bytelen, pos)
+			var tmpns = sits.fast_cstring(pos)
+			tmp_clean = tmpns.clean_utf8(bytelen)
+			if tmp_clean.items != tmpns then
+				arr.add(tmp_clean)
+			else
+				arr.add(new FlatString.full(sits, bytelen, pos, tmp_clean.length))
+			end
 			pos = st
 			remsp -= bytelen
 		end
-		if rets isa Concat then return rets.balance
-		return rets
+		return recurse_balance_rope(arr, arr.length)
 	end
 
 	# Read all the stream until the eof.

--- a/lib/core/text/ropes.nit
+++ b/lib/core/text/ropes.nit
@@ -264,25 +264,28 @@ private class Concat
 			end
 
 		end
-		return recurse_balance(children, children.length)
+		return recurse_balance_rope(children, children.length)
 	end
+end
 
-	fun recurse_balance(nodes: Array[String], len: Int): String do
-		var finpos = 0
-		var stpos = 0
-		while stpos < len do
-			if len - stpos > 1 then
-				nodes[finpos] = new Concat(nodes[stpos], nodes[stpos + 1])
-				stpos += 2
-			else
-				nodes[finpos] = nodes[stpos]
-				stpos += 1
-			end
-			finpos += 1
+# Returns a balanced `Concat` from the content of `nodes`
+#
+# /!\ To be used internally only
+protected fun recurse_balance_rope(nodes: Array[String], len: Int): String do
+	var finpos = 0
+	var stpos = 0
+	while stpos < len do
+		if len - stpos > 1 then
+			nodes[finpos] = new Concat(nodes[stpos], nodes[stpos + 1])
+			stpos += 2
+		else
+			nodes[finpos] = nodes[stpos]
+			stpos += 1
 		end
-		if finpos == 1 then return nodes[0]
-		return recurse_balance(nodes, finpos)
+		finpos += 1
 	end
+	if finpos == 1 then return nodes[0]
+	return recurse_balance_rope(nodes, finpos)
 end
 
 # Mutable `Rope`, optimized for concatenation operations


### PR DESCRIPTION
Some performance updates on streams, one is to limit the number of re-allocations when reading from a file by mimicking the behaviour of `mmap` (though in a much less-efficient manner).

The other is by improving greatly the runtime of `read_all` and of all subsequent operations by enlarging the size of a rope's leaves.

Depends on #1885 