### PR TITLE
Revamp `Text::format`

### DIFF
--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -988,7 +988,7 @@ abstract class Text
 				var fmt_end = i
 				var ciph_len = fmt_end - ciph_st + 1
 
-				var arg_index = substring(ciph_st, ciph_len).to_i - 1
+				var arg_index = substring(ciph_st, ciph_len).to_i
 				if arg_index >= args.length then continue
 
 				s.push substring(curr_st, fmt_st - curr_st)

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -370,7 +370,7 @@ class FlatString
 
 	redef fun substring(from, count)
 	do
-		assert count >= 0
+		if count <= 0 then return ""
 
 		if from < 0 then
 			count += from

--- a/src/frontend/i18n_phase.nit
+++ b/src/frontend/i18n_phase.nit
@@ -146,7 +146,9 @@ redef class ASuperstringExpr
 		for i in n_exprs do
 			if i isa AStartStringExpr or i isa AEndStringExpr or i isa AMidStringExpr then
 				assert i isa AStringFormExpr
-				fmt += i.value.as(not null)
+				var str = i.value
+				assert str != null
+				fmt += str.replace("%", "%%")
 			else
 				fmt += "%"
 				exprs.push i

--- a/src/frontend/i18n_phase.nit
+++ b/src/frontend/i18n_phase.nit
@@ -150,7 +150,7 @@ redef class ASuperstringExpr
 			else
 				fmt += "%"
 				exprs.push i
-				fmt += exprs.length.to_s
+				fmt += (exprs.length-1).to_s
 			end
 		end
 		fmt = fmt.escape_to_gettext


### PR DESCRIPTION
Change the behavior of `Text::format` so it uses an index from 0 (instead of 1), and the escape sequence to a double percentage sign (ex, `%%4` to get `%4`). Also, now `format` ignores `%` that are not followed by a number.

There were problems with the previous escape sequence (using `\%`):
1. In literal strings, the `\` itself has to be escaped, so a whole escaped sequence look like `\\%4`.
2. The extra `\\` were not removed from the resulting string, so it was still impossible to produce a `%4` because `\\%4` resulted in `\\%4`.

These changes were prompted by an error in the code generated the i18n phase on a lone `%` not related to the `format` method. Also, the index beginning at 1 were always confusing to me, it was a different behavior than `Array` and other 

@R4PaSs I would like your opinion on this.