### PR TITLE
JSON Parser Optimization

### DIFF
--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -1514,6 +1514,42 @@ abstract class Buffer
 	# In Buffers, the internal sequence of character is mutable
 	# Thus, `chars` can be used to modify the buffer.
 	redef fun chars: Sequence[Char] is abstract
+
+	# Appends `length` chars from `s` starting at index `from`
+	#
+	# ~~~nit
+	#	var b = new Buffer
+	#	b.append_substring("abcde", 1, 2)
+	#	assert b == "bc"
+	#	b.append_substring("vwxyz", 2, 3)
+	#	assert b == "bcxyz"
+	#	b.append_substring("ABCDE", 4, 300)
+	#	assert b == "bcxyzE"
+	#	b.append_substring("VWXYZ", 400, 1)
+	#	assert b == "bcxyzE"
+	# ~~~
+	fun append_substring(s: Text, from, length: Int) do
+		if from < 0 then
+			length += from
+			from = 0
+		end
+		var ln = s.length
+		if (length + from) > ln then length = ln - from
+		if length <= 0 then return
+		append_substring_impl(s, from, length)
+	end
+
+	# Unsafe version of `append_substring` for performance
+	#
+	# NOTE: Use only if sure about `from` and `length`, no checks
+	# or bound recalculation is done
+	fun append_substring_impl(s: Text, from, length: Int) do
+		var pos = from
+		for i in [0 .. length[ do
+			self.add s[pos]
+			pos += 1
+		end
+	end
 end
 
 # View for chars on Buffer objects, extends Sequence

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -1755,6 +1755,18 @@ redef class Char
 		return cp >= 0xD800 and cp <= 0xDFFF
 	end
 
+	# Is `self` a UTF-16 high surrogate ?
+	fun is_hi_surrogate: Bool do
+		var cp = code_point
+		return cp >= 0xD800 and cp <= 0xDBFF
+	end
+
+	# Is `self` a UTF-16 low surrogate ?
+	fun is_lo_surrogate: Bool do
+		var cp = code_point
+		return cp >= 0xDC00 and cp <= 0xDFFF
+	end
+
 	# Length of `self` in a UTF-8 String
 	fun u8char_len: Int do
 		var c = self.code_point

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -411,7 +411,7 @@ abstract class FlatString
 
 		if from < 0 then
 			count += from
-			if count < 0 then return ""
+			if count <= 0 then return ""
 			from = 0
 		end
 
@@ -1052,6 +1052,21 @@ class FlatBuffer
 		var r_items = new NativeString(byte_length)
 		its.copy_to(r_items, byte_length, bytefrom, 0)
 		return new FlatBuffer.with_infos(r_items, byte_length, byte_length, count)
+	end
+
+	redef fun append_substring_impl(s, from, length) do
+		if length <= 0 then return
+		if not s isa FlatText then
+			super
+			return
+		end
+		var bytest = s.char_to_byte_index(from)
+		var bytend = s.char_to_byte_index(from + length - 1)
+		var btln = bytend - bytest + 1
+		enlarge(btln + _bytelen)
+		s._items.copy_to(_items, btln, bytest, _bytelen)
+		_bytelen += btln
+		_length += length
 	end
 
 	redef fun reverse

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -924,7 +924,10 @@ class FlatBuffer
 		is_dirty = true
 		_bytelen = 0
 		_length = 0
-		if written then reset
+		if written then
+			_capacity = 16
+			reset
+		end
 	end
 
 	redef fun empty do return new Buffer

--- a/lib/json/static.nit
+++ b/lib/json/static.nit
@@ -439,6 +439,11 @@ redef class JsonParseError
 				"\"position\":{position.to_json}," +
 				"\"message\":{message.to_json}\}"
 	end
+
+	redef fun pretty_json_visit(buf, indents) do
+		buf.clear
+		buf.append(to_json)
+	end
 end
 
 redef class Position


### PR DESCRIPTION
This PR improves the speed of JSON parsing with the `string_parser` module. The new version of `parse_json_string` is heavily inspired by Python's implementation, available [here](https://github.com/python/cpython/blob/master/Modules/_json.c)

Time is usually either as performing as before or better, Valgrind also gives the new version an advantage, sometimes significant.

On `large_escaped` (~120M, lots of escaped characters), we have: 

* Before: 13 748 436 458 Ir
* After: 11 687 104 643 Ir

i.e. an improvement of ~18%

Time is:
* Before: 0m4.428s
* After: 0m3.932s

i.e. an improvement of ~13%

Note that on this particular test, although the number of allocations is limited as much as we can, Boehm still cannibalizes the runtime, seeing that the real time is ~2.6s.
Perf gives a total time of ~38% in GC_mark and ~7% in GC_cache_miss.

Some more optimizations can be thought, but this shows how important a good GC is necessary for the future, this program can be a good metric of how GC usage can be improved.

For further reference, Python3 on the same test gives the following output on time and Valgrind:

* Time (user): 0m1.760s
* Time (real): 0m2.177s
* Valgrind: 8 845 966 867 Ir