### PR TITLE
Faster ASCII-only strings

### DIFF
--- a/contrib/refund/tests/res/recl_soin_error2.res
+++ b/contrib/refund/tests/res/recl_soin_error2.res
@@ -1,3 +1,3 @@
 {
-	"message": "Wrong type for `soin` (expected Int got FlatString)"
+	"message": "Wrong type for `soin` (expected Int got ASCIIFlatString)"
 }

--- a/lib/core/text/ropes.nit
+++ b/lib/core/text/ropes.nit
@@ -172,7 +172,7 @@ private class Concat
 			from = 0
 		end
 
-		var ln = length
+		var ln = _length
 		if (count + from) > ln then count = ln - from
 		if count <= 0 then return ""
 		var end_index = from + count - 1

--- a/lib/json/serialization.nit
+++ b/lib/json/serialization.nit
@@ -355,7 +355,7 @@ class JsonDeserializer
 				var array_type = types.first
 
 				var typed_array
-				if array_type == "FlatString" then
+				if array_type == "ASCIIFlatString" or array_type == "UnicodeFlatString" then
 					if has_nullable then
 						typed_array = new Array[nullable FlatString]
 					else typed_array = new Array[FlatString]

--- a/tests/sav/base_class_name.res
+++ b/tests/sav/base_class_name.res
@@ -1,4 +1,4 @@
-FlatString
+ASCIIFlatString
 Int
 Test
 Test

--- a/tests/sav/nitce/base_class_name.res
+++ b/tests/sav/nitce/base_class_name.res
@@ -1,4 +1,4 @@
-FlatString
+ASCIIFlatString
 Int
 Test
 Test

--- a/tests/sav/nitce/test_meta.res
+++ b/tests/sav/nitce/test_meta.res
@@ -1,5 +1,5 @@
-FlatString
-FlatString
+ASCIIFlatString
+ASCIIFlatString
 Class
 Class
 

--- a/tests/sav/test_augmented.res
+++ b/tests/sav/test_augmented.res
@@ -1,7 +1,7 @@
 s isa Bytes
 StringAB
 537472696E674142
-s2 isa FlatString
+s2 isa UnicodeFlatString
 String𐏓
 s3 isa Bytes
 StringA�
@@ -11,13 +11,13 @@ s4 isa Regex
 true
 true
 false
-s5 isa FlatString
+s5 isa UnicodeFlatString
 String�
-s6 isa FlatString
+s6 isa ASCIIFlatString
 \nStr\x00
-s7 isa FlatString
+s7 isa ASCIIFlatString
 \nString66515\x41
-s8 isa FlatString
+s8 isa ASCIIFlatString
 
 String66515A
 s9 isa Regex

--- a/tests/sav/test_deriving.res
+++ b/tests/sav/test_deriving.res
@@ -1,4 +1,4 @@
-<A i: <Int> s: <FlatString>>
+<A i: <Int> s: <ASCIIFlatString>>
 i=5 s=Hello
 i:5; s:Hello
 
@@ -6,7 +6,7 @@ true
 true
 true
 
-<B i: <Int> s: <FlatString> a: <A i: <Int> s: <FlatString>>>
+<B i: <Int> s: <ASCIIFlatString> a: <A i: <Int> s: <ASCIIFlatString>>>
 i=100 s=World a=i:5; s:Hello
 i:100; s:World; a:i:5; s:Hello
 

--- a/tests/sav/test_deriving_alt1.res
+++ b/tests/sav/test_deriving_alt1.res
@@ -1,14 +1,14 @@
-<A i: <Int> s: <FlatString>>
+<A i: <Int> s: <ASCIIFlatString>>
 i=5 s=Hello
-<A i: <Int> s: <FlatString>>
+<A i: <Int> s: <ASCIIFlatString>>
 
 true
 true
 true
 
-<B i: <Int> s: <FlatString> a: <A i: <Int> s: <FlatString>>>
-i=100 s=World a=<A i: <Int> s: <FlatString>>
-<B i: <Int> s: <FlatString> a: <A i: <Int> s: <FlatString>>>
+<B i: <Int> s: <ASCIIFlatString> a: <A i: <Int> s: <ASCIIFlatString>>>
+i=100 s=World a=<A i: <Int> s: <ASCIIFlatString>>
+<B i: <Int> s: <ASCIIFlatString> a: <A i: <Int> s: <ASCIIFlatString>>>
 
 true
 true

--- a/tests/sav/test_deriving_alt2.res
+++ b/tests/sav/test_deriving_alt2.res
@@ -1,4 +1,4 @@
-<A i: <Int> s: <FlatString>>
+<A i: <Int> s: <ASCIIFlatString>>
 i=5 s=Hello
 i:5; s:Hello
 
@@ -6,7 +6,7 @@ false
 false
 true
 
-<B i: <Int> s: <FlatString> a: <A i: <Int> s: <FlatString>>>
+<B i: <Int> s: <ASCIIFlatString> a: <A i: <Int> s: <ASCIIFlatString>>>
 i=100 s=World a=i:5; s:Hello
 i:100; s:World; a:i:5; s:Hello
 

--- a/tests/sav/test_deriving_alt3.res
+++ b/tests/sav/test_deriving_alt3.res
@@ -1,4 +1,4 @@
-<A i: <Int> s: <FlatString>>
+<A i: <Int> s: <ASCIIFlatString>>
 i=5 s=Hello
 i:5; s:Hello
 
@@ -6,7 +6,7 @@ true
 true
 true
 
-<B i: <Int> s: <FlatString> a: <A i: <Int> s: <FlatString>>>
+<B i: <Int> s: <ASCIIFlatString> a: <A i: <Int> s: <ASCIIFlatString>>>
 i=100 s=World
 i:100; s:World
 

--- a/tests/sav/test_deriving_alt4.res
+++ b/tests/sav/test_deriving_alt4.res
@@ -1,4 +1,4 @@
-<A i: <Int> s: <FlatString>>
+<A i: <Int> s: <ASCIIFlatString>>
 i=5 s=Hello
 i:5; s:Hello
 
@@ -6,7 +6,7 @@ true
 true
 true
 
-<B a: <A i: <Int> s: <FlatString>>>
+<B a: <A i: <Int> s: <ASCIIFlatString>>>
 string=World a=i:5; s:Hello
 string:World; a:i:5; s:Hello
 

--- a/tests/sav/test_json_deserialization_plain.res
+++ b/tests/sav/test_json_deserialization_plain.res
@@ -23,7 +23,7 @@
 # Nit: <JsonObject i:123, s:hello, f:123.456, a:[one,two], o:<null>>
 
 # JSON: {"__class": "MyClass", "i": 123, "s": "hello", "f": 123.456, "a": ["one", "two"], "o": "Not the right type"}
-# Errors: 'Deserialization Error: Wrong type on `MyClass::o` expected `nullable MyClass`, got `FlatString`'
+# Errors: 'Deserialization Error: Wrong type on `MyClass::o` expected `nullable MyClass`, got `ASCIIFlatString`'
 # Nit: <MyClass i:123 s:hello f:123.456 a:[one, two] o:<null>>
 
 # JSON: not valid json

--- a/tests/sav/test_meta.res
+++ b/tests/sav/test_meta.res
@@ -1,7 +1,7 @@
-FlatString
-FlatString
-Class[FlatString]
-Class[Class[FlatString]]
+ASCIIFlatString
+ASCIIFlatString
+Class[ASCIIFlatString]
+Class[Class[ASCIIFlatString]]
 
 XObject
 XObject

--- a/tests/sav/test_text_stat.res
+++ b/tests/sav/test_text_stat.res
@@ -3,55 +3,20 @@ Usage of Strings:
 
 Allocations, by type:
 		
-	-FlatString = 29
+	-UnicodeFlatString = 0
+	-ASCIIFlatString = 30
 	-FlatBuffer = 2
 	-Concat = 0
 	-RopeBuffer = 0
 
 Calls to length, by type:
-	FlatString = 18 (cache misses 5, 27.77%)
+	FlatString = 18
 Indexed accesses, by type:
-	FlatString = 8
 Calls to bytelen for each type:
-	FlatString = 61
+	FlatString = 48
 Calls to position for each type:
-	FlatString = 17
 Calls to bytepos for each type:
-	FlatString = 9
-Calls to first_byte on FlatString 191
-Calls to last_byte on FlatString 19
-FlatStrings allocated with length 78 (86.813%)
+Calls to first_byte on FlatString 50
+Calls to last_byte on FlatString 10
 Length of travel for index distribution:
-* 0 = 11 => occurences 73.333%, cumulative 73.333% 
-* 1 = 8 => occurences 27.586%, cumulative 65.517% 
 Byte length of the FlatStrings created:
-* 0 = 6 => occurences 4.478%, cumulative 4.478% 
-* 1 = 24 => occurences 16.216%, cumulative 20.27% 
-* 2 = 30 => occurences 18.519%, cumulative 37.037% 
-* 3 = 29 => occurences 16.384%, cumulative 50.282% 
-* 4 = 3 => occurences 1.563%, cumulative 47.917% 
-* 5 = 20 => occurences 9.662%, cumulative 54.106% 
-* 6 = 26 => occurences 11.712%, cumulative 62.162% 
-* 9 = 1 => occurences 0.422%, cumulative 58.65% 
-* 10 = 9 => occurences 3.571%, cumulative 58.73% 
-* 11 = 2 => occurences 0.749%, cumulative 56.18% 
-* 12 = 1 => occurences 0.356%, cumulative 53.737% 
-* 13 = 1 => occurences 0.34%, cumulative 51.701% 
-* 14 = 1 => occurences 0.326%, cumulative 49.837% 
-* 15 = 7 => occurences 2.188%, cumulative 50.0% 
-* 16 = 5 => occurences 1.493%, cumulative 49.254% 
-* 17 = 1 => occurences 0.286%, cumulative 47.429% 
-* 25 = 2 => occurences 0.551%, cumulative 46.281% 
-* 26 = 1 => occurences 0.265%, cumulative 44.828% 
-* 31 = 2 => occurences 0.513%, cumulative 43.846% 
-* 32 = 1 => occurences 0.248%, cumulative 42.574% 
-* 33 = 1 => occurences 0.24%, cumulative 41.487% 
-* 34 = 2 => occurences 0.465%, cumulative 40.698% 
-* 35 = 1 => occurences 0.225%, cumulative 39.64% 
-* 37 = 1 => occurences 0.219%, cumulative 38.731% 
-* 39 = 1 => occurences 0.213%, cumulative 37.872% 
-* 40 = 1 => occurences 0.207%, cumulative 37.06% 
-* 43 = 1 => occurences 0.202%, cumulative 36.29% 
-* 46 = 1 => occurences 0.196%, cumulative 35.56% 
-* 51 = 14 => occurences 2.682%, cumulative 37.356% 
-* 52 = 5 => occurences 0.931%, cumulative 37.244% 


### PR DESCRIPTION
This simple PR re-introduces the concept of ASCII strings for faster no-overhead accesses to random characters in a string.

The class is private as it is to be used only internally, no client should care for the specific type of a String and all performance improvements will be automatic, should the optimization be possible.

Since we are dealing with UTF-8, the only case where O(1) access can efficiently and without much overhead (one `if` statement at creation) be determined, is when a string only contains ASCII characters.
Note that since the Buffer can change access semantics depending on what is appended during its lifetime, no ASCII-only FlatBuffer has been added.

This is implemented here by introducing two subclasses of FlatString, one for ASCII only strings, and one for regular Unicode strings (the old FlatString).

In terms of performance, in the compiler, there is a ~0.5% improvement, but in specific cases like JSON parsing for the `big_gov_data.json` (where not a single unicode character is present) bench, the difference amounts to ~35%.