### PR TITLE
Android: select the low-level implementations from other importations

### DIFF
--- a/contrib/asteronits/src/android.nit
+++ b/contrib/asteronits/src/android.nit
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ::android::platform
+import ::android
 import ::android::vibration
 
 import asteronits

--- a/contrib/tnitter/src/tnitter_app_android.nit
+++ b/contrib/tnitter/src/tnitter_app_android.nit
@@ -19,8 +19,7 @@ end
 
 import tnitter_app
 
-import android::ui
-import android::http_request
+import android
 import android::portrait
 
 redef class LabelAuthor

--- a/examples/calculator/src/android_calculator.nit
+++ b/examples/calculator/src/android_calculator.nit
@@ -16,7 +16,7 @@
 module android_calculator
 
 import calculator
-import android::ui
+import android
 
 redef class Button
 	init do set_android_style(native, (text or else "?").is_int)

--- a/lib/android/README.md
+++ b/lib/android/README.md
@@ -64,7 +64,16 @@ integer as argument. They are applied in the Android manifest as
   only be used by low-level implementations of Nit on Android.
   Its usefulness will be extended in the future to customize user applications.
 
-## Project entry points
+## Android implementation
+
+There is two core implementation for Nit apps on Android.
+`android::nit_activity` is used by apps with standard windows and native UI controls.
+`android::game` is used by, well, games and the game frameworks `mnit` and `gamnit`.
+
+Clients don't have to select the core implementation, it is imported by other relevant modules.
+For example, a module importing `app::ui` and `android` will trigger the importation of `android::nit_activity`.
+
+## Lock app orientation
 
 Importing `android::landscape` or `android::portrait` locks the generated
 application in the specified orientation. This can be useful for games and

--- a/lib/android/game.nit
+++ b/lib/android/game.nit
@@ -1,7 +1,5 @@
 # This file is part of NIT ( http://www.nitlanguage.org ).
 #
-# Copyright 2014 Alexis Laferrière <alexis.laf@xymus.net>
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,12 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Android services and implementation of app.nit
-#
-# This module provides basic logging facilities, advanced logging can be
-# achieved by importing `android::log`.
-module android
+# Android services and implementation of app.nit for gamnit and mnit
+module game
 
 import platform
+import native_app_glue
 import dalvik
 private import log
+private import assets
+
+redef class App
+	redef fun init_window
+	do
+		super
+		on_create
+		on_restore_state
+		on_start
+	end
+
+	redef fun term_window
+	do
+		super
+		on_stop
+	end
+
+	# Is the application currently paused?
+	var paused = true
+
+	redef fun pause
+	do
+		paused = true
+		on_pause
+		super
+	end
+
+	redef fun resume
+	do
+		paused = false
+		on_resume
+		super
+	end
+
+	redef fun save_state do on_save_state
+
+	redef fun lost_focus
+	do
+		paused = true
+		super
+	end
+
+	redef fun gained_focus
+	do
+		paused = false
+		super
+	end
+
+	redef fun destroy do on_destroy
+end

--- a/lib/android/input_events.nit
+++ b/lib/android/input_events.nit
@@ -18,7 +18,7 @@
 module input_events
 
 import mnit::input
-import android
+import android::game
 
 in "C header" `{
 	#include <android/log.h>

--- a/lib/android/landscape.nit
+++ b/lib/android/landscape.nit
@@ -20,4 +20,4 @@ module landscape is
 	android_manifest_activity """android:screenOrientation="sensorLandscape" """
 end
 
-import platform
+import android

--- a/lib/android/portrait.nit
+++ b/lib/android/portrait.nit
@@ -17,4 +17,4 @@ module portrait is android_manifest_activity """
 		android:screenOrientation="portrait"
 """
 
-import platform
+import android

--- a/lib/android/sensors.nit
+++ b/lib/android/sensors.nit
@@ -14,28 +14,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This module is used to manipulate android sensors
-# The sensor support is implemented in android_app module, so the user can enable the type of sensor he wants to use.
-# There is an example of how you can use the android sensors in nit/examples/mnit_ballz :
+# Access Android sensors
+#
+# Sensors are to be enabled when `App` is created.
+# The following example enables all sensors.
+# The events (`SensorEvent`, `ASensorAccelerometer`, `ASensorMagneticField`...)
+# are sent to the `input` callback of `App`
 #
 # ~~~~nitish
-# #FIXME rewrite the example
 # redef class App
-# 	sensors_support_enabled = true
-# 	accelerometer.enabled = true
-# 	accelerometer.eventrate = 10000
-# 	magnetic_field.enabled = true
-# 	gyroscope.enabled = true
-# 	light.enabled = true
-# 	proximity.enabled = true
+#     init
+#     do
+#         sensors_support_enabled = true
+#         accelerometer.enabled = true
+#         accelerometer.eventrate = 10000
+#         magnetic_field.enabled = true
+#         gyroscope.enabled = true
+#         light.enabled = true
+#         proximity.enabled = true
+#     end
 # end
 # ~~~~
-#
-# In this example, we enable the sensor support, then enable all types of sensors supported by the API, directly with `App` attributes
-# As a result, you get all type of SensorEvent (ASensorAccelerometer, ASensorMagneticField ...) in the `input` callback of `App`
 module sensors
 
-import android
+import game
 import mnit
 
 in "C header" `{

--- a/lib/app/audio.nit
+++ b/lib/app/audio.nit
@@ -27,7 +27,6 @@ import app_base
 import core::error
 
 # Platform variations
-# TODO: move on the platform once qualified names are understand in the condition
 import linux::audio is conditional(linux)
 import android::audio is conditional(android)
 

--- a/lib/app/data_store.nit
+++ b/lib/app/data_store.nit
@@ -23,7 +23,6 @@ import app_base
 import serialization
 
 # Platform variations
-# TODO: move on the platform once qualified names are understand in the condition
 import linux::data_store is conditional(linux)
 import android::data_store is conditional(android)
 import ios::data_store is conditional(ios)

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -18,9 +18,8 @@ module ui
 import app_base
 
 # Platform variations
-# TODO: move on the platform once qualified names are understand in the condition
 import linux::ui is conditional(linux)
-import android::ui is conditional(android) # FIXME it should be conditional to `android::platform`
+import android::ui is conditional(android)
 import ios::ui is conditional(ios)
 
 redef class App

--- a/lib/gamnit/display_android.nit
+++ b/lib/gamnit/display_android.nit
@@ -21,7 +21,7 @@ module display_android is
 	android_manifest """<uses-feature android:glEsVersion="0x00020000"/>"""
 end
 
-import ::android
+import ::android::game
 intrude import android::load_image
 
 private import gamnit::egl

--- a/lib/mnit/android/android_app.nit
+++ b/lib/mnit/android/android_app.nit
@@ -22,7 +22,7 @@ module android_app is android_manifest_activity """
 
 import mnit
 import mnit::opengles1
-import ::android
+import ::android::game
 intrude import ::android::input_events
 
 in "C" `{


### PR DESCRIPTION
This PR needs some context first: there is two low-level implementations for Nit apps on Android. The oldest is based on C code and `native_app_glue`, it is used by all our game engines. The new one is based on a custom Java class `NitActivity`, it is used to implement `app::ui` and should replace the oldest one when I have time to work on it.

Prior to this PR, importing `android` imported the old C implementation, and you had to import `android::ui` to get the Java implementation.

This PR changes this behavior and uses conditional importations to choose between the two low-level implementations. So importing `android` and `gamnit` uses the old C implementation (now `android::game`) and importing `android` and `app::ui` uses the new Java implementation (`android::nit_activity`).

This allows us to use the simple `nitc src/calculator.nit -m android`, instead of `nitc src/calculator.nit -m ../../lib/android/ui.nit`. And the most important is that the user doesn't have to chose between (or understand) the two low-level implementations.