### PR TITLE
lib/core: fix `Text::is_int`

### DIFF
--- a/lib/core/fixed_ints.nit
+++ b/lib/core/fixed_ints.nit
@@ -899,6 +899,7 @@ redef class Text
 	#     assert not "0x_".is_int
 	#     assert not "0xGE".is_int
 	#     assert not "".is_int
+	#     assert not "Not an Int".is_int
 	fun is_int: Bool do
 		if bytelen == 0 then return false
 		var s = remove_all('_')
@@ -913,7 +914,7 @@ redef class Text
 		if hd == "0x" or hd == "0X" then return rets.is_hex
 		if hd == "0b" or hd == "0B" then return rets.is_bin
 		if hd == "0o" or hd == "0O" then return rets.is_oct
-		return hd.is_dec
+		return rets.is_dec
 	end
 
 	redef fun to_i

--- a/lib/opts.nit
+++ b/lib/opts.nit
@@ -236,7 +236,13 @@ class OptionInt
 		super(help, default, names)
 	end
 
-	redef fun convert(str) do return str.to_i
+	redef fun convert(str)
+	do
+		if str.is_int then return str.to_i
+
+		errors.add "Expected an integer for option {names.join(", ")}."
+		return 0
+	end
 end
 
 # An option with a Float as parameter

--- a/tests/sav/test_opts_args5.res
+++ b/tests/sav/test_opts_args5.res
@@ -2,6 +2,8 @@ Arguments: 2
 -i
 one
 Rest: 0
+Errors: 1
+Expected an integer for option -i, --int.
 OptionBool: false
 OptionCount: 0
 OptionString: 


### PR DESCRIPTION
Fix #2019, `is_int` was always returning true. It was caused by the use of the wrong local variable.

Ping @R4PaSs and @Freddrickk.