### PR TITLE
Interpreter FFI: custom compile_dir, use /tmp/ by default, and delete after execution

### DIFF
--- a/lib/core/file.nit
+++ b/lib/core/file.nit
@@ -1145,11 +1145,16 @@ redef class String
 
 	# Create a directory (and all intermediate directories if needed)
 	#
+	# The optional `mode` parameter specifies the permissions of the directory,
+	# the default value is `0o777`.
+	#
 	# Return an error object in case of error.
 	#
 	#    assert "/etc/".mkdir != null
-	fun mkdir: nullable Error
+	fun mkdir(mode: nullable Int): nullable Error
 	do
+		mode = mode or else 0o777
+
 		var dirs = self.split_with("/")
 		var path = new FlatBuffer
 		if dirs.is_empty then return null
@@ -1162,7 +1167,7 @@ redef class String
 			if d.is_empty then continue
 			path.append(d)
 			path.add('/')
-			var res = path.to_s.to_cstring.file_mkdir
+			var res = path.to_s.to_cstring.file_mkdir(mode)
 			if not res and error == null then
 				error = new IOError("Cannot create directory `{path}`: {sys.errno.strerror}")
 			end
@@ -1326,7 +1331,7 @@ redef class NativeString
 		return stat_element;
 	`}
 
-	private fun file_mkdir: Bool `{ return !mkdir(self, 0777); `}
+	private fun file_mkdir(mode: Int): Bool `{ return !mkdir(self, mode); `}
 
 	private fun rmdir: Bool `{ return !rmdir(self); `}
 

--- a/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
+++ b/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
@@ -54,6 +54,15 @@ redef class AMethPropdef
 end
 
 redef class NaiveInterpreter
+	redef fun start(mainmodule)
+	do
+		super
+
+		# Delete temporary files
+		var compile_dir = compile_dir
+		if compile_dir.file_exists then compile_dir.rmdir
+	end
+
 	# Where to store generated C and extracted code
 	private var compile_dir: String is lazy do
 		# Prioritize the user supplied directory

--- a/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
+++ b/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
@@ -99,7 +99,7 @@ redef class AModule
 		var compile_dir = v.compile_dir
 		var foreign_code_lib_path = v.foreign_code_lib_path(mmodule)
 
-		if not compile_dir.file_exists then compile_dir.mkdir
+		if not compile_dir.file_exists then compile_dir.mkdir(0o700)
 
 		# Compile the common FFI part
 		ensure_compile_ffi_wrapper


### PR DESCRIPTION
Generate native files in the `/tmp/` directory and delete them after execution. The directory can be customized using `--compile-dir`.

This should fix #1974 and #1975.

To support some other OS, we will need to use something other than `getpid` and `/tmp/`. We could also improve upon this by reusing the generated libraries between executions.