### PR TITLE
core: fix some "call on nullable" warnings

### DIFF
--- a/lib/core/collection/abstract_collection.nit
+++ b/lib/core/collection/abstract_collection.nit
@@ -457,7 +457,9 @@ interface Set[E]
 		var res = 23 + length
 		# Note: the order of the elements must not change the hash value.
 		# So, unlike usual hash functions, the accumulator is not combined with itself.
-		for e in self do res += e.hash
+		for e in self do
+			if e != null then res += e.hash
+		end
 		return res
 	end
 

--- a/lib/core/collection/array.nit
+++ b/lib/core/collection/array.nit
@@ -321,7 +321,7 @@ class Array[E]
 	redef fun [](index)
 	do
 		assert index: index >= 0 and index < _length
-		return _items[index]
+		return _items.as(not null)[index]
 	end
 
 	redef fun []=(index, item)
@@ -333,7 +333,7 @@ class Array[E]
 		if _length <= index then
 			_length = index + 1
 		end
-		_items[index] = item
+		_items.as(not null)[index] = item
 	end
 
 	redef fun add(item)
@@ -343,7 +343,7 @@ class Array[E]
 			enlarge(l + 1)
 		end
 		_length = l + 1
-		_items[l] = item
+		_items.as(not null)[l] = item
 	end
 
 	# Slight optimization for arrays
@@ -358,13 +358,13 @@ class Array[E]
 		if items isa Array[E] then
 			var k = 0
 			while l < nl do
-				_items[l] = items._items[k]
+				_items.as(not null)[l] = items._items.as(not null)[k]
 				l += 1
 				k += 1
 			end
 		else
 			for item in items do
-				_items[l] = item
+				_items.as(not null)[l] = item
 				l += 1
 			end
 		end
@@ -404,7 +404,7 @@ class Array[E]
 		if cap <= c then return
 		while c <= cap do c = c * 2 + 2
 		var a = new NativeArray[E](c)
-		if _capacity > 0 then _items.copy_to(a, _length)
+		if _capacity > 0 then _items.as(not null).copy_to(a, _length)
 		_items = a
 		_capacity = c
 	end
@@ -474,9 +474,10 @@ class Array[E]
 		# Efficient implementation
 		var l = length
 		if l != o.length then return false
+		if l == 0 then return true
 		var i = 0
-		var it = _items
-		var oit = o._items
+		var it = _items.as(not null)
+		var oit = o._items.as(not null)
 		while i < l do
 			if it[i] != oit[i] then return false
 			i += 1
@@ -921,10 +922,11 @@ class ArrayCmp[E: nullable Comparable]
 
 	redef fun <=>(o)
 	do
-		var it = _items
-		var oit = o._items
 		var i = 0
 		var l = length
+		if l == 0 then return 0
+		var it = _items.as(not null)
+		var oit = o._items.as(not null)
 		var ol = o.length
 		var len
 		if l < ol then len = l else len = ol

--- a/lib/core/collection/list.nit
+++ b/lib/core/collection/list.nit
@@ -21,21 +21,21 @@ class List[E]
 
 # Access
 
-	redef fun [](index) do return get_node(index).item
+	redef fun [](index) do return get_node(index).as(not null).item
 
-	redef fun []=(index, item) do get_node(index).item = item
-
-	# O(1)
-	redef fun first do return _head.item
+	redef fun []=(index, item) do get_node(index).as(not null).item = item
 
 	# O(1)
-	redef fun first=(e) do _head.item = e
+	redef fun first do return _head.as(not null).item
 
 	# O(1)
-	redef fun last do return _tail.item
+	redef fun first=(e) do _head.as(not null).item = e
 
 	# O(1)
-	redef fun last=(e) do _tail.item = e
+	redef fun last do return _tail.as(not null).item
+
+	# O(1)
+	redef fun last=(e) do _tail.as(not null).item = e
 
 # Queries
 
@@ -87,11 +87,12 @@ class List[E]
 	redef fun push(e)
 	do
 		var node = new ListNode[E](e)
-		if _tail == null then
+		var tail = _tail
+		if tail == null then
 			_head = node
 		else
-			_tail.next = node
-			node.prev = _tail
+			tail.next = node
+			node.prev = tail
 		end
 		_tail = node
 		length += 1
@@ -101,11 +102,12 @@ class List[E]
 	redef fun unshift(e)
 	do
 		var node = new ListNode[E](e)
-		if _head == null then
+		var head = _head
+		if head == null then
 			_tail = node
 		else
-			node.next = _head
-			_head.prev = node
+			node.next = head
+			head.prev = node
 		end
 		_head = node
 		length += 1
@@ -127,11 +129,12 @@ class List[E]
 	# O(1)
 	fun link(l: List[E])
 	do
-		if _tail == null then
+		var tail = _tail
+		if tail == null then
 			_head = l._head
 		else if l._head != null then
-			_tail.next = l._head
-			_tail.next.prev = _tail
+			tail.next = l._head
+			tail.next.as(not null).prev = tail
 		end
 		_tail = l._tail
 		length += l.length
@@ -143,13 +146,13 @@ class List[E]
 	# O(1)
 	redef fun pop
 	do
-		var node = _tail
+		var node = _tail.as(not null)
 		_tail = node.prev
 		node.prev = null
 		if _tail == null then
 			_head = null
 		else
-			_tail.next = null
+			_tail.as(not null).next = null
 		end
 		length -= 1
 		return node.item
@@ -158,13 +161,13 @@ class List[E]
 	# O(1)
 	redef fun shift
 	do
-		var node = _head
+		var node = _head.as(not null)
 		_head = node.next
 		node.next = null
 		if _head == null then
 			_tail = null
 		else
-			_head.prev = null
+			_head.as(not null).prev = null
 		end
 		length -= 1
 		return node.item
@@ -236,14 +239,14 @@ class List[E]
 			if node.next == null then
 				_tail = null
 			else
-				node.next.prev = null
+				node.next.as(not null).prev = null
 			end
 		else if node.next == null then
 			_tail = node.prev
-			node.prev.next = null
+			node.prev.as(not null).next = null
 		else
-			node.prev.next = node.next
-			node.next.prev = node.prev
+			node.prev.as(not null).next = node.next
+			node.next.as(not null).prev = node.prev
 		end
 	end
 
@@ -266,16 +269,16 @@ end
 # This is the iterator class of List
 class ListIterator[E]
 	super IndexedIterator[E]
-	redef fun item do return _node.item
+	redef fun item do return _node.as(not null).item
 
 	# Set item `e` at self `index`.
-	fun item=(e: E) do _node.item = e
+	fun item=(e: E) do _node.as(not null).item = e
 
 	redef fun is_ok do return not _node == null
 
 	redef fun next
 	do
-		_node = _node.next
+		_node = _node.as(not null).next
 		_index += 1
 	end
 
@@ -312,7 +315,7 @@ private class ListReverseIterator[E]
 
 	redef fun next
 	do
-		_node = _node.prev
+		_node = _node.as(not null).prev
 		_index -= 1
 	end
 

--- a/lib/core/error.nit
+++ b/lib/core/error.nit
@@ -86,6 +86,6 @@ class MaybeError[V, E: Error]
 	redef fun to_s do
 		var e = maybe_error
 		if e != null then return e.to_s
-		return value.to_s
+		return value.as(not null).to_s
 	end
 end

--- a/lib/core/exec.nit
+++ b/lib/core/exec.nit
@@ -98,6 +98,7 @@ class Process
 		var args = new FlatBuffer
 		var l = 1 # Number of elements in args
 		args.append(command)
+		var arguments = self.arguments
 		if arguments != null then
 			for a in arguments do
 				args.add('\0')

--- a/lib/core/re.nit
+++ b/lib/core/re.nit
@@ -183,7 +183,7 @@ class Regex
 	# Cache of a single `regmatch_t` to prevent many calls to `malloc`
 	private var native_match: NativeMatchArray is lazy do
 		native_match_is_init = true
-		return new NativeMatchArray.malloc(native.re_nsub+1)
+		return new NativeMatchArray.malloc(native.as(not null).re_nsub+1)
 	end
 
 	private var native_match_is_init = false

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -2102,7 +2102,12 @@ end
 # see `alpha_comparator`
 private class AlphaComparator
 	super Comparator
-	redef fun compare(a, b) do return a.to_s <=> b.to_s
+	redef fun compare(a, b) do
+		if a == b then return 0
+		if a == null then return -1
+		if b == null then return 1
+		return a.to_s <=> b.to_s
+	end
 end
 
 # Stateless comparator that naively use `to_s` to compare things.

--- a/lib/core/text/ropes.nit
+++ b/lib/core/text/ropes.nit
@@ -821,7 +821,7 @@ private class ReverseRopeSubstrings
 	redef fun next do
 		if pos < 0 then return
 		var curr = iter.prev
-		var currit = curr.node
+		var currit = curr.as(not null).node
 		while curr != null do
 			currit = curr.node
 			if not currit isa Concat then
@@ -928,14 +928,14 @@ private class RopeSubstrings
 	redef fun next do
 		pos += str.length
 		if pos > max then return
-		var it = iter.prev
+		var it = iter.prev.as(not null)
 		var rnod = it.node
 		loop
 			if not rnod isa Concat then
 				it.ldone = true
 				it.rdone = true
 				str = rnod.as(FlatString)
-				iter = it.as(not null)
+				iter = it
 				break
 			end
 			if not it.ldone then
@@ -947,7 +947,7 @@ private class RopeSubstrings
 				rnod = rnod._right
 				it = new RopeCharIteratorPiece(rnod, false, false, it)
 			else
-				it = it.prev
+				it = it.prev.as(not null)
 				rnod = it.node
 				continue
 			end

--- a/tests/sav/test_new_native_alt1.res
+++ b/tests/sav/test_new_native_alt1.res
@@ -1,4 +1,4 @@
-Runtime error: Cast failed. Expected `E`, got `Bool` (../lib/core/collection/array.nit:989)
+Runtime error: Cast failed. Expected `E`, got `Bool` (../lib/core/collection/array.nit:991)
 NativeString
 0x4e
 Nit


### PR DESCRIPTION
Too tired too work but no enough to sleep...

According to Jenkins [here](http://gresil.org/jenkins/job/CI_github/4177/warnings2Result/package.795683049/), [here](http://gresil.org/jenkins/job/CI_github/4177/warnings2Result/package.-1960060028/) and [here](http://gresil.org/jenkins/job/CI_github/4177/warnings2Result/package.1056020115/), this PR should fix the remaining warning of `core/`.

The algorithm used for the human/pillow approach was:

~~~
1. can it be fixed shamelessly with a .as(not null) ?
    yes: add that sweet .as(not null) and hope for the best
2. is there more than one occurrence of the variable involved?
    yes: factorise with a local variable, add that sweet .as(not null) and hope for the best
3. is this code to complex for my human/pillow head?
    yes: shame = false, fallback to 1.
abort "Not yet occurred case..."
~~~

There is love for @R4PaSs (core::text), @xymus (core::re) and @privat (core::*).

TL;DR No more warnings in core.