### PR TITLE
nitcatalog: handle local images

### DIFF
--- a/lib/core/file.nit
+++ b/lib/core/file.nit
@@ -498,8 +498,8 @@ class Path
 		var output = dest.open_wo
 
 		while not input.eof do
-			var buffer = input.read(1024)
-			output.write buffer
+			var buffer = input.read_bytes(1024)
+			output.write_bytes buffer
 		end
 
 		input.close

--- a/src/doc/doc_down.nit
+++ b/src/doc/doc_down.nit
@@ -64,6 +64,8 @@ redef class MDoc
 	# Renders markdown line as a HTML comment block.
 	private fun lines_to_html(lines: Array[String]): Writable do
 		var res = new Template
+		var decorator = markdown_proc.emitter.decorator.as(NitdocDecorator)
+		decorator.current_mdoc = self
 		res.add "<div class=\"nitdoc\">"
 		# do not use DocUnit as synopsys
 		if not lines.is_empty then
@@ -88,6 +90,7 @@ redef class MDoc
 		# add other lines
 		res.add markdown_proc.process(lines.join("\n"))
 		res.add "</div>"
+		decorator.current_mdoc = null
 		return res
 
 	end
@@ -102,6 +105,11 @@ class NitdocDecorator
 	super HTMLDecorator
 
 	private var toolcontext = new ToolContext
+
+	# The currently processed mdoc.
+	#
+	# Unfortunately, this seems to be the simpler way to get the currently processed `MDoc` object.
+	var current_mdoc: nullable MDoc = null
 
 	redef fun add_code(v, block) do
 		var meta = block.meta or else "nit"

--- a/src/doc/doc_down.nit
+++ b/src/doc/doc_down.nit
@@ -93,10 +93,15 @@ redef class MDoc
 	end
 end
 
-private class NitdocDecorator
+# The specific markdown decorator used internally to process MDoc object.
+#
+# You should use the various methods of `MDoc` like `MDoc::html_documentation`
+#
+# The class is public so specific behavior can be plugged on it.
+class NitdocDecorator
 	super HTMLDecorator
 
-	var toolcontext = new ToolContext
+	private var toolcontext = new ToolContext
 
 	redef fun add_code(v, block) do
 		var meta = block.meta or else "nit"
@@ -143,7 +148,7 @@ private class NitdocDecorator
 		v.add "</code>"
 	end
 
-	fun code_from_text(buffer: Text, from, to: Int): String do
+	private fun code_from_text(buffer: Text, from, to: Int): String do
 		var out = new FlatBuffer
 		for i in [from..to[ do out.add buffer[i]
 		return out.write_to_string

--- a/src/nitcatalog.nit
+++ b/src/nitcatalog.nit
@@ -131,7 +131,68 @@ g.defer=true; g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
 	end
 end
 
+redef class NitdocDecorator
+	redef fun add_image(v, link, name, comment)
+	do
+		# Keep absolute links as is
+		if link.has_prefix("http://") or link.has_prefix("https://") then
+			super
+			return
+		end
+
+		do
+			# Get the directory of the doc object to deal with the relative link
+			var mdoc = current_mdoc
+			if mdoc == null then break
+			var source = mdoc.location.file
+			if source == null then break
+			var path = source.filename
+			var stat = path.file_stat
+			if stat == null then break
+			if not stat.is_dir then path = path.dirname
+
+			# Get the full path to the local resource
+			var fulllink = path / link.to_s
+			stat = fulllink.file_stat
+			if stat == null then break
+
+			# Get a collision-free catalog name for the resource
+			var hash = fulllink.md5
+			var ext = fulllink.file_extension
+			if ext != null then hash = hash + "." + ext
+
+			# Copy the local resource in the resource directory of the catalog
+			var res = catalog.outdir / "res" / hash
+			fulllink.file_copy_to(res)
+
+			# Hijack the link in the html.
+			link = ".." / "res" / hash
+			super(v, link, name, comment)
+			return
+		end
+
+		# Something went bad
+		catalog.modelbuilder.toolcontext.error(current_mdoc.location, "Error: cannot find local image `{link}`")
+		super
+	end
+
+	# The registered catalog
+	#
+	# It is used to deal with relative links in images.
+	var catalog: Catalog is noautoinit
+end
+
 redef class Catalog
+	redef init
+	do
+		# Register `self` to the global NitdocDecorator
+		# FIXME this is ugly. But no better idea at the moment.
+		modelbuilder.model.nitdoc_md_processor.emitter.decorator.as(NitdocDecorator).catalog = self
+	end
+
+	# The output directory where to generate pages
+	var outdir: String is noautoinit
+
 	# Return a empty `CatalogPage`.
 	fun new_page(rootpath: String): CatalogPage
 	do
@@ -519,6 +580,9 @@ end
 
 var out = opt_dir.value or else "catalog.out"
 (out/"p").mkdir
+(out/"res").mkdir
+
+catalog.outdir = out
 
 # Generate the css (hard coded)
 var css = """

--- a/tests/nitcatalog.args
+++ b/tests/nitcatalog.args
@@ -1,0 +1,1 @@
+test_prog --no-git -d "$WRITE" ; cat "$WRITE/p/test_prog.html"

--- a/tests/sav/nit_args6.res
+++ b/tests/sav/nit_args6.res
@@ -6,6 +6,10 @@ This program creates a fake model that can be used to test tools like:
 * `nitmetrics`
 * `nitx`
 * or others `modelbuilder`.
+
+An image:
+
+![Tinks3D](../../contrib/tinks/doc/tinks3d.png)
 # This file is part of NIT ( http://www.nitlanguage.org ).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/sav/nitcatalog_args1.res
+++ b/tests/sav/nitcatalog_args1.res
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<link rel="stylesheet" media="all" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+	<link rel="stylesheet" media="all" href="../style.css">
+<title>test_prog</title></head>
+<body>
+<div class='container-fluid'>
+ <div class='row'>
+  <nav id='topmenu' class='navbar navbar-default navbar-fixed-top' role='navigation'>
+   <div class='container-fluid'>
+    <div class='navbar-header'>
+     <button type='button' class='navbar-toggle' data-toggle='collapse' data-target='#topmenu-collapse'>
+      <span class='sr-only'>Toggle menu</span>
+      <span class='icon-bar'></span>
+      <span class='icon-bar'></span>
+      <span class='icon-bar'></span>
+     </button>
+     <span class='navbar-brand'><a href="http://nitlanguage.org/">Nitlanguage.org</a></span>
+    </div>
+    <div class='collapse navbar-collapse' id='topmenu-collapse'>
+     <ul class='nav navbar-nav'>
+      <li><a href="../index.html">Catalog</a></li>
+     </ul>
+    </div>
+   </div>
+  </nav>
+ </div>
+<div class="content">
+<h1 class="package-name">test_prog</h1>
+<div class="nitdoc"><p class="synopsys">Test program for model tools.</p><p>This program creates a fake model that can be used to test tools like:</p>
+<ul>
+<li><code class="nitcode"><span class="nitcode"><span class="line"><span class="nc_i">nitdoc</span></span></span></code></li>
+<li><code class="nitcode"><span class="nitcode"><span class="line"><span class="nc_i">nitmetrics</span></span></span></code></li>
+<li><code class="nitcode"><span class="nitcode"><span class="line"><span class="nc_i">nitx</span></span></span></code></li>
+<li>or others <code class="nitcode"><span class="nitcode"><span class="line"><span class="nc_i">modelbuilder</span></span></span></code>.</li>
+</ul>
+<p>An image:</p>
+<p><img src="../res/c94d8a73ccfe143ebde7599e88f5f5ce.png" alt="Tinks3D"/></p>
+</div><h2>Content</h2><ul>
+<li><strong>test_prog</strong>: <span class="synopsys nitdoc">Test program for model tools.</span> (test_prog)<ul>
+<li><strong>game</strong>: <span class="synopsys nitdoc">Gaming group</span> (test_prog/game)<ul>
+<li><strong>game</strong>: <span class="synopsys nitdoc">A game abstraction for RPG.</span> (test_prog/game/game.nit)</li>
+</ul>
+</li>
+<li><strong>platform</strong>: <span class="synopsys nitdoc">Fictive Crappy Platform.</span> (test_prog/platform)<ul>
+<li><strong>platform</strong>: <span class="synopsys nitdoc">Declares base types allowed on the platform.</span> (test_prog/platform/platform.nit)</li>
+</ul>
+</li>
+<li><strong>rpg</strong>: <span class="synopsys nitdoc">Role Playing Game group</span> (test_prog/rpg)<ul>
+<li><strong>careers</strong>: <span class="synopsys nitdoc">Careers of the game.</span> (test_prog/rpg/careers.nit)</li>
+<li><strong>character</strong>: <span class="synopsys nitdoc">Characters are playable entity in the world.</span> (test_prog/rpg/character.nit)</li>
+<li><strong>combat</strong>: <span class="synopsys nitdoc">COmbat interactions between characters.</span> (test_prog/rpg/combat.nit)</li>
+<li><strong>races</strong>: <span class="synopsys nitdoc">Races of the game.</span> (test_prog/rpg/races.nit)</li>
+<li><strong>rpg</strong>: <span class="synopsys nitdoc">A worlg RPG abstraction.</span> (test_prog/rpg/rpg.nit)</li>
+</ul>
+</li>
+<li><strong>test_prog</strong>: <span class="synopsys nitdoc">A test program with a fake model to check model tools.</span> (test_prog/test_prog.nit)</li>
+</ul>
+</li>
+</ul>
+</div>
+<div class="sidebar">
+<ul class="box">
+</ul>
+<ul class="box">
+<li><a href="http:&#47;&#47;nitlanguage.org">http:&#47;&#47;nitlanguage.org</a></li>
+<li><a href="http:&#47;&#47;www.example.com&#47;~jdoe"><img src="https://secure.gravatar.com/avatar/694ea0904ceaf766c6738166ed89bafb?size=20&amp;default=retro">&nbsp;John Doe</a></li><li><a href="http://opensource.org/licenses/Apache-2.0">Apache-2.0</a> license</li>
+</ul>
+<h3>Source Code</h3>
+<ul class="box">
+<li><a href="https:&#47;&#47;github.com&#47;nitlang&#47;nit&#47;tree&#47;master&#47;tests&#47;test_prog">https:&#47;&#47;github.com&#47;nitlang&#47;nit&#47;tree&#47;master&#47;tests&#47;test_prog</a></li>
+<li><tt>https:&#47;&#47;github.com&#47;nitlang&#47;nit.git</tt></li>
+</ul>
+<h3>Tags</h3>
+<a href="../index.html#tag_test">test</a>, <a href="../index.html#tag_game">game</a><h3>Requirements</h3>
+none<h3>Clients</h3>
+none<h3>Contributors</h3>
+<ul class="box"><li><a href="http:&#47;&#47;www.example.com&#47;~jdoe"><img src="https://secure.gravatar.com/avatar/694ea0904ceaf766c6738166ed89bafb?size=20&amp;default=retro">&nbsp;John Doe</a></li><li><img src="https://secure.gravatar.com/avatar/db3f2909768694ad2bb6409b44627182?size=20&amp;default=retro">&nbsp;Riri</li><li>Fifi (http:&#47;&#47;www.example.com&#47;~fifi)</li><li>Loulou</li></ul><h3>Stats</h3>
+<ul class="box">
+<li>8 modules</li>
+<li>22 classes</li>
+<li>68 methods</li>
+<li>439 lines of code</li>
+</ul>
+</div>
+</div> <!-- container-fluid -->
+<script src='https://code.jquery.com/jquery-latest.min.js'></script>
+<script src='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js'></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.8.1/bootstrap-table-all.min.js'></script>
+
+</body>
+</html>
+index.html
+p/
+people.html
+res/
+style.css
+table.html

--- a/tests/sav/test_sort_perf_args1.res
+++ b/tests/sav/test_sort_perf_args1.res
@@ -3,6 +3,7 @@ test_prog/
 |--test_prog/game
 |  |--test_prog/game/README.md
 |  `--test_prog/game/game.nit
+|--test_prog/package.ini
 |--test_prog/platform
 |  |--test_prog/platform/README.md
 |  `--test_prog/platform/platform.nit

--- a/tests/test_prog/README.md
+++ b/tests/test_prog/README.md
@@ -6,3 +6,7 @@ This program creates a fake model that can be used to test tools like:
 * `nitmetrics`
 * `nitx`
 * or others `modelbuilder`.
+
+An image:
+
+![Tinks3D](../../contrib/tinks/doc/tinks3d.png)

--- a/tests/test_prog/package.ini
+++ b/tests/test_prog/package.ini
@@ -1,0 +1,13 @@
+[package]
+name=test_prog
+version=0.1
+tags=test,game
+maintainer=John Doe <jdoe@example.com> (http://www.example.com/~jdoe), Spider-Man
+more_contributors=Riri <riri@example.com>, Fifi (http://www.example.com/~fifi), Loulou
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/tests/test_prog
+git=https://github.com/nitlang/nit.git
+git.directory=tests/test_prog
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues


### PR DESCRIPTION
nitcatalog is extended to detect links to local images, copy the resource in the catalog directory and hijack the generated link.
This should fix #2042 and fix the images in http://nitlanguage.org/catalog/p/tinks.html

Most is done by monkey-patching (aka dirty refinement) since the doc_down model uses an internal private global markdown decorator. I'm not sure what should be the best approach here, and I had to improvise since @Morriar is MIA.

Bonus:

* `file_copy_to` is fixed and do not corrupt binary files (thanks @R4PaSs)
* `tests/test_prog` is used to test the catalog