### PR TITLE
make the nitcatalog slightly more robust on person variations

### DIFF
--- a/src/catalog.nit
+++ b/src/catalog.nit
@@ -254,8 +254,13 @@ class Catalog
 	do
 		var p = persons.get_or_null(person)
 		if p == null then
-			p = new Person.parse(person)
-			persons[person] = p
+			var new_p = new Person.parse(person)
+			# Maybe, we already have this person in fact?
+			p = persons.get_or_null(new_p.to_s)
+			if p == null then
+				p = new_p
+				persons[p.to_s] = p
+			end
 		end
 		var projs = contrib2proj[p]
 		if not projs.has(mpackage) then


### PR DESCRIPTION
The various person-related fields were parsed verbatim.
So a slight change in spaces was enough to differentiate two persons.
Now the canonical person representation is used.

e.g. `Lucas Bajolet<r4pass@hotmail.com>` vs `Lucas Bajolet <r4pass@hotmail.com>
` is now the same person (hint: the change is the space between the `t` and the `<`).

Note that to present the original information,
 names/emails/url are still distinguished.

`Lucas Bajolet <r4pass@hotmail.com>`, `R4pass <r4pass@hotmail.com>
` and `Lucas Bajolet <lucas.bajolet@hotmail.com>
` are still 3 persons.