### PR TITLE
Interpreter FFI: fix running the interpreter FFI in the interpreter

### DIFF
--- a/src/frontend/check_annotation.nit
+++ b/src/frontend/check_annotation.nit
@@ -100,6 +100,7 @@ auto_inspect
 pkgconfig
 cflags
 ldflags
+light_ffi
 
 platform
 """

--- a/src/interpreter/dynamic_loading_ffi/dynamic_loading_ffi.nit
+++ b/src/interpreter/dynamic_loading_ffi/dynamic_loading_ffi.nit
@@ -125,10 +125,10 @@ private extern class CallArg `{ nit_call_arg* `}
 	fun pointer=(value: Pointer) `{ self->value_Pointer = value; `}
 
 	# The `Instance` held by this cell
-	fun instance: Instance `{ return (Instance)self->value_Pointer; `}
+	fun instance: Instance is light_ffi `{ return (Instance)self->value_Pointer; `}
 
 	# The `Instance` held by this cell
-	fun instance=(value: Instance) `{ self->value_Pointer = value; `}
+	fun instance=(value: Instance) is light_ffi `{ self->value_Pointer = value; `}
 
 	# The `NativeString` held by this cell
 	fun native_string: NativeString `{ return (char*)self->value_Pointer; `}

--- a/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
+++ b/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
@@ -37,8 +37,13 @@ redef class AMethPropdef
 	# * Must use the nested foreign code block of the FFI.
 	# * Must not have callbacks.
 	# * Must be implemented in C.
+	# * Must not have a parameter or return typed with a Nit standard class.
 	fun supported_by_dynamic_ffi: Bool
 	do
+		# If the user specfied `is light_ffi`, it must be supported
+		var nats = get_annotations("light_ffi")
+		if nats.not_empty then return true
+
 		var n_extern_code_block = n_extern_code_block
 		if not (n_extern_calls == null and n_extern_code_block != null and
 		        n_extern_code_block.is_c) then return false

--- a/tests/nit.args
+++ b/tests/nit.args
@@ -4,3 +4,4 @@ base_simple3.nit
 -D text=hello -D num=42 -D flag test_define.nit
 -e 'print "hello world"'
 -n -e 'print line' test_prog/README.md test_prog/test_prog.nit
+test_ffi_c_interpreter.nit

--- a/tests/sav/nit_args7.res
+++ b/tests/sav/nit_args7.res
@@ -1,0 +1,4 @@
+FOO
+BAR 1
+BAZ
+BAR 43

--- a/tests/sav/test_ffi_c_interpreter.res
+++ b/tests/sav/test_ffi_c_interpreter.res
@@ -1,0 +1,4 @@
+FOO
+BAR 1
+BAZ
+BAR 43

--- a/tests/test_ffi_c_interpreter.nit
+++ b/tests/test_ffi_c_interpreter.nit
@@ -1,0 +1,23 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import core::kernel
+
+fun foo `{ printf("FOO\n"); `}
+fun bar(i: Int) `{ printf("BAR %ld\n", i); `}
+fun baz: Int `{ printf("BAZ\n"); return 42; `}
+
+foo
+bar(1)
+bar(baz+1)


### PR DESCRIPTION
Let's start with a bit of context, the interpreter supports only the light FFI, a subset of the full FFI supported by the compiler. The interpreter uses an heuristic to guess which extern methods are supported. The problem of #2018, was in this heuristic. The heuristic states that if a parameter of an extern method is a standard Nit class and not an universal or an extern class, then that method probably uses the full FFI. However, sometimes this is false, like in the interpreter where instances of Nit standard classes are stored as pointer in the C code, still without using the full FFI.

To fix #2018, this PR intro a new annotation `light_ffi` to be used on extern methods wrongly detected as full FFI. It bypasses the heuristic and force the interpreter to compile and run the method. (or it tries to) This annotation should not be used otherwise, the heuristic is pretty good at detecting when a method is supported or not.