### PR TITLE
Make all Sets cloneable

### DIFF
--- a/lib/core/collection/abstract_collection.nit
+++ b/lib/core/collection/abstract_collection.nit
@@ -409,6 +409,7 @@ end
 #      assert s.has(b)      ==  true
 interface Set[E]
 	super SimpleCollection[E]
+	super Cloneable
 
 	redef fun has_only(item)
 	do
@@ -470,6 +471,8 @@ interface Set[E]
 		for v in self do if other.has(v) then nhs.add(v)
 		return nhs
 	end
+
+	redef fun clone do return union(self)
 
 	# Returns a new instance of `Set`.
 	#

--- a/lib/core/collection/array.nit
+++ b/lib/core/collection/array.nit
@@ -592,7 +592,6 @@ end
 # A set implemented with an Array.
 class ArraySet[E]
 	super Set[E]
-	super Cloneable
 
 	# The stored elements.
 	private var array: Array[E] is noinit

--- a/tests/sav/test_new_native_alt1.res
+++ b/tests/sav/test_new_native_alt1.res
@@ -1,4 +1,4 @@
-Runtime error: Cast failed. Expected `E`, got `Bool` (../lib/core/collection/array.nit:989)
+Runtime error: Cast failed. Expected `E`, got `Bool` (../lib/core/collection/array.nit:988)
 NativeString
 0x4e
 Nit


### PR DESCRIPTION
Since there is no reason to forbid it (or I have not seen one at the very least), here's a simple `clone` method that should work on any `Set`