### PR TITLE
lib/core: Fix substring issue in `ASCIIFlatString`

### DIFF
--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -666,15 +666,15 @@ private class ASCIIFlatString
 	end
 
 	redef fun substring(from, count) do
+		var ln = _length
 		if count <= 0 then return ""
-
+		if (count + from) > ln then count = ln - from
+		if count <= 0 then return ""
 		if from < 0 then
 			count += from
-			if count < 0 then return ""
+			if count <= 0 then return ""
 			from = 0
 		end
-		var ln = _length
-		if (count + from) > ln then count = ln - from
 		return new ASCIIFlatString.full_data(_items, count, from + _first_byte, count)
 	end
 

--- a/tests/sav/test_substring.res
+++ b/tests/sav/test_substring.res
@@ -43,3 +43,6 @@ test.has_suffix("test") => true
 test.has_suffix("bt") => false
 test.has_suffix("bat") => false
 test.has_suffix("foot") => false
+........
+
+........

--- a/tests/test_substring.nit
+++ b/tests/test_substring.nit
@@ -75,3 +75,6 @@ print("test.has_suffix(\"bt\") => {test.has_suffix("bt")}")
 print("test.has_suffix(\"bat\") => {test.has_suffix("bat")}")
 print("test.has_suffix(\"foot\") => {test.has_suffix("foot")}")
 
+print "........"
+print "/".substring(7, 1)
+print "........"


### PR DESCRIPTION
A bug in the validation part of `ASCIIFlatString::substring` caused some substrings to be created with a negative length, which could be the cause of various negative side-effects.

In the example added in the substring test, this caused `stdout` to close due to a call to `fwrite` with a negative count, which was in turn converted to unsigned (I suspect this is undefined behaviour), provoking the closure of the stream in the nit part.

Reported by @Morriar
Close #2089