### PR TITLE
Update gitignore to exclude DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ nitunit.xml
 
 .metadata/*
 .github_data
+.DS_Store


### PR DESCRIPTION
The .DS_Store file is automatically generated by the Mac OS filesystem to keep metainformation about that directory. This files is unnecessary to the project so should be excluded in the .gitignore

@privat 