### PR TITLE
app.nit services to set the size and alignment of labels

### DIFF
--- a/lib/android/ui/ui.nit
+++ b/lib/android/ui/ui.nit
@@ -201,20 +201,40 @@ redef class TextView
 		native.text = value.to_java_string
 	end
 
-	# Size of the text
-	fun text_size: Float do return native.text_size
+	redef fun size=(size) do set_size_native(app.native_activity, native, size or else 1.0)
 
-	# Size of the text
-	fun text_size=(text_size: nullable Float) do
-		if text_size != null then native.text_size = text_size
-	end
+	private fun set_size_native(context: NativeContext, view: NativeTextView, size: Float)
+	in "Java" `{
+		int s;
+		if (size == 1.0d)
+			s = android.R.style.TextAppearance_Medium;
+		else if (size < 1.0d)
+			s = android.R.style.TextAppearance_Small;
+		else // if (size > 1.0d)
+			s = android.R.style.TextAppearance_Large;
+
+		view.setTextAppearance(context, s);
+	`}
+
+	redef fun align=(align) do set_align_native(native, align or else 0.0)
+
+	private fun set_align_native(view: NativeTextView, align: Float)
+	in "Java" `{
+		int g;
+		if (align == 0.5d)
+			g = android.view.Gravity.CENTER_HORIZONTAL;
+		else if (align < 0.5d)
+			g = android.view.Gravity.LEFT;
+		else // if (align > 0.5d)
+			g = android.view.Gravity.RIGHT;
+
+		view.setGravity(g);
+	`}
 end
 
 redef class Label
 	redef type NATIVE: NativeTextView
 	redef var native do return (new NativeTextView(app.native_activity)).new_global_ref
-
-	init do native.set_text_appearance(app.native_activity, android_r_style_text_appearance_medium)
 end
 
 redef class CheckBox

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -161,6 +161,28 @@ abstract class TextView
 	#
 	# By default, or if set to `null`, no text is shown.
 	var text: nullable Text is writable, abstract, autoinit
+
+	# Set the relative size of the text
+	#
+	# A value of 1.0, the default, use the platform default text size.
+	# Values under 1.0 set a smaller text size, and over 1.0 a larger size.
+	#
+	# Implementation varies per platform, and some controls may be unaffected
+	# depending on the customization options of each platform.
+	# For consistent results, it is recommended to use only on instances
+	# of `Label` and `size` should be either 0.5, 1.0 or 1.5.
+	fun size=(size: nullable Float) is autoinit do end
+
+	# Align the text horizontally
+	#
+	# Use 0.0 to align left (the default), 0.5 to align in the center and
+	# 1.0 to align on the right.
+	#
+	# Implementation varies per platform, and some controls may be unaffected
+	# depending on the customization options of each platform.
+	# For consistent results, it is recommended to use only on instances
+	# of `Label` and `size` should be either 0.0, 0.5 or 1.0.
+	fun align=(center: nullable Float) is autoinit do end
 end
 
 # A control for the user to enter custom `text`

--- a/lib/gtk/v3_4/gtk_core.nit
+++ b/lib/gtk/v3_4/gtk_core.nit
@@ -457,18 +457,13 @@ end
 extern class GtkMisc `{GtkMisc *`}
 	super GtkWidget
 
-	fun alignment: GtkAlignment is abstract
-
-	fun alignment=(x: Float, y: Float) `{
+	fun set_alignment(x, y: Float) `{
 		gtk_misc_set_alignment(self, x, y);
 	`}
 
-	fun padding: GtkAlignment is abstract
-
-	fun padding=(x: Float, y: Float) `{
+	fun set_padding(x, y: Float) `{
 		gtk_misc_set_padding(self, x, y);
 	`}
-
 end
 
 # A single line text entry field

--- a/lib/gtk/v3_4/gtk_core.nit
+++ b/lib/gtk/v3_4/gtk_core.nit
@@ -697,6 +697,24 @@ extern class GtkLabel `{GtkLabel *`}
 		return gtk_label_get_angle(self);
 	`}
 
+	# Set simple formatted text content from a `format` string and the `content` which is escaped
+	#
+	# ~~~nitish
+	# GtkLabel lbl = new GtkLabel("Non-formatted text")
+	# lbl.set_markup("<span style=\"italic\">\%s</span>".to_cstring,
+	#                "Italic content")
+	# ~~~
+	fun set_markup(format, content: NativeString) `{
+		char *formatted = g_markup_printf_escaped(format, content);
+		gtk_label_set_markup(self, formatted);
+		g_free(formatted);
+	`}
+
+	# Set justification of the lines in the label relative to each other
+	fun justify=(value: GtkJustification) `{ gtk_label_set_justify(self, value); `}
+
+	# Get justification of the lines in the label relative to each other
+	fun justify: GtkJustification `{ return gtk_label_get_justify(self); `}
 end
 
 # A widget displaying an image

--- a/lib/ios/ui/ui.nit
+++ b/lib/ios/ui/ui.nit
@@ -201,6 +201,31 @@ redef class Label
 
 	redef fun text=(text) do native.text = (text or else "").to_nsstring
 	redef fun text do return native.text.to_s
+
+	redef fun size=(size)
+	do
+		size = size or else 1.0
+		var points = 8.0 + size * 8.0
+		set_size_native(native, points)
+	end
+
+	private fun set_size_native(native: UILabel, points: Float)
+	in "ObjC" `{
+		native.font = [UIFont systemFontOfSize: points];
+	`}
+
+	redef fun align=(align) do set_align_native(native, align or else 0.0)
+
+	private fun set_align_native(native: UILabel, align: Float)
+	in "ObjC" `{
+
+		if (align == 0.5)
+			native.textAlignment = NSTextAlignmentCenter;
+		else if (align < 0.5)
+			native.textAlignment = NSTextAlignmentLeft;
+		else//if (align > 0.5)
+			native.textAlignment = NSTextAlignmentRight;
+	`}
 end
 
 # On iOS, check boxes are a layout composed of a label and an `UISwitch`

--- a/lib/linux/ui.nit
+++ b/lib/linux/ui.nit
@@ -248,7 +248,46 @@ redef class Label
 	redef var native = new GtkLabel("")
 
 	redef fun text do return native.text
-	redef fun text=(value) do native.text = (value or else "").to_s
+
+	redef fun text=(value)
+	do
+		var cfmt = pango_markup_format.to_cstring
+		var cvalue = (value or else "").to_cstring
+		native.set_markup(cfmt, cvalue)
+	end
+
+	# Pango format string applied to the `text` attribute
+	var pango_markup_format = "\%s" is lazy
+
+	redef fun size=(size)
+	do
+		if size == null or size == 1.0 then
+			pango_markup_format = "\%s"
+		else if size < 1.0 then
+			pango_markup_format = "<span size=\"small\">\%s</span>"
+		else#if size > 1.0 then
+			pango_markup_format = "<span size=\"large\">\%s</span>"
+		end
+
+		# Force reloading `text`
+		text = text
+	end
+
+	redef fun align=(align)
+	do
+		align = align or else 0.0
+
+		# Set whole label alignement
+		native.set_alignment(align, 0.5)
+
+		# Set multiline justification
+		native.justify = if align == 0.5 then
+			new GtkJustification.center
+		else if align < 0.5 then
+			new GtkJustification.left
+		else#if align > 0.5 then
+			new GtkJustification.right
+	end
 end
 
 redef class CheckBox


### PR DESCRIPTION
Intro services to customize the size and alignment of text views. Only labels are supported on all platforms but Android also supports customizing text buttons. The behaviour on each platform varies a bit according to the available features. The goal is always to have the behaviour that is more natural on the platform instead of having the same exact look on each platform. Sticking to the recommended values should produce more consistent results, but using other values can create interesting effects.

For example, on Android and Linux, the text size is locked to a small/medium/large, but on iOS the size can be set to any variations relative to the default font size. On all platforms, 0.5 should result in a small font, 1.0 the default/medium size and 1.5 the large size. On iOS, other values will result in different text sizes.

I've used the same logic as `Text::justify` to set the alignment with a single float parameter.