### PR TITLE
nitcorn: skip the listening loop when running the tests

### DIFF
--- a/lib/nitcorn/examples/src/nitcorn_hello_world.nit
+++ b/lib/nitcorn/examples/src/nitcorn_hello_world.nit
@@ -77,9 +77,6 @@ vh.routes.add new Route("/hello/:name", new ParamAction)
 # Serve everything else with a standard `FileServer` with a root at "www/hello_world/"
 vh.routes.add new Route(null, new FileServer("www/hello_world/"))
 
-# Avoid executing when running tests
-if "NIT_TESTING".environ == "true" then exit 0
-
 var factory = new HttpFactory.and_libevent
 factory.config.virtual_hosts.add vh
 factory.run

--- a/lib/nitcorn/examples/src/nitcorn_reverse_proxy.nit
+++ b/lib/nitcorn/examples/src/nitcorn_reverse_proxy.nit
@@ -18,9 +18,6 @@
 
 import nitcorn
 
-# Avoid executing when running tests
-if "NIT_TESTING".environ == "true" then exit 0
-
 # Create the virtualhost for your nitcorn server
 var vh = new VirtualHost("localhost:8080")
 

--- a/lib/nitcorn/examples/src/restful_annot.nit
+++ b/lib/nitcorn/examples/src/restful_annot.nit
@@ -39,9 +39,6 @@ var vh = new VirtualHost("localhost:8080")
 # Serve everything with our restful action
 vh.routes.add new Route(null, new MyAction)
 
-# Avoid executing when running tests
-if "NIT_TESTING".environ == "true" then exit 0
-
 var factory = new HttpFactory.and_libevent
 factory.config.virtual_hosts.add vh
 factory.run

--- a/lib/nitcorn/reactor.nit
+++ b/lib/nitcorn/reactor.nit
@@ -133,10 +133,18 @@ class HttpFactory
 
 	redef fun spawn_connection(buf_ev) do return new HttpServer(buf_ev, self)
 
-	# Launch the main loop of this server
+	# Execute the main listening loop to accept connections
+	#
+	# After the loop ends, the underlying resources are freed.
+	#
+	# When the environment variable `NIT_TESTING` is set to `true`,
+	# the loop is not executed but the resources are still freed.
 	fun run
 	do
-		event_base.dispatch
+		if "NIT_TESTING".environ != "true" then
+			event_base.dispatch
+		end
+
 		event_base.destroy
 	end
 end


### PR DESCRIPTION
Until now, each nitcorn example checked if it was being tested, and if so it would quit to not block jenkins. This PR moves this check in the nitcorn module so it is the default behavior.

This should help for #1915 and future nitcorn programs.