### PR TITLE
GNU readline wrapper

### DIFF
--- a/lib/readline.ini
+++ b/lib/readline.ini
@@ -1,0 +1,11 @@
+[package]
+name=readline
+tags=lib
+maintainer=Frédéric Vachon <fredvac@gmail.com>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/readline.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/readline.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/readline.nit
+++ b/lib/readline.nit
@@ -1,0 +1,58 @@
+# This file is part of NIT (http://www.nitlanguage.org).
+#
+# Copyright 2016 Frédéric Vachon <fredvac@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GNU readline library wrapper
+module readline is ldflags "-lreadline"
+
+in "C" `{
+	#include <readline/readline.h>
+	#include <readline/history.h>
+`}
+
+private fun native_readline(prompt: NativeString): NativeString `{
+	return readline(prompt);
+`}
+
+private fun native_add_history(data: NativeString) `{
+	if (data == NULL) return;
+	add_history(data);
+`}
+
+# Set emacs keybindings mode
+fun set_vi_mode `{ rl_editing_mode = 0; `}
+
+# Set emacs keybindings mode
+fun set_emacs_mode `{ rl_editing_mode = 1; `}
+
+# Use the GNU Library readline function
+# Returns `null` if EOF is read
+# If `with_history` is true, it will save all commands in the history except
+# empty strings and white characters strings
+fun readline(message: String, with_history: nullable Bool): nullable String do
+	var line = native_readline(message.to_cstring)
+	if line.address_is_null then return null
+
+	var nit_str = line.to_s
+
+	if with_history != null and with_history then
+		if nit_str.trim != "" then native_add_history(line)
+	end
+
+	return nit_str
+end
+
+# Adds the data String to the history no matter what it contains
+fun add_history(data: String) do native_add_history data.to_cstring

--- a/tests/sav/test_readline.res
+++ b/tests/sav/test_readline.res
@@ -1,0 +1,9 @@
+prompt>line 1
+line 1
+prompt>line 2
+line 2
+prompt>line 2bis
+line 2bis
+prompt>line 3  ine   3 
+line 3
+prompt>

--- a/tests/test_readline.inputs
+++ b/tests/test_readline.inputs
@@ -1,0 +1,4 @@
+line 1
+line 2
+line 2bis
+line 3 ine3

--- a/tests/test_readline.nit
+++ b/tests/test_readline.nit
@@ -1,0 +1,21 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import readline
+
+loop
+	var line = readline("prompt>", true)
+	if line == null then break
+	print line
+end


### PR DESCRIPTION
This is a tiny wrapper for the GNU readline library. For some reasons, pkg-config doesn't know about libreadline so I had to hardcode the cflags using the ldflags module annotation.

Signed-off-by: Frédéric Vachon <fredvac@gmail.com>