### PR TITLE
compiler: add a native implementation of NativeArray::memmove

### DIFF
--- a/lib/core/collection/array.nit
+++ b/lib/core/collection/array.nit
@@ -992,8 +992,7 @@ universal NativeArray[E]
 	fun copy_to(dest: NativeArray[E], length: Int) is intern
 
 	# Copy `length` items to `dest` starting from `dest`.
-	fun memmove(start: Int, length: Int, dest: NativeArray[E], dest_start: Int) do
-		# TODO native one
+	fun memmove(start: Int, length: Int, dest: NativeArray[E], dest_start: Int) is intern do
 		if start < dest_start then
 			var i = length
 			while i > 0 do

--- a/src/compiler/global_compiler.nit
+++ b/src/compiler/global_compiler.nit
@@ -396,6 +396,11 @@ class GlobalCompilerVisitor
 			var recv1 = "((struct {arguments[1].mcasttype.c_name}*){arguments[1]})->values"
 			self.add("memmove({recv1},{recv},{arguments[2]}*sizeof({elttype.ctype}));")
 			return true
+		else if pname == "memmove" then
+			# fun memmove(start: Int, length: Int, dest: NativeArray[E], dest_start: Int) is intern do
+			var recv1 = "((struct {arguments[3].mcasttype.c_name}*){arguments[3]})->values"
+			self.add("memmove({recv1}+{arguments[4]}, {recv}+{arguments[1]}, {arguments[2]}*sizeof({elttype.ctype}));")
+			return true
 		end
 		return false
 	end

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -2121,6 +2121,11 @@ class SeparateCompilerVisitor
 			var recv1 = "((struct instance_{nclass.c_name}*){arguments[1]})->values"
 			self.add("memmove({recv1}, {recv}, {arguments[2]}*sizeof({elttype.ctype}));")
 			return true
+		else if pname == "memmove" then
+			# fun memmove(start: Int, length: Int, dest: NativeArray[E], dest_start: Int) is intern do
+			var recv1 = "((struct instance_{nclass.c_name}*){arguments[3]})->values"
+			self.add("memmove({recv1}+{arguments[4]}, {recv}+{arguments[1]}, {arguments[2]}*sizeof({elttype.ctype}));")
+			return true
 		end
 		return false
 	end


### PR DESCRIPTION
This is a simple patch but it needed the regen of `c_src` for boostrap reason