### PR TITLE
serialization: new annotation to rename an attribute in the serialization format

### DIFF
--- a/lib/serialization/README.md
+++ b/lib/serialization/README.md
@@ -103,6 +103,26 @@ The `noserialize` annotation mark an exception in a `serialize` module or class 
   end
   ~~~
 
+## The `serialize_as` annotation
+
+By default, an attribute is identified in the serialization format by its Nit name.
+The `serialize_as` attribute changes this behavior and sets the name of an attribute in the serialization format.
+
+This annotation can be useful to change the name of an attribute to what is expected by a remote service.
+Or to use identifiers in the serialization format that are reserved keywords in Nit (like `class` and `type`).
+
+~~~
+class UserCredentials
+	serialize
+
+	# Rename to "username" in JSON for compatibility with remote service
+	var name: String is serialize_as "username"
+
+	# Rename to a shorter "ap" for a smaller JSON file
+	var avatar_path: String = "/somepath/"+name is lazy, serialize_as "ap"
+end
+~~~
+
 ## Custom serializable classes
 
 The annotation `serialize` should be enough for most cases,

--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -46,6 +46,7 @@ module serialization is
 	new_annotation auto_serializable
 	new_annotation serialize
 	new_annotation noserialize
+	new_annotation serialize_as
 end
 
 # Abstract serialization service to be sub-classed by specialized services.

--- a/src/frontend/serialization_phase.nit
+++ b/src/frontend/serialization_phase.nit
@@ -179,6 +179,16 @@ private class SerializationPhasePreModel
 	do
 		var npropdefs = nclassdef.n_propdefs
 
+		# Do not insert a `from_deserializer` if it already exists
+		for npropdef in npropdefs do
+			if npropdef isa AMethPropdef then
+				var methid = npropdef.n_methid
+				if methid != null and methid.collect_text == "from_deserializer" then
+					return
+				end
+			end
+		end
+
 		var code = new Array[String]
 		code.add """
 redef init from_deserializer(v: Deserializer)

--- a/tests/sav/nitce/test_json_deserialization_alt1.res
+++ b/tests/sav/nitce/test_json_deserialization_alt1.res
@@ -2,7 +2,7 @@
 <A: true a 0.123 1234 asdf false p4ssw0rd>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null}
+{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}
 
 # Back in Nit:
 <A: true a 0.123 1234 asdf false p4ssw0rd>
@@ -11,7 +11,7 @@
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}
 
 # Back in Nit:
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
@@ -20,7 +20,7 @@
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null}, "b": {"__kind": "obj", "__id": 2, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}, "b": {"__kind": "obj", "__id": 2, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
 
 # Back in Nit:
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
@@ -30,7 +30,7 @@
 <- false p4ssw0rd> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "new line ->\n<-", "n": null, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
 
 # Back in Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/sav/test_json_deserialization.res
+++ b/tests/sav/test_json_deserialization.res
@@ -2,7 +2,7 @@
 <A: true a 0.123 1234 asdf false p4ssw0rd>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null}
+{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}
 
 # Back in Nit:
 <A: true a 0.123 1234 asdf false p4ssw0rd>
@@ -11,7 +11,7 @@
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}
 
 # Back in Nit:
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
@@ -20,7 +20,7 @@
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null}, "b": {"__kind": "obj", "__id": 2, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}, "b": {"__kind": "obj", "__id": 2, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
 
 # Back in Nit:
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
@@ -30,7 +30,7 @@
 <- false p4ssw0rd> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "new line ->\n<-", "n": null, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
 
 # Back in Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/sav/test_json_deserialization_alt1.res
+++ b/tests/sav/test_json_deserialization_alt1.res
@@ -2,7 +2,7 @@
 <A: true a 0.123 1234 asdf false p4ssw0rd>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null}
+{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}
 
 # Back in Nit:
 <A: true a 0.123 1234 asdf false p4ssw0rd>
@@ -11,7 +11,7 @@
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}
 
 # Back in Nit:
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
@@ -20,7 +20,7 @@
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null}, "b": {"__kind": "obj", "__id": 2, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}, "b": {"__kind": "obj", "__id": 2, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
 
 # Back in Nit:
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
@@ -30,7 +30,7 @@
 <- false p4ssw0rd> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "new line ->\n<-", "n": null, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
 
 # Back in Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/sav/test_json_deserialization_alt2.res
+++ b/tests/sav/test_json_deserialization_alt2.res
@@ -2,26 +2,26 @@
 <A: true a 0.123 1234 asdf false p4ssw0rd>
 
 # Json:
-{"b": true, "c": "a", "f": 0.123, "i": 1234, "s": "asdf", "n": null}
+{"b": true, "c": "a", "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
 
 # Json:
-{"b": false, "c": "b", "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}
+{"b": false, "c": "b", "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
 
 # Json:
-{"a": {"b": true, "c": "a", "f": 0.123, "i": 1234, "s": "asdf", "n": null}, "b": {"b": false, "c": "b", "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}, "aa": {"b": true, "c": "a", "f": 0.123, "i": 1234, "s": "asdf", "n": null}}
+{"a": {"b": true, "c": "a", "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}, "b": {"b": false, "c": "b", "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}, "aa": {"b": true, "c": "a", "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false p4ssw0rd> 1111 	f"\/> true>
 
 # Json:
-{"b": false, "c": "b", "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "ii": 1111, "ss": "\tf\"\r\\/", "d": null}
+{"b": false, "c": "b", "f": 123.123, "i": 2345, "serialization_specific_name": "new line ->\n<-", "n": null, "ii": 1111, "ss": "\tf\"\r\\/", "d": null}
 
 # Nit:
 <E: a: hello, 1234, 123.4; b: hella, 2345, 234.5>

--- a/tests/test_deserialization.nit
+++ b/tests/test_deserialization.nit
@@ -24,7 +24,7 @@ class A
 	var c: Char
 	var f: Float
 	var i: Int
-	var s: String
+	var s: String is serialize_as "serialization_specific_name"
 	var n: nullable Int
 	var password = "p4ssw0rd" is lazy, noserialize
 


### PR DESCRIPTION
By default, an attribute is identified in the serialization format by its Nit name. The `serialize_as` attribute changes this behavior and sets the name of an attribute in the serialization format. It works with both the JSON and the binary implementations.

This annotation can be useful to change the name of an attribute to what is expected by a remote service. Or to use identifiers in the serialization format that are reserved keywords in Nit (like `class` and `type`).