### PR TITLE
Faster text get

### DIFF
--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -1250,6 +1250,10 @@ redef class NativeString
 	#
 	# Very unsafe, make sure to have room for this char prior to calling this function.
 	private fun set_char_at(pos: Int, c: Char) do
+		if c.code_point < 128 then
+			self[pos] = c.code_point.to_b
+			return
+		end
 		var ln = c.u8char_len
 		native_set_char(pos, c, ln)
 	end

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -52,6 +52,7 @@ redef class FlatText
 	fun char_to_byte_index(index: Int): Int do
 		var dpos = index - _position
 		var b = _bytepos
+		var its = _items
 
 		if dpos == 0 then return b
 		if dpos == 1 then
@@ -61,7 +62,7 @@ redef class FlatText
 			return b
 		end
 		if dpos == -1 then
-			b = _items.find_beginning_of_char_at(b - 1)
+			b = its.find_beginning_of_char_at(b - 1)
 			_bytepos = b
 			_position = index
 			return b
@@ -74,7 +75,6 @@ redef class FlatText
 		var delta_end = (ln - 1) - index
 		var delta_cache = (pos - index).abs
 		var min = delta_begin
-		var its = _items
 
 		if delta_cache < min then min = delta_cache
 		if delta_end < min then min = delta_end

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -55,7 +55,11 @@ redef class FlatText
 		var its = _items
 
 		if dpos == 1 then
-			b += _items.length_of_char_at(b)
+			if its[b] & 0x80u8 == 0x00u8 then
+				b += 1
+			else
+				b += its.length_of_char_at(b)
+			end
 			_bytepos = b
 			_position = index
 			return b

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -296,7 +296,49 @@ redef class FlatText
 	end
 
 	redef fun [](index) do
-		assert index >= 0 and index < _length
+		var len = _length
+
+		# Statistically:
+		# * ~70% want the next char
+		# * ~23% want the previous
+		# * ~7% want the same char
+		#
+		# So it makes sense to shortcut early. And early is here.
+		var dpos = index - _position
+		var b = _bytepos
+		if dpos == 1 and index < len - 1 then
+			var its = _items
+			var c = its[b]
+			if c & 0x80u8 == 0x00u8 then
+				# We want the next, and current is easy.
+				# So next is easy to find!
+				b += 1
+				_position = index
+				_bytepos = b
+				# The rest will be done by `dpos==0` bellow.
+				dpos = 0
+			end
+		else if dpos == -1 and index > 1 then
+			var its = _items
+			var c = its[b-1]
+			if c & 0x80u8 == 0x00u8 then
+				# We want the previous, and it is easy.
+				b -= 1
+				dpos = 0
+				_position = index
+				_bytepos = b
+				return c.ascii
+			end
+		end
+		if dpos == 0 then
+			# We know what we want (+0 or +1) just get it now!
+			var its = _items
+			var c = its[b]
+			if c & 0x80u8 == 0x00u8 then return c.ascii
+			return items.char_at(b)
+		end
+
+		assert index >= 0 and index < len
 		return fetch_char_at(index)
 	end
 

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -54,7 +54,6 @@ redef class FlatText
 		var b = _bytepos
 		var its = _items
 
-		if dpos == 0 then return b
 		if dpos == 1 then
 			b += _items.length_of_char_at(b)
 			_bytepos = b
@@ -67,6 +66,7 @@ redef class FlatText
 			_position = index
 			return b
 		end
+		if dpos == 0 then return b
 
 		var ln = _length
 		var pos = _position

--- a/tests/sav/nitcg/test_text_stat.res
+++ b/tests/sav/nitcg/test_text_stat.res
@@ -9,37 +9,37 @@ Allocations, by type:
 	-RopeBuffer = 0
 
 Calls to length, by type:
-	FlatString = 23 (cache misses 5, 21.73%)
+	FlatString = 18 (cache misses 5, 27.77%)
 Indexed accesses, by type:
-	FlatString = 13
+	FlatString = 8
 Calls to bytelen for each type:
 	FlatString = 61
 Calls to position for each type:
-	FlatString = 27
+	FlatString = 17
 Calls to bytepos for each type:
-	FlatString = 14
-Calls to first_byte on FlatString 216
+	FlatString = 9
+Calls to first_byte on FlatString 191
 Calls to last_byte on FlatString 19
 FlatStrings allocated with length 78 (86.813%)
 Length of travel for index distribution:
-* null = 16 => occurences 80.0%, cumulative 80.0% 
-* 1 = 14 => occurences 35.0%, cumulative 75.0% 
+* null = 11 => occurences 73.333%, cumulative 73.333% 
+* 1 = 8 => occurences 27.586%, cumulative 65.517% 
 Byte length of the FlatStrings created:
 * null = 6 => occurences 4.444%, cumulative 4.444% 
-* 1 = 21 => occurences 14.094%, cumulative 18.121% 
-* 2 = 33 => occurences 20.245%, cumulative 36.81% 
+* 1 = 24 => occurences 16.107%, cumulative 20.134% 
+* 2 = 30 => occurences 18.405%, cumulative 36.81% 
 * 3 = 29 => occurences 16.292%, cumulative 50.0% 
-* 4 = 9 => occurences 4.663%, cumulative 50.777% 
-* 5 = 20 => occurences 9.615%, cumulative 56.731% 
-* 6 = 21 => occurences 9.417%, cumulative 62.332% 
+* 4 = 5 => occurences 2.591%, cumulative 48.705% 
+* 5 = 20 => occurences 9.615%, cumulative 54.808% 
+* 6 = 25 => occurences 11.211%, cumulative 62.332% 
 * 9 = 1 => occurences 0.42%, cumulative 58.824% 
 * 10 = 9 => occurences 3.557%, cumulative 58.893% 
 * 11 = 2 => occurences 0.746%, cumulative 56.343% 
 * 12 = 1 => occurences 0.355%, cumulative 53.901% 
 * 13 = 1 => occurences 0.339%, cumulative 51.864% 
 * 14 = 1 => occurences 0.325%, cumulative 50.0% 
-* 15 = 5 => occurences 1.558%, cumulative 49.533% 
-* 16 = 7 => occurences 2.083%, cumulative 49.405% 
+* 15 = 7 => occurences 2.181%, cumulative 50.156% 
+* 16 = 5 => occurences 1.488%, cumulative 49.405% 
 * 17 = 1 => occurences 0.285%, cumulative 47.578% 
 * 25 = 2 => occurences 0.549%, cumulative 46.429% 
 * 26 = 1 => occurences 0.265%, cumulative 44.974% 
@@ -53,5 +53,5 @@ Byte length of the FlatStrings created:
 * 40 = 1 => occurences 0.207%, cumulative 37.19% 
 * 43 = 1 => occurences 0.201%, cumulative 36.419% 
 * 46 = 1 => occurences 0.196%, cumulative 35.686% 
-* 48 = 1 => occurences 0.191%, cumulative 34.99% 
-* 51 = 21 => occurences 3.918%, cumulative 38.06% 
+* 51 = 20 => occurences 3.824%, cumulative 38.623% 
+* 55 = 1 => occurences 0.186%, cumulative 37.732% 

--- a/tests/sav/test_text_stat.res
+++ b/tests/sav/test_text_stat.res
@@ -9,48 +9,49 @@ Allocations, by type:
 	-RopeBuffer = 0
 
 Calls to length, by type:
-	FlatString = 23 (cache misses 5, 21.73%)
+	FlatString = 18 (cache misses 5, 27.77%)
 Indexed accesses, by type:
-	FlatString = 13
+	FlatString = 8
 Calls to bytelen for each type:
 	FlatString = 61
 Calls to position for each type:
-	FlatString = 27
+	FlatString = 17
 Calls to bytepos for each type:
-	FlatString = 14
-Calls to first_byte on FlatString 216
+	FlatString = 9
+Calls to first_byte on FlatString 191
 Calls to last_byte on FlatString 19
 FlatStrings allocated with length 78 (86.813%)
 Length of travel for index distribution:
-* 0 = 16 => occurences 80.0%, cumulative 80.0% 
-* 1 = 14 => occurences 35.0%, cumulative 75.0% 
+* 0 = 11 => occurences 73.333%, cumulative 73.333% 
+* 1 = 8 => occurences 27.586%, cumulative 65.517% 
 Byte length of the FlatStrings created:
 * 0 = 6 => occurences 4.478%, cumulative 4.478% 
-* 1 = 21 => occurences 14.189%, cumulative 18.243% 
-* 2 = 33 => occurences 20.37%, cumulative 37.037% 
+* 1 = 24 => occurences 16.216%, cumulative 20.27% 
+* 2 = 30 => occurences 18.519%, cumulative 37.037% 
 * 3 = 29 => occurences 16.384%, cumulative 50.282% 
-* 4 = 7 => occurences 3.646%, cumulative 50.0% 
-* 5 = 20 => occurences 9.662%, cumulative 56.039% 
-* 6 = 21 => occurences 9.459%, cumulative 61.712% 
-* 9 = 1 => occurences 0.422%, cumulative 58.228% 
-* 10 = 9 => occurences 3.571%, cumulative 58.333% 
-* 11 = 2 => occurences 0.749%, cumulative 55.805% 
-* 12 = 1 => occurences 0.356%, cumulative 53.381% 
-* 13 = 1 => occurences 0.34%, cumulative 51.361% 
-* 14 = 1 => occurences 0.326%, cumulative 49.511% 
-* 15 = 5 => occurences 1.563%, cumulative 49.063% 
-* 16 = 7 => occurences 2.09%, cumulative 48.955% 
-* 17 = 1 => occurences 0.286%, cumulative 47.143% 
-* 25 = 2 => occurences 0.551%, cumulative 46.006% 
-* 26 = 1 => occurences 0.265%, cumulative 44.562% 
-* 31 = 2 => occurences 0.513%, cumulative 43.59% 
-* 32 = 1 => occurences 0.248%, cumulative 42.327% 
-* 33 = 1 => occurences 0.24%, cumulative 41.247% 
-* 34 = 2 => occurences 0.465%, cumulative 40.465% 
-* 35 = 1 => occurences 0.225%, cumulative 39.414% 
-* 37 = 1 => occurences 0.219%, cumulative 38.512% 
-* 39 = 1 => occurences 0.213%, cumulative 37.66% 
-* 40 = 1 => occurences 0.207%, cumulative 36.853% 
-* 43 = 1 => occurences 0.202%, cumulative 36.089% 
-* 46 = 1 => occurences 0.196%, cumulative 35.363% 
-* 48 = 3 => occurences 0.575%, cumulative 35.057% 
+* 4 = 3 => occurences 1.563%, cumulative 47.917% 
+* 5 = 20 => occurences 9.662%, cumulative 54.106% 
+* 6 = 26 => occurences 11.712%, cumulative 62.162% 
+* 9 = 1 => occurences 0.422%, cumulative 58.65% 
+* 10 = 9 => occurences 3.571%, cumulative 58.73% 
+* 11 = 2 => occurences 0.749%, cumulative 56.18% 
+* 12 = 1 => occurences 0.356%, cumulative 53.737% 
+* 13 = 1 => occurences 0.34%, cumulative 51.701% 
+* 14 = 1 => occurences 0.326%, cumulative 49.837% 
+* 15 = 7 => occurences 2.188%, cumulative 50.0% 
+* 16 = 5 => occurences 1.493%, cumulative 49.254% 
+* 17 = 1 => occurences 0.286%, cumulative 47.429% 
+* 25 = 2 => occurences 0.551%, cumulative 46.281% 
+* 26 = 1 => occurences 0.265%, cumulative 44.828% 
+* 31 = 2 => occurences 0.513%, cumulative 43.846% 
+* 32 = 1 => occurences 0.248%, cumulative 42.574% 
+* 33 = 1 => occurences 0.24%, cumulative 41.487% 
+* 34 = 2 => occurences 0.465%, cumulative 40.698% 
+* 35 = 1 => occurences 0.225%, cumulative 39.64% 
+* 37 = 1 => occurences 0.219%, cumulative 38.731% 
+* 39 = 1 => occurences 0.213%, cumulative 37.872% 
+* 40 = 1 => occurences 0.207%, cumulative 37.06% 
+* 43 = 1 => occurences 0.202%, cumulative 36.29% 
+* 46 = 1 => occurences 0.196%, cumulative 35.56% 
+* 51 = 14 => occurences 2.682%, cumulative 37.356% 
+* 52 = 5 => occurences 0.931%, cumulative 37.244% 


### PR DESCRIPTION
Try to improve the efficiency of the FlatText[] method by shortcuting some common and easy cases.

using benchmarks/json:

![bench_json](https://cloud.githubusercontent.com/assets/135828/13518437/bc07c954-e19b-11e5-9ddf-8f69307fcd0a.png)



Ping @R4PaSs for review