### PR TITLE
Alternative intern

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -1180,7 +1180,7 @@ abstract class AbstractCompilerVisitor
 
 	fun calloc_array(ret_type: MType, arguments: Array[RuntimeVariable]) is abstract
 
-	fun native_array_def(pname: String, ret_type: nullable MType, arguments: Array[RuntimeVariable]) is abstract
+	fun native_array_def(pname: String, ret_type: nullable MType, arguments: Array[RuntimeVariable]): Bool do return false
 
 	# Return an element of a native array.
 	# The method is unsafe and is just a direct wrapper for the specific implementation of native arrays
@@ -2491,8 +2491,7 @@ redef class AMethPropdef
 				return true
 			end
 		else if cname == "NativeArray" then
-			v.native_array_def(pname, ret, arguments)
-			return true
+			return v.native_array_def(pname, ret, arguments)
 		else if cname == "Int8" then
 			if pname == "output" then
 				v.add("printf(\"%\"PRIi8 \"\\n\", {arguments.first});")

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -2135,7 +2135,8 @@ redef class AMethPropdef
 		# Try special compilation
 		if mpropdef.is_intern then
 			if compile_intern_to_c(v, mpropdef, arguments) then return
-		else if mpropdef.is_extern then
+		end
+		if mpropdef.is_extern then
 			if mpropdef.mproperty.is_init then
 				if compile_externinit_to_c(v, mpropdef, arguments) then return
 			else

--- a/src/compiler/global_compiler.nit
+++ b/src/compiler/global_compiler.nit
@@ -385,18 +385,19 @@ class GlobalCompilerVisitor
 		var recv = "((struct {arguments[0].mcasttype.c_name}*){arguments[0]})->values"
 		if pname == "[]" then
 			self.ret(self.new_expr("{recv}[{arguments[1]}]", ret_type.as(not null)))
-			return
+			return true
 		else if pname == "[]=" then
 			self.add("{recv}[{arguments[1]}]={arguments[2]};")
-			return
+			return true
 		else if pname == "length" then
 			self.ret(self.new_expr("((struct {arguments[0].mcasttype.c_name}*){arguments[0]})->length", ret_type.as(not null)))
-			return
+			return true
 		else if pname == "copy_to" then
 			var recv1 = "((struct {arguments[1].mcasttype.c_name}*){arguments[1]})->values"
 			self.add("memmove({recv1},{recv},{arguments[2]}*sizeof({elttype.ctype}));")
-			return
+			return true
 		end
+		return false
 	end
 
 	redef fun native_array_instance(elttype: MType, length: RuntimeVariable): RuntimeVariable

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -2110,18 +2110,19 @@ class SeparateCompilerVisitor
 			var res = self.new_expr("{recv}[{arguments[1]}]", compiler.mainmodule.object_type)
 			res.mcasttype = ret_type.as(not null)
 			self.ret(res)
-			return
+			return true
 		else if pname == "[]=" then
 			self.add("{recv}[{arguments[1]}]={arguments[2]};")
-			return
+			return true
 		else if pname == "length" then
 			self.ret(self.new_expr("((struct instance_{nclass.c_name}*){arguments[0]})->length", ret_type.as(not null)))
-			return
+			return true
 		else if pname == "copy_to" then
 			var recv1 = "((struct instance_{nclass.c_name}*){arguments[1]})->values"
 			self.add("memmove({recv1}, {recv}, {arguments[2]}*sizeof({elttype.ctype}));")
-			return
+			return true
 		end
+		return false
 	end
 
 	redef fun native_array_get(nat, i)

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -876,21 +876,27 @@ redef class AMethPropdef
 			v.call(superpd, arguments)
 		end
 
+		# First, try intern
 		if mpropdef.is_intern or mpropdef.is_extern then
 			var res = intern_call(v, mpropdef, arguments)
 			if res != v.error_instance then return res
 		end
-
+		# Then, try extern
+		if mpropdef.is_extern then
+			var res = call_extern(v, mpropdef, arguments, f)
+			if res != v.error_instance then return res
+		end
+		# Else try block
 		if n_block != null then
 			v.stmt(self.n_block)
 			return null
 		end
 
+		# Fail if nothing succeed
 		if mpropdef.is_intern then
 			fatal(v, "NOT YET IMPLEMENTED intern {mpropdef}")
 		else if mpropdef.is_extern then
-			var res = call_extern(v, mpropdef, arguments, f)
-			if res != v.error_instance then return res
+			fatal(v, "NOT YET IMPLEMENTED extern {mpropdef}")
 		else
 			fatal(v, "NOT YET IMPLEMENTED <wat?> {mpropdef}")
 		end
@@ -900,7 +906,6 @@ redef class AMethPropdef
 	# Call this extern method
 	protected fun call_extern(v: NaiveInterpreter, mpropdef: MMethodDef, arguments: Array[Instance], f: Frame): nullable Instance
 	do
-		fatal(v, "NOT YET IMPLEMENTED extern {mpropdef}")
 		return v.error_instance
 	end
 

--- a/src/nitni/nitni_base.nit
+++ b/src/nitni/nitni_base.nit
@@ -140,7 +140,7 @@ redef class MNullableType
 	redef fun mangled_cname do return "nullable_{mtype.mangled_cname}"
 end
 
-redef class MVirtualType
+redef class MFormalType
 	redef fun mangled_cname do return to_s
 end
 

--- a/tests/sav/niti/fixme/test_intern_extern.res
+++ b/tests/sav/niti/fixme/test_intern_extern.res
@@ -1,0 +1,1 @@
+UNDEFINED

--- a/tests/sav/test_intern_extern.res
+++ b/tests/sav/test_intern_extern.res
@@ -1,0 +1,6 @@
+A::foo from C
+A::bar from Nit
+NA::foo from C
+NA::bar from Nit
+Int::foo from C
+Int::bar from Nit

--- a/tests/test_intern_extern.nit
+++ b/tests/test_intern_extern.nit
@@ -1,0 +1,39 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+	fun foo is intern `{ puts("A::foo from C"); `}
+	fun bar is intern do print "A::bar from Nit"
+end
+
+redef class NativeArray[E]
+	fun foo is intern `{ puts("NA::foo from C"); `}
+	fun bar is intern do print "NA::bar from Nit"
+end
+
+redef class Int
+	fun foo is intern `{ puts("Int::foo from C"); `}
+	fun bar is intern do print "Int::bar from Nit"
+end
+
+var a = new A
+a.foo
+a.bar
+
+var na = new NativeArray[Object](5)
+na.foo
+na.bar
+
+1.foo
+1.bar


### PR DESCRIPTION
Improve the handling of alternative of intern methods since an extern body can be used as a fallback.

~~~
redef class Int
   fun foo is intern `{ return foo(self) `}
end
~~~

Moreover, NativeArray intern alternatives is now fixed with nitc.

There is still an issue with the extern methods of NativeArray in the interpreter.