### PR TITLE
nitcorn: fix path resolution for vararg routes

### DIFF
--- a/lib/nitcorn/reactor.nit
+++ b/lib/nitcorn/reactor.nit
@@ -154,7 +154,7 @@ end
 
 redef class ServerConfig
 	# Handle to retreive the `HttpFactory` on config change
-	private var factory: HttpFactory
+	private var factory: HttpFactory is noinit
 
 	private init with_factory(factory: HttpFactory) do self.factory = factory
 end
@@ -182,7 +182,8 @@ redef class Sys
 				listeners_count[name, port] = 1
 			end
 		else
-			listeners_count[name, port] += 1
+			var value = listeners_count[name, port].as(not null)
+			listeners_count[name, port] = value + 1
 		end
 
 		interfac.registered = true
@@ -200,7 +201,8 @@ redef class Interfaces
 	redef fun add(e)
 	do
 		super
-		if vh.server_config != null then sys.listen_on(e, vh.server_config.factory)
+		var config = vh.server_config
+		if config != null then sys.listen_on(e, config.factory)
 	end
 
 	# TODO remove

--- a/lib/nitcorn/reactor.nit
+++ b/lib/nitcorn/reactor.nit
@@ -72,7 +72,7 @@ class HttpServer
 				request.uri_params = route.parse_params(request.uri)
 
 				var handler = route.handler
-				var root = route.path
+				var root = route.resolve_path(request)
 				var turi
 				if root != null then
 					turi = ("/" + request.uri.substring_from(root.length)).simplify_path

--- a/lib/nitcorn/vararg_routes.nit
+++ b/lib/nitcorn/vararg_routes.nit
@@ -14,12 +14,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Routes with uri parameters.
+# Routes with parameters.
 #
-# Using `vararg_routes`, a `Route` can contain variable parts
-# that will be matched against a `HttpRequest` path.
+# Using `vararg_routes`, a `Route` path can contain variable parts
+# that will be matched against a `HttpRequest` URL.
 #
-# Variable parts of path can be specified using the `:` prefix.
+# Variable parameters of a route path can be specified using the `:` prefix:
+#
+# ~~~nitish
+# var iface = "http://localhost:3000"
+# var vh = new VirtualHost(iface)
+# vh.routes.add new Route("/blog/articles/:articleId", new BlogArticleAction)
+# ~~~
+#
+# Route arguments can be accessed from the `HttpRequest` within a nitcorn `Action`:
+#
+# ~~~nitish
+# class BlogArticleAction
+#	super Action
+#
+#	redef fun answer(request, url) do
+#		var param = request.param("articleId")
+#		if param == null then
+#			return new HttpResponse(400)
+#		end
+#
+#		print url # let's say "/blog/articles/12"
+#		print param # 12
+#
+#		return new HttpResponse(200)
+#	end
+# end
+# ~~~
 #
 # ## Route matching
 #
@@ -92,9 +118,6 @@
 # assert req.param("id") == "1234"
 # assert req.param("foo") == null
 # ~~~
-#
-# Note that normally, all this work is done by nitcorn.
-# Params can then be accessed in the `HttpRequest` given to `Action::answer`.
 module vararg_routes
 
 import server_config

--- a/lib/nitcorn/vararg_routes.nit
+++ b/lib/nitcorn/vararg_routes.nit
@@ -108,6 +108,20 @@ redef class Route
 		parse_pattern(path)
 	end
 
+	# Replace `self.path` parameters with concrete values from the `request` URI.
+	fun resolve_path(request: HttpRequest): nullable String do
+		if pattern_parts.is_empty then return self.path
+		var path = "/"
+		for part in pattern_parts do
+			if part isa UriString then
+				path /= part.string
+			else if part isa UriParam then
+				path /= request.param(part.name) or else part.name
+			end
+		end
+		return path
+	end
+
 	# Cut `path` into `UriParts`.
 	private fun parse_pattern(path: nullable String) do
 		if path == null then return


### PR DESCRIPTION
Routes with parameters like `/blog/articles/:articleId` where not matched correctly.

It worked until today and I'm not really sure how? Anyway, this PR resolve the route with request parameters before performing the match.

Also done some cleaning in warnings and doc.