### PR TITLE
Faster hex parsing

### DIFF
--- a/contrib/pep8analysis/src/model/operands.nit
+++ b/contrib/pep8analysis/src/model/operands.nit
@@ -33,8 +33,7 @@ redef class AStringValue
 end
 
 redef class AHexValue
-	#TODO
-	redef fun to_i do return n_hex.text.to_hex
+	redef fun to_i do return n_hex.text.trim.to_hex(2)
 end
 
 redef class TString # TkBlock

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -248,7 +248,17 @@ abstract class Text
 	# If `self` contains only digits and alpha <= 'f', return the corresponding integer.
 	#
 	#     assert "ff".to_hex == 255
-	fun to_hex: Int do return a_to(16)
+	fun to_hex(pos, ln: nullable Int): Int do
+		var res = 0
+		if pos == null then pos = 0
+		if ln == null then ln = length - pos
+		var max = pos + ln
+		for i in [pos .. max[ do
+			res <<= 4
+			res += self[i].from_hex
+		end
+		return res
+	end
 
 	# If `self` contains only digits <= '7', return the corresponding integer.
 	#

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -1600,6 +1600,12 @@ redef class Char
 	#     assert 'ま'.bytes == [0xE3u8, 0x81u8, 0xBEu8]
 	fun bytes: SequenceRead[Byte] do return to_s.bytes
 
+	# Is `self` an UTF-16 surrogate pair ?
+	fun is_surrogate: Bool do
+		var cp = code_point
+		return cp >= 0xD800 and cp <= 0xDFFF
+	end
+
 	# Length of `self` in a UTF-8 String
 	private fun u8char_len: Int do
 		var c = self.code_point

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -1732,6 +1732,19 @@ redef class Char
 	do
 		return self.is_numeric or self.is_alpha
 	end
+
+	# Returns `self` to its int value
+	#
+	# REQUIRE: `is_hexdigit`
+	fun from_hex: Int do
+		if self >= '0' and self <= '9' then return code_point - 0x30
+		if self >= 'A' and self <= 'F' then return code_point - 0x37
+		if self >= 'a' and self <= 'f' then return code_point - 0x57
+		# Happens if self is not a hexdigit
+		assert self.is_hexdigit
+		# To make flow analysis happy
+		abort
+	end
 end
 
 redef class Collection[E]

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -278,6 +278,23 @@ redef class FlatText
 	end
 
 	redef fun [](index) do return _items.char_at(char_to_byte_index(index))
+
+	# If `self` contains only digits and alpha <= 'f', return the corresponding integer.
+	#
+	#     assert "ff".to_hex == 255
+	redef fun to_hex(pos, ln) do
+		var res = 0
+		if pos == null then pos = 0
+		if ln == null then ln = length - pos
+		pos = char_to_byte_index(pos)
+		var its = _items
+		var max = pos + ln
+		for i in [pos .. max[ do
+			res <<= 4
+			res += its[i].ascii.from_hex
+		end
+		return res
+	end
 end
 
 # Immutable strings of characters.


### PR DESCRIPTION
As said in #1895, we need faster parsing of UTF-16 escaping sequences, this PR is the answer.

It makes the runtime of the `large_escaped` benchmark go down from ~5s to ~3.5s, and with valgrind, from 26GIr to 20GIr

Note: based on #1886, only the 4 last commits are of interest here