### PR TITLE
Intro support for async HTTP requests and ListLayout for iOS

### DIFF
--- a/contrib/tnitter/Makefile
+++ b/contrib/tnitter/Makefile
@@ -10,6 +10,9 @@ bin/tnitter: $(shell ../../bin/nitls -M src/tnitter_app.nit)
 	mkdir -p bin/
 	../../bin/nitc -o bin/tnitter src/tnitter_app.nit -m linux -D tnitter_server_uri=http://$(SERVER)
 
+# ---
+# Android
+
 android: bin/tnitter.apk
 bin/tnitter.apk: $(shell ../../bin/nitls -M src/tnitter_app_android.nit) res/drawable-ldpi/icon.png
 	mkdir -p bin/
@@ -22,6 +25,21 @@ android-release: $(shell ../../bin/nitls -M src/tnitter_app_android.nit) res/dra
 res/drawable-ldpi/icon.png: art/icon.svg
 	mkdir -p res
 	../inkscape_tools/bin/svg_to_icons art/icon.svg --android --out res/
+
+# ---
+# iOS
+
+ios: bin/tnitter.app
+bin/tnitter.app: $(shell ../../bin/nitls -M src/tnitter_app.nit ios)
+	mkdir -p bin/
+	../../bin/nitc -o bin/tnitter.app src/tnitter_app.nit -m ios -D tnitter_server_uri=http://$(SERVER)
+
+ios-release: $(shell ../../bin/nitls -M src/tnitter_app.nit ios)
+	mkdir -p bin/
+	../../bin/nitc -o bin/tnitter.app src/tnitter_app.nit -m ios -D tnitter_server_uri=http://tnitter.xymus.net
+
+# ---
+# Misc
 
 clean:
 	rm -r res bin

--- a/lib/app/http_request.nit
+++ b/lib/app/http_request.nit
@@ -21,6 +21,7 @@ import json::serialization
 
 import linux::http_request is conditional(linux)
 import android::http_request is conditional(android)
+import ios::http_request is conditional(ios)
 
 redef class App
 	# Platform specific service to execute `task` on the main/UI thread

--- a/lib/cocoa/foundation.nit
+++ b/lib/cocoa/foundation.nit
@@ -53,3 +53,99 @@ redef class Text
 	# Get a `NSString` from `self`
 	fun to_nsstring: NSString do return to_cstring.to_nsstring(length)
 end
+
+# Wrapper of byte buffers
+extern class NSData in "ObjC" `{ NSData * `}
+
+	# Pointer to contained data
+	fun bytes: NativeString in "ObjC" `{ return (char*)self.bytes; `}
+
+	# Number of bytes containted in `self`
+	fun length: Int in "ObjC" `{ return self.length; `}
+
+	redef fun to_s do return bytes.to_s_with_length(length)
+end
+
+# Error condition
+extern class NSError in "ObjC" `{ NSError * `}
+
+	# Wraps: `[self initWithDomain:(NSString)domain code:(NSInteger)code userInfo:(NSDictionary)dict]`
+	#new init_with_domain_code_user_info(domain: NSString, code: Int, dict: NSDictionary) in "ObjC" `{
+	#	return [[NSError alloc] initWithDomain: domain code: code userInfo: dict];
+	#`}
+
+	# Wraps: `NSError.domain`
+	fun domain: NSString in "ObjC" `{
+		return [self domain];
+	`}
+
+	# Wraps: `NSError.code`
+	fun code: Int in "ObjC" `{
+		return [self code];
+	`}
+
+	# Wraps: `NSError.userInfo`
+	#fun user_info: NSDictionary in "ObjC" `{
+	#	return [self userInfo];
+	#`}
+
+	# Wraps: `NSError.localizedDescription`
+	fun localized_description: NSString in "ObjC" `{
+		return [self localizedDescription];
+	`}
+
+	# Wraps: `NSError.localizedFailureReason`
+	fun localized_failure_reason: NSString in "ObjC" `{
+		return [self localizedFailureReason];
+	`}
+
+	# Wraps: `NSError.localizedRecoverySuggestion`
+	fun localized_recovery_suggestion: NSString in "ObjC" `{
+		return [self localizedRecoverySuggestion];
+	`}
+
+	# Wraps: `NSError.localizedRecoveryOptions`
+	#fun localized_recovery_options: NSArray in "ObjC" `{
+	#	return [self localizedRecoveryOptions];
+	#`}
+
+	# Wraps: `NSError.recoveryAttempter`
+	fun recovery_attempter: NSObject in "ObjC" `{
+		return [self recoveryAttempter];
+	`}
+
+	# Wraps: `NSError.helpAnchor`
+	fun help_anchor: NSString in "ObjC" `{
+		return [self helpAnchor];
+	`}
+end
+
+# Path to a specific node in a tree of nested array collections
+extern class NSIndexPath in "ObjC" `{ NSIndexPath * `}
+	super NSObject
+
+	# Wraps: `[self initWithIndex:(NSUInteger)index]`
+	new init_with_index(index: Int) in "ObjC" `{
+		return [[NSIndexPath alloc] initWithIndex: index];
+	`}
+
+	# Wraps: `NSIndexPath.length`
+	fun length: Int in "ObjC" `{
+		return [self length];
+	`}
+
+	# Wraps: `[self indexPathByAddingIndex:(NSUInteger)index]`
+	fun index_path_by_adding_index(index: Int): NSIndexPath in "ObjC" `{
+		return [self indexPathByAddingIndex: index];
+	`}
+
+	# Wraps: `[self indexPathByRemovingLastIndex]`
+	fun index_path_by_removing_last_index: NSIndexPath in "ObjC" `{
+		return [self indexPathByRemovingLastIndex];
+	`}
+
+	# Wraps: `[self indexAtPosition:(NSUInteger)position]`
+	fun index_at_position(position: Int): Int in "ObjC" `{
+		return [self indexAtPosition: position];
+	`}
+end

--- a/lib/cocoa/foundation.nit
+++ b/lib/cocoa/foundation.nit
@@ -31,6 +31,9 @@ end
 extern class NSString in "ObjC" `{ NSString * `}
 	super NSObject
 
+	# Null pointer
+	new nil in "ObjC" `{ return nil; `}
+
 	# Get an UTF8 encoded `char*` copy of `self`
 	fun utf8_string: NativeString in "ObjC" `{ return (char *)[self UTF8String]; `}
 

--- a/lib/ios/http_request.nit
+++ b/lib/ios/http_request.nit
@@ -1,0 +1,70 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Implementation of `app::http_request` for iOS
+module http_request
+
+import ios
+import cocoa::foundation
+intrude import app::http_request
+
+redef class App
+	redef fun run_on_ui_thread(task) import Task.main in "ObjC" `{
+		Task_incr_ref(task);
+		dispatch_async(dispatch_get_main_queue(), ^{
+			Task_main(task);
+			Task_decr_ref(task);
+		});
+	`}
+end
+
+redef class Text
+	redef fun http_get
+	do
+		var error_ref = new Ref[NSString]("Unknown Error".to_nsstring)
+		var data = to_nsstring.native_http_get(60.0, error_ref)
+
+		if data.address_is_null then
+			# There was an error
+			var error = new IOError(error_ref.item.to_s)
+			return new HttpRequestResult(null, error)
+		else
+			# TODO use the real return code instead of 200
+			return new HttpRequestResult(data.to_s, null, 200)
+		end
+	end
+end
+
+redef class NSString
+	private fun native_http_get(timeout: Float, error_ref: Ref[NSString]): NSData
+	import Ref[NSString].item= in "ObjC" `{
+
+		NSURL *url = [NSURL URLWithString:self];
+		NSURLRequest *request = [NSURLRequest requestWithURL:url
+			cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:timeout];
+
+		NSURLResponse *response = nil;
+		NSError *error = nil;
+		NSData *data = [NSURLConnection sendSynchronousRequest:request
+			returningResponse:&response error:&error];
+
+		if (data == nil) {
+			// Report error
+			Ref_of_NSString_item__assign(error_ref, [error localizedDescription]);
+			return nil;
+		}
+
+		return data;
+	`}
+end

--- a/lib/ios/ui/uikit.nit
+++ b/lib/ios/ui/uikit.nit
@@ -527,3 +527,67 @@ extern class UIStackViewAlignment in "ObjC" `{ NSInteger `}
     new bottom in "ObjC" `{ return UIStackViewAlignmentBottom; `}
     new last_baseline in "ObjC" `{ return UIStackViewAlignmentLastBaseline; `}
 end
+
+# View to display and edit hierarchical lists of information
+extern class UITableView in "ObjC" `{ UITableView * `}
+	super UIView
+
+	# Wraps: `[self initWithFrame:(CGRect)frame style:(UITableViewStyle)style]`
+	new (style: UITableViewStyle) in "ObjC" `{
+		return [[UITableView alloc] initWithFrame: [[UIScreen mainScreen] bounds] style:style];
+	`}
+
+	# Wraps: `[self reloadData]`
+	fun reload_data in "ObjC" `{ [self reloadData]; `}
+
+	# Wraps: `self.autoresizingMask =`
+	fun autoresizing_mask in "ObjC" `{
+		self.autoresizingMask = UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth;
+	`}
+
+	# Wraps: `self.delegate =`
+	fun delegate=(delegate: UITableViewDelegate) in "ObjC" `{ self.delegate = delegate; `}
+
+	# Wraps: `self.dataSource =`
+	fun data_source=(source: UITableViewDataSource) in "ObjC" `{ self.dataSource = source; `}
+
+	# Wraps: `[self dequeueReusableCellWithIdentifier]`
+	fun dequeue_reusable_cell_with_identifier(identifier: NSString): UITableViewCell in "ObjC" `{
+		return [self dequeueReusableCellWithIdentifier:identifier];
+	`}
+end
+
+# Delegate for a `UITableView` to configure selection, sections, cells and more
+extern class UITableViewDelegate in "ObjC" `{ id<UITableViewDelegate> `}
+	super NSObject
+end
+
+# Mediator the data model for a `UITableView`
+extern class UITableViewDataSource in "ObjC" `{ id<UITableViewDataSource> `}
+	super NSObject
+end
+
+# Cell of a `UITableViewCell`
+extern class UITableViewCell in "ObjC" `{ UITableViewCell * `}
+	super NSObject
+
+	new (identifier: NSString) in "ObjC" `{
+		return [[UITableViewCell alloc]
+			initWithStyle:UITableViewCellStyleDefault
+			reuseIdentifier:identifier];
+	`}
+
+	# Wraps: `[self textLabel]`
+	fun text_label: UILabel in "ObjC" `{ return [self textLabel]; `}
+
+	# Wraps: `[self contentView]`
+	fun content_view: UIView in "ObjC" `{ return [self contentView]; `}
+end
+
+# Style of a `UITableView`
+extern class UITableViewStyle in "ObjC" `{ UITableViewStyle* `}
+	super NSObject
+
+	new plain in "ObjC" `{ return UITableViewStylePlain; `}
+	new grouped in "ObjC" `{ return UITableViewStyleGrouped; `}
+end

--- a/lib/pthreads/pthreads.nit
+++ b/lib/pthreads/pthreads.nit
@@ -36,7 +36,14 @@ in "C" `{
 	// TODO protect with: #ifdef WITH_LIBGC
 	// We might have to add the next line to gc_chooser.c too, especially
 	// if we get an error like "thread not registered with GC".
-	#ifndef ANDROID
+	#ifdef __APPLE__
+		#include "TargetConditionals.h"
+		#if TARGET_OS_IPHONE == 1
+			#define IOS
+		#endif
+	#endif
+
+	#if !defined(__ANDROID__) && !defined(IOS)
 		#define GC_THREADS
 		#include <gc.h>
 	#endif

--- a/src/platform/xcode_templates.nit
+++ b/src/platform/xcode_templates.nit
@@ -550,6 +550,11 @@ class PlistTemplate
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key><true/>
+	</dict>
 </dict>
 </plist>
 """


### PR DESCRIPTION
This PR completes the implementation app::UI for iOS by implementing `ListLayout` using a `UITableView`. It also introduces the implementation of `http_request` using services from the foundation framework. 

These features enable the Tnitter portable application to be compiled for iOS without modification.

The remaining API of app.nit still missing on IOS are `data_store`, `audio` and maybe `assets`.  At this point, only `data_store` is required for fully featured portable applications using the native UI.

---

As with #1942, some generated code has been commented so it can be reactivated when useful and when the needed types are also wrapped.