### PR TITLE
Intro parsers to load 3D models from .obj and .mtl files

### DIFF
--- a/lib/android/android.nit
+++ b/lib/android/android.nit
@@ -24,6 +24,7 @@ import platform
 import native_app_glue
 import dalvik
 private import log
+private import assets
 
 redef class App
 	redef fun init_window

--- a/lib/android/assets.nit
+++ b/lib/android/assets.nit
@@ -1,0 +1,70 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Implementation of `app::assets`
+#
+# This module is a client of `assets_and_resources` as the latter
+# covers the services of Android.
+module assets
+
+intrude import assets_and_resources
+
+redef class TextAsset
+	redef fun load
+	do
+		jni_env.push_local_frame 8
+
+		var manager = app.asset_manager
+		var stream = manager.open(path)
+		if stream.is_java_null then
+			self.error = new Error("Failed to open asset at '{path}'")
+			jni_env.pop_local_frame
+			self.to_s = ""
+			return ""
+		end
+
+		var text = stream.read_all
+		stream.close
+		if text.is_java_null then
+			self.error = new Error("Failed to read content of asset file at '{path}'")
+			jni_env.pop_local_frame
+			self.to_s = ""
+			return ""
+		end
+
+		var content = text.to_s
+		jni_env.pop_local_frame
+		self.to_s = content
+		return content
+	end
+end
+
+redef class NativeInputStream
+
+	# Read and return all the content of this stream
+	private fun read_all: JavaString in "Java" `{
+		// `available` returns the n of bytes currently available, not the total.
+		// This may cause problems in the future with large asset files.
+		try {
+			int size = self.available();
+			byte[] bytes = new byte[size];
+			self.read(bytes, 0, size);
+
+			return new String(bytes);
+		} catch (java.lang.Exception exception) {
+			exception.printStackTrace();
+			return null;
+		}
+	`}
+end

--- a/lib/android/assets_and_resources.nit
+++ b/lib/android/assets_and_resources.nit
@@ -138,7 +138,7 @@ class AssetManager
 
 	# Return a string array of all the assets at the given path
 	fun list(path: String): Array[String] do
-		sys.jni_env.push_local_frame(1)
+		sys.jni_env.push_local_frame(8)
 		var java_array = native_assets_manager.list(path.to_java_string)
 		var nit_array = new Array[String]
 		for s in java_array do
@@ -150,16 +150,15 @@ class AssetManager
 
 	# Open an asset using ACCESS_STREAMING mode, returning a NativeInputStream
 	private fun open(file_name: String): NativeInputStream do
-		sys.jni_env.push_local_frame(1)
+		sys.jni_env.push_local_frame(2)
 		var return_value =  native_assets_manager.open(file_name.to_java_string)
-		sys.jni_env.pop_local_frame
-		return return_value
+		return return_value.pop_from_local_frame
 	end
 
 	# Open an asset using it's name and returning a NativeAssetFileDescriptor
 	# `file_name` is
 	private fun open_fd(file_name: String): NativeAssetFileDescriptor do
-		sys.jni_env.push_local_frame(1)
+		sys.jni_env.push_local_frame(2)
 		var return_value = native_assets_manager.open_fd(file_name.to_java_string).new_global_ref
 		sys.jni_env.pop_local_frame
 		return return_value
@@ -373,7 +372,7 @@ extern class NativeAssetFileDescriptor in "Java" `{ android.content.res.AssetFil
 	fun declared_length: Int in "Java" `{ return (int)self.getDeclaredLength(); `}
 	# fun extras: Bundle in "Java" `{ return self.getExtras(); `}
 
-	fun  file_descriptor: NativeFileDescriptor in "Java" `{
+	fun file_descriptor: NativeFileDescriptor in "Java" `{
 		FileDescriptor fd =  self.getFileDescriptor();
 		if (fd == null) {
 			Log.e("AssetFileDesciptorError", "Can't retrieve the FileDescriptor of this AssetFileDescriptor");

--- a/lib/android/ui/ui.nit
+++ b/lib/android/ui/ui.nit
@@ -27,6 +27,7 @@ import nit_activity
 
 import app::ui
 private import data_store
+import assets
 
 redef class Control
 	# The Android element used to implement `self`

--- a/lib/app/app.nit
+++ b/lib/app/app.nit
@@ -21,3 +21,4 @@
 module app
 
 import app_base
+import assets

--- a/lib/app/assets.nit
+++ b/lib/app/assets.nit
@@ -1,0 +1,44 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Portable services to load resources from the assets folder
+module assets
+
+# Resource from the assets folder
+#
+# At compilation, the asset folder should be at the root of the package.
+# In practice, this is usually next to the folders `src` and `bin`.
+#
+# These assets are packaged with the application.
+abstract class Asset
+
+	# Path to this asset within the assets folder
+	var path: String
+end
+
+# Text file from the assets folder
+#
+# Use `to_s` to get the content of this asset.
+class TextAsset
+	super Asset
+
+	# Text content of this asset
+	redef var to_s = load is lazy
+
+	# Load this asset
+	fun load: String is abstract
+
+	# Error on the last call to `load`, if any
+	var error: nullable Error = null
+end

--- a/lib/core/collection/hash_collection.nit
+++ b/lib/core/collection/hash_collection.nit
@@ -20,6 +20,11 @@ redef class Map[K, V]
 	new do return new HashMap[K, V]
 end
 
+redef class Set[E]
+	# Get an instance of `HashMap[K, V]`, the default implementation
+	new do return new HashSet[E]
+end
+
 # A HashCollection is an array of HashNode[K] indexed by the K hash value
 private abstract class HashCollection[K]
 	type N: HashNode[K]

--- a/lib/gamnit/model_parsers/model_parser_base.nit
+++ b/lib/gamnit/model_parsers/model_parser_base.nit
@@ -1,0 +1,181 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Services to parse models from a text description
+module model_parser_base
+
+import parser_base
+
+# Vector of 3 values, either `x, y, z`, `u, v, z` or `r, g, b`
+class Vec3
+
+	# X value
+	var x = 0.0 is writable
+
+	# Y value
+	var y = 0.0 is writable
+
+	# Z value
+	var z = 0.0 is writable
+
+	# U value (redirection as `x`)
+	fun u: Float do return x
+
+	# Set U value (redirection for `x=`)
+	fun u=(value: Float) do x = value
+
+	# V value (redirection as `y`)
+	fun v: Float do return y
+
+	# Set V value (redirection for `y=`)
+	fun v=(value: Float) do y = value
+
+	# R value
+	fun r: Float do return x
+
+	# Set R value (redirection for `x=`)
+	fun r=(value: Float) do x = value
+
+	# G value
+	fun g: Float do return y
+
+	# Set G value (redirection for `y=`)
+	fun g=(value: Float) do y = value
+
+	# B value
+	fun b: Float do return z
+
+	# Set B value (redirection for `z=`)
+	fun b=(value: Float) do z = value
+
+	# Return all values into a new `Array[Float]`
+	fun to_a: Array[Float] do return [x, y, z]
+
+	redef fun to_s do return "<{class_name} {x} {y} {z}>"
+end
+
+# Vector of 4 values, either `x, y, z, w`, `u, v, z, w` or `r, g, b, a`
+class Vec4
+	super Vec3
+
+	# W value
+	var w = 1.0 is writable
+
+	# A value (redirection to `z`)
+	fun a: Float do return z
+
+	# Set A value (redirection for `z=`)
+	fun a=(value: Float) do z = value
+
+	# Return all values into a new `Array[Float]`
+	redef fun to_a do return [x, y, z, w]
+
+	redef fun to_s do return "<{class_name} {x} {y} {z} {w}>"
+end
+
+redef class StringProcessor
+	# Read a single token after skipping preceding whitespaces
+	#
+	# Returns an empty string when at `eof`
+	protected fun read_token: String
+	do
+		while not eof and src[pos].is_whitespace and src[pos] != '\n' do
+			pos += 1
+		end
+
+		var start = pos
+		ignore_until_whitespace_or_comment
+		var ending = pos
+		var str = src.substring(start, ending-start)
+		return str
+	end
+
+	# Read 3 or 4 numbers and return them as a `Vec4`
+	#
+	# If there is no fourth value, `Vec4::w` is set to 1.0.
+	protected fun read_vec4: Vec4
+	do
+		var vec = new Vec4
+		vec.x = read_number
+		vec.y = read_number
+		vec.z = read_number
+
+		var wstr = read_token
+		if wstr.length > 0 then
+			vec.w = if wstr.is_numeric then wstr.to_f else 0.0
+		else
+			vec.w = 1.0
+		end
+
+		return vec
+	end
+
+	# Read 2 or 3 numbers and return them as a `Vec3`
+	#
+	# If there is no third value, `Vec3::z` is set to 0.0.
+	protected fun read_vec3: Vec3
+	do
+		var vec = new Vec3
+		vec.x = read_number
+		vec.y = read_number # Make optional
+
+		var wstr = read_token
+		if wstr.length > 0 then
+			vec.z = if wstr.is_numeric then wstr.to_f else 0.0
+		else
+			vec.z = 0.0
+		end
+
+		return vec
+	end
+
+	# Advance `pos` until a whitespace or `#` is encountered
+	protected fun ignore_until_whitespace_or_comment: Int
+	do
+		while src.length > pos and not src[pos].is_whitespace and src[pos] != '#' do
+			pos += 1
+		end
+		return pos
+	end
+
+	# Read a token and parse it as a `Float`
+	protected fun read_number: Float
+	do
+		var str = read_token
+		return if str.is_numeric then str.to_f else 0.0
+	end
+
+	# Advance `pos` until the next end of line or a `#`
+	protected fun read_until_eol_or_comment: String
+	do
+		ignore_whitespaces
+		var start = pos
+		while not eof and src[pos] != '#' and src[pos] != '\n' do
+			pos += 1
+		end
+		var ending = pos
+		var str = src.substring(start, ending-start)
+		return str.trim
+	end
+
+	# Advance `pos` to skip the next end of line
+	protected fun skip_eol
+	do
+		while not eof do
+			var c = src.chars[pos]
+			pos += 1
+			if c == '\n' then break
+		end
+	end
+end

--- a/lib/gamnit/model_parsers/mtl.nit
+++ b/lib/gamnit/model_parsers/mtl.nit
@@ -1,0 +1,131 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Services to parse .mtl material files
+module mtl
+
+import model_parser_base
+
+# Parser of `.mtl` files
+#
+# ~~~
+# var mtl_src = """
+# # Green material with low reflections
+# newmtl GreenMaterial
+# Ns 96.078431
+# Ka 0.000000 0.000000 0.000000
+# Kd 0.027186 0.180434 0.012088
+# Ks 0.500000 0.500000 0.500000
+# Ni 1.000000
+# d 1.000000
+# illum 2
+# """
+#
+# var parser = new MtlFileParser(mtl_src)
+# var name_to_mtls = parser.parse
+# assert name_to_mtls.keys.join == "GreenMaterial"
+# ~~~
+class MtlFileParser
+	super StringProcessor
+
+	# Read and parse source and return all materials organized by their names
+	fun parse: Map[String, MtlDef]
+	do
+		var mat_lib = new Map[String, MtlDef]
+		var material: nullable MtlDef = null
+
+		while not eof do
+			var token = read_token
+			if token == "newmtl" then
+				var name = read_until_eol_or_comment
+				material = new MtlDef(name)
+				mat_lib[name] = material
+			else if material != null then
+				if token == "Ka" then
+					material.ambient = read_vec3
+				else if token == "Kd" then
+					material.diffuse = read_vec3
+				else if token == "Ks" then
+					material.specular = read_vec3
+				else if token == "d" then
+					material.dissolved = read_number
+				else if token == "Tr" then
+					material.dissolved = 1.0 - read_number
+				else if token == "illum" then
+					material.illumination_model = read_number.to_i
+				else if token == "map_Kd" then
+					material.map_diffuse = read_until_eol_or_comment
+				else if token == "map_Bump" then
+					material.map_bump = read_until_eol_or_comment
+				else if token == "map_Ks" then
+					material.map_specular = read_until_eol_or_comment
+				else if token == "map_Ns" then
+					material.map_exponent = read_until_eol_or_comment
+
+				# TODO other line type headers
+				else if token == "Ns" then
+				else if token == "Ni" then
+				else if token == "sharpness" then
+				else if token == "bump" then
+				end
+			end
+			skip_eol
+		end
+
+		return mat_lib
+	end
+end
+
+# Material defined in a `.mtl` file
+class MtlDef
+
+	# Name of this material
+	var name: String
+
+	# Ambient color
+	var ambient = new Vec3 is lazy
+
+	# Diffuse color
+	var diffuse = new Vec3 is lazy
+
+	# Specular color
+	var specular = new Vec3 is lazy
+
+	# Dissolved level, where 1.0 is fully visible
+	var dissolved = 1.0
+
+	# Transparency level, where 1.0 is fully invisible
+	fun transparency: Float do return 1.0 - dissolved
+
+	# Illumination model
+	var illumination_model = 0
+
+	# Diffuse map
+	var map_diffuse: nullable String = null
+
+	# Bump map or normals texture
+	var map_bump: nullable String = null
+
+	# Specular reflectivity map
+	var map_specular: nullable String = null
+
+	# Specular exponent map
+	var map_exponent: nullable String = null
+
+	# Collect non-null maps from `map_diffuse, map_bump, map_specular, map_exponent`
+	fun maps: Array[String]
+	do
+		return [for m in [map_diffuse, map_bump, map_specular, map_exponent] do if m != null then m]
+	end
+end

--- a/lib/gamnit/model_parsers/obj.nit
+++ b/lib/gamnit/model_parsers/obj.nit
@@ -1,0 +1,230 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Services to parse .obj geometry files
+module obj
+
+import model_parser_base
+
+# Parser of .obj files in ASCII format
+#
+# Instantiate from a `String` and use `parse` to extract the `ObjDef`.
+#
+# ~~~
+# var obj_src = """
+# # Model of a cube
+# mtllib material_file.mtl
+# o Cube
+# v 1.000000 0.000000 0.000000
+# v 1.000000 0.000000 1.000000
+# v 0.000000 0.000000 1.000000
+# v 0.000000 0.000000 0.000000
+# v 1.000000 1.000000 0.999999
+# v 0.999999 1.000000 1.000001
+# v 0.000000 1.000000 1.000000
+# v 0.000000 1.000000 0.000000
+# usemtl GreenMaterial
+# s off
+# f 1 2 3 4
+# f 5 6 7 8
+# f 1 5 8 2
+# f 2 8 7 3
+# f 3 7 6 4
+# f 5 1 4 6
+# """
+#
+# var parser = new ObjFileParser(obj_src)
+# var parsed_obj = parser.parse
+# assert parsed_obj.is_coherent
+# ~~~
+class ObjFileParser
+	super StringProcessor
+
+	private var geometry = new ObjDef is lazy
+
+	private var current_material_lib: nullable String = null
+
+	private var current_material_name: nullable String = null
+
+	# Execute parsing of `src` to extract an `ObjDef`
+	fun parse: nullable ObjDef
+	do
+		while not eof do
+			var token = read_token
+			if token.is_empty or token == "#" then
+				# Ignore empty lines and comments
+			else if token == "v" then # Vertex points
+				var vec = read_vec4
+				geometry.vertex_points.add vec
+			else if token == "vt" then # Texture coords
+				var vec = read_vec3
+				geometry.texture_coords.add vec
+			else if token == "vn" then # Normals
+				var vec = read_vec3 # This one should not accept `w` values
+				geometry.normals.add vec
+			else if token == "vp" then # Parameter space vertices
+				var vec = read_vec3
+				geometry.params.add vec
+			else if token == "f" then # Faces
+				var face = read_face
+				geometry.faces.add face
+			else if token == "mtllib" then
+				current_material_lib = read_until_eol_or_comment
+			else if token == "usemtl" then
+				current_material_name = read_until_eol_or_comment
+
+			# TODO other line type headers
+			else if token == "s" then
+			else if token == "o" then
+			else if token == "g" then
+			end
+			skip_eol
+		end
+		return geometry
+	end
+
+	private fun read_face: ObjFace
+	do
+		var face = new ObjFace(current_material_lib, current_material_name)
+
+		loop
+			var r = read_face_index_set(face)
+			if not r then break
+		end
+
+		return face
+	end
+
+	private fun read_face_index_set(face: ObjFace): Bool
+	do
+		var token = read_token
+
+		var parts = token.split('/')
+		if parts.is_empty or parts.first.is_empty then return false
+
+		var v = new ObjVertex
+		for i in parts.length.times, part in parts do
+			part = part.trim
+
+			var n = null
+			if not part.is_empty and part.is_numeric then n = part.to_i
+
+			if i == 0 then
+				n = n or else 0 # Error if n == null
+				if n < 0 then n = geometry.vertex_points.length + n
+				v.vertex_point_index = n
+			else if i == 1 then
+				if n != null and n < 0 then n = geometry.texture_coords.length + n
+				v.texture_coord_index = n
+			else if i == 2 then
+				if n != null and n < 0 then n = geometry.normals.length + n
+				v.normal_index = n
+			else abort
+		end
+		face.vertices.add v
+
+		return true
+	end
+end
+
+# Geometry from a .obj file
+class ObjDef
+	# Vertex coordinates
+	var vertex_points = new Array[Vec4]
+
+	# Texture coordinates
+	var texture_coords = new Array[Vec3]
+
+	# Normals
+	var normals = new Array[Vec3]
+
+	# Surface parameters
+	var params = new Array[Vec3]
+
+	# Faces
+	var faces = new Array[ObjFace]
+
+	# Referenced material libraries
+	fun material_libs: Set[String] do
+		var libs = new Set[String]
+		for face in faces do
+			var lib = face.material_lib
+			if lib != null then libs.add lib
+		end
+		return libs
+	end
+
+	# Check the coherence of the model
+	#
+	# Returns `false` on error and prints details to stderr.
+	#
+	# This service can be useful for debugging, however it should not
+	# be executed at each execution of a game.
+	fun is_coherent: Bool
+	do
+		for f in faces do
+			if f.vertices.length < 3 then return error("ObjFace with less than 3 vertices")
+
+			for v in f.vertices do
+				var i = v.vertex_point_index
+				if i < 1 then return error("Vertex point index < 1")
+				if i > vertex_points.length then return error("Vertex point index > than length")
+
+				var j = v.texture_coord_index
+				if j != null then
+					if j < 1 then return error("Texture coord index < 1")
+					if j > texture_coords.length then return error("Texture coord index > than length")
+				end
+
+				j = v.normal_index
+				if j != null then
+					if j < 1 then return error("Normal index < 1")
+					if j > normals.length then return error("Normal index > than length")
+				end
+			end
+		end
+		return true
+	end
+
+	# Service to print errors for `is_coherent`
+	private fun error(msg: Text): Bool
+	do
+		print_error "ObjDef Error: {msg}"
+		return false
+	end
+end
+
+# Flat surface of an `ObjDef`
+class ObjFace
+	# Vertex composing this surface, thene should be 3 or more
+	var vertices = new Array[ObjVertex]
+
+	# Relative path to the .mtl material lib
+	var material_lib: nullable String
+
+	# Name of the material in `material_lib`
+	var material_name: nullable String
+end
+
+# Vertex composing a `ObjFace`
+class ObjVertex
+	# Vertex coordinates index in `ObjDef::vertex_points`, starting at 1
+	var vertex_point_index = 0
+
+	# Texture coordinates index in `ObjDef::texture_coords`, starting at 1
+	var texture_coord_index: nullable Int = null
+
+	# Normal index in `ObjDef::normals`, starting at 1
+	var normal_index: nullable Int = null
+end

--- a/lib/java/io.nit
+++ b/lib/java/io.nit
@@ -168,4 +168,15 @@ extern class NativeInputStream in "Java" `{ java.io.InputStream `}
 			e.printStackTrace();
 		}
 	`}
+
+	# HACK for bug #845
+	redef fun new_global_ref import sys, Sys.jni_env `{
+		Sys sys = NativeInputStream_sys(self);
+		JNIEnv *env = Sys_jni_env(sys);
+		return (*env)->NewGlobalRef(env, self);
+	`}
+
+	redef fun pop_from_local_frame_with_env(jni_env) `{
+		return (*jni_env)->PopLocalFrame(jni_env, self);
+	`}
 end

--- a/lib/linux/linux.nit
+++ b/lib/linux/linux.nit
@@ -46,3 +46,19 @@ redef class App
 		on_destroy
 	end
 end
+
+redef class TextAsset
+	redef fun load
+	do
+		var path = app.assets_dir / path
+		var reader = path.to_path.open_ro
+		var content = reader.read_all
+		reader.close
+
+		var error = reader.last_error
+		if error != null then self.error = error
+
+		self.to_s = content
+		return content
+	end
+end

--- a/lib/mnit/assets.nit
+++ b/lib/mnit/assets.nit
@@ -21,24 +21,24 @@ import mnit_app
 import mnit::display
 
 # General asset
-interface Asset
+interface MnitAsset
 end
 
 # An String is an asset, returned from a text file
 redef class String
-	super Asset
+	super MnitAsset
 end
 
 # An Image is an asset
 redef interface Image
-	super Asset
+	super MnitAsset
 end
 
 redef class App
 	# Load a genereal asset from file name
 	# Will find the file within the assets/ directory
 	# Crashes if file not found
-	fun load_asset( id: String ): Asset
+	fun load_asset( id: String ): MnitAsset
 	do
 		var asset = try_loading_asset( id )
 		if asset == null then # error
@@ -63,5 +63,5 @@ redef class App
 	end
 
 	# Load an assets without error if not found
-	fun try_loading_asset( id: String ): nullable Asset is abstract
+	fun try_loading_asset( id: String ): nullable MnitAsset is abstract
 end

--- a/lib/parser_base.nit
+++ b/lib/parser_base.nit
@@ -101,12 +101,15 @@ class StringProcessor
 
 	# Ignores any printable character until a whitespace is encountered
 	protected fun ignore_until_whitespace: Int do
-		while not src[pos].is_whitespace do pos += 1
+		while src.length > pos and not src[pos].is_whitespace do pos += 1
 		return pos
 	end
 
 	# Returns the current location as a `Location` object
 	protected fun hot_location: Location do return new Location(line, line_offset)
+
+	# Is `pos` at the end of the source?
+	protected fun eof: Bool do return pos >= src.length
 end
 
 # Information about the location of an entity in a source document


### PR DESCRIPTION
Intro parsers to load 3D models from the ASCII based format of .obj and .mtl files. Also as support intro a new kind of asset, `app::TextAsset`, with lazy loading in the style of `Sound` and `Texture`.

Model parsing services will be used by the 3D API of gamnit to load 3D models generated by modeler tools like Blender.

The services in `gamnit::model_parsers` are independent of gamnit. However since they are game related, it is a nice package to classify them in. They still can be used by any other 3D graphics engine, as `gamnit::network` which is also independent but game oriented. This adds a small duplication in their representation because a model is stored differently once loaded in gamnit. But the format in gamnit is so low-level (only arrays of Float) that we need an intermediate representation to triangulate faces and stuff like that.

Services of `model_parser_base` may be moved to other modules in the future as needed. The services added to `StringProcessor`, may be useful to other parsers and thus it could be moved up to `parser_base`. `Vec3` and `Vec4` apply an API similar to `vec3 & vec4` of GLSL. I may move them up to gamnit or glesv2 and add more services to transform from and to points, colors and other float based data vectors.