### PR TITLE
iOS: support apps with multiple windows, and a better ListLayout

### DIFF
--- a/lib/ios/ui/ui.nit
+++ b/lib/ios/ui/ui.nit
@@ -120,9 +120,9 @@ redef class CompositeControl
 	do
 		super
 
-		var native_view = view.native
-		assert native_view isa UIView
-		native_view.remove_from_superview
+		if view isa View then
+			view.native.remove_from_superview
+		end
 	end
 end
 

--- a/lib/ios/ui/uikit.nit
+++ b/lib/ios/ui/uikit.nit
@@ -94,7 +94,28 @@ extern class UIWindow in "ObjC" `{ UIWindow * `}
 	`}
 end
 
-# Base class for contorl objects
+# Manages a set of views
+extern class UIViewController in "ObjC" `{ UIViewController * `}
+	super NSObject
+
+	new in "ObjC" `{
+		return [[UIViewController alloc]initWithNibName:nil bundle:nil];
+	`}
+
+	# Wraps: `self.view`
+	fun view: UIView in "ObjC" `{ return self.view; `}
+
+	# Wraps: `self.view`
+	fun view=(view: UIView) in "ObjC" `{ self.view = view; `}
+
+	# Wraps: `self.title`
+	fun title: NSString in "ObjC" `{ return self.title; `}
+
+	# Wraps: `self.title`
+	fun title=(title: NSString) in "ObjC" `{ self.title = title; `}
+end
+
+# Base class for control objects
 extern class UIControl in "ObjC" `{ UIControl * `}
 	super UIView
 

--- a/lib/ios/ui/uikit.nit
+++ b/lib/ios/ui/uikit.nit
@@ -24,7 +24,7 @@ import ios
 extern class UIView in "ObjC" `{ UIView * `}
 	super NSObject
 
-	new in "ObjC" `{ return [[UIView alloc] initWithFrame: [[UIScreen mainScreen] applicationFrame]]; `}
+	new in "ObjC" `{ return [[UIView alloc] init]; `}
 
 	# Wraps: `UIView.addSubview`
 	fun add_subview(view: UIView) in "ObjC" `{
@@ -86,7 +86,7 @@ end
 extern class UIWindow in "ObjC" `{ UIWindow * `}
 	super UIView
 
-	new in "ObjC" `{ return [[UIWindow alloc] initWithFrame: [[UIScreen mainScreen] bounds]]; `}
+	new in "ObjC" `{ return [[UIWindow alloc] init]; `}
 
 	# Wraps: `[self makeKeyAndVisible]`
 	fun make_key_and_visible in "ObjC" `{
@@ -419,7 +419,7 @@ end
 extern class UITextField in "ObjC" `{ UITextField * `}
 	super UIControl
 
-	new in "ObjC" `{ return [[UITextField alloc] initWithFrame: [[UIScreen mainScreen] applicationFrame]]; `}
+	new in "ObjC" `{ return [[UITextField alloc] init]; `}
 
 	# Wraps: `UITextField.text`
 	fun text: NSString in "ObjC" `{
@@ -442,7 +442,7 @@ extern class UIStackView in "ObjC" `{ UIStackView * `}
 	super UIView
 
 	new in "ObjC" `{
-		return [[UIStackView alloc] initWithArrangedSubviews: [NSArray array]];
+		return [[UIStackView alloc] init];
 	`}
 
 	# Wraps: `[self addArrangedSubview:(UIView)view]`
@@ -611,8 +611,7 @@ end
 extern class UISwitch in "ObjC" `{ UISwitch * `}
 	super UIView
 
-	# Wraps: `[self initWithFrame:(CGRect)frame]`
-	new in "ObjC" `{ return [[UISwitch alloc] initWithFrame: [[UIScreen mainScreen] applicationFrame]]; `}
+	new in "ObjC" `{ return [[UISwitch alloc] init]; `}
 
 	# Wraps: `UISwitch.onTintColor`
 #	fun on_tint_color: UIColor in "ObjC" `{

--- a/lib/ios/ui/uikit.nit
+++ b/lib/ios/ui/uikit.nit
@@ -648,3 +648,10 @@ extern class UISwitch in "ObjC" `{ UISwitch * `}
 		[self setOn: on animated: animated];
 	`}
 end
+
+# Support for displaying content larger than the window
+extern class UIScrollView in "ObjC" `{ UIScrollView* `}
+	super UIView
+
+	new in "ObjC" `{ return [[UIScrollView alloc] init]; `}
+end

--- a/src/platform/xcode_templates.nit
+++ b/src/platform/xcode_templates.nit
@@ -494,7 +494,7 @@ class PlistTemplate
 	<key>CFBundleShortVersionString</key>
 	<string>{{{short_version}}}</string>
 	<key>CFBundleSignature</key>
-	<string>\\?\\?\\?\\?</string>
+	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>{{{bundle_version}}}</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Support multiple windows on iOS by using a UINavigationController as the root controller which shows the navigation bar at the top of the screen. The navigation bar shows the "Back" button automatically when switching windows. It has room for a title, which can be set manually. This is not ideal as pure portable apps don't define a title leaving the bar mostly empty. This could be fixed either by always asking for a title or by using the app names a default title.

Rewrite the implementation of the ListLayout using a UIStackView in a UIScrollView. This implementation is easier to adapt to different content, and it much more simple than the previous one which used a UITableView. The table view implementation has been kept as a different iOS specific control, but it may be removed in the future.