### PR TITLE
Tnitter app: fix list layout on GNU/Linux with GTK+

### DIFF
--- a/contrib/tnitter/src/tnitter_app.nit
+++ b/contrib/tnitter/src/tnitter_app.nit
@@ -73,8 +73,7 @@ class TnitterWindow
 	# Update the screen to show the new `posts`
 	fun apply_update(posts: Array[Post])
 	do
-		layout.remove list_posts
-		list_posts = new ListLayout(parent=layout)
+		list_posts.clear
 		for post in posts do
 			var line = new VerticalLayout(parent=list_posts)
 			var author = new LabelAuthor(parent=line, text="@"+post.user)

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -118,6 +118,9 @@ class CompositeControl
 	# Is `item` in `self`?
 	fun has(item: Control): Bool do return items.has(item)
 
+	# Remove all items from `self`
+	fun clear do for item in items.to_a do remove item
+
 	redef fun on_create do for i in items do i.on_create
 
 	redef fun on_start do for i in items do i.on_start

--- a/lib/gtk/v3_10.nit
+++ b/lib/gtk/v3_10.nit
@@ -70,7 +70,7 @@ end
 
 # A single row of a `GtkListBox`
 extern class GtkListBoxRow `{ GtkListBoxRow* `}
-	super GtkWidget
+	super GtkBin
 
 	new `{ return (GtkListBoxRow*)gtk_list_box_row_new(); `}
 

--- a/lib/linux/ui.nit
+++ b/lib/linux/ui.nit
@@ -186,6 +186,9 @@ redef class ListLayout
 	# Container inside `native`
 	var native_list_box = new GtkListBox
 
+	# `GtkListBoxRow` used to contains children `View`s
+	var native_rows = new Map[View, GtkListBoxRow]
+
 	init do
 		native_list_box.selection_mode = new GtkSelectionMode.none
 		native.add native_list_box
@@ -199,13 +202,32 @@ redef class ListLayout
 	redef fun add(item)
 	do
 		super
-		if item isa View then native_list_box.add item.native
+		if item isa View then
+			var native_row = new GtkListBoxRow
+			#native_row.activable = false # TODO with GTK 3.14
+			#native_row.selectable = false
+			native_row.add item.native
+
+			native_rows[item] = native_row
+			native_list_box.add native_row
+			native_row.show
+		end
 	end
 
 	redef fun remove(item)
 	do
 		super
-		if item isa View then native_list_box.remove item.native
+		if item isa View then
+			var native_row = native_rows.get_or_null(item)
+			if native_row == null then
+				print_error "Error: {self} does not contains {item}"
+				return
+			end
+
+			native_list_box.remove native_row
+			native_rows.keys.remove item
+			native_row.destroy
+		end
 	end
 end
 


### PR DESCRIPTION
Update GNU/Linux implementation of `ListLayout` to follow the specification of `GtkListBox` which should only have children of type `GtkListBoxRow`. This was an issue in Tnitter where removing children from the `GtkListBox` was broken.