### PR TITLE
iOS and text: fix UTF-8 support on iOS and improve doc on FFI related text services

### DIFF
--- a/lib/cocoa/foundation.nit
+++ b/lib/cocoa/foundation.nit
@@ -45,13 +45,13 @@ redef class NativeString
 	fun to_nsstring(length: Int): NSString in "ObjC" `{
 		return [[NSString alloc] initWithBytes:self
 			length:length
-			encoding:NSASCIIStringEncoding];
+			encoding:NSUTF8StringEncoding];
 	`}
 end
 
 redef class Text
 	# Get a `NSString` from `self`
-	fun to_nsstring: NSString do return to_cstring.to_nsstring(length)
+	fun to_nsstring: NSString do return to_cstring.to_nsstring(bytelen)
 end
 
 # Wrapper of byte buffers

--- a/lib/cocoa/foundation.nit
+++ b/lib/cocoa/foundation.nit
@@ -63,7 +63,7 @@ extern class NSData in "ObjC" `{ NSData * `}
 	# Number of bytes containted in `self`
 	fun length: Int in "ObjC" `{ return self.length; `}
 
-	redef fun to_s do return bytes.to_s_with_length(length)
+	redef fun to_s do return bytes.to_s_with_copy_and_length(length)
 end
 
 # Error condition

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -2041,22 +2041,43 @@ do
 end
 
 redef class NativeString
-	# Returns `self` as a new String.
+	# Get a `String` from the data at `self` copied into Nit memory
+	#
+	# Require: `self` is a null-terminated string.
 	fun to_s_with_copy: String is abstract
 
-	# Returns `self` as a String of `length`.
+	# Get a `String` from `length` bytes at `self`
+	#
+	# The result may point to the data at `self` or
+	# it may make a copy in Nit controlled memory.
+	# This method should only be used when `self` was allocated by the Nit GC,
+	# or when manually controlling the deallocation of `self`.
 	fun to_s_with_length(length: Int): String is abstract
 
-	# Returns a new instance of `String` with self as `_items`
+	# Get a `String` from the raw `length` bytes at `self`
 	#
-	# /!\: Does not clean the items for compliance with UTF-8,
-	# Use only if you know what you are doing
-	fun to_s_unsafe(len: nullable Int): String is abstract
+	# The default value of `length` is the number of bytes before
+	# the first null character.
+	#
+	# The created `String` points to the data at `self`.
+	# This method should be used when `self` was allocated by the Nit GC,
+	# or when manually controlling the deallocation of `self`.
+	#
+	# /!\: This service does not clean the items for compliance with UTF-8,
+	# use only when the data has already been verified as valid UTF-8.
+	fun to_s_unsafe(length: nullable Int): String is abstract
 
-	# Returns `self` as a String with `bytelen` and `length` set
+	# Get a `String` from the raw `bytelen` bytes at `self` with `unilen` Unicode characters
 	#
-	# SEE: `abstract_text::Text` for more infos on the difference
-	# between `Text::bytelen` and `Text::length`
+	# The created `String` points to the data at `self`.
+	# This method should be used when `self` was allocated by the Nit GC,
+	# or when manually controlling the deallocation of `self`.
+	#
+	# /!\: This service does not clean the items for compliance with UTF-8,
+	# use only when the data has already been verified as valid UTF-8.
+	#
+	# SEE: `abstract_text::Text` for more info on the difference
+	# between `Text::bytelen` and `Text::length`.
 	fun to_s_full(bytelen, unilen: Int): String is abstract
 end
 

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -1168,8 +1168,7 @@ redef class NativeString
 		return to_s_with_length(cstring_length)
 	end
 
-	# Returns `self` as a String of `length`.
-	redef fun to_s_with_length(length): FlatString
+	redef fun to_s_with_length(length)
 	do
 		assert length >= 0
 		return clean_utf8(length)
@@ -1184,7 +1183,6 @@ redef class NativeString
 		return new FlatString.with_infos(self, len, 0)
 	end
 
-	# Returns `self` as a new String.
 	redef fun to_s_with_copy do return to_s_with_copy_and_length(cstring_length)
 
 	# Get a `String` from `length` bytes at `self` copied into Nit memory

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -1185,9 +1185,11 @@ redef class NativeString
 	end
 
 	# Returns `self` as a new String.
-	redef fun to_s_with_copy: FlatString
+	redef fun to_s_with_copy do return to_s_with_copy_and_length(cstring_length)
+
+	# Get a `String` from `length` bytes at `self` copied into Nit memory
+	fun to_s_with_copy_and_length(length: Int): String
 	do
-		var length = cstring_length
 		var r = clean_utf8(length)
 		if r.items != self then return r
 		var new_self = new NativeString(length + 1)


### PR DESCRIPTION
This PR fix the support for UTF-8 on iOS by simply updating the encoding and use the correct number of bytes. This does not completely resolve #1945 as the error messages are still present and I suspect that the UTF-8 cleaning does not work, however I'll update the issue (or open a different one) to reflect that.

Intro the service `to_s_with_copy_and_length` which complements `to_s_with_copy` and `to_s_with_length` . The name is a mouthful, but using optional parameters was not desirable since this service will often be used from a foreign language.

Also improves the doc of the existing services to get a Nit `String` from a `NativeString`. The new doc is more detailed and oriented towards users of the FFI by putting emphasis on where the raw data resides and wether it is cleaned or not.

Also note the removal of return type declarations in method refinements which was not consistent with the introduction.