### PR TITLE
app.nit UI: intro the CheckBox and implementation on Android, iOS & GNU/Linux

### DIFF
--- a/lib/android/ui/native_ui.nit
+++ b/lib/android/ui/native_ui.nit
@@ -992,3 +992,69 @@ fun android_r_style_text_appearance_medium: Int in "Java" `{
 fun android_r_style_text_appearance_small: Int in "Java" `{
 	return android.R.style.TextAppearance_Small;
 `}
+
+# Java class: android.widget.Checkable
+extern class Android_widget_Checkable in "Java" `{ android.widget.Checkable `}
+	super JavaObject
+
+	# Java implementation: android.widget.Checkable.setChecked(boolean)
+	fun set_checked(arg0: Bool) in "Java" `{
+		self.setChecked(arg0);
+	`}
+
+	# Java implementation: boolean android.widget.Checkable.isChecked()
+	fun is_checked: Bool in "Java" `{
+		return self.isChecked();
+	`}
+
+	# Java implementation: android.widget.Checkable.toggle()
+	fun toggle in "Java" `{
+		self.toggle();
+	`}
+
+	redef fun new_global_ref import sys, Sys.jni_env `{
+		Sys sys = Android_widget_Checkable_sys(self);
+		JNIEnv *env = Sys_jni_env(sys);
+		return (*env)->NewGlobalRef(env, self);
+	`}
+
+	redef fun pop_from_local_frame_with_env(jni_env) `{
+		return (*jni_env)->PopLocalFrame(jni_env, self);
+	`}
+end
+
+# Java abstract class: android.widget.CompoundButton
+extern class Android_widget_CompoundButton in "Java" `{ android.widget.CompoundButton `}
+	super NativeButton
+	super Android_widget_Checkable
+
+	redef fun new_global_ref import sys, Sys.jni_env `{
+		Sys sys = Android_widget_CompoundButton_sys(self);
+		JNIEnv *env = Sys_jni_env(sys);
+		return (*env)->NewGlobalRef(env, self);
+	`}
+
+	redef fun pop_from_local_frame_with_env(jni_env) `{
+		return (*jni_env)->PopLocalFrame(jni_env, self);
+	`}
+end
+
+# Java class: android.widget.CheckBox
+extern class Android_widget_CheckBox in "Java" `{ android.widget.CheckBox `}
+	super Android_widget_CompoundButton
+
+	# Java constructor: android.widget.CheckBox
+	new (a: NativeContext) in "Java" `{
+		return new android.widget.CheckBox(a);
+	`}
+
+	redef fun new_global_ref import sys, Sys.jni_env `{
+		Sys sys = Android_widget_CheckBox_sys(self);
+		JNIEnv *env = Sys_jni_env(sys);
+		return (*env)->NewGlobalRef(env, self);
+	`}
+
+	redef fun pop_from_local_frame_with_env(jni_env) `{
+		return (*jni_env)->PopLocalFrame(jni_env, self);
+	`}
+end

--- a/lib/android/ui/ui.nit
+++ b/lib/android/ui/ui.nit
@@ -166,6 +166,14 @@ redef class Label
 	init do native.set_text_appearance(app.native_activity, android_r_style_text_appearance_medium)
 end
 
+redef class CheckBox
+	redef type NATIVE: Android_widget_CompoundButton
+	redef var native do return (new Android_widget_CheckBox(app.native_activity)).new_global_ref
+
+	redef fun is_checked do return native.is_checked
+	redef fun is_checked=(value) do native.set_checked(value)
+end
+
 redef class TextInput
 	redef type NATIVE: NativeEditText
 	redef var native = (new NativeEditText(app.native_activity)).new_global_ref

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -178,6 +178,14 @@ class Label
 	super TextView
 end
 
+# Toggle control with two states and a label
+class CheckBox
+	super TextView
+
+	# Is this control in the checked/on state?
+	var is_checked = false is writable
+end
+
 # A `Button` press event
 class ButtonPressEvent
 	super AppEvent

--- a/lib/gtk/v3_4/gtk_widgets_ext.nit
+++ b/lib/gtk/v3_4/gtk_widgets_ext.nit
@@ -246,3 +246,22 @@ extern class GtkColorButton `{GtkColorButton *`}
 	`}
 end
 
+# Button remaining "pressed-in" when clicked
+extern class GtkToggleButton `{ GtkToggleButton * `}
+	super GtkButton
+
+	# Current state, returns `true` if pressed/checked
+	fun active: Bool `{ return gtk_toggle_button_get_active(self); `}
+
+	# Set current state, `true` for pressed/checked
+	fun active=(value: Bool) `{ gtk_toggle_button_set_active(self, value); `}
+end
+
+# Check box next to a label
+extern class GtkCheckButton `{ GtkCheckButton * `}
+	super GtkToggleButton
+
+	new `{ return (GtkCheckButton *)gtk_check_button_new(); `}
+
+	new with_label(lbl: NativeString) `{ return (GtkCheckButton *)gtk_check_button_new_with_label((gchar *)lbl); `}
+end

--- a/lib/ios/ui/ui.nit
+++ b/lib/ios/ui/ui.nit
@@ -203,6 +203,39 @@ redef class Label
 	redef fun text do return native.text.to_s
 end
 
+# On iOS, check boxes are a layout composed of a label and an `UISwitch`
+redef class CheckBox
+
+	redef type NATIVE: UIStackView
+	redef fun native do return layout.native
+
+	# Root layout implementing this check box
+	var layout = new HorizontalLayout(parent=self.parent)
+
+	# Label with the text
+	var lbl = new Label(parent=layout)
+
+	# `UISwitch` acting as the real check box
+	var ui_switch: UISwitch is noautoinit
+
+	init do
+		# Tweak the layout so it is centered
+		layout.native.distribution = new UIStackViewDistribution.fill_proportionally
+		layout.native.alignment = new UIStackViewAlignment.center
+		layout.native.layout_margins_relative_arrangement = true
+
+		var s = new UISwitch
+		native.add_arranged_subview s
+		ui_switch = s
+	end
+
+	redef fun text=(text) do lbl.text = text
+	redef fun text do return lbl.text
+
+	redef fun is_checked do return ui_switch.on
+	redef fun is_checked=(value) do ui_switch.set_on_animated(value, true)
+end
+
 redef class TextInput
 
 	redef type NATIVE: UITextField

--- a/lib/ios/ui/uikit.nit
+++ b/lib/ios/ui/uikit.nit
@@ -495,14 +495,24 @@ extern class UIStackView in "ObjC" `{ UIStackView * `}
 	fun spacing=(value: Float) in "ObjC" `{ self.spacing = value; `}
 
 	# Wraps: `UIStackView.baselineRelativeArrangement`
-	#fun baseline_relative_arrangement: Bool in "ObjC" `{
-	#	return [self baselineRelativeArrangement];
-	#`}
+	fun baseline_relative_arrangement: Bool in "ObjC" `{
+		return self.baselineRelativeArrangement;
+	`}
+
+	# Wraps: `UIStackView.baselineRelativeArrangement`
+	fun baseline_relative_arrangement=(value: Bool) in "ObjC" `{
+		self.baselineRelativeArrangement = value;
+	`}
 
 	# Wraps: `UIStackView.layoutMarginsRelativeArrangement`
-	#fun layout_margins_relative_arrangement: Bool in "ObjC" `{
-	#	return [self layoutMarginsRelativeArrangement];
-	#`}
+	fun layout_margins_relative_arrangement: Bool in "ObjC" `{
+		return self.layoutMarginsRelativeArrangement;
+	`}
+
+	# Wraps: `UIStackView.layoutMarginsRelativeArrangement`
+	fun layout_margins_relative_arrangement=(value: Bool) in "ObjC" `{
+		self.layoutMarginsRelativeArrangement = value;
+	`}
 end
 
 # Defines the orientation of the arranged views in `UIStackView`

--- a/lib/ios/ui/uikit.nit
+++ b/lib/ios/ui/uikit.nit
@@ -596,3 +596,46 @@ extern class UITableViewStyle in "ObjC" `{ UITableViewStyle* `}
 	new plain in "ObjC" `{ return UITableViewStylePlain; `}
 	new grouped in "ObjC" `{ return UITableViewStyleGrouped; `}
 end
+
+# On/Off button
+extern class UISwitch in "ObjC" `{ UISwitch * `}
+	super UIView
+
+	# Wraps: `[self initWithFrame:(CGRect)frame]`
+	new in "ObjC" `{ return [[UISwitch alloc] initWithFrame: [[UIScreen mainScreen] applicationFrame]]; `}
+
+	# Wraps: `UISwitch.onTintColor`
+#	fun on_tint_color: UIColor in "ObjC" `{
+#		return [self onTintColor];
+#	`}
+
+	# Wraps: `UISwitch.tintColor`
+#	fun tint_color: UIColor in "ObjC" `{
+#		return [self tintColor];
+#	`}
+
+	# Wraps: `UISwitch.thumbTintColor`
+#	fun thumb_tint_color: UIColor in "ObjC" `{
+#		return [self thumbTintColor];
+#	`}
+
+	# Wraps: `UISwitch.onImage`
+#	fun on_image: UIImage in "ObjC" `{
+#		return [self onImage];
+#	`}
+
+	# Wraps: `UISwitch.offImage`
+#	fun off_image: UIImage in "ObjC" `{
+#		return [self offImage];
+#	`}
+
+	# Wraps: `UISwitch.on`
+	fun on: Bool in "ObjC" `{
+		return self.on;
+	`}
+
+	# Wraps: `[self setOn:(BOOL)on animated:(BOOL)animated]`
+	fun set_on_animated(on: Bool, animated: Bool) in "ObjC" `{
+		[self setOn: on animated: animated];
+	`}
+end

--- a/lib/linux/ui.nit
+++ b/lib/linux/ui.nit
@@ -149,6 +149,17 @@ redef class Label
 	redef fun text=(value) do native.text = (value or else "").to_s
 end
 
+redef class CheckBox
+	redef type NATIVE: GtkCheckButton
+	redef var native = new GtkCheckButton
+
+	redef fun text do return native.text
+	redef fun text=(value) do native.text = (value or else "").to_s
+
+	redef fun is_checked do return native.active
+	redef fun is_checked=(value) do native.active = value
+end
+
 redef class TextInput
 	redef type NATIVE: GtkEntry
 	redef var native = new GtkEntry


### PR DESCRIPTION
The check box control varies per platform. For app.nit, we chose to implement it as a form available on Android and GNU/Linux with GTK+, the classic check box with a label.

On GNU/Linux there is the GTK+ check box widget which is used as is. On Android, there is two similar controls, the toggle (for On/Off, like in the preferences window) and the check button (which is more similar to the GTK check box). We used the check button for consistency, but it could be changed in the future. On iOS, there is only the UISwitch, an on/off button, without a label. The app.nit CheckBox is implemented by a layout composed of the UISwitch and a label.