### PR TITLE
JSON serialization: write pretty JSON

### DIFF
--- a/lib/json/serialization.nit
+++ b/lib/json/serialization.nit
@@ -142,7 +142,8 @@ class JsonSerializer
 			if plain_json then
 				for o in open_objects do
 					if object.is_same_serialized(o) then
-						# Cycle detected
+						# Cycle, can't be managed in plain json
+						warn "Cycle detected in serialized object, replacing reference with 'null'."
 						stream.write "null"
 						return
 					end

--- a/lib/json/serialization.nit
+++ b/lib/json/serialization.nit
@@ -553,6 +553,7 @@ redef class Collection[E]
 				else v.stream.write ", "
 
 				if not v.try_to_serialize(e) then
+					assert e != null # null would have been serialized
 					v.warn("element of type {e.class_name} is not serializable.")
 				end
 			end
@@ -614,6 +615,7 @@ redef class Map[K, V]
 				v.stream.write k.to_s.to_json
 				v.stream.write ": "
 				if not v.try_to_serialize(val) then
+					assert val != null # null would have been serialized
 					v.warn("element of type {val.class_name} is not serializable.")
 					v.stream.write "null"
 				end

--- a/lib/json/serialization.nit
+++ b/lib/json/serialization.nit
@@ -99,7 +99,7 @@ class JsonSerializer
 	# Target writing stream
 	var stream: Writer
 
-	# Write plain JSON? easier to read but does not support Nit deserialization
+	# Write plain JSON? Standard JSON without metadata for deserialization
 	#
 	# If `false`, the default, serialize to support deserialization:
 	#
@@ -121,8 +121,17 @@ class JsonSerializer
 	# * Does not support cycles, will replace the problematic references by `null`.
 	# * Does not serialize the meta-data needed to deserialize the objects
 	#   back to regular Nit objects.
-	# * Keys of Nit `HashMap` are converted to their string reprensentation using `to_s`.
+	# * Keys of Nit `HashMap` are converted to their string representation using `to_s`.
 	var plain_json = false is writable
+
+	# Write pretty JSON for human eyes?
+	#
+	# Toggles skipping lines between attributes of an object and
+	# properly indent the written JSON.
+	var pretty_json = false is writable
+
+	# Current indentation level used for writing `pretty_json`
+	private var indent_level = 0
 
 	# List of the current open objects, the first is the main target of the serialization
 	#
@@ -163,10 +172,11 @@ class JsonSerializer
 	redef fun serialize_attribute(name, value)
 	do
 		if not plain_json or not first_attribute then
-			stream.write ", "
+			stream.write ","
 			first_attribute = false
 		end
 
+		new_line_and_indent
 		stream.write "\""
 		stream.write name
 		stream.write "\": "
@@ -178,12 +188,26 @@ class JsonSerializer
 		if not plain_json and cache.has_object(object) then
 			# if already serialized, add local reference
 			var id = cache.id_for(object)
-			stream.write "\{\"__kind\": \"ref\", \"__id\": "
+			stream.write "\{"
+			indent_level += 1
+			new_line_and_indent
+			stream.write "\"__kind\": \"ref\", \"__id\": "
 			stream.write id.to_s
+			indent_level -= 1
+			new_line_and_indent
 			stream.write "\}"
 		else
 			# serialize here
 			serialize object
+		end
+	end
+
+	# Write a new line and indent it, only if `pretty_json`
+	private fun new_line_and_indent
+	do
+		if pretty_json then
+			stream.write "\n"
+			for i in indent_level.times do stream.write "\t"
 		end
 	end
 end
@@ -476,7 +500,9 @@ redef class Serializable
 	do
 		var id = v.cache.new_id_for(self)
 		v.stream.write "\{"
+		v.indent_level += 1
 		if not v.plain_json then
+			v.new_line_and_indent
 			v.stream.write "\"__kind\": \"obj\", \"__id\": "
 			v.stream.write id.to_s
 			v.stream.write ", \"__class\": \""
@@ -484,6 +510,9 @@ redef class Serializable
 			v.stream.write "\""
 		end
 		core_serialize_to(v)
+
+		v.indent_level -= 1
+		v.new_line_and_indent
 		v.stream.write "\}"
 	end
 
@@ -546,17 +575,21 @@ redef class Collection[E]
 	private fun serialize_to_pure_json(v: JsonSerializer)
 	do
 			v.stream.write "["
+			v.indent_level += 1
 			var is_first = true
 			for e in self do
 				if is_first then
 					is_first = false
-				else v.stream.write ", "
+				else v.stream.write ","
+				v.new_line_and_indent
 
 				if not v.try_to_serialize(e) then
 					assert e != null # null would have been serialized
 					v.warn("element of type {e.class_name} is not serializable.")
 				end
 			end
+			v.indent_level -= 1
+			v.new_line_and_indent
 			v.stream.write "]"
 	end
 end
@@ -567,16 +600,23 @@ redef class SimpleCollection[E]
 		# Register as pseudo object
 		if not v.plain_json then
 			var id = v.cache.new_id_for(self)
-			v.stream.write """{"__kind": "obj", "__id": """
+			v.stream.write """{"""
+			v.indent_level += 1
+			v.new_line_and_indent
+			v.stream.write """"__kind": "obj", "__id": """
 			v.stream.write id.to_s
 			v.stream.write """, "__class": """"
 			v.stream.write class_name
-			v.stream.write """", "__items": """
+			v.stream.write """","""
+			v.new_line_and_indent
+			v.stream.write """"__items": """
 		end
 
 		serialize_to_pure_json v
 
 		if not v.plain_json then
+			v.indent_level -= 1
+			v.new_line_and_indent
 			v.stream.write "\}"
 		end
 	end
@@ -605,11 +645,13 @@ redef class Map[K, V]
 
 		if v.plain_json then
 			v.stream.write "\{"
+			v.indent_level += 1
 			var first = true
 			for key, val in self do
 				if not first then
-					v.stream.write ", "
+					v.stream.write ","
 				else first = false
+				v.new_line_and_indent
 
 				var k = key or else "null"
 				v.stream.write k.to_s.to_json
@@ -620,21 +662,32 @@ redef class Map[K, V]
 					v.stream.write "null"
 				end
 			end
+			v.indent_level -= 1
+			v.new_line_and_indent
 			v.stream.write "\}"
 		else
-			v.stream.write """{"__kind": "obj", "__id": """
+			v.stream.write "\{"
+			v.indent_level += 1
+			v.new_line_and_indent
+			v.stream.write """"__kind": "obj", "__id": """
 			v.stream.write id.to_s
 			v.stream.write """, "__class": """"
 			v.stream.write class_name
 			v.stream.write """", "__length": """
 			v.stream.write length.to_s
 
-			v.stream.write """, "__keys": """
+			v.stream.write ","
+			v.new_line_and_indent
+			v.stream.write """"__keys": """
 			keys.serialize_to_pure_json v
 
-			v.stream.write """, "__values": """
+			v.stream.write ","
+			v.new_line_and_indent
+			v.stream.write """"__values": """
 			values.serialize_to_pure_json v
 
+			v.indent_level -= 1
+			v.new_line_and_indent
 			v.stream.write "\}"
 		end
 	end

--- a/tests/sav/nitce/test_json_deserialization_alt1.res
+++ b/tests/sav/nitce/test_json_deserialization_alt1.res
@@ -2,7 +2,7 @@
 <A: true a 0.123 1234 asdf false p4ssw0rd>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"serialization_specific_name": "asdf","n": null}
 
 # Back in Nit:
 <A: true a 0.123 1234 asdf false p4ssw0rd>
@@ -11,7 +11,7 @@
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"serialization_specific_name": "hjkl","n": 12,"ii": 1111,"ss": "qwer"}
 
 # Back in Nit:
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
@@ -20,7 +20,7 @@
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}, "b": {"__kind": "obj", "__id": 2, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"serialization_specific_name": "asdf","n": null},"b": {"__kind": "obj", "__id": 2, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"serialization_specific_name": "hjkl","n": 12,"ii": 1111,"ss": "qwer"},"aa": {"__kind": "ref", "__id": 1}}
 
 # Back in Nit:
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
@@ -30,7 +30,7 @@
 <- false p4ssw0rd> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "new line ->\n<-", "n": null, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"serialization_specific_name": "new line ->\n<-","n": null,"ii": 1111,"ss": "\tf\"\r\\/","d": {"__kind": "ref", "__id": 0}}
 
 # Back in Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
@@ -40,7 +40,7 @@
 <E: a: hello, 1234, 123.4; b: hella, 2345, 234.5>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "E", "a": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": ["hello", 1234, 123.4]}, "b": {"__kind": "obj", "__id": 2, "__class": "Array", "__items": ["hella", 2345, 234.5]}}
+{"__kind": "obj", "__id": 0, "__class": "E","a": {"__kind": "obj", "__id": 1, "__class": "Array","__items": ["hello",1234,123.4]},"b": {"__kind": "obj", "__id": 2, "__class": "Array","__items": ["hella",2345,234.5]}}
 
 # Back in Nit:
 <E: a: hello, 1234, 123.4; b: hella, 2345, 234.5>
@@ -49,7 +49,7 @@
 <E: 2222>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "F", "n": 2222}
+{"__kind": "obj", "__id": 0, "__class": "F","n": 2222}
 
 # Back in Nit:
 null
@@ -58,7 +58,7 @@ null
 <E: 33.33>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "F", "n": 33.33}
+{"__kind": "obj", "__id": 0, "__class": "F","n": 33.33}
 
 # Back in Nit:
 null
@@ -67,7 +67,7 @@ null
 <G: hs: -1, 0; s: one, two; hm: one. 1, two. 2; am: three. 3, four. 4>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "G", "hs": {"__kind": "obj", "__id": 1, "__class": "HashSet", "__items": [-1, 0]}, "s": {"__kind": "obj", "__id": 2, "__class": "ArraySet", "__items": ["one", "two"]}, "hm": {"__kind": "obj", "__id": 3, "__class": "HashMap", "__length": 2, "__keys": ["one", "two"], "__values": [1, 2]}, "am": {"__kind": "obj", "__id": 4, "__class": "ArrayMap", "__length": 2, "__keys": ["three", "four"], "__values": ["3", "4"]}}
+{"__kind": "obj", "__id": 0, "__class": "G","hs": {"__kind": "obj", "__id": 1, "__class": "HashSet","__items": [-1,0]},"s": {"__kind": "obj", "__id": 2, "__class": "ArraySet","__items": ["one","two"]},"hm": {"__kind": "obj", "__id": 3, "__class": "HashMap", "__length": 2,"__keys": ["one","two"],"__values": [1,2]},"am": {"__kind": "obj", "__id": 4, "__class": "ArrayMap", "__length": 2,"__keys": ["three","four"],"__values": ["3","4"]}}
 
 # Back in Nit:
 <G: hs: ; s: ; hm: ; am: >

--- a/tests/sav/nitce/test_json_deserialization_alt3.res
+++ b/tests/sav/nitce/test_json_deserialization_alt3.res
@@ -1,0 +1,192 @@
+# Nit:
+<A: true a 0.123 1234 asdf false p4ssw0rd>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "A",
+	"b": true,
+	"c": {"__kind": "char", "__val": "a"},
+	"f": 0.123,
+	"i": 1234,
+	"serialization_specific_name": "asdf",
+	"n": null
+}
+
+# Back in Nit:
+<A: true a 0.123 1234 asdf false p4ssw0rd>
+
+# Nit:
+<B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "B",
+	"b": false,
+	"c": {"__kind": "char", "__val": "b"},
+	"f": 123.123,
+	"i": 2345,
+	"serialization_specific_name": "hjkl",
+	"n": 12,
+	"ii": 1111,
+	"ss": "qwer"
+}
+
+# Back in Nit:
+<B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
+
+# Nit:
+<C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "C",
+	"a": {
+		"__kind": "obj", "__id": 1, "__class": "A",
+		"b": true,
+		"c": {"__kind": "char", "__val": "a"},
+		"f": 0.123,
+		"i": 1234,
+		"serialization_specific_name": "asdf",
+		"n": null
+	},
+	"b": {
+		"__kind": "obj", "__id": 2, "__class": "B",
+		"b": false,
+		"c": {"__kind": "char", "__val": "b"},
+		"f": 123.123,
+		"i": 2345,
+		"serialization_specific_name": "hjkl",
+		"n": 12,
+		"ii": 1111,
+		"ss": "qwer"
+	},
+	"aa": {
+		"__kind": "ref", "__id": 1
+	}
+}
+
+# Back in Nit:
+<C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
+
+# Nit:
+<D: <B: <A: false b 123.123 2345 new line ->
+<- false p4ssw0rd> 1111 	f"\/> true>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "D",
+	"b": false,
+	"c": {"__kind": "char", "__val": "b"},
+	"f": 123.123,
+	"i": 2345,
+	"serialization_specific_name": "new line ->\n<-",
+	"n": null,
+	"ii": 1111,
+	"ss": "\tf\"\r\\/",
+	"d": {
+		"__kind": "ref", "__id": 0
+	}
+}
+
+# Back in Nit:
+<D: <B: <A: false b 123.123 2345 new line ->
+<- false p4ssw0rd> 1111 	f"\/> true>
+
+# Nit:
+<E: a: hello, 1234, 123.4; b: hella, 2345, 234.5>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "E",
+	"a": {
+		"__kind": "obj", "__id": 1, "__class": "Array",
+		"__items": [
+			"hello",
+			1234,
+			123.4
+		]
+	},
+	"b": {
+		"__kind": "obj", "__id": 2, "__class": "Array",
+		"__items": [
+			"hella",
+			2345,
+			234.5
+		]
+	}
+}
+
+# Back in Nit:
+<E: a: hello, 1234, 123.4; b: hella, 2345, 234.5>
+
+# Nit:
+<E: 2222>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "F",
+	"n": 2222
+}
+
+# Back in Nit:
+null
+
+# Nit:
+<E: 33.33>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "F",
+	"n": 33.33
+}
+
+# Back in Nit:
+null
+
+# Nit:
+<G: hs: -1, 0; s: one, two; hm: one. 1, two. 2; am: three. 3, four. 4>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "G",
+	"hs": {
+		"__kind": "obj", "__id": 1, "__class": "HashSet",
+		"__items": [
+			-1,
+			0
+		]
+	},
+	"s": {
+		"__kind": "obj", "__id": 2, "__class": "ArraySet",
+		"__items": [
+			"one",
+			"two"
+		]
+	},
+	"hm": {
+		"__kind": "obj", "__id": 3, "__class": "HashMap", "__length": 2,
+		"__keys": [
+			"one",
+			"two"
+		],
+		"__values": [
+			1,
+			2
+		]
+	},
+	"am": {
+		"__kind": "obj", "__id": 4, "__class": "ArrayMap", "__length": 2,
+		"__keys": [
+			"three",
+			"four"
+		],
+		"__values": [
+			"3",
+			"4"
+		]
+	}
+}
+
+# Back in Nit:
+<G: hs: ; s: ; hm: ; am: >
+

--- a/tests/sav/nitce/test_serialization.res
+++ b/tests/sav/nitce/test_serialization.res
@@ -2,24 +2,24 @@
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "\tf\"\r\\/","d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/nitce/test_serialization_alt2.res
+++ b/tests/sav/nitce/test_serialization_alt2.res
@@ -5,24 +5,24 @@ alt/test_serialization_alt2.nit:64,1--72,3: Warning: superfluous use of `auto_se
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]}}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__items": [88, "hello", null]}}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array","__items": [88,"hello",null]}},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/nitce/test_serialization_alt3.res
+++ b/tests/sav/nitce/test_serialization_alt3.res
@@ -3,24 +3,24 @@ alt/test_serialization_alt3.nit:40,1--51,3: Warning: superfluous use of `noseria
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]}}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__items": [88, "hello", null]}}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array","__items": [88,"hello",null]}},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/nitce/test_serialization_alt4.res
+++ b/tests/sav/nitce/test_serialization_alt4.res
@@ -3,24 +3,24 @@ alt/test_serialization_alt4.nit:29,2--31,26: Warning: superfluous use of `serial
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "\tf\"\r\\/","d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/nitce/test_serialization_alt5.res
+++ b/tests/sav/nitce/test_serialization_alt5.res
@@ -3,24 +3,24 @@ alt/test_serialization_alt5.nit:22,1--38,3: Warning: duplicated annotation `seri
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "\tf\"\r\\/","d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/nitce/test_serialization_redef.res
+++ b/tests/sav/nitce/test_serialization_redef.res
@@ -2,24 +2,24 @@
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "\tf\"\r\\/","d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/nitce/test_serialization_redef_alt0.res
+++ b/tests/sav/nitce/test_serialization_redef_alt0.res
@@ -2,24 +2,24 @@
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"iii": 6789,"sss": "redef"}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"iii": 6789,"sss": "redef","ii": 1111,"ss": "qwer"}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array","__items": [88,"hello",null]},"iii": 6789,"sss": "redef"},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array","__items": [88,"hello",null]},"iii": 6789,"sss": "redef","ii": 1111,"ss": "qwer"},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"iii": 6789,"sss": "redef","ii": 1111,"ss": "\tf\"\r\\/","d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/nitce/test_serialization_redef_alt1.res
+++ b/tests/sav/nitce/test_serialization_redef_alt1.res
@@ -2,24 +2,24 @@
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer","ffff": 6.789,"bbbb": false}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer","ffff": 6.789,"bbbb": false},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "ii": 1111, "ss": "\tf\"\r\\/", "ffff": 6.789, "bbbb": false, "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"ii": 1111,"ss": "\tf\"\r\\/","ffff": 6.789,"bbbb": false,"d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/nitce/test_serialization_redef_alt2.res
+++ b/tests/sav/nitce/test_serialization_redef_alt2.res
@@ -2,24 +2,24 @@
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"iii": 6789,"sss": "redef"}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"iii": 6789,"sss": "redef","ii": 1111,"ss": "qwer","ffff": 6.789,"bbbb": false}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array","__items": [88,"hello",null]},"iii": 6789,"sss": "redef"},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array","__items": [88,"hello",null]},"iii": 6789,"sss": "redef","ii": 1111,"ss": "qwer","ffff": 6.789,"bbbb": false},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "\tf\"\r\\/", "ffff": 6.789, "bbbb": false, "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array","__items": [88,"hello",null]},"iii": 6789,"sss": "redef","ii": 1111,"ss": "\tf\"\r\\/","ffff": 6.789,"bbbb": false,"d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/test_json_deserialization.res
+++ b/tests/sav/test_json_deserialization.res
@@ -2,7 +2,7 @@
 <A: true a 0.123 1234 asdf false p4ssw0rd>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"serialization_specific_name": "asdf","n": null}
 
 # Back in Nit:
 <A: true a 0.123 1234 asdf false p4ssw0rd>
@@ -11,7 +11,7 @@
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"serialization_specific_name": "hjkl","n": 12,"ii": 1111,"ss": "qwer"}
 
 # Back in Nit:
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
@@ -20,7 +20,7 @@
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}, "b": {"__kind": "obj", "__id": 2, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"serialization_specific_name": "asdf","n": null},"b": {"__kind": "obj", "__id": 2, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"serialization_specific_name": "hjkl","n": 12,"ii": 1111,"ss": "qwer"},"aa": {"__kind": "ref", "__id": 1}}
 
 # Back in Nit:
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
@@ -30,7 +30,7 @@
 <- false p4ssw0rd> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "new line ->\n<-", "n": null, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"serialization_specific_name": "new line ->\n<-","n": null,"ii": 1111,"ss": "\tf\"\r\\/","d": {"__kind": "ref", "__id": 0}}
 
 # Back in Nit:
 <D: <B: <A: false b 123.123 2345 new line ->

--- a/tests/sav/test_json_deserialization_alt1.res
+++ b/tests/sav/test_json_deserialization_alt1.res
@@ -2,7 +2,7 @@
 <A: true a 0.123 1234 asdf false p4ssw0rd>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"serialization_specific_name": "asdf","n": null}
 
 # Back in Nit:
 <A: true a 0.123 1234 asdf false p4ssw0rd>
@@ -11,7 +11,7 @@
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"serialization_specific_name": "hjkl","n": 12,"ii": 1111,"ss": "qwer"}
 
 # Back in Nit:
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
@@ -20,7 +20,7 @@
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}, "b": {"__kind": "obj", "__id": 2, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"serialization_specific_name": "asdf","n": null},"b": {"__kind": "obj", "__id": 2, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"serialization_specific_name": "hjkl","n": 12,"ii": 1111,"ss": "qwer"},"aa": {"__kind": "ref", "__id": 1}}
 
 # Back in Nit:
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
@@ -30,7 +30,7 @@
 <- false p4ssw0rd> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "serialization_specific_name": "new line ->\n<-", "n": null, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"serialization_specific_name": "new line ->\n<-","n": null,"ii": 1111,"ss": "\tf\"\r\\/","d": {"__kind": "ref", "__id": 0}}
 
 # Back in Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
@@ -40,7 +40,7 @@
 <E: a: hello, 1234, 123.4; b: hella, 2345, 234.5>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "E", "a": {"__kind": "obj", "__id": 1, "__class": "Array[Object]", "__items": ["hello", 1234, 123.4]}, "b": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Serializable]", "__items": ["hella", 2345, 234.5]}}
+{"__kind": "obj", "__id": 0, "__class": "E","a": {"__kind": "obj", "__id": 1, "__class": "Array[Object]","__items": ["hello",1234,123.4]},"b": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Serializable]","__items": ["hella",2345,234.5]}}
 
 # Back in Nit:
 <E: a: hello, 1234, 123.4; b: hella, 2345, 234.5>
@@ -49,7 +49,7 @@
 <E: 2222>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "F[Int]", "n": 2222}
+{"__kind": "obj", "__id": 0, "__class": "F[Int]","n": 2222}
 
 # Back in Nit:
 <E: 2222>
@@ -58,7 +58,7 @@
 <E: 33.33>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "F[Float]", "n": 33.33}
+{"__kind": "obj", "__id": 0, "__class": "F[Float]","n": 33.33}
 
 # Back in Nit:
 <E: 33.33>
@@ -67,7 +67,7 @@
 <G: hs: -1, 0; s: one, two; hm: one. 1, two. 2; am: three. 3, four. 4>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "G", "hs": {"__kind": "obj", "__id": 1, "__class": "HashSet[Int]", "__items": [-1, 0]}, "s": {"__kind": "obj", "__id": 2, "__class": "ArraySet[String]", "__items": ["one", "two"]}, "hm": {"__kind": "obj", "__id": 3, "__class": "HashMap[String, Int]", "__length": 2, "__keys": ["one", "two"], "__values": [1, 2]}, "am": {"__kind": "obj", "__id": 4, "__class": "ArrayMap[String, String]", "__length": 2, "__keys": ["three", "four"], "__values": ["3", "4"]}}
+{"__kind": "obj", "__id": 0, "__class": "G","hs": {"__kind": "obj", "__id": 1, "__class": "HashSet[Int]","__items": [-1,0]},"s": {"__kind": "obj", "__id": 2, "__class": "ArraySet[String]","__items": ["one","two"]},"hm": {"__kind": "obj", "__id": 3, "__class": "HashMap[String, Int]", "__length": 2,"__keys": ["one","two"],"__values": [1,2]},"am": {"__kind": "obj", "__id": 4, "__class": "ArrayMap[String, String]", "__length": 2,"__keys": ["three","four"],"__values": ["3","4"]}}
 
 # Back in Nit:
 <G: hs: -1, 0; s: one, two; hm: one. 1, two. 2; am: three. 3, four. 4>

--- a/tests/sav/test_json_deserialization_alt2.res
+++ b/tests/sav/test_json_deserialization_alt2.res
@@ -2,19 +2,19 @@
 <A: true a 0.123 1234 asdf false p4ssw0rd>
 
 # Json:
-{"b": true, "c": "a", "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}
+{"b": true,"c": "a","f": 0.123,"i": 1234,"serialization_specific_name": "asdf","n": null}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
 
 # Json:
-{"b": false, "c": "b", "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}
+{"b": false,"c": "b","f": 123.123,"i": 2345,"serialization_specific_name": "hjkl","n": 12,"ii": 1111,"ss": "qwer"}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
 
 # Json:
-{"a": {"b": true, "c": "a", "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}, "b": {"b": false, "c": "b", "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}, "aa": {"b": true, "c": "a", "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}}
+{"a": {"b": true,"c": "a","f": 0.123,"i": 1234,"serialization_specific_name": "asdf","n": null},"b": {"b": false,"c": "b","f": 123.123,"i": 2345,"serialization_specific_name": "hjkl","n": 12,"ii": 1111,"ss": "qwer"},"aa": {"b": true,"c": "a","f": 0.123,"i": 1234,"serialization_specific_name": "asdf","n": null}}
 
 Serialization warning: Cycle detected in serialized object, replacing reference with 'null'.
 # Nit:
@@ -22,13 +22,13 @@ Serialization warning: Cycle detected in serialized object, replacing reference 
 <- false p4ssw0rd> 1111 	f"\/> true>
 
 # Json:
-{"b": false, "c": "b", "f": 123.123, "i": 2345, "serialization_specific_name": "new line ->\n<-", "n": null, "ii": 1111, "ss": "\tf\"\r\\/", "d": null}
+{"b": false,"c": "b","f": 123.123,"i": 2345,"serialization_specific_name": "new line ->\n<-","n": null,"ii": 1111,"ss": "\tf\"\r\\/","d": null}
 
 # Nit:
 <E: a: hello, 1234, 123.4; b: hella, 2345, 234.5>
 
 # Json:
-{"a": ["hello", 1234, 123.4], "b": ["hella", 2345, 234.5]}
+{"a": ["hello",1234,123.4],"b": ["hella",2345,234.5]}
 
 # Nit:
 <E: 2222>
@@ -46,5 +46,5 @@ Serialization warning: Cycle detected in serialized object, replacing reference 
 <G: hs: -1, 0; s: one, two; hm: one. 1, two. 2; am: three. 3, four. 4>
 
 # Json:
-{"hs": [-1, 0], "s": ["one", "two"], "hm": {"one": 1, "two": 2}, "am": {"three": "3", "four": "4"}}
+{"hs": [-1,0],"s": ["one","two"],"hm": {"one": 1,"two": 2},"am": {"three": "3","four": "4"}}
 

--- a/tests/sav/test_json_deserialization_alt2.res
+++ b/tests/sav/test_json_deserialization_alt2.res
@@ -16,6 +16,7 @@
 # Json:
 {"a": {"b": true, "c": "a", "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}, "b": {"b": false, "c": "b", "f": 123.123, "i": 2345, "serialization_specific_name": "hjkl", "n": 12, "ii": 1111, "ss": "qwer"}, "aa": {"b": true, "c": "a", "f": 0.123, "i": 1234, "serialization_specific_name": "asdf", "n": null}}
 
+Serialization warning: Cycle detected in serialized object, replacing reference with 'null'.
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false p4ssw0rd> 1111 	f"\/> true>

--- a/tests/sav/test_json_deserialization_alt3.res
+++ b/tests/sav/test_json_deserialization_alt3.res
@@ -1,0 +1,192 @@
+# Nit:
+<A: true a 0.123 1234 asdf false p4ssw0rd>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "A",
+	"b": true,
+	"c": {"__kind": "char", "__val": "a"},
+	"f": 0.123,
+	"i": 1234,
+	"serialization_specific_name": "asdf",
+	"n": null
+}
+
+# Back in Nit:
+<A: true a 0.123 1234 asdf false p4ssw0rd>
+
+# Nit:
+<B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "B",
+	"b": false,
+	"c": {"__kind": "char", "__val": "b"},
+	"f": 123.123,
+	"i": 2345,
+	"serialization_specific_name": "hjkl",
+	"n": 12,
+	"ii": 1111,
+	"ss": "qwer"
+}
+
+# Back in Nit:
+<B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
+
+# Nit:
+<C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "C",
+	"a": {
+		"__kind": "obj", "__id": 1, "__class": "A",
+		"b": true,
+		"c": {"__kind": "char", "__val": "a"},
+		"f": 0.123,
+		"i": 1234,
+		"serialization_specific_name": "asdf",
+		"n": null
+	},
+	"b": {
+		"__kind": "obj", "__id": 2, "__class": "B",
+		"b": false,
+		"c": {"__kind": "char", "__val": "b"},
+		"f": 123.123,
+		"i": 2345,
+		"serialization_specific_name": "hjkl",
+		"n": 12,
+		"ii": 1111,
+		"ss": "qwer"
+	},
+	"aa": {
+		"__kind": "ref", "__id": 1
+	}
+}
+
+# Back in Nit:
+<C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
+
+# Nit:
+<D: <B: <A: false b 123.123 2345 new line ->
+<- false p4ssw0rd> 1111 	f"\/> true>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "D",
+	"b": false,
+	"c": {"__kind": "char", "__val": "b"},
+	"f": 123.123,
+	"i": 2345,
+	"serialization_specific_name": "new line ->\n<-",
+	"n": null,
+	"ii": 1111,
+	"ss": "\tf\"\r\\/",
+	"d": {
+		"__kind": "ref", "__id": 0
+	}
+}
+
+# Back in Nit:
+<D: <B: <A: false b 123.123 2345 new line ->
+<- false p4ssw0rd> 1111 	f"\/> true>
+
+# Nit:
+<E: a: hello, 1234, 123.4; b: hella, 2345, 234.5>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "E",
+	"a": {
+		"__kind": "obj", "__id": 1, "__class": "Array[Object]",
+		"__items": [
+			"hello",
+			1234,
+			123.4
+		]
+	},
+	"b": {
+		"__kind": "obj", "__id": 2, "__class": "Array[nullable Serializable]",
+		"__items": [
+			"hella",
+			2345,
+			234.5
+		]
+	}
+}
+
+# Back in Nit:
+<E: a: hello, 1234, 123.4; b: hella, 2345, 234.5>
+
+# Nit:
+<E: 2222>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "F[Int]",
+	"n": 2222
+}
+
+# Back in Nit:
+null
+
+# Nit:
+<E: 33.33>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "F[Float]",
+	"n": 33.33
+}
+
+# Back in Nit:
+null
+
+# Nit:
+<G: hs: -1, 0; s: one, two; hm: one. 1, two. 2; am: three. 3, four. 4>
+
+# Json:
+{
+	"__kind": "obj", "__id": 0, "__class": "G",
+	"hs": {
+		"__kind": "obj", "__id": 1, "__class": "HashSet[Int]",
+		"__items": [
+			-1,
+			0
+		]
+	},
+	"s": {
+		"__kind": "obj", "__id": 2, "__class": "ArraySet[String]",
+		"__items": [
+			"one",
+			"two"
+		]
+	},
+	"hm": {
+		"__kind": "obj", "__id": 3, "__class": "HashMap[String, Int]", "__length": 2,
+		"__keys": [
+			"one",
+			"two"
+		],
+		"__values": [
+			1,
+			2
+		]
+	},
+	"am": {
+		"__kind": "obj", "__id": 4, "__class": "ArrayMap[String, String]", "__length": 2,
+		"__keys": [
+			"three",
+			"four"
+		],
+		"__values": [
+			"3",
+			"4"
+		]
+	}
+}
+
+# Back in Nit:
+<G: hs: ; s: ; hm: ; am: >
+

--- a/tests/sav/test_json_deserialization_alt4.res
+++ b/tests/sav/test_json_deserialization_alt4.res
@@ -1,0 +1,135 @@
+# Nit:
+<A: true a 0.123 1234 asdf false p4ssw0rd>
+
+# Json:
+{
+	"b": true,
+	"c": "a",
+	"f": 0.123,
+	"i": 1234,
+	"serialization_specific_name": "asdf",
+	"n": null
+}
+
+# Nit:
+<B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>
+
+# Json:
+{
+	"b": false,
+	"c": "b",
+	"f": 123.123,
+	"i": 2345,
+	"serialization_specific_name": "hjkl",
+	"n": 12,
+	"ii": 1111,
+	"ss": "qwer"
+}
+
+# Nit:
+<C: <A: true a 0.123 1234 asdf false p4ssw0rd> <B: <A: false b 123.123 2345 hjkl true p4ssw0rd> 1111 qwer>>
+
+# Json:
+{
+	"a": {
+		"b": true,
+		"c": "a",
+		"f": 0.123,
+		"i": 1234,
+		"serialization_specific_name": "asdf",
+		"n": null
+	},
+	"b": {
+		"b": false,
+		"c": "b",
+		"f": 123.123,
+		"i": 2345,
+		"serialization_specific_name": "hjkl",
+		"n": 12,
+		"ii": 1111,
+		"ss": "qwer"
+	},
+	"aa": {
+		"b": true,
+		"c": "a",
+		"f": 0.123,
+		"i": 1234,
+		"serialization_specific_name": "asdf",
+		"n": null
+	}
+}
+
+Serialization warning: Cycle detected in serialized object, replacing reference with 'null'.
+# Nit:
+<D: <B: <A: false b 123.123 2345 new line ->
+<- false p4ssw0rd> 1111 	f"\/> true>
+
+# Json:
+{
+	"b": false,
+	"c": "b",
+	"f": 123.123,
+	"i": 2345,
+	"serialization_specific_name": "new line ->\n<-",
+	"n": null,
+	"ii": 1111,
+	"ss": "\tf\"\r\\/",
+	"d": null
+}
+
+# Nit:
+<E: a: hello, 1234, 123.4; b: hella, 2345, 234.5>
+
+# Json:
+{
+	"a": [
+		"hello",
+		1234,
+		123.4
+	],
+	"b": [
+		"hella",
+		2345,
+		234.5
+	]
+}
+
+# Nit:
+<E: 2222>
+
+# Json:
+{
+	"n": 2222
+}
+
+# Nit:
+<E: 33.33>
+
+# Json:
+{
+	"n": 33.33
+}
+
+# Nit:
+<G: hs: -1, 0; s: one, two; hm: one. 1, two. 2; am: three. 3, four. 4>
+
+# Json:
+{
+	"hs": [
+		-1,
+		0
+	],
+	"s": [
+		"one",
+		"two"
+	],
+	"hm": {
+		"one": 1,
+		"two": 2
+	},
+	"am": {
+		"three": "3",
+		"four": "4"
+	}
+}
+

--- a/tests/sav/test_serialization.res
+++ b/tests/sav/test_serialization.res
@@ -2,24 +2,24 @@
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "\tf\"\r\\/","d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/test_serialization_alt1.res
+++ b/tests/sav/test_serialization_alt1.res
@@ -2,24 +2,25 @@
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"b": true, "c": "a", "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": [88, "hello", null]}
+{"b": true,"c": "a","f": 0.123,"i": 1234,"s": "asdf","n": null,"array": [88,"hello",null]}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"b": false, "c": "b", "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": [88, "hello", null], "ii": 1111, "ss": "qwer"}
+{"b": false,"c": "b","f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": [88,"hello",null],"ii": 1111,"ss": "qwer"}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"a": {"b": true, "c": "a", "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": [88, "hello", null]}, "b": {"b": false, "c": "b", "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": [88, "hello", null], "ii": 1111, "ss": "qwer"}, "aa": {"b": true, "c": "a", "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": [88, "hello", null]}}
+{"a": {"b": true,"c": "a","f": 0.123,"i": 1234,"s": "asdf","n": null,"array": [88,"hello",null]},"b": {"b": false,"c": "b","f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": [88,"hello",null],"ii": 1111,"ss": "qwer"},"aa": {"b": true,"c": "a","f": 0.123,"i": 1234,"s": "asdf","n": null,"array": [88,"hello",null]}}
 
+Serialization warning: Cycle detected in serialized object, replacing reference with 'null'.
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"b": false, "c": "b", "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": [88, "hello", null], "ii": 1111, "ss": "\tf\"\r\\/", "d": null}
+{"b": false,"c": "b","f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": [88,"hello",null],"ii": 1111,"ss": "\tf\"\r\\/","d": null}
 

--- a/tests/sav/test_serialization_alt2.res
+++ b/tests/sav/test_serialization_alt2.res
@@ -5,24 +5,24 @@ alt/test_serialization_alt2.nit:64,1--72,3: Warning: superfluous use of `auto_se
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]}}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]","__items": [88,"hello",null]}},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/test_serialization_alt3.res
+++ b/tests/sav/test_serialization_alt3.res
@@ -3,24 +3,24 @@ alt/test_serialization_alt3.nit:40,1--51,3: Warning: superfluous use of `noseria
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]}}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]","__items": [88,"hello",null]}},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/test_serialization_alt4.res
+++ b/tests/sav/test_serialization_alt4.res
@@ -3,24 +3,24 @@ alt/test_serialization_alt4.nit:29,2--31,26: Warning: superfluous use of `serial
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "\tf\"\r\\/","d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/test_serialization_alt5.res
+++ b/tests/sav/test_serialization_alt5.res
@@ -3,24 +3,24 @@ alt/test_serialization_alt5.nit:22,1--38,3: Warning: duplicated annotation `seri
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "\tf\"\r\\/","d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/test_serialization_redef.res
+++ b/tests/sav/test_serialization_redef.res
@@ -2,24 +2,24 @@
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer"},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "\tf\"\r\\/","d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/test_serialization_redef_alt0.res
+++ b/tests/sav/test_serialization_redef_alt0.res
@@ -2,24 +2,24 @@
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"iii": 6789,"sss": "redef"}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer"}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"iii": 6789,"sss": "redef","ii": 1111,"ss": "qwer"}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer"}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"iii": 6789,"sss": "redef"},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"iii": 6789,"sss": "redef","ii": 1111,"ss": "qwer"},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "\tf\"\r\\/", "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"iii": 6789,"sss": "redef","ii": 1111,"ss": "\tf\"\r\\/","d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/test_serialization_redef_alt1.res
+++ b/tests/sav/test_serialization_redef_alt1.res
@@ -2,24 +2,24 @@
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]}}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer","ffff": 6.789,"bbbb": false}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]","__items": [88,"hello",null]}},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "qwer","ffff": 6.789,"bbbb": false},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "ii": 1111, "ss": "\tf\"\r\\/", "ffff": 6.789, "bbbb": false, "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"ii": 1111,"ss": "\tf\"\r\\/","ffff": 6.789,"bbbb": false,"d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/sav/test_serialization_redef_alt2.res
+++ b/tests/sav/test_serialization_redef_alt2.res
@@ -2,24 +2,24 @@
 <A: true a 0.123 1234 asdf false>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}
+{"__kind": "obj", "__id": 0, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"iii": 6789,"sss": "redef"}
 
 # Nit:
 <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}
+{"__kind": "obj", "__id": 0, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"iii": 6789,"sss": "redef","ii": 1111,"ss": "qwer","ffff": 6.789,"bbbb": false}
 
 # Nit:
 <C: <A: true a 0.123 1234 asdf false> <B: <A: false b 123.123 2345 hjkl true> 1111 qwer>>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "C", "a": {"__kind": "obj", "__id": 1, "__class": "A", "b": true, "c": {"__kind": "char", "__val": "a"}, "f": 0.123, "i": 1234, "s": "asdf", "n": null, "array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef"}, "b": {"__kind": "obj", "__id": 3, "__class": "B", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "hjkl", "n": 12, "array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "qwer", "ffff": 6.789, "bbbb": false}, "aa": {"__kind": "ref", "__id": 1}}
+{"__kind": "obj", "__id": 0, "__class": "C","a": {"__kind": "obj", "__id": 1, "__class": "A","b": true,"c": {"__kind": "char", "__val": "a"},"f": 0.123,"i": 1234,"s": "asdf","n": null,"array": {"__kind": "obj", "__id": 2, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"iii": 6789,"sss": "redef"},"b": {"__kind": "obj", "__id": 3, "__class": "B","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "hjkl","n": 12,"array": {"__kind": "obj", "__id": 4, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"iii": 6789,"sss": "redef","ii": 1111,"ss": "qwer","ffff": 6.789,"bbbb": false},"aa": {"__kind": "ref", "__id": 1}}
 
 # Nit:
 <D: <B: <A: false b 123.123 2345 new line ->
 <- false> 1111 	f"\/> true>
 
 # Json:
-{"__kind": "obj", "__id": 0, "__class": "D", "b": false, "c": {"__kind": "char", "__val": "b"}, "f": 123.123, "i": 2345, "s": "new line ->\n<-", "n": null, "array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]", "__items": [88, "hello", null]}, "iii": 6789, "sss": "redef", "ii": 1111, "ss": "\tf\"\r\\/", "ffff": 6.789, "bbbb": false, "d": {"__kind": "ref", "__id": 0}}
+{"__kind": "obj", "__id": 0, "__class": "D","b": false,"c": {"__kind": "char", "__val": "b"},"f": 123.123,"i": 2345,"s": "new line ->\n<-","n": null,"array": {"__kind": "obj", "__id": 1, "__class": "Array[nullable Object]","__items": [88,"hello",null]},"iii": 6789,"sss": "redef","ii": 1111,"ss": "\tf\"\r\\/","ffff": 6.789,"bbbb": false,"d": {"__kind": "ref", "__id": 0}}
 

--- a/tests/test_json_deserialization.nit
+++ b/tests/test_json_deserialization.nit
@@ -18,20 +18,25 @@ import json::serialization
 
 var entities = new TestEntities
 
-var tests = entities.without_generics#alt1##alt2#
+var tests = entities.without_generics#alt1##alt2##alt3##alt4#
 #alt1#var tests = entities.with_generics
 #alt2#var tests = entities.with_generics
+#alt3#var tests = entities.with_generics
+#alt4#var tests = entities.with_generics
 
 for o in tests do
 	var stream = new StringWriter
 	var serializer = new JsonSerializer(stream)
 	#alt2#serializer.plain_json = true
+	#alt3#serializer.pretty_json = true
+	#alt4#serializer.plain_json = true
+	#alt4#serializer.pretty_json = true
 	serializer.serialize(o)
 
-	var deserializer = new JsonDeserializer(stream.to_s)#alt2#
-	var deserialized = deserializer.deserialize#alt2#
+	var deserializer = new JsonDeserializer(stream.to_s)#alt2##alt4#
+	var deserialized = deserializer.deserialize#alt2##alt4#
 
 	print "# Nit:\n{o}\n"
 	print "# Json:\n{stream}\n"
-	print "# Back in Nit:\n{deserialized or else "null"}\n"#alt2#
+	print "# Back in Nit:\n{deserialized or else "null"}\n"#alt2##alt4#
 end


### PR DESCRIPTION
Intro an option in `JsonSerializer` to write pretty indented JSON. By default, the generated JSON is somewhat minified, this could be improved if needed.

See the generated JSON in the tests below. I chose to leave the metadata and other special short objects non-indented as they are not intended for humans. The option `plain_json` is fully compatible with `pretty_json` (see alt4.res), I expect them to be used together often.

This was requested by @Morriar and it could allow us to deprecate the `json::static` writer API.