### PR TITLE
Promote location in MEntity

### DIFF
--- a/src/loader.nit
+++ b/src/loader.nit
@@ -381,9 +381,9 @@ redef class ModelBuilder
 
 		if mgroup == null then
 			# singleton package
-			var mpackage = new MPackage(pn, model)
-			mgroup = new MGroup(pn, mpackage, null) # same name for the root group
-			mgroup.filepath = path
+			var loc = new Location.opaque_file(path)
+			var mpackage = new MPackage(pn, model, loc)
+			mgroup = new MGroup(pn, loc, mpackage, null) # same name for the root group
 			mpackage.root = mgroup
 			toolcontext.info("found singleton package `{pn}` at {path}", 2)
 
@@ -482,17 +482,18 @@ redef class ModelBuilder
 			end
 		end
 
+		var loc = new Location.opaque_file(dirpath)
 		var mgroup
 		if parent == null then
 			# no parent, thus new package
 			if ini != null then pn = ini["package.name"] or else pn
-			var mpackage = new MPackage(pn, model)
-			mgroup = new MGroup(pn, mpackage, null) # same name for the root group
+			var mpackage = new MPackage(pn, model, loc)
+			mgroup = new MGroup(pn, loc, mpackage, null) # same name for the root group
 			mpackage.root = mgroup
 			toolcontext.info("found package `{mpackage}` at {dirpath}", 2)
 			mpackage.ini = ini
 		else
-			mgroup = new MGroup(pn, parent.mpackage, parent)
+			mgroup = new MGroup(pn, loc, parent.mpackage, parent)
 			toolcontext.info("found sub group `{mgroup.full_name}` at {dirpath}", 2)
 		end
 

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -395,8 +395,7 @@ redef class ModelBuilder
 			end
 		end
 
-		var src = new SourceFile.from_string(path, "")
-		var loc = new Location(src, 0, 0, 0, 0)
+		var loc = new Location.opaque_file(path)
 		var res = new MModule(model, mgroup, pn, loc)
 		res.filepath = path
 

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -397,7 +397,6 @@ redef class ModelBuilder
 
 		var loc = new Location.opaque_file(path)
 		var res = new MModule(model, mgroup, pn, loc)
-		res.filepath = path
 
 		identified_modules_by_path[rp] = res
 		identified_modules_by_path[path] = res
@@ -507,7 +506,6 @@ redef class ModelBuilder
 			mdoc.original_mentity = mgroup
 		end
 
-		mgroup.filepath = dirpath
 		mgroups[rdp] = mgroup
 		return mgroup
 	end

--- a/src/location.nit
+++ b/src/location.nit
@@ -140,6 +140,15 @@ class Location
 		end
 	end
 
+	# Initialize a location corresponding to an opaque file.
+	#
+	# The path is used as is and is not open nor read.
+	init opaque_file(path: String)
+	do
+		var source = new SourceFile.from_string(path, "")
+		init(source, 0, 0, 0, 0)
+	end
+
 	# The index in the start character in the source
 	fun pstart: Int do return file.line_starts[line_start-1] + column_start-1
 

--- a/src/model/mmodule.nit
+++ b/src/model/mmodule.nit
@@ -17,7 +17,6 @@
 # modules and module hierarchies in the metamodel
 module mmodule
 
-import location
 import mpackage
 private import more_collections
 
@@ -95,8 +94,7 @@ class MModule
 	# The short name of the module
 	redef var name: String
 
-	# The origin of the definition
-	var location: Location is writable
+	redef var location: Location is writable
 
 	# Alias for `name`
 	redef fun to_s do return self.name

--- a/src/model/mmodule.nit
+++ b/src/model/mmodule.nit
@@ -81,7 +81,13 @@ class MModule
 	var mgroup: nullable MGroup
 
 	# The path of the module source, if any
-	var filepath: nullable String = null is writable
+	#
+	# safe alias to `location.file.filepath`
+	fun filepath: nullable String do
+		var res = self.location.file
+		if res == null then return null
+		return res.filename
+	end
 
 	# The package of the module if any
 	# Safe alias for `mgroup.mpackage`

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -285,8 +285,9 @@ redef class MModule
 			if name == "Bool" and self.model.get_mclasses_by_name("Object") != null then
 				# Bool is injected because it is needed by engine to code the result
 				# of the implicit casts.
-				var c = new MClass(self, name, null, enum_kind, public_visibility)
-				var cladef = new MClassDef(self, c.mclass_type, new Location(null, 0,0,0,0))
+				var loc = model.no_location
+				var c = new MClass(self, name, loc, null, enum_kind, public_visibility)
+				var cladef = new MClassDef(self, c.mclass_type, loc)
 				cladef.set_supertypes([object_type])
 				cladef.add_in_hierarchy
 				return c
@@ -1951,6 +1952,8 @@ abstract class MProperty
 
 	# The (short) name of the property
 	redef var name
+
+	redef var location
 
 	# The canonical name of the property.
 	#

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -1167,6 +1167,8 @@ class MClassType
 
 	redef fun model do return self.mclass.intro_mmodule.model
 
+	redef fun location do return mclass.location
+
 	# TODO: private init because strongly bounded to its mclass. see `mclass.mclass_type`
 
 	# The formal arguments of the type
@@ -1372,6 +1374,8 @@ class MVirtualType
 	# Its the definitions of this property that determine the bound or the virtual type.
 	var mproperty: MVirtualTypeProp
 
+	redef fun location do return mproperty.location
+
 	redef fun model do return self.mproperty.intro_mclassdef.mmodule.model
 
 	redef fun lookup_bound(mmodule: MModule, resolved_receiver: MType): MType
@@ -1502,6 +1506,8 @@ class MParameterType
 
 	redef fun model do return self.mclass.intro_mmodule.model
 
+	redef fun location do return mclass.location
+
 	# The position of the parameter (0 for the first parameter)
 	# FIXME: is `position` a better name?
 	var rank: Int
@@ -1626,6 +1632,8 @@ abstract class MProxyType
 	super MType
 	# The base type
 	var mtype: MType
+
+	redef fun location do return mtype.location
 
 	redef fun model do return self.mtype.model
 	redef fun need_anchor do return mtype.need_anchor

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -386,6 +386,8 @@ class MClass
 	# In Nit, the name of a class cannot evolve in refinements
 	redef var name
 
+	redef var location
+
 	# The canonical name of the class
 	#
 	# It is the name of the class prefixed by the full_name of the `intro_mmodule`
@@ -588,8 +590,7 @@ class MClassDef
 	# ENSURE: `bound_mtype.mclass == self.mclass`
 	var bound_mtype: MClassType
 
-	# The origin of the definition
-	var location: Location
+	redef var location: Location
 
 	# Internal name combining the module and the class
 	# Example: "mymodule$MyClass"
@@ -2241,8 +2242,7 @@ abstract class MPropDef
 	# The associated global property
 	var mproperty: MPROPERTY
 
-	# The origin of the definition
-	var location: Location
+	redef var location: Location
 
 	init
 	do

--- a/src/model/model_base.nit
+++ b/src/model/model_base.nit
@@ -16,6 +16,7 @@
 
 # The abstract concept of model and related common things
 module model_base
+import location
 
 # The container class of a Nit object-oriented model.
 # A model knows modules, classes and properties and can retrieve them.
@@ -23,6 +24,11 @@ class Model
 	super MEntity
 
 	redef fun model do return self
+
+	# Place-holder object that means no-location
+	#
+	# See `MEntity::location`
+	var no_location = new Location(null, 0, 0, 0, 0)
 end
 
 # A named and possibly documented entity in the model.
@@ -64,6 +70,16 @@ abstract class MEntity
 	# Is is not suitable to use it directly with the user (e.g. in message) and
 	# indirect use should be restricted (e.g. to name a web-page)
 	fun c_name: String is abstract
+
+	# The origin of the definition.
+	#
+	# Most model entities are defined in a specific place in the source base.
+	#
+	# Because most model entities have one,
+	# it is simpler for the client to have a non-nullable return value.
+	# For entities that lack a location, mock-up special locations are used instead.
+	# By default it is `model.no_location`.
+	fun location: Location do return model.no_location
 
 	# A Model Entity has a direct link to its model
 	fun model: Model is abstract

--- a/src/model/mpackage.nit
+++ b/src/model/mpackage.nit
@@ -34,6 +34,8 @@ class MPackage
 	# The model of the package
 	redef var model: Model
 
+	redef var location
+
 	# The root of the group tree
 	var root: nullable MGroup = null is writable
 
@@ -65,6 +67,8 @@ class MGroup
 	# The name of the group
 	# empty name for a default group in a single-module package
 	redef var name: String
+
+	redef var location
 
 	# The enclosing package
 	var mpackage: MPackage

--- a/src/model/mpackage.nit
+++ b/src/model/mpackage.nit
@@ -98,7 +98,14 @@ class MGroup
 	fun is_root: Bool do return mpackage.root == self
 
 	# The filepath (usually a directory) of the group, if any
-	var filepath: nullable String = null is writable
+	#
+	# safe alias to `location.file.filename`
+	fun filepath: nullable String do
+		var res
+		res = self.location.file
+		if res == null then return null
+		return res.filename
+	end
 
 	init
 	do

--- a/src/modelize/modelize_class.nit
+++ b/src/modelize/modelize_class.nit
@@ -122,7 +122,7 @@ redef class ModelBuilder
 				end
 			end
 
-			mclass = new MClass(mmodule, name, names, mkind, mvisibility)
+			mclass = new MClass(mmodule, name, nclassdef.location, names, mkind, mvisibility)
 			#print "new class {mclass}"
 		else if nclassdef isa AStdClassdef and nmodule.mclass2nclassdef.has_key(mclass) then
 			error(nclassdef, "Error: a class `{name}` is already defined at line {nmodule.mclass2nclassdef[mclass].location.line_start}.")

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -145,7 +145,7 @@ redef class ModelBuilder
 		# Look for the init in Object, or create it
 		if mclassdef.mclass.name == "Object" and the_root_init_mmethod == null then
 			# Create the implicit root-init method
-			var mprop = new MMethod(mclassdef, "init", mclassdef.mclass.visibility)
+			var mprop = new MMethod(mclassdef, "init", nclassdef.location, mclassdef.mclass.visibility)
 			mprop.is_root_init = true
 			var mpropdef = new MMethodDef(mclassdef, mprop, nclassdef.location)
 			var mparameters = new Array[MParameter]
@@ -822,7 +822,7 @@ redef class AMethPropdef
 		end
 		if mprop == null then
 			var mvisibility = new_property_visibility(modelbuilder, mclassdef, self.n_visibility)
-			mprop = new MMethod(mclassdef, name, mvisibility)
+			mprop = new MMethod(mclassdef, name, self.location, mvisibility)
 			if look_like_a_root_init and modelbuilder.the_root_init_mmethod == null then
 				modelbuilder.the_root_init_mmethod = mprop
 				mprop.is_root_init = true
@@ -1186,7 +1186,7 @@ redef class AAttrPropdef
 				modelbuilder.error(self, "Error: attempt to define attribute `{name}` in the {mclass.kind} `{mclass}`.")
 			end
 
-			var mprop = new MAttribute(mclassdef, "_" + name, private_visibility)
+			var mprop = new MAttribute(mclassdef, "_" + name, self.location, private_visibility)
 			var mpropdef = new MAttributeDef(mclassdef, mprop, self.location)
 			self.mpropdef = mpropdef
 			modelbuilder.mpropdef2npropdef[mpropdef] = self
@@ -1196,7 +1196,7 @@ redef class AAttrPropdef
 		var mreadprop = modelbuilder.try_get_mproperty_by_name(nid2, mclassdef, readname).as(nullable MMethod)
 		if mreadprop == null then
 			var mvisibility = new_property_visibility(modelbuilder, mclassdef, self.n_visibility)
-			mreadprop = new MMethod(mclassdef, readname, mvisibility)
+			mreadprop = new MMethod(mclassdef, readname, self.location, mvisibility)
 			if not self.check_redef_keyword(modelbuilder, mclassdef, n_kwredef, false, mreadprop) then return
 		else
 			if not self.check_redef_keyword(modelbuilder, mclassdef, n_kwredef, true, mreadprop) then return
@@ -1248,7 +1248,7 @@ redef class AAttrPropdef
 				return
 			end
 			is_lazy = true
-			var mlazyprop = new MAttribute(mclassdef, "lazy _" + name, none_visibility)
+			var mlazyprop = new MAttribute(mclassdef, "lazy _" + name, self.location, none_visibility)
 			mlazyprop.is_fictive = true
 			var mlazypropdef = new MAttributeDef(mclassdef, mlazyprop, self.location)
 			mlazypropdef.is_fictive = true
@@ -1295,7 +1295,7 @@ redef class AAttrPropdef
 				# By default, use protected visibility at most
 				if mvisibility > protected_visibility then mvisibility = protected_visibility
 			end
-			mwriteprop = new MMethod(mclassdef, writename, mvisibility)
+			mwriteprop = new MMethod(mclassdef, writename, self.location, mvisibility)
 			if not self.check_redef_keyword(modelbuilder, mclassdef, nwkwredef, false, mwriteprop) then return
 			mwriteprop.deprecation = mreadprop.deprecation
 		else
@@ -1602,7 +1602,7 @@ redef class ATypePropdef
 		var mprop = modelbuilder.try_get_mproperty_by_name(self.n_qid, mclassdef, name)
 		if mprop == null then
 			var mvisibility = new_property_visibility(modelbuilder, mclassdef, self.n_visibility)
-			mprop = new MVirtualTypeProp(mclassdef, name, mvisibility)
+			mprop = new MVirtualTypeProp(mclassdef, name, self.location, mvisibility)
 			for c in name.chars do if c >= 'a' and c<= 'z' then
 				modelbuilder.warning(n_qid, "bad-type-name", "Warning: lowercase in the virtual type `{name}`.")
 				break

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -637,8 +637,7 @@ end
 class CallSite
 	super MEntity
 
-	# The associated location of the callsite
-	var location: Location
+	redef var location: Location
 
 	# The static type of the receiver (possibly unresolved)
 	var recv: MType

--- a/src/test_model_visitor.nit
+++ b/src/test_model_visitor.nit
@@ -117,6 +117,6 @@ do
 		var c = ""
 		var d = e.mdoc_or_fallback
 		if d != null and d.content.not_empty then c = d.content.first
-		print "{n}\t{e.class_name}\t{c}"
+		print "{n}\t{e.class_name}\t{e.location}\t{c}"
 	end
 end

--- a/tests/sav/test_model_visitor_args1.res
+++ b/tests/sav/test_model_visitor_args1.res
@@ -110,58 +110,58 @@ Names:
   base_simple3: 12 (1.06%)
 
 # All entities
-base_simple3	MPackage	
-base_simple3>	MGroup	
-base_simple3::base_simple3	MModule	
-base_simple3::Object	MClass	
-base_simple3$Object	MClassDef	
-base_simple3::Object::init	MMethod	
-base_simple3$Object$init	MMethodDef	
-base_simple3::Bool	MClass	
-base_simple3$Bool	MClassDef	
-base_simple3::Int	MClass	
-base_simple3$Int	MClassDef	
-base_simple3::Int::output	MMethod	
-base_simple3$Int$output	MMethodDef	
-base_simple3::A	MClass	
-base_simple3$A	MClassDef	
-base_simple3$A$Object::init	MMethodDef	
-base_simple3::A::run	MMethod	
-base_simple3$A$run	MMethodDef	
-base_simple3::B	MClass	
-base_simple3$B	MClassDef	
-base_simple3::base_simple3::B::_val	MAttribute	
-base_simple3$B$_val	MAttributeDef	
-base_simple3::B::val	MMethod	
-base_simple3$B$val	MMethodDef	
-base_simple3::B::val=	MMethod	
-base_simple3$B$val=	MMethodDef	
-base_simple3::B::init	MMethod	
-base_simple3$B$init	MMethodDef	
-base_simple3::B::run	MMethod	
-base_simple3$B$run	MMethodDef	
-base_simple3::C	MClass	
-base_simple3$C	MClassDef	
-base_simple3::base_simple3::C::_val1	MAttribute	
-base_simple3$C$_val1	MAttributeDef	
-base_simple3::C::val1	MMethod	
-base_simple3$C$val1	MMethodDef	
-base_simple3::C::val1=	MMethod	
-base_simple3$C$val1=	MMethodDef	
-base_simple3::base_simple3::C::_val2	MAttribute	
-base_simple3$C$_val2	MAttributeDef	
-base_simple3::C::val2	MMethod	
-base_simple3$C$val2	MMethodDef	
-base_simple3::C::val2=	MMethod	
-base_simple3$C$val2=	MMethodDef	
-base_simple3$C$Object::init	MMethodDef	
-base_simple3::Sys	MClass	
-base_simple3$Sys	MClassDef	
-base_simple3::Sys::foo	MMethod	
-base_simple3$Sys$foo	MMethodDef	
-base_simple3::Sys::bar	MMethod	
-base_simple3$Sys$bar	MMethodDef	
-base_simple3::Sys::baz	MMethod	
-base_simple3$Sys$baz	MMethodDef	
-base_simple3::Sys::main	MMethod	
-base_simple3$Sys$main	MMethodDef	
+base_simple3	MPackage	base_simple3.nit	
+base_simple3>	MGroup	base_simple3.nit	
+base_simple3::base_simple3	MModule	base_simple3.nit:17,1--66,13	
+base_simple3::Object	MClass	base_simple3.nit:19,1--20,3	
+base_simple3$Object	MClassDef	base_simple3.nit:19,1--20,3	
+base_simple3::Object::init	MMethod	base_simple3.nit:19,1--20,3	
+base_simple3$Object$init	MMethodDef	base_simple3.nit:19,1--20,3	
+base_simple3::Bool	MClass	base_simple3.nit:22,1--23,3	
+base_simple3$Bool	MClassDef	base_simple3.nit:22,1--23,3	
+base_simple3::Int	MClass	base_simple3.nit:25,1--27,3	
+base_simple3$Int	MClassDef	base_simple3.nit:25,1--27,3	
+base_simple3::Int::output	MMethod	base_simple3.nit:26,2--21	
+base_simple3$Int$output	MMethodDef	base_simple3.nit:26,2--21	
+base_simple3::A	MClass	base_simple3.nit:29,1--32,3	
+base_simple3$A	MClassDef	base_simple3.nit:29,1--32,3	
+base_simple3$A$Object::init	MMethodDef	base_simple3.nit:30,2--17	
+base_simple3::A::run	MMethod	base_simple3.nit:31,2--20	
+base_simple3$A$run	MMethodDef	base_simple3.nit:31,2--20	
+base_simple3::B	MClass	base_simple3.nit:34,1--42,3	
+base_simple3$B	MClassDef	base_simple3.nit:34,1--42,3	
+base_simple3::base_simple3::B::_val	MAttribute	base_simple3.nit:35,2--13	
+base_simple3$B$_val	MAttributeDef	base_simple3.nit:35,2--13	
+base_simple3::B::val	MMethod	base_simple3.nit:35,2--13	
+base_simple3$B$val	MMethodDef	base_simple3.nit:35,2--13	
+base_simple3::B::val=	MMethod	base_simple3.nit:35,2--13	
+base_simple3$B$val=	MMethodDef	base_simple3.nit:35,2--13	
+base_simple3::B::init	MMethod	base_simple3.nit:36,2--40,4	
+base_simple3$B$init	MMethodDef	base_simple3.nit:36,2--40,4	
+base_simple3::B::run	MMethod	base_simple3.nit:41,2--22	
+base_simple3$B$run	MMethodDef	base_simple3.nit:41,2--22	
+base_simple3::C	MClass	base_simple3.nit:44,1--47,3	
+base_simple3$C	MClassDef	base_simple3.nit:44,1--47,3	
+base_simple3::base_simple3::C::_val1	MAttribute	base_simple3.nit:45,2--14	
+base_simple3$C$_val1	MAttributeDef	base_simple3.nit:45,2--14	
+base_simple3::C::val1	MMethod	base_simple3.nit:45,2--14	
+base_simple3$C$val1	MMethodDef	base_simple3.nit:45,2--14	
+base_simple3::C::val1=	MMethod	base_simple3.nit:45,2--14	
+base_simple3$C$val1=	MMethodDef	base_simple3.nit:45,2--14	
+base_simple3::base_simple3::C::_val2	MAttribute	base_simple3.nit:46,2--19	
+base_simple3$C$_val2	MAttributeDef	base_simple3.nit:46,2--19	
+base_simple3::C::val2	MMethod	base_simple3.nit:46,2--19	
+base_simple3$C$val2	MMethodDef	base_simple3.nit:46,2--19	
+base_simple3::C::val2=	MMethod	base_simple3.nit:46,2--19	
+base_simple3$C$val2=	MMethodDef	base_simple3.nit:46,2--19	
+base_simple3$C$Object::init	MMethodDef	base_simple3.nit:44,1--47,3	
+base_simple3::Sys	MClass	base_simple3.nit:49,1--19	
+base_simple3$Sys	MClassDef	base_simple3.nit:49,1--19	
+base_simple3::Sys::foo	MMethod	base_simple3.nit:49,1--19	
+base_simple3$Sys$foo	MMethodDef	base_simple3.nit:49,1--19	
+base_simple3::Sys::bar	MMethod	base_simple3.nit:50,1--27	
+base_simple3$Sys$bar	MMethodDef	base_simple3.nit:50,1--27	
+base_simple3::Sys::baz	MMethod	base_simple3.nit:51,1--24	
+base_simple3$Sys$baz	MMethodDef	base_simple3.nit:51,1--24	
+base_simple3::Sys::main	MMethod	base_simple3.nit:53,1--66,13	
+base_simple3$Sys$main	MMethodDef	base_simple3.nit:53,1--66,13	

--- a/tests/sav/test_model_visitor_args2.res
+++ b/tests/sav/test_model_visitor_args2.res
@@ -106,101 +106,101 @@ Names:
   names: 5 (0.28%)
 
 # All entities
-names	MPackage	Group of modules used to test various full_name configurations and conflicts.
-names>	MGroup	Group of modules used to test various full_name configurations and conflicts.
-names::n3	MModule	The bottom module
-names::n3$A1	MClassDef	a refinement of a subclass in a submodule
-names::n3$A1$A::a	MMethodDef	a refinement (3 distinct modules)
-names::n3$A1$::n0::P::p	MMethodDef	a refinement (3 distinct modules)
-names::n3$::n1::P1	MClassDef	a refinement of a subclass in a submodule
-names::n3$::n1::P1$A::a	MMethodDef	a refinement (3 distinct modules)
-names::n3$::n1::P1$::n0::P::p	MMethodDef	a refinement (3 distinct modules)
-names::n0	MModule	Root module
-names::Object	MClass	
-names$Object	MClassDef	Root interface
-names::Object::init	MMethod	
-names$Object$init	MMethodDef	
-names::A	MClass	
-names$A	MClassDef	A public class
-names::A::a	MMethod	
-names$A$a	MMethodDef	A public method in a public class
-names::n0::A::z	MMethod	
-names$A$z	MMethodDef	A private method in a public class
-names::A0	MClass	
-names$A0	MClassDef	A public subclass in the same module
-names$A0$A::a	MMethodDef	Redefinition it the same module of a public method
-names$A0$::n0::A::z	MMethodDef	Redefinition it the same module of a private method
-names$A0$::n0::P::p	MMethodDef	Redefinition it the same module of a private method
-names::n0::P	MClass	
-names::n0$P	MClassDef	A private class
-names::n0::P::p	MMethod	
-names::n0$P$p	MMethodDef	A private method in a private class
-names::n0::P0	MClass	
-names::n0$P0	MClassDef	A private subclass introduced in the same module
-names::n0$P0$A::a	MMethodDef	Redefinition it the same module of a public method
-names::n0$P0$::n0::A::z	MMethodDef	Redefinition it the same module of a private method
-names::n0$P0$::n0::P::p	MMethodDef	Redefinition it the same module of a private method
-names::n1	MModule	Second module
-names::n1$A	MClassDef	A refinement of a class
-names::n1$A$a	MMethodDef	A refinement in the same class
-names::n1$A$z	MMethodDef	A refinement in the same class
-names::n1::A::b	MMethod	
-names::n1$A$b	MMethodDef	A public method introduced in a refinement
-names::n1$A0	MClassDef	A refinement of a subclass
-names::n1$A0$A::a	MMethodDef	A refinement+redefinition
-names::n1$A0$::n0::A::z	MMethodDef	A refinement+redefinition
-names::n1$A0$::n0::P::p	MMethodDef	A refinement+redefinition
-names::A1	MClass	
-names$A1	MClassDef	A subclass introduced in a submodule
-names$A1$A::a	MMethodDef	A redefinition in a subclass from a different module
-names$A1$::n0::A::z	MMethodDef	A redefinition in a subclass from a different module
-names$A1$::n0::P::p	MMethodDef	A redefinition in a subclass from a different module
-names::n1$::n0::P	MClassDef	A refinement of a class
-names::n1$::n0::P$p	MMethodDef	A refinement in the same class
-names::n1$::n0::P0	MClassDef	A refinement of a subclass
-names::n1$::n0::P0$A::a	MMethodDef	A refinement+redefinition
-names::n1$::n0::P0$::n0::A::z	MMethodDef	A refinement+redefinition
-names::n1$::n0::P0$::n0::P::p	MMethodDef	A refinement+redefinition
-names::n1::P1	MClass	
-names::n1$P1	MClassDef	A private subclass introduced in a different module
-names::n1$P1$A::a	MMethodDef	A redefinition in a subclass from a different module
-names::n1$P1$::n0::A::z	MMethodDef	A redefinition in a subclass from a different module
-names::n1$P1$::n0::P::p	MMethodDef	A redefinition in a subclass from a different module
-names::n2	MModule	A alternative second module, used to make name conflicts
-names::n2$A	MClassDef	A refinement of a class
-names::n2::A::b	MMethod	
-names::n2$A$b	MMethodDef	Name conflict? A second public method
-names::n2::A::z	MMethod	
-names::n2$A$z	MMethodDef	Name conflict? A second private method
-names::n2::P	MClass	
-names::n2$P	MClassDef	Name conflict? A second private class
-names::n2::P::p	MMethod	
-names::n2$P$p	MMethodDef	Name conflict? A private method in an homonym class.
-names1	MPackage	An alternative second module in a distinct package
-names1>	MGroup	An alternative second module in a distinct package
-names1::names1	MModule	An alternative second module in a distinct package
-names1::names1$names::A	MClassDef	A refinement of a class
-names1::names1$names::A$a	MMethodDef	A refinement in the same class
-names1::names1$names::A$z	MMethodDef	A refinement in the same class
-names1::names1::A::b	MMethod	
-names1::names1$names::A$b	MMethodDef	A public method introduced in a refinement
-names1::names1$names::A0	MClassDef	A refinement of a subclass
-names1::names1$names::A0$names::A::a	MMethodDef	A refinement+redefinition
-names1::names1$names::A0$names::n0::A::z	MMethodDef	A refinement+redefinition
-names1::names1$names::A0$names::n0::P::p	MMethodDef	A refinement+redefinition
-names1::A1	MClass	
-names1$A1	MClassDef	A subclass introduced in a submodule
-names1$A1$names::A::a	MMethodDef	A redefinition in a subclass from a different module
-names1$A1$names::n0::A::z	MMethodDef	A redefinition in a subclass from a different module
-names1$A1$names::n0::P::p	MMethodDef	A redefinition in a subclass from a different module
-names1::names1$names::n0::P	MClassDef	A refinement of a class
-names1::names1$names::n0::P$p	MMethodDef	A refinement in the same class
-names1::names1$names::n0::P0	MClassDef	A refinement of a subclass
-names1::names1$names::n0::P0$names::A::a	MMethodDef	A refinement+redefinition
-names1::names1$names::n0::P0$names::n0::A::z	MMethodDef	A refinement+redefinition
-names1::names1$names::n0::P0$names::n0::P::p	MMethodDef	A refinement+redefinition
-names1::names1::P1	MClass	
-names1::names1$P1	MClassDef	A private subclass introduced in a different module
-names1::names1$P1$names::A::a	MMethodDef	A redefinition in a subclass from a different module
-names1::names1$P1$names::n0::A::z	MMethodDef	A redefinition in a subclass from a different module
-names1::names1$P1$names::n0::P::p	MMethodDef	A redefinition in a subclass from a different module
+names	MPackage	names	Group of modules used to test various full_name configurations and conflicts.
+names>	MGroup	names	Group of modules used to test various full_name configurations and conflicts.
+names::n3	MModule	names/n3.nit:15,1--35,3	The bottom module
+names::n3$A1	MClassDef	names/n3.nit:21,1--27,3	a refinement of a subclass in a submodule
+names::n3$A1$A::a	MMethodDef	names/n3.nit:23,2--24,19	a refinement (3 distinct modules)
+names::n3$A1$::n0::P::p	MMethodDef	names/n3.nit:25,2--26,19	a refinement (3 distinct modules)
+names::n3$::n1::P1	MClassDef	names/n3.nit:29,1--35,3	a refinement of a subclass in a submodule
+names::n3$::n1::P1$A::a	MMethodDef	names/n3.nit:31,2--32,19	a refinement (3 distinct modules)
+names::n3$::n1::P1$::n0::P::p	MMethodDef	names/n3.nit:33,2--34,19	a refinement (3 distinct modules)
+names::n0	MModule	names/n0.nit:15,1--67,3	Root module
+names::Object	MClass	names/n0.nit:20,1--22,3	
+names$Object	MClassDef	names/n0.nit:20,1--22,3	Root interface
+names::Object::init	MMethod	names/n0.nit:20,1--22,3	
+names$Object$init	MMethodDef	names/n0.nit:20,1--22,3	
+names::A	MClass	names/n0.nit:24,1--31,3	
+names$A	MClassDef	names/n0.nit:24,1--31,3	A public class
+names::A::a	MMethod	names/n0.nit:26,2--27,13	
+names$A$a	MMethodDef	names/n0.nit:26,2--27,13	A public method in a public class
+names::n0::A::z	MMethod	names/n0.nit:29,2--30,21	
+names$A$z	MMethodDef	names/n0.nit:29,2--30,21	A private method in a public class
+names::A0	MClass	names/n0.nit:33,1--46,3	
+names$A0	MClassDef	names/n0.nit:33,1--46,3	A public subclass in the same module
+names$A0$A::a	MMethodDef	names/n0.nit:38,2--39,19	Redefinition it the same module of a public method
+names$A0$::n0::A::z	MMethodDef	names/n0.nit:41,2--42,19	Redefinition it the same module of a private method
+names$A0$::n0::P::p	MMethodDef	names/n0.nit:44,2--45,19	Redefinition it the same module of a private method
+names::n0::P	MClass	names/n0.nit:48,1--52,3	
+names::n0$P	MClassDef	names/n0.nit:48,1--52,3	A private class
+names::n0::P::p	MMethod	names/n0.nit:50,2--51,13	
+names::n0$P$p	MMethodDef	names/n0.nit:50,2--51,13	A private method in a private class
+names::n0::P0	MClass	names/n0.nit:54,1--67,3	
+names::n0$P0	MClassDef	names/n0.nit:54,1--67,3	A private subclass introduced in the same module
+names::n0$P0$A::a	MMethodDef	names/n0.nit:59,2--60,19	Redefinition it the same module of a public method
+names::n0$P0$::n0::A::z	MMethodDef	names/n0.nit:62,2--63,19	Redefinition it the same module of a private method
+names::n0$P0$::n0::P::p	MMethodDef	names/n0.nit:65,2--66,19	Redefinition it the same module of a private method
+names::n1	MModule	names/n1.nit:15,1--90,3	Second module
+names::n1$A	MClassDef	names/n1.nit:20,1--30,3	A refinement of a class
+names::n1$A$a	MMethodDef	names/n1.nit:22,2--23,19	A refinement in the same class
+names::n1$A$z	MMethodDef	names/n1.nit:25,2--26,19	A refinement in the same class
+names::n1::A::b	MMethod	names/n1.nit:28,2--29,13	
+names::n1$A$b	MMethodDef	names/n1.nit:28,2--29,13	A public method introduced in a refinement
+names::n1$A0	MClassDef	names/n1.nit:32,1--42,3	A refinement of a subclass
+names::n1$A0$A::a	MMethodDef	names/n1.nit:34,2--35,19	A refinement+redefinition
+names::n1$A0$::n0::A::z	MMethodDef	names/n1.nit:37,2--38,19	A refinement+redefinition
+names::n1$A0$::n0::P::p	MMethodDef	names/n1.nit:40,2--41,19	A refinement+redefinition
+names::A1	MClass	names/n1.nit:44,1--57,3	
+names$A1	MClassDef	names/n1.nit:44,1--57,3	A subclass introduced in a submodule
+names$A1$A::a	MMethodDef	names/n1.nit:49,2--50,19	A redefinition in a subclass from a different module
+names$A1$::n0::A::z	MMethodDef	names/n1.nit:52,2--53,19	A redefinition in a subclass from a different module
+names$A1$::n0::P::p	MMethodDef	names/n1.nit:55,2--56,19	A redefinition in a subclass from a different module
+names::n1$::n0::P	MClassDef	names/n1.nit:59,1--63,3	A refinement of a class
+names::n1$::n0::P$p	MMethodDef	names/n1.nit:61,2--62,19	A refinement in the same class
+names::n1$::n0::P0	MClassDef	names/n1.nit:65,1--75,3	A refinement of a subclass
+names::n1$::n0::P0$A::a	MMethodDef	names/n1.nit:67,2--68,19	A refinement+redefinition
+names::n1$::n0::P0$::n0::A::z	MMethodDef	names/n1.nit:70,2--71,19	A refinement+redefinition
+names::n1$::n0::P0$::n0::P::p	MMethodDef	names/n1.nit:73,2--74,19	A refinement+redefinition
+names::n1::P1	MClass	names/n1.nit:77,1--90,3	
+names::n1$P1	MClassDef	names/n1.nit:77,1--90,3	A private subclass introduced in a different module
+names::n1$P1$A::a	MMethodDef	names/n1.nit:82,2--83,19	A redefinition in a subclass from a different module
+names::n1$P1$::n0::A::z	MMethodDef	names/n1.nit:85,2--86,19	A redefinition in a subclass from a different module
+names::n1$P1$::n0::P::p	MMethodDef	names/n1.nit:88,2--89,19	A redefinition in a subclass from a different module
+names::n2	MModule	names/n2.nit:15,1--33,3	A alternative second module, used to make name conflicts
+names::n2$A	MClassDef	names/n2.nit:20,1--27,3	A refinement of a class
+names::n2::A::b	MMethod	names/n2.nit:22,2--23,13	
+names::n2$A$b	MMethodDef	names/n2.nit:22,2--23,13	Name conflict? A second public method
+names::n2::A::z	MMethod	names/n2.nit:25,2--26,13	
+names::n2$A$z	MMethodDef	names/n2.nit:25,2--26,13	Name conflict? A second private method
+names::n2::P	MClass	names/n2.nit:29,1--33,3	
+names::n2$P	MClassDef	names/n2.nit:29,1--33,3	Name conflict? A second private class
+names::n2::P::p	MMethod	names/n2.nit:31,2--32,13	
+names::n2$P$p	MMethodDef	names/n2.nit:31,2--32,13	Name conflict? A private method in an homonym class.
+names1	MPackage	names1.nit	An alternative second module in a distinct package
+names1>	MGroup	names1.nit	An alternative second module in a distinct package
+names1::names1	MModule	names1.nit:15,1--90,3	An alternative second module in a distinct package
+names1::names1$names::A	MClassDef	names1.nit:20,1--30,3	A refinement of a class
+names1::names1$names::A$a	MMethodDef	names1.nit:22,2--23,19	A refinement in the same class
+names1::names1$names::A$z	MMethodDef	names1.nit:25,2--26,19	A refinement in the same class
+names1::names1::A::b	MMethod	names1.nit:28,2--29,13	
+names1::names1$names::A$b	MMethodDef	names1.nit:28,2--29,13	A public method introduced in a refinement
+names1::names1$names::A0	MClassDef	names1.nit:32,1--42,3	A refinement of a subclass
+names1::names1$names::A0$names::A::a	MMethodDef	names1.nit:34,2--35,19	A refinement+redefinition
+names1::names1$names::A0$names::n0::A::z	MMethodDef	names1.nit:37,2--38,19	A refinement+redefinition
+names1::names1$names::A0$names::n0::P::p	MMethodDef	names1.nit:40,2--41,19	A refinement+redefinition
+names1::A1	MClass	names1.nit:44,1--57,3	
+names1$A1	MClassDef	names1.nit:44,1--57,3	A subclass introduced in a submodule
+names1$A1$names::A::a	MMethodDef	names1.nit:49,2--50,19	A redefinition in a subclass from a different module
+names1$A1$names::n0::A::z	MMethodDef	names1.nit:52,2--53,19	A redefinition in a subclass from a different module
+names1$A1$names::n0::P::p	MMethodDef	names1.nit:55,2--56,19	A redefinition in a subclass from a different module
+names1::names1$names::n0::P	MClassDef	names1.nit:59,1--63,3	A refinement of a class
+names1::names1$names::n0::P$p	MMethodDef	names1.nit:61,2--62,19	A refinement in the same class
+names1::names1$names::n0::P0	MClassDef	names1.nit:65,1--75,3	A refinement of a subclass
+names1::names1$names::n0::P0$names::A::a	MMethodDef	names1.nit:67,2--68,19	A refinement+redefinition
+names1::names1$names::n0::P0$names::n0::A::z	MMethodDef	names1.nit:70,2--71,19	A refinement+redefinition
+names1::names1$names::n0::P0$names::n0::P::p	MMethodDef	names1.nit:73,2--74,19	A refinement+redefinition
+names1::names1::P1	MClass	names1.nit:77,1--90,3	
+names1::names1$P1	MClassDef	names1.nit:77,1--90,3	A private subclass introduced in a different module
+names1::names1$P1$names::A::a	MMethodDef	names1.nit:82,2--83,19	A redefinition in a subclass from a different module
+names1::names1$P1$names::n0::A::z	MMethodDef	names1.nit:85,2--86,19	A redefinition in a subclass from a different module
+names1::names1$P1$names::n0::P::p	MMethodDef	names1.nit:88,2--89,19	A redefinition in a subclass from a different module


### PR DESCRIPTION
For some unknown historical reasons, the location was only provided to some specific model entities. By extending it to all entities, this simplify clients that need to process, visit or filter entities.

Location is not nullable for all entities. This is simpler but need some place-holder object for fictive location. ie some location objects that mean "no location".