### PR TITLE
Base64: Revamped base64_decode and added a strict mode

### DIFF
--- a/lib/core/kernel.nit
+++ b/lib/core/kernel.nit
@@ -699,6 +699,9 @@ universal Byte
 			return self
 		end
 	end
+
+	# Is `self` an ASCII whitespace ?
+	fun is_whitespace: Bool do return self == 0x7Fu8 or self <= 0x20u8
 end
 
 # Native integer numbers.

--- a/tests/sav/error_class_glob.res
+++ b/tests/sav/error_class_glob.res
@@ -6,8 +6,8 @@
 ../lib/core/kernel.nit:431,1--486,3: Error: `kernel$Numeric` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
 ../lib/core/kernel.nit:492,1--515,3: Error: `kernel$Bool` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
 ../lib/core/kernel.nit:517,1--599,3: Error: `kernel$Float` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
-../lib/core/kernel.nit:601,1--702,3: Error: `kernel$Byte` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
-../lib/core/kernel.nit:704,1--882,3: Error: `kernel$Int` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
-../lib/core/kernel.nit:884,1--1052,3: Error: `kernel$Char` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
-../lib/core/kernel.nit:1054,1--1061,3: Error: `kernel$Pointer` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
-../lib/core/kernel.nit:1063,1--1072,3: Error: `kernel$Task` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
+../lib/core/kernel.nit:601,1--705,3: Error: `kernel$Byte` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
+../lib/core/kernel.nit:707,1--885,3: Error: `kernel$Int` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
+../lib/core/kernel.nit:887,1--1055,3: Error: `kernel$Char` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
+../lib/core/kernel.nit:1057,1--1064,3: Error: `kernel$Pointer` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
+../lib/core/kernel.nit:1066,1--1075,3: Error: `kernel$Task` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?

--- a/tests/sav/nitce/fixme/base_gen_reassign_alt4.res
+++ b/tests/sav/nitce/fixme/base_gen_reassign_alt4.res
@@ -1,4 +1,4 @@
-Runtime error: Cast failed. Expected `OTHER`, got `Float` (../lib/core/kernel.nit:725)
+Runtime error: Cast failed. Expected `OTHER`, got `Float` (../lib/core/kernel.nit:728)
 11
 21
 31

--- a/tests/sav/nitce/fixme/base_gen_reassign_alt5.res
+++ b/tests/sav/nitce/fixme/base_gen_reassign_alt5.res
@@ -1,4 +1,4 @@
-Runtime error: Cast failed. Expected `OTHER`, got `Float` (../lib/core/kernel.nit:725)
+Runtime error: Cast failed. Expected `OTHER`, got `Float` (../lib/core/kernel.nit:728)
 11
 21
 31

--- a/tests/sav/nitce/fixme/base_gen_reassign_alt6.res
+++ b/tests/sav/nitce/fixme/base_gen_reassign_alt6.res
@@ -1,4 +1,4 @@
-Runtime error: Cast failed. Expected `OTHER`, got `Float` (../lib/core/kernel.nit:725)
+Runtime error: Cast failed. Expected `OTHER`, got `Float` (../lib/core/kernel.nit:728)
 11
 21
 31

--- a/tests/sav/nituml_args3.res
+++ b/tests/sav/nituml_args3.res
@@ -51,7 +51,7 @@ Float [
 Numeric -> Float [dir=back arrowtail=open style=dashed];
 
 Byte [
- label = "{Byte||+ %(i: Byte): Byte\l+ \<\<(i: Int): Byte\l+ \>\>(i: Int): Byte\l+ ascii(): Char\l}"
+ label = "{Byte||+ %(i: Byte): Byte\l+ \<\<(i: Int): Byte\l+ \>\>(i: Int): Byte\l+ ascii(): Char\l+ is_whitespace(): Bool\l}"
 ]
 Discrete -> Byte [dir=back arrowtail=open style=dashed];
 Numeric -> Byte [dir=back arrowtail=open style=dashed];

--- a/tests/sav/nituml_args4.res
+++ b/tests/sav/nituml_args4.res
@@ -51,7 +51,7 @@ Float [
 Numeric -> Float [dir=back arrowtail=open style=dashed];
 
 Byte [
- label = "{Byte||+ %(i: Byte): Byte\l+ \<\<(i: Int): Byte\l+ \>\>(i: Int): Byte\l+ ascii(): Char\l}"
+ label = "{Byte||+ %(i: Byte): Byte\l+ \<\<(i: Int): Byte\l+ \>\>(i: Int): Byte\l+ ascii(): Char\l+ is_whitespace(): Bool\l}"
 ]
 Discrete -> Byte [dir=back arrowtail=open style=dashed];
 Numeric -> Byte [dir=back arrowtail=open style=dashed];

--- a/tests/sav/test_base64.res
+++ b/tests/sav/test_base64.res
@@ -12,3 +12,16 @@ Zm9v:     foo
 Zm9vYg==: foob
 Zm9vYmE=: fooba
 Zm9vYmFy: foobar
+Zm9vYg: foob
+Zm9vYmE: fooba
+Zm9v*Yg: foob
+:
+Znm=.is_base64? true
+Znm===.is_base64? false
+Z.sd=.is_base64? false
+Z==D.is_base64? false
+:
+Znm=: No error
+Znm===: Invalid padding length
+Z.sd=: Invalid Base64 character at position 1: .
+Z==D: Invalid padding character D at position 3

--- a/tests/test_base64.nit
+++ b/tests/test_base64.nit
@@ -24,10 +24,30 @@ print "foob:   " + "foob".encode_base64
 print "fooba:  " + "fooba".encode_base64
 print "foobar: " + "foobar".encode_base64
 
-print ":" + "".decode_base64
-print "Zg==:     " + "Zg==".decode_base64
-print "Zm8=:     " + "Zm8=".decode_base64
-print "Zm9v:     " + "Zm9v".decode_base64
-print "Zm9vYg==: " + "Zm9vYg==".decode_base64
-print "Zm9vYmE=: " + "Zm9vYmE=".decode_base64
-print "Zm9vYmFy: " + "Zm9vYmFy".decode_base64
+print ":" + "".decode_base64.to_s
+print "Zg==:     " + "Zg==".decode_base64.to_s
+print "Zm8=:     " + "Zm8=".decode_base64.to_s
+print "Zm9v:     " + "Zm9v".decode_base64.to_s
+print "Zm9vYg==: " + "Zm9vYg==".decode_base64.to_s
+print "Zm9vYmE=: " + "Zm9vYmE=".decode_base64.to_s
+print "Zm9vYmFy: " + "Zm9vYmFy".decode_base64.to_s
+
+print "Zm9vYg: " + "Zm9vYg".decode_base64.to_s
+print "Zm9vYmE: " + "Zm9vYmE".decode_base64.to_s
+print "Zm9v*Yg: " + "Zm9v*Yg".decode_base64.to_s
+
+print ":"
+print "Znm=.is_base64? " + "Znm=".is_base64.to_s
+print "Znm===.is_base64? " + "Znm===".is_base64.to_s
+print "Z.sd=.is_base64? " + "Z.sd=".is_base64.to_s
+print "Z==D.is_base64? " + "Z==D".is_base64.to_s
+
+print ":"
+printn "Znm=: "
+print "Znm=".check_base64 or else "No error"
+printn "Znm===: "
+print "Znm===".check_base64 or else "No error"
+printn "Z.sd=: "
+print "Z.sd=".check_base64 or else "No error"
+printn "Z==D: "
+print "Z==D".check_base64 or else "No error"


### PR DESCRIPTION
As talked with @ppepos, base64_decode now supports either `strict` or `non-strict`
modes when decoding a base64 string.

The `strict` mode is inspired from the `-i` option from the Unix `base64` command, which ignores non-compliant characters and non-padded `base64` strings.

This is more or less what we do now, `strict` being the default.

Since only one allocation and copy is done now, performance should be better.
There is however one pitfall of this implementation due to the `nullable Object` contract from `Collection[K]`, causing multiple boxings, some further optimization could be done on that front.