### PR TITLE
Poset: add clone, ==, hash and sub

### DIFF
--- a/lib/poset.nit
+++ b/lib/poset.nit
@@ -380,6 +380,55 @@ class POSet[E]
 		sort(lin)
 		return lin
 	end
+
+	# Return an induced sub-poset
+	#
+	# The elements of the result are those given in argument.
+	#
+	# ~~~
+	# var pos = new POSet[String]
+	# pos.add_chain(["A", "B", "C", "D", "E"])
+	# pos.add_chain(["A", "X", "C", "Y", "E"])
+	#
+	# var pos2 = pos.sub(["A", "B", "D", "Y", "E"])
+	# assert pos2.has_exactly(["A", "B", "D", "Y", "E"])
+	# ~~~
+	#
+	# The full relationship is preserved between the provided elements.
+	#
+	# ~~~
+	# for e1 in pos2 do for e2 in pos2 do
+	#    assert pos2.has_edge(e1, e2) == pos.has_edge(e1, e2)
+	# end
+	# ~~~
+	#
+	# Not that by definition, the direct relationship is the transitive
+	# reduction of the full reduction. Thus, the direct relationship of the
+	# sub-poset may not be included in the direct relationship of self because an
+	# indirect edge becomes a direct one if all the intermediates elements
+	# are absent in the sub-poset.
+	#
+	# ~~~
+	# assert pos.has_direct_edge("B", "D")  == false
+	# assert pos2.has_direct_edge("B", "D") == true
+	#
+	# assert pos2["B"].direct_greaters.has_exactly(["D", "Y"])
+	# ~~~
+	fun sub(elements: Collection[E]): POSet[E]
+	do
+		var res = new POSet[E]
+		for e in self do
+			if not elements.has(e) then continue
+			res.add_node(e)
+		end
+		for e in res do
+			for f in self[e].greaters do
+				if not elements.has(f) then continue
+				res.add_edge(e, f)
+			end
+		end
+		return res
+	end
 end
 
 # View of an objet in a poset

--- a/lib/poset.nit
+++ b/lib/poset.nit
@@ -74,6 +74,7 @@ module poset
 class POSet[E]
 	super Collection[E]
 	super Comparator
+	super Cloneable
 
 	redef type COMPARED: E is fixed
 
@@ -380,6 +381,8 @@ class POSet[E]
 		sort(lin)
 		return lin
 	end
+
+	redef fun clone do return sub(self)
 
 	# Return an induced sub-poset
 	#

--- a/lib/poset.nit
+++ b/lib/poset.nit
@@ -417,6 +417,14 @@ class POSet[E]
 	#
 	# assert pos2["B"].direct_greaters.has_exactly(["D", "Y"])
 	# ~~~
+	#
+	# If the `elements` contains all then the result is a clone of self.
+	#
+	# ~~~
+	# var pos3 = pos.sub(pos)
+	# assert pos3 == pos
+	# assert pos3 == pos.clone
+	# ~~~
 	fun sub(elements: Collection[E]): POSet[E]
 	do
 		var res = new POSet[E]
@@ -429,6 +437,50 @@ class POSet[E]
 				if not elements.has(f) then continue
 				res.add_edge(e, f)
 			end
+		end
+		return res
+	end
+
+	# Two posets are equal if they contain the same elements and edges.
+	#
+	# ~~~
+	# var pos1 = new POSet[String]
+	# pos1.add_chain(["A", "B", "C", "D", "E"])
+	# pos1.add_chain(["A", "X", "C", "Y", "E"])
+	#
+	# var pos2 = new POSet[Object]
+	# pos2.add_edge("Y", "E")
+	# pos2.add_chain(["A", "X", "C", "D", "E"])
+	# pos2.add_chain(["A", "B", "C", "Y"])
+	#
+	# assert pos1 == pos2
+	#
+	# pos1.add_edge("D", "Y")
+	# assert pos1 != pos2
+	#
+	# pos2.add_edge("D", "Y")
+	# assert pos1 == pos2
+	#
+	# pos1.add_node("Z")
+	# assert pos1 != pos2
+	# ~~~
+	redef fun ==(other) do
+		if not other isa POSet[nullable Object] then return false
+		if not self.elements.keys.has_exactly(other.elements.keys) then return false
+		for e, ee in elements do
+			if ee.direct_greaters != other[e].direct_greaters then return false
+		end
+		assert hash == other.hash
+		return true
+	end
+
+	redef fun hash
+	do
+		var res = 0
+		for e, ee in elements do
+			if e == null then continue
+			res += e.hash
+			res += ee.direct_greaters.length
 		end
 		return res
 	end


### PR DESCRIPTION
Extends the POSet class with some useful methods to compare and (partially) copy posets.