### PR TITLE
gamnit: intro static particles, Sprite tint & invert_x,  and fix a few bugs

### DIFF
--- a/contrib/inkscape_tools/src/svg_to_png_and_nit.nit
+++ b/contrib/inkscape_tools/src/svg_to_png_and_nit.nit
@@ -207,7 +207,7 @@ class GamnitImageSetSrc
 			var lines = new Array[String]
 			for image in images do
 				var coordinates = document.coordinates(image)
-				lines.add "\t\tmain_image.subtexture({coordinates})"
+				lines.add "\t\troot_texture.subtexture({coordinates})"
 			end
 
 			attributes.add """

--- a/lib/gamnit/depth/depth.nit
+++ b/lib/gamnit/depth/depth.nit
@@ -30,7 +30,7 @@ redef class App
 		world_camera.near = 0.1
 
 		# Prepare programs
-		var programs = [versatile_program, normals_program, explosion_program, smoke_program: GamnitProgram]
+		var programs = [versatile_program, normals_program, explosion_program, smoke_program, static_program: GamnitProgram]
 		for program in programs do
 			program.compile_and_link
 			var gamnit_error = program.error

--- a/lib/gamnit/depth/depth.nit
+++ b/lib/gamnit/depth/depth.nit
@@ -56,11 +56,13 @@ redef class App
 			end
 		end
 
+		frame_core_world_sprites display
+
 		# Toggle writing to the depth buffer for particles effects
 		glDepthMask false
 		for system in particle_systems do system.draw
 		glDepthMask true
 
-		frame_core_flat display
+		frame_core_ui_sprites display
 	end
 end

--- a/lib/gamnit/depth/particles.nit
+++ b/lib/gamnit/depth/particles.nit
@@ -39,6 +39,9 @@ import depth_core
 
 redef class App
 
+	# Graphics program to display static non-moving particles
+	var static_program = new ParticleProgram
+
 	# Graphics program to display blowing up particles
 	var explosion_program = new ExplosionProgram
 
@@ -153,7 +156,7 @@ end
 #
 # This program should be subclassed to create custom particle effects.
 # Either `vertex_shader_source` and `vertex_shader_core` can be refined.
-abstract class ParticleProgram
+class ParticleProgram
 	super GamnitProgramFromSource
 
 	redef var vertex_shader_source = """

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -59,7 +59,15 @@ class Sprite
 	var scale = 1.0 is writable
 
 	# Transparency applied to the texture on draw
-	var alpha = 1.0 is writable
+	fun alpha: Float do return tint[3]
+
+	# Transparency applied to the texture on draw
+	fun alpha=(value: Float) do tint[3] = value
+
+	# Tint applied to the texture on draw
+	#
+	# Require: `tint.length == 4`
+	var tint: Array[Float] = [1.0, 1.0, 1.0, 1.0] is writable
 
 	private fun draw
 	do
@@ -73,7 +81,7 @@ class Sprite
 		simple_2d_program.scale.array_enabled = false
 
 		simple_2d_program.translation.uniform(center.x, -center.y, center.z, 0.0)
-		simple_2d_program.color.uniform(1.0, 1.0, 1.0, alpha)
+		simple_2d_program.color.uniform(tint[0], tint[1], tint[2], tint[3])
 		simple_2d_program.scale.uniform scale
 
 		simple_2d_program.use_texture.uniform true

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -55,6 +55,9 @@ class Sprite
 	# Rotation on the Z axis
 	var rotation = 0.0 is writable
 
+	# Mirror `texture` horizontally, inverting each pixel on the X axis
+	var invert_x = false is writable
+
 	# Scale applied to this sprite
 	var scale = 1.0 is writable
 
@@ -86,7 +89,10 @@ class Sprite
 
 		simple_2d_program.use_texture.uniform true
 		simple_2d_program.texture.uniform 0
-		simple_2d_program.tex_coord.array(texture.texture_coords, 2)
+		simple_2d_program.tex_coord.array(
+			if invert_x then
+				texture.texture_coords_invert_x
+			else texture.texture_coords, 2)
 		simple_2d_program.coord.array(texture.vertices, 3)
 
 		simple_2d_program.rotation.uniform new Matrix.rotation(rotation, 0.0, 0.0, 1.0)
@@ -293,6 +299,18 @@ redef class Texture
 
 		var texture_coords = new Array[Float]
 		for v in [c, d, a, b] do texture_coords.add_all v
+		return texture_coords
+	end
+
+	# Coordinates of this texture on the `root` texture, with the X axis inverted
+	private var texture_coords_invert_x: Array[Float] is lazy do
+		var a = [offset_left,  offset_bottom]
+		var b = [offset_right, offset_bottom]
+		var c = [offset_left,  offset_top]
+		var d = [offset_right, offset_top]
+
+		var texture_coords = new Array[Float]
+		for v in [d, c, b, a] do texture_coords.add_all v
 		return texture_coords
 	end
 end

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -184,10 +184,14 @@ redef class App
 	end
 
 	# Draw the whole screen, all `glDraw...` calls should be executed here
-	protected fun frame_core_draw(display: GamnitDisplay) do frame_core_flat display
+	protected fun frame_core_draw(display: GamnitDisplay)
+	do
+		frame_core_world_sprites display
+		frame_core_ui_sprites display
+	end
 
-	# Draw sprites in `sprites` and `ui_sprites`
-	protected fun frame_core_flat(display: GamnitDisplay)
+	# Draw world sprites from `sprites`
+	protected fun frame_core_world_sprites(display: GamnitDisplay)
 	do
 		simple_2d_program.use
 
@@ -200,6 +204,17 @@ redef class App
 		# World sprites
 		simple_2d_program.mvp.uniform world_camera.mvp_matrix
 		for sprite in sprites do sprite.draw
+	end
+
+	# Draw UI sprites from `ui_sprites`
+	protected fun frame_core_ui_sprites(display: GamnitDisplay)
+	do
+		simple_2d_program.use
+
+		# Set constant configs
+		simple_2d_program.coord.array_enabled = true
+		simple_2d_program.tex_coord.array_enabled = true
+		simple_2d_program.color.array_enabled = false
 
 		# Reset only the depth buffer
 		glClear gl_DEPTH_BUFFER_BIT
@@ -227,7 +242,7 @@ redef class App
 		var display = display
 		assert display != null
 		glClear gl_COLOR_BUFFER_BIT
-		frame_core_flat display
+		frame_core_ui_sprites display
 		display.flip
 
 		ui_sprites.remove splash

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -128,7 +128,7 @@ redef class App
 	# UI sprites to draw in reference to `ui_camera`, over world `sprites`
 	var ui_sprites: Sequence[Sprite] = new List[Sprite]
 
-	private var clock = new Clock
+	private var clock = new Clock is lazy
 
 	redef fun on_create
 	do


### PR DESCRIPTION
Intro a few new features:
* `Sprite::tint` to tint the color of a sprite.
* `Sprite::invert_x` to draw a sprite with the X axis inverted.
* `App::static_program` a particle program to display simple static and long lived particles. Can be useful to display clouds.

Fix a few bugs:
* `svg_to_png_and_nit` generated invalid code for array of textures when the target was gamnit.
* `App::clock` was instantiated with `app`, this caused the first `dt` of `App::update` to be much larger than expected.
* Divide `frame_core_flat` in 2 to allow the depth framework to draw particles after the world sprites but before the UI sprites.