### PR TITLE
nitcorn & xymus.net: better log and tracking

### DIFF
--- a/contrib/tnitter/src/action.nit
+++ b/contrib/tnitter/src/action.nit
@@ -82,6 +82,9 @@ class TnitterWeb
 	<link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
 	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 	<script src="//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
+	<script>
+		{{{javascript_header or else ""}}}
+	</script>
 </head>
 <body>
 
@@ -92,6 +95,9 @@ class TnitterWeb
 </div>
 </body>
 </html>"""
+
+	# Custom JavaScript code added within a `<script>` block to each page
+	var javascript_header: nullable Writable = null is writable
 
 	redef fun answer(request, turi)
 	do

--- a/lib/nitcorn/examples/src/xymus_net.nit
+++ b/lib/nitcorn/examples/src/xymus_net.nit
@@ -120,7 +120,9 @@ class OpportunityMasterHeader
 end
 
 redef class TnitterWeb
-	redef var header: String = (new MasterHeader("tnitter", true)).to_s
+	redef var header = (new MasterHeader("tnitter", true)).to_s
+
+	redef fun javascript_header do return tracking_code
 end
 
 redef class BenitluxDocument

--- a/lib/nitcorn/http_response.nit
+++ b/lib/nitcorn/http_response.nit
@@ -70,7 +70,7 @@ class HttpResponse
 		end
 
 		# Set server ID
-		if not header.keys.has("Server") then header["Server"] = "unitcorn"
+		if not header.keys.has("Server") then header["Server"] = "nitcorn"
 	end
 
 	# Get this reponse as a string according to HTTP protocol

--- a/lib/nitcorn/log.nit
+++ b/lib/nitcorn/log.nit
@@ -40,6 +40,20 @@ redef class Action
 	end
 end
 
+redef class HttpServer
+	redef fun read_http_request(str)
+	do
+		print "{remote_address}: received HTTP request"
+		super
+	end
+
+	redef fun respond(response)
+	do
+		super
+		if log_nitcorn_actions then print "{remote_address}: response header '{response.header.join(",", ":")}' to '{remote_address}'"
+	end
+end
+
 redef fun print(object) do
 	var timestamp = new Tm.gmtime
 	super "{timestamp.year}/{timestamp.mon}/{timestamp.mday} "+

--- a/lib/nitcorn/log.nit
+++ b/lib/nitcorn/log.nit
@@ -27,16 +27,16 @@ redef class Action
 			super
 			return
 		end
-		print """{{{class_name}}} enter:
-uri="{{{truncated_uri}}}"
-query="{{{request.query_string}}}"
-body:{{{request.body.length}}} bytes"""
+
+		print "{http_server.remote_address}: {class_name} prepare for url:'{request.url}' body:'{request.body}' cookie:'{request.cookie.join(",", ":")}'"
+
 		var clock = new Clock
+
 		super
+
 		var perf = sys.perfs[class_name]
 		perf.add(clock.lapse)
 		if perf.count % perfs_print_period == 0 then print "{class_name} perfs: {perf}:"
-		print "{class_name} return: uri={truncated_uri}"
 	end
 end
 
@@ -52,7 +52,7 @@ redef fun print_error(object) do
 	"{timestamp.hour}:{timestamp.min}:{timestamp.sec}: {object}"
 end
 
-# Should the actions be logged ?
+# Should the actions be logged? This may log sensitive data.
 fun log_nitcorn_actions: Bool do return false
 
 # Number of actions executed before printing the perfs

--- a/lib/nitcorn/reactor.nit
+++ b/lib/nitcorn/reactor.nit
@@ -35,6 +35,9 @@ class HttpServer
 
 	private var parser = new HttpRequestParser is lazy
 
+	# Human readable address of the remote client
+	var remote_address: String
+
 	redef fun read_http_request(str)
 	do
 		var request_object = parser.parse_http_request(str.to_s)
@@ -131,7 +134,7 @@ class HttpFactory
 	# You can use this to create the first `HttpFactory`, which is the most common.
 	init and_libevent do init(new NativeEventBase)
 
-	redef fun spawn_connection(buf_ev) do return new HttpServer(buf_ev, self)
+	redef fun spawn_connection(buf_ev, address) do return new HttpServer(buf_ev, self, address)
 
 	# Execute the main listening loop to accept connections
 	#

--- a/lib/nitcorn/sessions.nit
+++ b/lib/nitcorn/sessions.nit
@@ -62,7 +62,7 @@ redef class Sys
 	private var next_session_id_cache: nullable Int = null
 
 	# Salt used to hash the session id
-	protected var session_salt = "Default unitcorn session salt"
+	protected var session_salt = "Default nitcorn session salt"
 end
 
 redef class Int


### PR DESCRIPTION
Better services to debug nitcorn servers and understand users behavior:

* Improve `nitcorn::log` with an uniform print format and the remote IP address.
* Alow custom JavaScript code in Tnitter which is used to insert Google Analytics code in xymus.net.