### PR TITLE
interpreter: fix rand by leaving rand methods to the FFI

### DIFF
--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -1002,9 +1002,6 @@ redef class AMethPropdef
 				return v.int32_instance(recvval.to_i32)
 			else if pname == "to_u32" then
 				return v.uint32_instance(recvval.to_u32)
-			else if pname == "rand" then
-				var res = recvval.rand
-				return v.int_instance(res)
 			end
 		else if cname == "Byte" then
 			var recvval = args[0].to_b
@@ -1130,8 +1127,6 @@ redef class AMethPropdef
 				return v.float_instance(args[0].to_f.log)
 			else if pname == "pow" then
 				return v.float_instance(args[0].to_f.pow(args[1].to_f))
-			else if pname == "rand" then
-				return v.float_instance(args[0].to_f.rand)
 			else if pname == "abs" then
 				return v.float_instance(args[0].to_f.abs)
 			else if pname == "hypot_with" then


### PR DESCRIPTION
This PR fix `rand` with the interpreter so setting a seed with `srand_from` produces predictable results in the following calls to `rand`, and the same results as the same compiled program. The problem was caused by the interception of `rand` which was executed in the interpreter itself, while `srand_from` was executed on the side of the interpreted program. So setting the seed did not affect in anyway the values returned by `rand`.