### PR TITLE
JSON: merge 2 services into `serialize_to_json` and isolate from `static`

### DIFF
--- a/contrib/benitlux/src/benitlux_controller.nit
+++ b/contrib/benitlux/src/benitlux_controller.nit
@@ -348,7 +348,7 @@ redef class HttpResponse
 	init ok(data: Serializable)
 	do
 		init 200
-		body = data.to_json_string
+		body = data.serialize_to_json
 	end
 
 	# Respond with a `BenitluxError` in JSON and a code 403
@@ -356,7 +356,7 @@ redef class HttpResponse
 	do
 		init 403
 		var error = new BenitluxTokenError("Forbidden", "Invalid or outdated token.")
-		body = error.to_json_string
+		body = error.serialize_to_json
 	end
 
 	# Respond with a `BenitluxError` in JSON and a code 400
@@ -364,7 +364,7 @@ redef class HttpResponse
 	do
 		init 400
 		var error = new BenitluxError("Bad Request", "Application error, or it needs to be updated.")
-		body = error.to_json_string
+		body = error.serialize_to_json
 	end
 
 	# Respond with a `BenitluxError` in JSON and a code 500
@@ -372,6 +372,6 @@ redef class HttpResponse
 	do
 		init 500
 		var error = new BenitluxError("Internal Server Error", "Server error, try again later.")
-		body = error.to_json_string
+		body = error.serialize_to_json
 	end
 end

--- a/contrib/tinks/src/client/linux_client.nit
+++ b/contrib/tinks/src/client/linux_client.nit
@@ -54,8 +54,7 @@ redef class App
 
 		# Save the default config to pretty Json
 		var cc = new ClientConfig
-		var json = cc.to_plain_json
-		json = json.replace(",", ",\n")
+		var json = cc.serialize_to_json(plain=true, pretty=true)
 		json.write_to_file config_path
 
 		return cc

--- a/contrib/tnitter/src/action.nit
+++ b/contrib/tnitter/src/action.nit
@@ -266,14 +266,14 @@ class TnitterREST
 			db.close
 
 			var response = new HttpResponse(200)
-			response.body = posts.to_json_string
+			response.body = posts.serialize_to_json
 			return response
 		end
 
 		# Format not recognized
 		var error = new Error("Bad Request")
 		var response = new HttpResponse(400)
-		response.body = error.to_json_string
+		response.body = error.serialize_to_json
 		return response
 	end
 end

--- a/contrib/tnitter/src/push.nit
+++ b/contrib/tnitter/src/push.nit
@@ -46,7 +46,7 @@ redef class DB
 		# Everyone gets the same response
 		var posts = list_posts(0, 16)
 		var response = new HttpResponse(400)
-		response.body = posts.to_json_string
+		response.body = posts.serialize_to_json
 
 		for conn in push_connections do
 			# Complete the answer to `conn`

--- a/lib/json/serialization.nit
+++ b/lib/json/serialization.nit
@@ -107,6 +107,7 @@ module serialization
 import ::serialization::caching
 private import ::serialization::engine_tools
 private import static
+private import string_parser
 
 # Serializer of Nit objects to Json string.
 class JsonSerializer

--- a/lib/json/serialization.nit
+++ b/lib/json/serialization.nit
@@ -533,7 +533,15 @@ redef class Serializable
 		return stream.to_s
 	end
 
-	private fun accept_json_serializer(v: JsonSerializer)
+	# Refinable service to customize the serialization of this class to JSON
+	#
+	# This method can be refined to customize the serialization by either
+	# writing pure JSON directly on the stream `v.stream` or
+	# by using other services of `JsonSerializer`.
+	#
+	# Most of the time, it is preferable to refine the method `core_serialize_to`
+	# which is used by all the serialization engines, not just JSON.
+	protected fun accept_json_serializer(v: JsonSerializer)
 	do
 		var id = v.cache.new_id_for(self)
 		v.stream.write "\{"

--- a/lib/json/serialization.nit
+++ b/lib/json/serialization.nit
@@ -162,7 +162,7 @@ class JsonSerializer
 			end
 
 			first_attribute = true
-			object.serialize_to_json self
+			object.accept_json_serializer self
 			first_attribute = false
 
 			if plain_json then open_objects.pop
@@ -492,11 +492,11 @@ redef class Text
 		return res
 	end
 
-	redef fun serialize_to_json(v) do v.stream.write(to_json)
+	redef fun accept_json_serializer(v) do v.stream.write(to_json)
 end
 
 redef class Serializable
-	private fun serialize_to_json(v: JsonSerializer)
+	private fun accept_json_serializer(v: JsonSerializer)
 	do
 		var id = v.cache.new_id_for(self)
 		v.stream.write "\{"
@@ -542,32 +542,32 @@ redef class Serializable
 end
 
 redef class Int
-	redef fun serialize_to_json(v) do v.stream.write(to_s)
+	redef fun accept_json_serializer(v) do v.stream.write to_s
 end
 
 redef class Float
-	redef fun serialize_to_json(v) do v.stream.write(to_s)
+	redef fun accept_json_serializer(v) do v.stream.write to_s
 end
 
 redef class Bool
-	redef fun serialize_to_json(v) do v.stream.write(to_s)
+	redef fun accept_json_serializer(v) do v.stream.write to_s
 end
 
 redef class Char
-	redef fun serialize_to_json(v)
+	redef fun accept_json_serializer(v)
 	do
 		if v.plain_json then
-			v.stream.write to_s.to_json
+			to_s.accept_json_serializer v
 		else
 			v.stream.write "\{\"__kind\": \"char\", \"__val\": "
-			v.stream.write to_s.to_json
+			to_s.accept_json_serializer v
 			v.stream.write "\}"
 		end
 	end
 end
 
 redef class NativeString
-	redef fun serialize_to_json(v) do to_s.serialize_to_json(v)
+	redef fun accept_json_serializer(v) do to_s.accept_json_serializer(v)
 end
 
 redef class Collection[E]
@@ -595,7 +595,7 @@ redef class Collection[E]
 end
 
 redef class SimpleCollection[E]
-	redef fun serialize_to_json(v)
+	redef fun accept_json_serializer(v)
 	do
 		# Register as pseudo object
 		if not v.plain_json then
@@ -638,7 +638,7 @@ redef class SimpleCollection[E]
 end
 
 redef class Map[K, V]
-	redef fun serialize_to_json(v)
+	redef fun accept_json_serializer(v)
 	do
 		# Register as pseudo object
 		var id = v.cache.new_id_for(self)
@@ -654,7 +654,7 @@ redef class Map[K, V]
 				v.new_line_and_indent
 
 				var k = key or else "null"
-				v.stream.write k.to_s.to_json
+				k.to_s.accept_json_serializer v
 				v.stream.write ": "
 				if not v.try_to_serialize(val) then
 					assert val != null # null would have been serialized

--- a/lib/json/serialization.nit
+++ b/lib/json/serialization.nit
@@ -93,6 +93,10 @@
 # var deserializer = new JsonDeserializer(json_code)
 #
 # var meet = deserializer.deserialize
+#
+# # Check for errors
+# assert deserializer.errors.is_empty
+#
 # assert meet isa MeetupConfig
 # assert meet.description == "My Awesome Meetup"
 # assert meet.max_participants == null

--- a/lib/json/serialization.nit
+++ b/lib/json/serialization.nit
@@ -90,7 +90,7 @@ module serialization
 
 import ::serialization::caching
 private import ::serialization::engine_tools
-import static
+private import static
 
 # Serializer of Nit objects to Json string.
 class JsonSerializer
@@ -220,10 +220,10 @@ class JsonDeserializer
 	private var text: Text
 
 	# Root json object parsed from input text.
-	private var root: nullable Jsonable is noinit
+	private var root: nullable Object is noinit
 
 	# Depth-first path in the serialized object tree.
-	private var path = new Array[JsonObject]
+	private var path = new Array[Map[String, nullable Object]]
 
 	# Last encountered object reference id.
 	#
@@ -232,7 +232,7 @@ class JsonDeserializer
 
 	init do
 		var root = text.parse_json
-		if root isa JsonObject then path.add(root)
+		if root isa Map[String, nullable Object] then path.add(root)
 		self.root = root
 	end
 
@@ -268,7 +268,7 @@ class JsonDeserializer
 			return null
 		end
 
-		if object isa JsonObject then
+		if object isa Map[String, nullable Object] then
 			var kind = null
 			if object.keys.has("__kind") then
 				kind = object["__kind"]
@@ -467,7 +467,7 @@ class JsonDeserializer
 	# deserialized = deserializer.deserialize
 	# assert deserialized isa MyError
 	# ~~~
-	protected fun class_name_heuristic(json_object: JsonObject): nullable String
+	protected fun class_name_heuristic(json_object: Map[String, nullable Object]): nullable String
 	do
 		return null
 	end

--- a/lib/json/static.nit
+++ b/lib/json/static.nit
@@ -31,6 +31,9 @@ private import json_lexer
 interface Jsonable
 	# Encode `self` in JSON.
 	#
+	# This is a recursive method which can be refined by any subclasses.
+	# To write any `Serializable` object to JSON, see `serialize_to_json`.
+	#
 	# SEE: `append_json`
 	fun to_json: String is abstract
 

--- a/tests/sav/test_json_deserialization_plain.res
+++ b/tests/sav/test_json_deserialization_plain.res
@@ -27,6 +27,6 @@
 # Nit: <MyClass i:123 s:hello f:123.456 a:[one, two] o:<null>>
 
 # JSON: not valid json
-# Errors: 'Error Parsing JSON: [1:1-1:2] Unexpected character 'n'; is acceptable instead: value'
+# Errors: 'Parsing error at line 1, position 1: Error: bad JSON entity'
 # Nit: null
 


### PR DESCRIPTION
The first goal of this PR is to create a simple but customizable service to write Nit objects to JSON (replacing `to_json_string` and `to_plain_json`). It also clarifies how the serialization of a single object can be customized by refining `accept_json_serializer` which allows the same customization of the existing recursive `to_json` but on any `Serializable` objects.

The second goal is to isolate `json::serialization` from `json::static`. This allows to hide the complexity of `static` to clients of `serialization` and will help to deprecate the `static` writing services. After this PR, `serialization` uses really only one service from `static`, `String::to_json` which escapes strings. While `paser_json` uses the new @R4PaSs implementation. The types of `static` didn't add any useful services in the context of the `JsonDeserializer` (they only have writing services) and added both complexity and dependencies to the module.

All of this would make it easy (if there is still interest) to unify all JSON writing APIs and replace the current `Jsonable::to_json` with a single `Serializable::to_json` using the implementation of the new method `serialize_to_json`. And we can update the existing `redef fun to_json` to `redef fun accept_json_serializer`  writing to a stream instead of a string.