### PR TITLE
app.nit on Android: implement multiple windows support with fragments

### DIFF
--- a/lib/android/http_request.nit
+++ b/lib/android/http_request.nit
@@ -110,3 +110,8 @@ private extern class JavaHttpResponse in "Java" `{ org.apache.http.HttpResponse 
 		}
 	`}
 end
+
+# Force linearization of print
+#
+# TODO prioritize `android::log`
+redef fun print(object) do super

--- a/lib/android/service/service.nit
+++ b/lib/android/service/service.nit
@@ -137,7 +137,7 @@ end
 
 redef class NativeContext
 	private fun start_service in "Java" `{
-		android.content.Intent indent =
+		android.content.Intent intent =
 			new android.content.Intent(self, nit.app.NitService.class);
 		self.startService(intent);
 	`}

--- a/lib/android/ui/native_ui.nit
+++ b/lib/android/ui/native_ui.nit
@@ -54,6 +54,12 @@ extern class NativeView in "Java" `{ android.view.View `}
 
 	fun enabled: Bool in "Java" `{ return self.isEnabled(); `}
 	fun enabled=(value: Bool) in "Java" `{ self.setEnabled(value); `}
+
+	# Java implementation: int android.view.View.getId()
+	fun id: Int in "Java" `{ return self.getId(); `}
+
+	# Java implementation: android.view.View.setId(int)
+	fun id=(id: Int) in "Java" `{ self.setId((int)id); `}
 end
 
 # A collection of `NativeView`
@@ -448,6 +454,21 @@ extern class Android_widget_ArrayAdapter in "Java" `{ android.widget.ArrayAdapte
 	`}
 end
 
+# Java class: android.app.Fragment
+extern class Android_app_Fragment in "Java" `{ android.app.Fragment `}
+	super JavaObject
+
+	redef fun new_global_ref import sys, Sys.jni_env `{
+		Sys sys = Android_app_Fragment_sys(self);
+		JNIEnv *env = Sys_jni_env(sys);
+		return (*env)->NewGlobalRef(env, self);
+	`}
+
+	redef fun pop_from_local_frame_with_env(jni_env) `{
+		return (*jni_env)->PopLocalFrame(jni_env, self);
+	`}
+end
+
 # Java class: android.widget.AbsListView
 extern class Android_widget_AbsListView in "Java" `{ android.widget.AbsListView `}
 	#super Android_widget_AdapterView
@@ -455,7 +476,7 @@ extern class Android_widget_AbsListView in "Java" `{ android.widget.AbsListView 
 	#super Android_view_ViewTreeObserver_OnGlobalLayoutListener
 	#super Android_widget_Filter_FilterListener
 	#super Android_view_ViewTreeObserver_OnTouchModeChangeListener
-	super NativeView
+	super NativeViewGroup
 
 	# Java implementation:  android.widget.AbsListView.setAdapter(android.widget.Adapter)
 	fun set_adapter(arg0: Android_widget_ListAdapter) in "Java" `{

--- a/lib/android/ui/ui.nit
+++ b/lib/android/ui/ui.nit
@@ -37,6 +37,21 @@ redef class Control
 	type NATIVE: JavaObject
 end
 
+redef class NativeActivity
+
+	private fun remove_title_bar in "Java" `{
+		self.requestWindowFeature(android.view.Window.FEATURE_NO_TITLE);
+	`}
+end
+
+redef class App
+	redef fun on_create
+	do
+		app.native_activity.remove_title_bar
+		super
+	end
+end
+
 redef class Window
 	redef var native = app.native_activity.new_global_ref
 

--- a/lib/android/ui/ui.nit
+++ b/lib/android/ui/ui.nit
@@ -42,28 +42,64 @@ redef class NativeActivity
 	private fun remove_title_bar in "Java" `{
 		self.requestWindowFeature(android.view.Window.FEATURE_NO_TITLE);
 	`}
+
+	# Insert a single layout as the root of the activity window
+	private fun insert_root_layout(root_layout_id: Int)
+	in "Java" `{
+		android.widget.FrameLayout layout = new android.widget.FrameLayout(self);
+		layout.setId((int)root_layout_id);
+		self.setContentView(layout);
+	`}
+
+	# Replace the currently visible fragment, if any, with `native_fragment`
+	private fun show_fragment(root_layout_id: Int, native_fragment: Android_app_Fragment)
+	in "Java" `{
+		android.app.FragmentTransaction transaction = self.getFragmentManager().beginTransaction();
+		transaction.replace((int)root_layout_id, native_fragment);
+		transaction.commit();
+	`}
 end
 
 redef class App
 	redef fun on_create
 	do
 		app.native_activity.remove_title_bar
+		native_activity.insert_root_layout(root_layout_id)
+		super
+	end
+
+	# Identifier of the container holding the fragments
+	private var root_layout_id = 0xFFFF
+
+	redef fun window=(window)
+	do
+		native_activity.show_fragment(root_layout_id, window.native)
 		super
 	end
 end
 
+# On Android, a window is implemented with the fragment `native`
 redef class Window
-	redef var native = app.native_activity.new_global_ref
+	redef var native = (new Android_app_Fragment(self)).new_global_ref
 
-	redef type NATIVE: NativeActivity
+	redef type NATIVE: Android_app_Fragment
+
+	# Root high-level view of this window
+	var view: nullable View = null
 
 	redef fun add(item)
 	do
+		if item isa View then view = item
 		super
+	end
 
-		# FIXME abstract the Android restriction where `content_view` must be a layout
-		assert item isa Layout
-		native.content_view = item.native
+	private fun on_create_fragment: NativeView
+	do
+		on_create
+
+		var view = view
+		assert view != null else print_error "{class_name} needs a `view` after `Window::on_create` returns"
+		return view.native
 	end
 end
 
@@ -231,6 +267,22 @@ redef class NativeButton
 					return true;
 				}
 				return false;
+			}
+		};
+	`}
+end
+
+redef class Android_app_Fragment
+	private new (nit_window: Window)
+	import Window.on_create_fragment in "Java" `{
+		final int final_nit_window = nit_window;
+
+		return new android.app.Fragment(){
+			@Override
+			public android.view.View onCreateView(android.view.LayoutInflater inflater,
+				android.view.ViewGroup container, android.os.Bundle state) {
+
+				return Window_on_create_fragment(final_nit_window);
 			}
 		};
 	`}


### PR DESCRIPTION
This PR intro support for Andorid apps composed of multiple windows. There is now one fragment par app.nit window, and it is set as visible when assigned to `app.window=`.

Support for multi-windows apps on other platforms will be provided by future PRs, along with a portable API for the back button and to navigate between windows. This system, on Android at least, could probably be extended to show more that one window at a time on larger tablet devices.