### PR TITLE
frontend & vim plugin: no doc warnings on `new` factories and no doc preview with omnifunc

### DIFF
--- a/misc/vim/plugin/nit.vim
+++ b/misc/vim/plugin/nit.vim
@@ -46,7 +46,7 @@ function NitComplete()
 
 		" This gives us better results for Nit
 		set noignorecase
-		set completeopt=longest,menuone,preview
+		set completeopt=longest,menuone
 
 		" Do not predict small 3 letters keywords (or their prefix), they slow down
 		" prediction and some also require double-enter on end of line.

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -589,7 +589,7 @@ redef class APropdef
 			var mdoc = ndoc.to_mdoc
 			mpropdef.mdoc = mdoc
 			mdoc.original_mentity = mpropdef
-		else if mpropdef.is_intro and mpropdef.mproperty.visibility >= protected_visibility then
+		else if mpropdef.is_intro and mpropdef.mproperty.visibility >= protected_visibility and mpropdef.name != "new" then
 			modelbuilder.advice(self, "missing-doc", "Documentation warning: Undocumented property `{mpropdef.mproperty}`")
 		end
 


### PR DESCRIPTION
Do no show missing-doc warnings on anonymous `new` factories. These factories usually replace de default init and as such are documented with the class.

The Nit omnifunc is used to complete words in vim, it popups up when pressing Ctrl-X Ctrl-O. The default behavior was to show the doc of the highlighted suggestion in the preview window. This was not appreciated by some, and it was unneeded since the popup menu already shows the synopsis.

This can still be customized by the user by setting the `completeopt` global variable. And as before, the doc can be shown in the preview window by calling `:Nitdoc` with the cursor over the string to search for.