### PR TITLE
Json benchmark

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ujson4c"]
+	path = benchmarks/json/thirdparty/ujson4c
+	url = https://github.com/esnme/ujson4c

--- a/benchmarks/json/Makefile
+++ b/benchmarks/json/Makefile
@@ -1,0 +1,2 @@
+all:
+	./bench_json.sh

--- a/benchmarks/json/bench_json.sh
+++ b/benchmarks/json/bench_json.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shell script to bench json parsers over different documents
+
+source ../bench_common.sh
+source ../bench_plot.sh
+
+## CONFIGURATION OPTIONS ##
+
+# Default number of times a command must be run with bench_command
+# Can be overrided with 'the option -n'
+count=5
+
+## HANDLE OPTIONS ##
+
+function init_repo()
+{
+	echo "Preparing submodules"
+	git submodule update --init
+	echo "Submodules ready"
+	mkdir -p inputs
+	echo "Preparing data for benchmarks"
+	if [ ! -e inputs/large_escaped.json ]; then
+		echo "Downloading file 1/4"
+		wget -O inputs/large_escaped.json https://github.com/seductiveapps/largeJSON/blob/master/100mb.json?raw=true
+	fi
+	echo "File 1/4 ready"
+	if [ ! -e inputs/magic.json ]; then
+		echo "Downloading file 2/4"
+		wget -O inputs/magic.json http://mtgjson.com/json/AllSets-x.json
+	fi
+	echo "File 2/4 ready"
+	if [ ! -e inputs/big_twitter.json ]; then
+		echo "Downloading file 3/4"
+		wget -O inputs/twitter.json https://github.com/miloyip/nativejson-benchmark/raw/master/data/twitter.json
+		cd inputs
+		./multiply_twitter.sh
+		rm twitter.json
+		cd ..
+	fi
+	echo "File 3/4 ready"
+	if [ ! -e inputs/big_gov_data.json ]; then
+		echo "Downloading file 4/4"
+		wget -O inputs/gov_data.json https://edg.epa.gov/data.json
+		cd inputs
+		./multiply_gov.sh
+		rm gov_data.json
+		cd ..
+	fi
+	echo "File 4/4 ready"
+}
+
+function usage()
+{
+	echo "run_bench: ./bench_json.sh [options]"
+	echo "  -v: verbose mode"
+	echo "  -n count: number of execution for each bar (default: $count)"
+	echo "  -h: this help"
+}
+
+stop=false
+while [ "$stop" = false ]; do
+	case "$1" in
+		-v) verbose=true; shift;;
+		-h) usage; exit;;
+		-n) count="$2"; shift; shift;;
+		*) stop=true
+	esac
+done
+
+init_repo
+
+mkdir -p out
+
+echo "Compiling engines"
+
+echo "C JSON Parser"
+
+gcc -O2 -I thirdparty/ujson4c/src -I thirdparty/ujson4c/3rdparty/ thirdparty/ujson4c/3rdparty/ultrajsondec.c scripts/c_parser.c -o scripts/c_parser -lm
+
+echo "Go JSON Parser"
+
+go build -o scripts/json_parse scripts/json_parse.go
+
+echo "Nit/NitCC Parser"
+
+nitc --semi-global scripts/nitcc_parser.nit -o scripts/nitcc_parser
+
+echo "Nit/Ad-Hoc UTF-8 Parser, No Ropes"
+
+nitc --semi-global scripts/nit_adhoc_utf_noropes.nit -o scripts/nit_adhoc_utf_noropes
+
+echo "Nit/Ad-Hoc UTF-8 Parser, With Ropes"
+
+nitc --semi-global scripts/nit_adhoc_utf_ropes.nit -o scripts/nit_adhoc_utf_ropes
+
+declare -a script_names=('C' 'Python 3' 'Python 2' 'Go' 'Nit Ad-hoc UTF-8 No Ropes' 'Nit Ad-hoc UTF-8 + Ropes' 'Ruby ext')
+declare -a script_cmds=('./scripts/c_parser' 'python3 scripts/python.py' 'python2 scripts/python.py' './scripts/json_parse' './scripts/nit_adhoc_utf_noropes' './scripts/nit_adhoc_utf_ropes' 'ruby scripts/json_ext.rb')
+
+for script in `seq 1 ${#script_cmds[@]}`; do
+	echo "Preparing res for ${script_names[$script - 1]}"
+	prepare_res "./out/${script_names[$script - 1]}.dat" "${script_names[$script - 1]}" "${script_names[$script - 1]}"
+	for file in inputs/*.json; do
+		fname=`basename $file .json`
+		bench_command $file "Benching file $file using ${script_cmds[$script - 1]} parser" ${script_cmds[$script - 1]} $file
+	done;
+done;
+
+rm scripts/nitcc_parser
+rm scripts/json_parse
+rm scripts/c_parser
+rm scripts/nit_adhoc_utf_noropes
+rm scripts/nit_adhoc_utf_ropes
+
+plot out/bench_json.gnu

--- a/benchmarks/json/inputs/multiply_gov.sh
+++ b/benchmarks/json/inputs/multiply_gov.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "[" > big_gov_data.json
+for i in $(seq 10); do
+  test "$i" != "1" && echo "," >> big_gov_data.json
+    cat gov_data.json >> big_gov_data.json
+done
+echo "]" >> big_gov_data.json

--- a/benchmarks/json/inputs/multiply_twitter.sh
+++ b/benchmarks/json/inputs/multiply_twitter.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "[" > big_twitter.json
+for i in $(seq 100); do
+  test "$i" != "1" && echo "," >> big_twitter.json
+    cat twitter.json >> big_twitter.json
+done
+echo "]" >> big_twitter.json

--- a/benchmarks/json/scripts/c_parser.c
+++ b/benchmarks/json/scripts/c_parser.c
@@ -1,0 +1,48 @@
+#include "ujdecode.c"
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <assert.h>
+
+// Gets the byte size of a file
+int file_byte_size(char* path)
+{
+	int f = open(path, O_RDONLY);
+	if(f == -1)
+		return -1;
+	struct stat s;
+	int ln = 0;
+	if(!fstat(f, &s))
+		ln = s.st_size;
+	close(f);
+	return ln;
+}
+
+int main(int argc, char** argv)
+{
+	if(argc == 1) {
+		printf("Usage: ./c_parser file\n");
+		exit(1);
+	}
+
+	int fl_sz = file_byte_size(argv[1]);
+	char* input = malloc(fl_sz);
+
+	FILE* ifl = fopen(argv[1], "r");
+	if(ifl == NULL) {
+		printf("Error: cannot read file %s, are you sure permissions are set correctly ?\n", argv[1]);
+		exit(2);
+	}
+	int rd = fread(input, 1, fl_sz, ifl);
+	assert(rd == fl_sz);
+
+	void *state;
+
+	UJObject obj = UJDecode(input, fl_sz, NULL, &state);
+
+	free(input);
+	UJFree(state);
+}

--- a/benchmarks/json/scripts/json_ext.rb
+++ b/benchmarks/json/scripts/json_ext.rb
@@ -1,0 +1,4 @@
+require 'json/ext'
+
+txt = IO.read(ARGV.first)
+my_hash = JSON.parse(txt)

--- a/benchmarks/json/scripts/json_parse.go
+++ b/benchmarks/json/scripts/json_parse.go
@@ -1,0 +1,20 @@
+package main
+
+import "io/ioutil"
+import "encoding/json"
+import "os"
+import "fmt"
+
+func main() {
+	if len(os.Args) == 1 {
+		fmt.Println("Usage ./json_parse file")
+		os.Exit(-1)
+	}
+	dat, err := ioutil.ReadFile(os.Args[1])
+	if err != nil { panic(err) }
+
+	var obj interface{}
+
+	jsonerr := json.Unmarshal(dat, &obj)
+	if jsonerr != nil { panic(jsonerr) }
+}

--- a/benchmarks/json/scripts/json_pure.rb
+++ b/benchmarks/json/scripts/json_pure.rb
@@ -1,0 +1,4 @@
+require 'json/pure'
+
+txt = IO.read(ARGV.first)
+my_hash = JSON.parse(txt)

--- a/benchmarks/json/scripts/nit_adhoc_utf_noropes.nit
+++ b/benchmarks/json/scripts/nit_adhoc_utf_noropes.nit
@@ -1,0 +1,18 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json::string_parser
+
+var text = args.first.to_path.read_all_bytes.to_s
+var json = text.parse_json

--- a/benchmarks/json/scripts/nit_adhoc_utf_ropes.nit
+++ b/benchmarks/json/scripts/nit_adhoc_utf_ropes.nit
@@ -1,0 +1,21 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json::string_parser
+
+var f = new FileReader.open(args.first)
+
+var text = f.read_all
+f.close
+var json = text.parse_json

--- a/benchmarks/json/scripts/nitcc_parser.nit
+++ b/benchmarks/json/scripts/nitcc_parser.nit
@@ -1,0 +1,18 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+var text = args.first.to_path.read_all
+var json = text.parse_json

--- a/benchmarks/json/scripts/python.py
+++ b/benchmarks/json/scripts/python.py
@@ -1,0 +1,5 @@
+import sys
+import json
+
+json_data=open(sys.argv[1]).read()
+data = json.loads(json_data)


### PR DESCRIPTION
Added a JSON parser benchmark between different languages and Nit using 3 variants:

* Nit/NitCC: The old parser relying on NitCC, which is slow and memory-consuming (more than 6 Gio RAM for the 100Mio escaping-intensive file)
* Nit/Ad-hoc UTF-8 no ropes: The new parser working exclusively on `FlatString`
* Nit/Ad-hoc UTF-8 with ropes: The new parser with a mix of `Concat` and `FlatString` 

![vr5fa](https://cloud.githubusercontent.com/assets/1444825/11787549/4375a4e6-a25a-11e5-87b3-ac4346dee3bd.jpg)

I hear you all clamouring, well, here are the results (after #1885 and #1887, naturally):

![output](https://cloud.githubusercontent.com/assets/1444825/11787622/b24c0c98-a25a-11e5-8cff-0e0afe03c9d8.png)

So yeah, I guess we could do better when it comes to escaping since the biggest difference in runtime is in the `large_escape` benchmark which coincidentally contains mostly `\uXXXX` characters.

Other than that, we do as well as Go and better than Ruby (also worse than Python, but this does not count), which is nice.

About the inputs:

* large_escaped is an unusual file since it contains large strings with lots of unicode escaping sequences which should highlight the handling of String-to-Int conversions and Unicode-escape-sequences-to-UTF-8-characters, and it is big, as in very big (94.7 Mio)
* magic, a normally-formatted 54 Mio JSON file with quite a bunch of Unicode characters
* gov_data, a 6.9 Mio JSON file with ASCII characters only
* twitter, a 64 kio JSON file with a lot of japanese characters

I might add some more files later to better represent the variety of inputs, but right now is a good time to push the benchmark suite, enjoy !

Note: Since the ad-hoc JSON parser is benched, #1886 will need to be merged prior to this one if the bench is to work on your machines