### PR TITLE
pep8-analysis: tolerate explicitely positive numbers

### DIFF
--- a/contrib/pep8analysis/src/parser/pep8.sablecc3
+++ b/contrib/pep8analysis/src/parser/pep8.sablecc3
@@ -57,7 +57,7 @@ blank = (' ' | tab)+;
 
 eol = eol_helper;
 
-number = '-'? digit+;
+number = ('-'|'+')? digit+;
 float = digit* '.' digit+;
 char = (''' [[any - '''] - '\'] ''')
 	| (''' '\' any ''')


### PR DESCRIPTION
Fixes syntax errors when parsing:

```
.EQUATE +0
```
