### PR TITLE
core/list: fix `List::clear` so it resets `length` to 0

### DIFF
--- a/lib/core/collection/list.nit
+++ b/lib/core/collection/list.nit
@@ -186,6 +186,7 @@ class List[E]
 	do
 		_head = null
 		_tail = null
+		length = 0
 	end
 
 


### PR DESCRIPTION
This bug lead to segmentation faults when iterating over the items of a list after a call to `clear`.