### PR TITLE
Improve `Text::justify` and use it for a pretty `PerfMap::to_s`

### DIFF
--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -495,18 +495,21 @@ abstract class Text
 		end
 	end
 
-	# Justify a self in a space of `length`
+	# Justify `self` in a space of `length`
 	#
 	# `left` is the space ratio on the left side.
 	# * 0.0 for left-justified (no space at the left)
 	# * 1.0 for right-justified (all spaces at the left)
 	# * 0.5 for centered (half the spaces at the left)
 	#
+	# `char`, or `' '` by default, is repeated to pad the empty space.
+	#
 	# Examples
 	#
 	#     assert "hello".justify(10, 0.0)  == "hello     "
 	#     assert "hello".justify(10, 1.0)  == "     hello"
 	#     assert "hello".justify(10, 0.5)  == "  hello   "
+	#     assert "hello".justify(10, 0.5, '.') == "..hello..."
 	#
 	# If `length` is not enough, `self` is returned as is.
 	#
@@ -515,13 +518,14 @@ abstract class Text
 	# REQUIRE: `left >= 0.0 and left <= 1.0`
 	# ENSURE: `self.length <= length implies result.length == length`
 	# ENSURE: `self.length >= length implies result == self`
-	fun justify(length: Int, left: Float): String
+	fun justify(length: Int, left: Float, char: nullable Char): String
 	do
+		var pad = (char or else ' ').to_s
 		var diff = length - self.length
 		if diff <= 0 then return to_s
 		assert left >= 0.0 and left <= 1.0
 		var before = (diff.to_f * left).to_i
-		return " " * before + self + " " * (diff-before)
+		return pad * before + self + pad * (diff-before)
 	end
 
 	# Mangle a string to be a unique string only made of alphanumeric characters and underscores.

--- a/lib/performance_analysis.nit
+++ b/lib/performance_analysis.nit
@@ -60,7 +60,45 @@ class PerfMap
 		return ts
 	end
 
-	redef fun to_s do return "* " + join("\n* ", ": ")
+	redef fun to_s
+	do
+		var prec = 3
+
+		var table = new Map[String, Array[String]]
+		for event, stats in self do
+			table[event] = [event,
+				stats.min.to_precision(prec),
+				stats.max.to_precision(prec),
+				stats.avg.to_precision(prec),
+				stats.sum.to_precision(prec),
+				stats.count.to_s]
+		end
+
+		var widths = [0] * 6
+		for event, row in table do
+			for i in row.length.times do
+				widths[i] = widths[i].max(row[i].length)
+			end
+		end
+
+		var s = "# {"Event".justify(widths[0], 0.0)} {"min".justify(widths[1], 0.5)} {"max".justify(widths[2], 0.5)} {"avg".justify(widths[3], 0.5)} {"sum".justify(widths[4], 0.5)} {"count".justify(widths[5], 0.5)}\n"
+
+		var sorted_events = table.keys.to_a
+		alpha_comparator.sort sorted_events
+		for event in sorted_events do
+			var row = table[event]
+			s += "*"
+			for c in row.length.times do
+				var cell = row[c]
+				s += " "
+				if c == 0 then
+					s += cell.justify(widths[c], 0.0, '.')
+				else s += cell.justify(widths[c], 1.0)
+			end
+			s += "\n"
+		end
+		return s
+	end
 end
 
 # Statistics on wall clock execution time of a category of events by `name`


### PR DESCRIPTION
This PR introduces padding services ( `pad_left` and `pad_right`) to `Text` and uses it for a cleaner print in `performance_analysis`.

Seeing how the left-pad package was critical to the node.js ecosystem motivated this PR. These methods should be useful in the long term!