### PR TITLE
Minor fix to atan2 and triangulate

### DIFF
--- a/lib/core/math.nit
+++ b/lib/core/math.nit
@@ -524,11 +524,11 @@ redef class Sys
 	end
 end
 
-# Computes the arc tangent given `x` and `y`.
+# Computes the arc tangent given `y` and `x`.
 #
 #     assert atan2(-0.0, 1.0) == -0.0
 #     assert atan2(0.0, 1.0) == 0.0
-fun atan2(x: Float, y: Float): Float `{ return atan2(x, y); `}
+fun atan2(y: Float, x: Float): Float `{ return atan2(y, x); `}
 
 # Approximate value of **pi**.
 fun pi: Float do return 3.14159265

--- a/lib/geometry/polygon.nit
+++ b/lib/geometry/polygon.nit
@@ -444,7 +444,6 @@ end
 # Useful for converting a concave polygon into multiple convex ones
 fun triangulate(pts: Array[Point[Float]], results: Array[ConvexPolygon]) do
 	var poly = new Polygon(pts)
-	poly.sort_ccw
 	pts = poly.points
 	recursive_triangulate(pts, results)
 end


### PR DESCRIPTION
Fix reversed axes in `atan2`, but since it is actually just a change in the name of the variables (and doc) it should not break the clients.

Also sorting points of a polygon in `triangulate` completely invalidated some complex polygons.