### PR TITLE
Android service support: reliably run Nit code in the background

### DIFF
--- a/lib/android/assets_and_resources.nit
+++ b/lib/android/assets_and_resources.nit
@@ -121,7 +121,7 @@ end
 class AssetManager
 
 	# Native asset manager
-	private var native_assets_manager: NativeAssetManager = app.native_activity.assets.new_global_ref is lazy
+	private var native_assets_manager: NativeAssetManager = app.native_context.assets.new_global_ref is lazy
 
 	# Close this asset manager
 	fun close do native_assets_manager.close
@@ -400,8 +400,8 @@ end
 redef class App
 	# Resource Manager used to manage resources placed in the `res` folder of the app
 	var resource_manager: ResourcesManager is lazy do
-		var res = native_activity.resources
-		var pkg = native_activity.package_name
+		var res = native_context.resources
+		var pkg = native_context.package_name
 		return new ResourcesManager.native(res, pkg.to_s)
 	end
 
@@ -409,7 +409,7 @@ redef class App
 	var asset_manager: AssetManager is lazy do return new AssetManager
 end
 
-redef extern class NativeActivity
+redef extern class NativeContext
 
 	# Get the native AssetsManager of the application, used to initialize the nit's AssetManager
 	private fun assets: NativeAssetManager in "Java" `{

--- a/lib/android/http_request.nit
+++ b/lib/android/http_request.nit
@@ -30,7 +30,15 @@ in "Java" `{
 `}
 
 redef class App
-	redef fun run_on_ui_thread(task) do app.native_activity.run_on_ui_thread task
+	redef fun run_on_ui_thread(task)
+	do
+		if app.activities.not_empty then
+			app.native_activity.run_on_ui_thread task
+		else
+			# There is no UI, it must be a service, run on the caller thread
+			task.main
+		end
+	end
 end
 
 redef class Text

--- a/lib/android/intent/intent_api10.nit
+++ b/lib/android/intent/intent_api10.nit
@@ -1305,7 +1305,7 @@ class Intent
 	redef fun to_s do return intent.to_native_s.to_s
 end
 
-redef extern class NativeActivity
+redef extern class NativeContext
 	private fun start_activity(intent: NativeIntent) in "Java" `{ self.startActivity(intent); `}
 	private fun start_service(intent: NativeIntent) in "Java" `{ self.startService(intent); `}
 	private fun stop_service(intent: NativeIntent) in "Java" `{ self.stopService(intent); `}
@@ -1331,11 +1331,11 @@ end
 redef class App
 
 	# Execute the intent and launch the appropriate application
-	fun start_activity(intent: Intent) do native_activity.start_activity(intent.intent)
+	fun start_activity(intent: Intent) do native_context.start_activity(intent.intent)
 
 	# Start a service that will be running until the `stop_service` call
-	fun start_service(intent: Intent) do native_activity.start_service(intent.intent)
+	fun start_service(intent: Intent) do native_context.start_service(intent.intent)
 
 	# Stop service
-	fun stop_service(intent: Intent) do native_activity.stop_service(intent.intent)
+	fun stop_service(intent: Intent) do native_context.stop_service(intent.intent)
 end

--- a/lib/android/notification/notification.nit
+++ b/lib/android/notification/notification.nit
@@ -109,7 +109,7 @@ class Notification
 		if id != null then
 			sys.jni_env.push_local_frame(8)
 
-			var manager = app.native_activity.notification_manager
+			var manager = app.native_context.notification_manager
 			manager.cancel(tag.to_java_string, id)
 
 			self.id = null

--- a/lib/android/service/NitBroadcastReceiver.java
+++ b/lib/android/service/NitBroadcastReceiver.java
@@ -1,0 +1,29 @@
+/* This file is part of NIT ( http://www.nitlanguage.org ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nit.app;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+// BroadcastReceiver launching NitService
+public class NitBroadcastReceiver extends BroadcastReceiver {
+
+	@Override
+	public void onReceive(Context context, Intent intent) {
+		context.startService(new Intent(context, NitService.class));
+	}
+}

--- a/lib/android/service/NitService.java
+++ b/lib/android/service/NitService.java
@@ -1,0 +1,58 @@
+/* This file is part of NIT ( http://www.nitlanguage.org ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nit.app;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+// Service implemented in Nit
+public class NitService extends Service {
+
+	protected int nitService = 0;
+
+	static {
+		System.loadLibrary("main");
+	}
+
+	@Override
+	public int onStartCommand(Intent intent, int flags, int id) {
+		return nitOnStartCommand(nitService, intent, flags, id);
+	}
+
+	@Override
+	public void onCreate() {
+		nitService = nitNewService();
+		nitOnCreate(nitService);
+		super.onCreate();
+	}
+
+	@Override
+	public void onDestroy() {
+		nitOnDestroy(nitService);
+		super.onDestroy();
+	}
+
+	@Override
+	public IBinder onBind(Intent arg) {
+		return null;
+	}
+
+	protected native int nitNewService();
+	protected native int nitOnStartCommand(int nitService, Intent intent, int flags, int id);
+	protected native void nitOnCreate(int nitService);
+	protected native void nitOnDestroy(int nitService);
+}

--- a/lib/android/service/at_boot.nit
+++ b/lib/android/service/at_boot.nit
@@ -1,0 +1,30 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Import this module to launch `Service` at device boot
+module at_boot is
+	extra_java_files "NitBroadcastReceiver.java"
+	android_manifest """
+<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+"""
+	android_manifest_application """
+<receiver android:name="nit.app.NitBroadcastReceiver">
+	<intent-filter>
+		<action android:name="android.intent.action.BOOT_COMPLETED" />
+	</intent-filter>
+</receiver>
+"""
+end
+
+import service

--- a/lib/android/service/service.nit
+++ b/lib/android/service/service.nit
@@ -1,0 +1,159 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Android service support for _app.nit_ centered around the class `Service`
+module service is
+	extra_java_files "NitService.java"
+	android_manifest_application """<service android:name="nit.app.NitService"></service>"""
+end
+
+import android::nit_activity
+
+in "C" `{
+	// Nit's App running instance, declared in `nit_activity`
+	extern App global_app;
+
+	JNIEXPORT jint JNICALL Java_nit_app_NitService_nitNewService
+		(JNIEnv *env, jobject java_service)
+	{
+		// Pin a ref to the Java service in the Java GC
+		java_service = (*env)->NewGlobalRef(env, java_service);
+
+		// Create the service in Nit and pin it in the Nit GC
+		Service nit_service = App_register_service(global_app, java_service);
+
+		// FIXME replace the previous call to register_service by
+		// the following line when #1941 is fixed:
+		//Service nit_service = new_Service(java_service);
+
+		Service_incr_ref(nit_service);
+
+		return (jint)(void*)nit_service;
+	}
+
+	JNIEXPORT jint JNICALL Java_nit_app_NitService_nitOnStartCommand
+		(JNIEnv *env, jobject java_service, jint nit_service, jobject intent, jint flags, jint id)
+	{
+		return Service_on_start_command((Service)nit_service, intent, flags, id);
+	}
+
+	JNIEXPORT void JNICALL Java_nit_app_NitService_nitOnCreate
+		(JNIEnv *env, jobject java_service, jint nit_service)
+	{
+		Service_on_create((Service)nit_service);
+	}
+
+	JNIEXPORT void JNICALL Java_nit_app_NitService_nitOnDestroy
+		(JNIEnv *env, jobject java_service, jint nit_service)
+	{
+		Service_on_destroy((Service)nit_service);
+
+		// Unpin the service instances in both Nit and Java
+		java_service = Service_native((Service)nit_service);
+		(*env)->DeleteGlobalRef(env, java_service);
+		Service_decr_ref(nit_service);
+	}
+`}
+
+redef class App
+
+	# Current instance of `Service`, if any
+	var service: nullable Service = null
+
+	# Launch `Service` in the background, it will be set as `service` when ready
+	fun start_service do native_context.start_service
+
+	# Register a service from Java/C
+	#
+	# FIXME remove when #1941 is fixed
+	private fun register_service(java_service: NativeService): Service
+	do
+		return new Service(java_service.new_global_ref)
+	end
+
+	# Prioritize an activity context if one is running, fallback on a service
+	redef fun native_context
+	do
+		if activities.not_empty then return super
+
+		var service = service
+		assert service != null
+		return service.native
+	end
+
+	# Dummy method to force the compilation of callbacks from C
+	#
+	# The callbacks are used in the launch of a Nit service from C code.
+	private fun force_service_callbacks_in_c import Service, register_service,
+		Service.on_start_command, Service.on_create, Service.on_destroy, Service.native `{ `}
+
+	redef fun setup
+	do
+		super
+
+		# Call the dummy method to force their compilation in global compilation
+		force_service_callbacks_in_c
+	end
+end
+
+# Android service with its life-cycle callbacks
+class Service
+	# Java service with the Android context of this service
+	var native: NativeService
+
+	# The service has been created
+	fun on_create do app.service = self
+
+	# The service received a start command (may happen more then once per service)
+	#
+	# Should return either `start_sticky`, `start_not_sticky` or `start_redeliver_intent`.
+	fun on_start_command(intent: JavaObject, flags, id: Int): Int do return start_sticky
+
+	# The service is being destroyed
+	fun on_destroy do app.service = null
+end
+
+# Wrapper of Java class `android.app.Service`
+extern class NativeService in "Java" `{ android.app.Service `}
+	super NativeContext
+
+	redef fun new_global_ref import sys, Sys.jni_env `{
+		Sys sys = NativeService_sys(self);
+		JNIEnv *env = Sys_jni_env(sys);
+		return (*env)->NewGlobalRef(env, self);
+	`}
+end
+
+redef class NativeContext
+	private fun start_service in "Java" `{
+		android.content.Intent indent =
+			new android.content.Intent(self, nit.app.NitService.class);
+		self.startService(intent);
+	`}
+end
+
+# The service is explicitly started and stopped, it is restarted if stopped by the system
+#
+# Return value of `Service::on_start_command`.
+fun start_sticky: Int in "Java" `{ return android.app.Service.START_STICKY; `}
+
+# The service may be stopped by the system and will not be restarted
+#
+# Return value of `Service::on_start_command`.
+fun start_not_sticky: Int in "Java" `{ return android.app.Service.START_NOT_STICKY; `}
+
+# The service is explicitly started and stopped, it is restarted with the last intent if stopped by the system
+#
+# Return value of `Service::on_start_command`.
+fun start_redeliver_intent: Int in "Java" `{ return android.app.Service.START_REDELIVER_INTENT; `}

--- a/lib/android/shared_preferences/shared_preferences_api10.nit
+++ b/lib/android/shared_preferences/shared_preferences_api10.nit
@@ -144,7 +144,6 @@ end
 
 # Provides services to save and load data for the android platform
 class SharedPreferences
-	protected var context: NativeActivity
 	protected var shared_preferences: NativeSharedPreferences
 	protected var editor: NativeSharedPreferencesEditor
 
@@ -153,9 +152,8 @@ class SharedPreferences
 
 	protected init(app: App, file_name: String, mode: Int)
 	do
-		self.context = app.native_activity
 		sys.jni_env.push_local_frame(1)
-		setup(file_name.to_java_string, mode)
+		setup(file_name.to_java_string, mode, app.native_context)
 		sys.jni_env.pop_local_frame
 	end
 
@@ -174,13 +172,13 @@ class SharedPreferences
 		self.editor = editor.new_global_ref
 	end
 
-	private fun setup(file_name: JavaString, mode: Int) import context, set_vars in "Java" `{
-		Activity context = (Activity) SharedPreferences_context(self);
+	private fun setup(file_name: JavaString, mode: Int, context: NativeContext) import set_vars in "Java" `{
 		SharedPreferences sp;
 
 		// Uses default SharedPreferences if file_name is an empty String
 		if (file_name.equals("")) {
-			sp = context.getPreferences((int)mode);
+			Activity activity = (Activity)context;
+			sp = activity.getPreferences((int)mode);
 		} else {
 			sp = context.getSharedPreferences(file_name, (int)mode);
 		}
@@ -405,6 +403,6 @@ end
 
 redef class App
 	var shared_preferences: SharedPreferences is lazy do
-		return new SharedPreferences.privately(self, "")
+		return new SharedPreferences.privately(self, "app.nit")
 	end
 end

--- a/lib/android/toast.nit
+++ b/lib/android/toast.nit
@@ -28,13 +28,12 @@ redef class App
 	fun toast(message: String, is_long: Bool)
 	do
 		var jstr = message.to_java_string
-		native_toast(jstr, is_long)
+		native_toast(jstr, is_long, native_activity)
 		jstr.delete_local_ref
 	end
 
-	private fun native_toast(message: JavaString, is_long: Bool)
-	import native_activity in "Java" `{
-		final android.app.Activity context = App_native_activity(self);
+	private fun native_toast(message: JavaString, is_long: Bool, native_activity: NativeActivity) in "Java" `{
+		final android.app.Activity context = native_activity;
 		final CharSequence final_message = message;
 		final int duration = is_long? Toast.LENGTH_LONG: Toast.LENGTH_SHORT;
 

--- a/lib/android/vibration.nit
+++ b/lib/android/vibration.nit
@@ -49,10 +49,10 @@ end
 redef class App
 	# Get the handle to this device vibrator as a global ref
 	var vibrator: Vibrator is lazy do
-		var v = vibrator_native(native_activity)
+		var v = vibrator_native(native_context)
 		return v.new_global_ref
 	end
-	private fun vibrator_native(context: NativeActivity): Vibrator in "Java" `{
+	private fun vibrator_native(context: NativeContext): Vibrator in "Java" `{
 		android.os.Vibrator v = (android.os.Vibrator)
 			context.getSystemService(android.content.Context.VIBRATOR_SERVICE);
 		return v;


### PR DESCRIPTION
Add support to create Android services in Nit, working alongside activities implemented in Nit. The service can be launched on demande or at the device boot. Only one Nit service at a time can run per package. However the same service can be started more than once and you can do pretty much anything on the Nit side since it shares the same process as the activities.

Uses a broadcast receiver to launch service at boot. This receiver could be used to catch other broadcast, but it currently does not preserve the original intent.

Also updates most Android related modules to use `native_context` instead of `native_activity` so they can be called from services, when the Android API allows it. Some services had to be modified sightly, like the default `SharedPreferences` which is now named (instead of using the one attached to the activity). It should not break any clients as most use `data_store` which was already named.