### PR TITLE
check_contrib: filter-out contrib/nitc when checking Makefile of projects

### DIFF
--- a/misc/jenkins/check_contrib.sh
+++ b/misc/jenkins/check_contrib.sh
@@ -22,7 +22,7 @@
 #
 #     check_contrib.sh check android
 
-projects=`echo lib/*/Makefile examples/*/Makefile contrib/*/Makefile`
+projects=`ls -1 lib/*/Makefile examples/*/Makefile contrib/*/Makefile | grep -v contrib/nitc/`
 rules=$*
 
 failed=


### PR DESCRIPTION
src/Makefile is already executed at the begin of the tests, so a double execution is mostly useless and time-expensive.