### PR TITLE
lib/markdown: improve performance a bit

### DIFF
--- a/benchmarks/markdown/engines/nitmd/nitmd.nit
+++ b/benchmarks/markdown/engines/nitmd/nitmd.nit
@@ -19,6 +19,7 @@ var n = args[1].to_i
 
 var str = file.to_path.read_all
 var parser = new MarkdownProcessor
+parser.no_location = true
 for i in [1..n] do
 	print parser.process(str)
 end

--- a/lib/markdown/markdown.nit
+++ b/lib/markdown/markdown.nit
@@ -2332,18 +2332,11 @@ redef class Text
 			if c == '\\' and pos + 1 < length then
 				pos = escape(out, self[pos + 1], pos)
 			else
-				var end_reached = false
-				for n in nend do
-					if c == n then
-						end_reached = true
-						break
-					end
-				end
-				if end_reached then break
+				for n in nend do if c == n then break label
 				out.add c
 			end
 			pos += 1
-		end
+		end label
 		if pos == length then return -1
 		return pos
 	end

--- a/lib/markdown/markdown.nit
+++ b/lib/markdown/markdown.nit
@@ -610,10 +610,12 @@ class MarkdownEmitter
 	end
 
 	# Append `c` to current buffer.
-	fun addc(c: Char) do add c.to_s
+	fun addc(c: Char) do
+		current_buffer.add c
+	end
 
 	# Append a "\n" line break.
-	fun addn do add "\n"
+	fun addn do addc '\n'
 end
 
 # A Link Reference.

--- a/lib/markdown/markdown.nit
+++ b/lib/markdown/markdown.nit
@@ -133,6 +133,14 @@ class MarkdownProcessor
 	# ~~~
 	var ext_mode = true
 
+	# Disable attaching MDLocation to Tokens
+	#
+	# Locations are useful for some tools but they may
+	# cause an important time and space overhead.
+	#
+	# Default = `false`
+	var no_location = false is writable
+
 	init do self.emitter = new MarkdownEmitter(self)
 
 	# Process the mardown `input` string and return the processed output.
@@ -397,11 +405,16 @@ class MarkdownProcessor
 			c2 = ' '
 		end
 
-		var loc = new MDLocation(
-			current_loc.line_start,
-			current_loc.column_start + pos,
-			current_loc.line_start,
-			current_loc.column_start + pos)
+		var loc
+		if no_location then
+			loc = null
+		else
+			loc = new MDLocation(
+				current_loc.line_start,
+				current_loc.column_start + pos,
+				current_loc.line_start,
+				current_loc.column_start + pos)
+		end
 
 		if c == '*' then
 			if c1 == '*' then
@@ -1940,7 +1953,7 @@ end
 abstract class Token
 
 	# Location of `self` in the original input.
-	var location: MDLocation
+	var location: nullable MDLocation
 
 	# Position of `self` in input independant from lines.
 	var pos: Int

--- a/lib/markdown/test_markdown.nit
+++ b/lib/markdown/test_markdown.nit
@@ -2830,7 +2830,7 @@ class TestTokenProcessor
 	redef fun token_at(input, pos) do
 		var token = super
 		if token isa TokenNone then return token
-		var res = "{token.class_name} at {token.location}"
+		var res = "{token.class_name} at {token.location or else "?"}"
 		var exp = test_stack.shift
 		print ""
 		print "EXP {exp}"


### PR DESCRIPTION
Using benchmarks/markdown:

* nitmd_master is before
* nitmd_md is this now
* nitmd_md_fast is with #1973 in addition
* the 3 same avain with with --semi-global
* 2 Java libs: txtmark, markdown4j

![bench_markdown](https://cloud.githubusercontent.com/assets/135828/13517453/b008a7fe-e191-11e5-80c8-d17cd85df6be.png)


There is still a lot of performance improvements to do anyway. 