### PR TITLE
engine: handle the compilation/interpretation of multiple varargs

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -2080,19 +2080,20 @@ redef class MMethodDef
 		var msignature = self.msignature.as(not null)
 
 		for i in [0..msignature.arity[ do
+			var mp = msignature.mparameters[i]
 			# skip test for vararg since the array is instantiated with the correct polymorphic type
-			if msignature.vararg_rank == i then continue
+			if mp.is_vararg then continue
 
 			# skip if the cast is not required
 			var origmtype =  self.mproperty.intro.msignature.mparameters[i].mtype
 			if not origmtype.need_anchor then continue
 
 			# get the parameter type
-			var mtype = msignature.mparameters[i].mtype
+			var mtype = mp.mtype
 
 			# generate the cast
 			# note that v decides if and how to implements the cast
-			v.add("/* Covariant cast for argument {i} ({msignature.mparameters[i].name}) {arguments[i+1].inspect} isa {mtype} */")
+			v.add("/* Covariant cast for argument {i} ({mp.name}) {arguments[i+1].inspect} isa {mtype} */")
 			v.add_cast(arguments[i+1], mtype, "covariance")
 		end
 	end

--- a/src/compiler/global_compiler.nit
+++ b/src/compiler/global_compiler.nit
@@ -605,8 +605,9 @@ class GlobalCompilerVisitor
 	do
 		var recv = args.first
 		for i in [0..m.msignature.arity[ do
-			var t = m.msignature.mparameters[i].mtype
-			if i == m.msignature.vararg_rank then
+			var mp = m.msignature.mparameters[i]
+			var t = mp.mtype
+			if mp.is_vararg then
 				t = args[i+1].mtype
 			end
 			t = self.resolve_for(t, recv)
@@ -618,8 +619,9 @@ class GlobalCompilerVisitor
 	do
 		var recv = args.first
 		for i in [0..m.msignature.arity[ do
-			var t = m.msignature.mparameters[i].mtype
-			if i == m.msignature.vararg_rank then
+			var mp = m.msignature.mparameters[i]
+			var t = mp.mtype
+			if mp.is_vararg then
 				t = args[i+1].mtype
 			end
 			t = self.resolve_for(t, recv)
@@ -997,8 +999,9 @@ private class CustomizedRuntimeFunction
 		comment.append("(self: {recv}")
 		arguments.add(selfvar)
 		for i in [0..mmethoddef.msignature.arity[ do
-			var mtype = mmethoddef.msignature.mparameters[i].mtype
-			if i == mmethoddef.msignature.vararg_rank then
+			var mp = mmethoddef.msignature.mparameters[i]
+			var mtype = mp.mtype
+			if mp.is_vararg then
 				mtype = v.mmodule.array_type(mtype)
 			end
 			mtype = v.resolve_for(mtype, selfvar)

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -1174,8 +1174,9 @@ class SeparateCompilerVisitor
 			args.first = self.autobox(args.first, m.mclassdef.mclass.mclass_type)
 		end
 		for i in [0..msignature.arity[ do
-			var t = msignature.mparameters[i].mtype
-			if i == msignature.vararg_rank then
+			var mp = msignature.mparameters[i]
+			var t = mp.mtype
+			if mp.is_vararg then
 				t = args[i+1].mtype
 			end
 			args[i+1] = self.autobox(args[i+1], t)
@@ -1189,8 +1190,9 @@ class SeparateCompilerVisitor
 			args.first = self.unbox_extern(args.first, m.mclassdef.mclass.mclass_type)
 		end
 		for i in [0..msignature.arity[ do
-			var t = msignature.mparameters[i].mtype
-			if i == msignature.vararg_rank then
+			var mp = msignature.mparameters[i]
+			var t = mp.mtype
+			if mp.is_vararg then
 				t = args[i+1].mtype
 			end
 			if m.is_extern then args[i+1] = self.unbox_extern(args[i+1], t)
@@ -2246,8 +2248,9 @@ class SeparateRuntimeFunction
 		var sig = new FlatBuffer
 		sig.append("({called_recv.ctype} self")
 		for i in [0..called_signature.arity[ do
-			var mtype = called_signature.mparameters[i].mtype
-			if i == called_signature.vararg_rank then
+			var mp = called_signature.mparameters[i]
+			var mtype = mp.mtype
+			if mp.is_vararg then
 				mtype = mmethoddef.mclassdef.mmodule.array_type(mtype)
 			end
 			sig.append(", {mtype.ctype} p{i}")
@@ -2282,8 +2285,9 @@ class SeparateRuntimeFunction
 		comment.append("({selfvar}: {selfvar.mtype}")
 		arguments.add(selfvar)
 		for i in [0..msignature.arity[ do
-			var mtype = msignature.mparameters[i].mtype
-			if i == msignature.vararg_rank then
+			var mp = msignature.mparameters[i]
+			var mtype = mp.mtype
+			if mp.is_vararg then
 				mtype = v.mmodule.array_type(mtype)
 			end
 			comment.append(", {mtype}")

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -528,8 +528,10 @@ class NaiveInterpreter
 	do
 		var msignature = mpropdef.msignature.as(not null)
 		for i in [0..msignature.arity[ do
+			var mp = msignature.mparameters[i]
+
 			# skip test for vararg since the array is instantiated with the correct polymorphic type
-			if msignature.vararg_rank == i then continue
+			if mp.is_vararg then continue
 
 			# skip if the cast is not required
 			var origmtype =  mpropdef.mproperty.intro.msignature.mparameters[i].mtype
@@ -538,7 +540,7 @@ class NaiveInterpreter
 			#print "{mpropdef}: {mpropdef.mproperty.intro.msignature.mparameters[i]}"
 
 			# get the parameter type
-			var mtype = msignature.mparameters[i].mtype
+			var mtype = mp.mtype
 			var anchor = args.first.mtype.as(MClassType)
 			var amtype = mtype.anchor_to(self.mainmodule, anchor)
 			if not args[i+1].mtype.is_subtype(self.mainmodule, anchor, amtype) then


### PR DESCRIPTION
While working on new constructors #1800, it appeared that the compilation of signatures with more than one vararg was broken.

The current engines never compile execute such a signature; signatures with multiple varargs only exists in the model to validate the arguments of the `new` syntax. The bug cannot be exhibited (so no specific tests).

Most of the changes are the same pattern: ask each parameter if it is a vararg instead of waiting a specific one.