### PR TITLE
More byte digests

### DIFF
--- a/lib/core/bytes.nit
+++ b/lib/core/bytes.nit
@@ -251,7 +251,15 @@ class Bytes
 		return slice(from, length)
 	end
 
-	# Returns self as a hexadecimal digest
+	# Returns self as an hexadecimal digest.
+	#
+	# Also known as plain hexdump or postscript hexdump.
+	#
+	# ~~~
+	# var b = "abcd".to_bytes
+	# assert b.hexdigest == "61626364"
+	# assert b.hexdigest.hexdigest_to_bytes == b
+	# ~~~
 	fun hexdigest: String do
 		var elen = length * 2
 		var ns = new NativeString(elen)
@@ -583,6 +591,7 @@ redef class Text
 	# Returns a new `Bytes` instance with the digest as content
 	#
 	#     assert "0B1F4D".hexdigest_to_bytes == [0x0Bu8, 0x1Fu8, 0x4Du8]
+	#     assert "0B1F4D".hexdigest_to_bytes.hexdigest == "0B1F4D"
 	#
 	# REQUIRE: `self` is a valid hexdigest and hexdigest.length % 2 == 0
 	fun hexdigest_to_bytes: Bytes do


### PR DESCRIPTION
Improve and some back-and-forth transformations between Byte and Text.

~~~nit
var b = "abcd".to_bytes
assert b.chexdigest == "\\x61\\x62\\x63\\x64"
assert b.chexdigest.unescape_to_bytes == b
assert b.binarydigest == "01100001011000100110001101100100"
assert b.binarydigest.binarydigest_to_bytes == b

assert "1".binarydigest_to_bytes.hexdigest == "01"
assert "1 0 1".binarydigest_to_bytes.hexdigest == "05"
assert "7".hexdigest_to_bytes.hexdigest == "07"
assert "a B cd \\xe".hexdigest_to_bytes.hexdigest == "0ABCDE"
~~~