### PR TITLE
src/nitlight: Updated client to avoid crashes on unparsed modules

### DIFF
--- a/src/nitlight.nit
+++ b/src/nitlight.nit
@@ -41,7 +41,7 @@ var args = toolcontext.option_context.rest
 var mmodules = modelbuilder.parse_full(args)
 modelbuilder.run_phases
 
-if opt_full.value then mmodules = model.mmodules
+if opt_full.value then mmodules = modelbuilder.parsed_modules
 
 var dir = opt_dir.value
 if dir != null then


### PR DESCRIPTION
Since the loader has been upgraded, `nitlight` crashed when using the `--full` option since some modules were recognized by the model but left unparsed, causing the program to crash when fetching the `AModule` from `modelbuilder.mmodule2node`.

This PR fixes the issue by rendering only loaded and parsed modules from the importation chain.