### PR TITLE
http_request: intro an attribute to delay sending the request

### DIFF
--- a/contrib/tnitter/src/tnitter_app.nit
+++ b/contrib/tnitter/src/tnitter_app.nit
@@ -36,7 +36,7 @@ import json::serialization
 import model
 
 # Delay in seconds before the next request after an error
-fun request_delay_on_error: Int do return 60
+fun request_delay_on_error: Float do return 60.0
 
 redef class App
 	redef fun on_create
@@ -106,13 +106,7 @@ abstract class AsyncTnitterRequest
 	redef var rest_action
 
 	# Should this request be delayed by `request_delay_on_error` seconds?
-	var delay: Bool
-
-	redef fun main
-	do
-		if delay then nanosleep(request_delay_on_error, 0)
-		return super
-	end
+	fun after_error(value: Bool) is autoinit do if value then delay = request_delay_on_error
 end
 
 # Async request to list latest posts, either immediately or by push notification

--- a/lib/app/http_request.nit
+++ b/lib/app/http_request.nit
@@ -48,6 +48,9 @@ class AsyncHttpRequest
 	# Should the response content be deserialized from JSON?
 	var deserialize_json = true is writable
 
+	# Delay in seconds before sending this request
+	var delay = 0.0 is writable
+
 	redef fun start
 	do
 		before
@@ -56,6 +59,9 @@ class AsyncHttpRequest
 
 	redef fun main
 	do
+		var delay = delay
+		if delay > 0.0 then delay.sleep
+
 		var uri = rest_server_uri / rest_action
 
 		# Execute REST request


### PR DESCRIPTION
Move up the delay service from Tnitter to AsyncHttpRequest. It can be useful for other apps, for regular polling or to avoid to overwhelm the server on errors.