### PR TITLE
nitcorn: cache served files, custom JS for FileServer and do not depend on curl

### DIFF
--- a/lib/nitcorn/examples/src/nitcorn_reverse_proxy.nit
+++ b/lib/nitcorn/examples/src/nitcorn_reverse_proxy.nit
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a simple example of how to use a ProxyAction with Nitcorn
+# Minimal example using a `ProxyAction`
 
-import nitcorn
+import nitcorn::proxy
 
 # Create the virtualhost for your nitcorn server
 var vh = new VirtualHost("localhost:8080")

--- a/lib/nitcorn/file_server.nit
+++ b/lib/nitcorn/file_server.nit
@@ -65,6 +65,9 @@ class FileServer
 	# Header of each directory page
 	var header: nullable Writable = null is writable
 
+	# Custom JavaScript code added within a `<script>` block to each page
+	var javascript_header: nullable Writable = null is writable
+
 	redef fun answer(request, turi)
 	do
 		var response
@@ -129,6 +132,9 @@ class FileServer
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+	<script>
+		{{{javascript_header or else ""}}}
+	</script>
 	<title>{{{title}}}</title>
 </head>
 <body>

--- a/lib/nitcorn/file_server.nit
+++ b/lib/nitcorn/file_server.nit
@@ -68,6 +68,9 @@ class FileServer
 	# Custom JavaScript code added within a `<script>` block to each page
 	var javascript_header: nullable Writable = null is writable
 
+	# Caching attributes of served files, used as the `cache-control` field in response headers
+	var cache_control = "public, max-age=360" is writable
+
 	redef fun answer(request, turi)
 	do
 		var response
@@ -160,6 +163,9 @@ class FileServer
 							response.header["Content-Type"] = media_type
 						else response.header["Content-Type"] = "application/octet-stream"
 					end
+
+					# Cache control
+					response.header["cache-control"] = cache_control
 				end
 
 			else response = new HttpResponse(404)

--- a/lib/nitcorn/nitcorn.nit
+++ b/lib/nitcorn/nitcorn.nit
@@ -61,4 +61,3 @@ module nitcorn
 import reactor
 import file_server
 import sessions
-import proxy


### PR DESCRIPTION
This PR extends `FileServer` with caching of served files and custom JavaScript code for the header. The caching is set to 1h by default, but it can be customized.

Removing the default import of the `proxy` module with nitcorn, it depends on curl, and thus adds a (small) overhead to all nitcorn programs and need the library. This could be reverted when `proxy` is updated to use only libevent.