### PR TITLE
app.nit UI: Intro an attribute to toggle password entry on TextFields

### DIFF
--- a/lib/android/ui/ui.nit
+++ b/lib/android/ui/ui.nit
@@ -169,6 +169,26 @@ end
 redef class TextInput
 	redef type NATIVE: NativeEditText
 	redef var native = (new NativeEditText(app.native_activity)).new_global_ref
+
+	redef fun is_password=(value)
+	do
+		native.is_password = value or else false
+		super
+	end
+end
+
+redef class NativeEditText
+
+	# Configure this view to hide passwords
+	fun is_password=(value: Bool) in "Java" `{
+		if (value) {
+			self.setInputType(android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD);
+			self.setTransformationMethod(android.text.method.PasswordTransformationMethod.getInstance());
+		} else {
+			self.setInputType(android.text.InputType.TYPE_CLASS_TEXT);
+			self.setTransformationMethod(null);
+		}
+	`}
 end
 
 redef class Button

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -163,6 +163,9 @@ end
 # A control for the user to enter custom `text`
 class TextInput
 	super TextView
+
+	# Hide password or any content entered in this view?
+	var is_password: nullable Bool is writable
 end
 
 # A pushable button, raises `ButtonPressEvent`

--- a/lib/ios/ui/ui.nit
+++ b/lib/ios/ui/ui.nit
@@ -210,6 +210,12 @@ redef class TextInput
 
 	redef fun text=(text) do native.text = (text or else "").to_nsstring
 	redef fun text do return native.text.to_s
+
+	redef fun is_password=(value)
+	do
+		native.secure_text_entry = value or else false
+		super
+	end
 end
 
 redef class Button

--- a/lib/ios/ui/uikit.nit
+++ b/lib/ios/ui/uikit.nit
@@ -430,6 +430,11 @@ extern class UITextField in "ObjC" `{ UITextField * `}
 	fun text=(text: NSString) in "ObjC" `{
 		self.text = text;
 	`}
+
+	# Wraps: `UITextField.secureTextEntry`
+	fun secure_text_entry=(value: Bool) in "ObjC" `{
+		self.secureTextEntry = value;
+	`}
 end
 
 # Lays out a collection of views in either a column or a row

--- a/lib/linux/ui.nit
+++ b/lib/linux/ui.nit
@@ -158,4 +158,10 @@ redef class TextInput
 		if value == null then value = ""
 		native.text = value.to_s
 	end
+
+	redef fun is_password=(value)
+	do
+		native.visibility = value != true
+		super
+	end
 end


### PR DESCRIPTION
The attribute `TextField::is_password` toggles hiding the content of the field using platform specific services. So on Android, not only is the text hidden but it also notifies the soft keyboard to behave accordingly.

In the future, we could add alternative modes for email entry and more.