### PR TITLE
More nitunit improvement

### DIFF
--- a/share/man/nitunit.md
+++ b/share/man/nitunit.md
@@ -237,12 +237,18 @@ With the `--full` option, all imported modules (even those in standard) are also
 ### `-o`, `--output`
 Output name (default is 'nitunit.xml').
 
-### `nitunit` produces a XML file comatible with JUnit.
+`nitunit` produces a XML file compatible with JUnit.
 
 ### `--dir`
 Working directory (default is '.nitunit').
 
 In order to execute the tests, nit files are generated then compiled and executed in the giver working directory.
+
+### `--nitc`
+nitc compiler to use.
+
+By default, nitunit tries to locate the `nitc` program with the environment variable `NITC` or heuristics.
+The option is used to indicate a specific nitc binary.
 
 ### `--no-act`
 Does not compile and run tests.
@@ -270,6 +276,13 @@ Also generate test case for private methods.
 
 ### `--only-show`
 Only display the skeleton, do not write any file.
+
+
+# ENVIRONMENT VARIABLES
+
+### `NITC`
+
+Indicate the specific Nit compiler executable to use. See `--nitc`.
 
 # SEE ALSO
 

--- a/share/man/nitunit.md
+++ b/share/man/nitunit.md
@@ -169,6 +169,34 @@ class TestFoo
 end
 ~~~~
 
+## Black Box Testing
+
+Sometimes, it is easier to validate a `TestCase` by comparing its output with a text file containing the expected result.
+
+For each TestCase `test_bar` of a TestSuite `test_mod.nit`, if the corresponding file `test_mod.sav/test_bar.res` exists, then the output of the test is compared with the file.
+
+The `diff(1)` command is used to perform the comparison.
+The test is failed if non-zero is returned by `diff`.
+
+~~~
+module test_mod is test_suite
+class TestFoo
+	fun test_bar do
+		print "Hello!"
+	end
+end
+~~~
+
+Where `test_mod.sav/test_bar.res` contains
+
+~~~raw
+Hello!
+~~~
+
+If no corresponding `.res` file exists, then the output of the TestCase is ignored.
+
+## Configuring TestSuites
+
 `TestSuites` also provide methods to configure the test run:
 
 `before_test` and `after_test`: methods called before/after each test case.

--- a/src/nitunit.nit
+++ b/src/nitunit.nit
@@ -65,6 +65,10 @@ end
 
 "NIT_TESTING".setenv("true")
 
+var test_dir = toolcontext.test_dir
+test_dir.mkdir
+"# This file prevents the Nit modules of the directory to be part of the package".write_to_file(test_dir / "packages.ini")
+
 var page = new HTMLTag("testsuites")
 
 if toolcontext.opt_full.value then mmodules = model.mmodules

--- a/src/nitunit.nit
+++ b/src/nitunit.nit
@@ -20,7 +20,7 @@ import testing
 
 var toolcontext = new ToolContext
 
-toolcontext.option_context.add_option(toolcontext.opt_full, toolcontext.opt_output, toolcontext.opt_dir, toolcontext.opt_noact, toolcontext.opt_pattern, toolcontext.opt_file, toolcontext.opt_gen_unit, toolcontext.opt_gen_force, toolcontext.opt_gen_private, toolcontext.opt_gen_show)
+toolcontext.option_context.add_option(toolcontext.opt_full, toolcontext.opt_output, toolcontext.opt_dir, toolcontext.opt_noact, toolcontext.opt_pattern, toolcontext.opt_file, toolcontext.opt_gen_unit, toolcontext.opt_gen_force, toolcontext.opt_gen_private, toolcontext.opt_gen_show, toolcontext.opt_nitc)
 toolcontext.tooldescription = "Usage: nitunit [OPTION]... <file.nit>...\nExecutes the unit tests from Nit source files."
 
 toolcontext.process_options(args)

--- a/src/testing/testing_base.nit
+++ b/src/testing/testing_base.nit
@@ -93,3 +93,39 @@ ulimit -t {{{ulimit_usertime}}} 2> /dev/null
 	# Default: 10 CPU minute
 	var ulimit_usertime = 600 is writable
 end
+
+redef class String
+	# If needed, truncate `self` at `max_length` characters and append an informative `message`.
+	#
+	# ~~~
+	# assert "hello".trunc(10) == "hello"
+	# assert "hello".trunc(2) == "he[truncated. Full size is 5]"
+	# assert "hello".trunc(2, "...") == "he..."
+	# ~~~
+	fun trunc(max_length: Int, message: nullable String): String
+	do
+		if length <= max_length then return self
+		if message == null then message = "[truncated. Full size is {length}]"
+		return substring(0, max_length) + message
+	end
+
+	# Use a special notation for whitespace characters that are not `'\n'` (LFD) or `' '` (space).
+	#
+	# ~~~
+	# assert "hello".filter_nonprintable == "hello"
+	# assert "\r\n\t".filter_nonprintable == "^13\n^9"
+	# ~~~
+	fun filter_nonprintable: String
+	do
+		var buf = new Buffer
+		for c in self do
+			var cp = c.code_point
+			if cp < 32 and c != '\n' then
+				buf.append "^{cp}"
+			else
+				buf.add c
+			end
+		end
+		return buf.to_s
+	end
+end

--- a/src/testing/testing_base.nit
+++ b/src/testing/testing_base.nit
@@ -27,6 +27,8 @@ redef class ToolContext
 	var opt_dir = new OptionString("Working directory (default is '.nitunit')", "--dir")
 	# opt --no-act
 	var opt_noact = new OptionBool("Does not compile and run tests", "--no-act")
+	# opt --nitc
+	var opt_nitc = new OptionString("nitc compiler to use", "--nitc")
 
 	# Working directory for testing.
 	fun test_dir: String do
@@ -40,10 +42,28 @@ redef class ToolContext
 	# If not `nitc` is suitable, then prints an error and quit.
 	fun find_nitc: String
 	do
+		var nitc = opt_nitc.value
+		if nitc != null then
+			if not nitc.file_exists then
+				fatal_error(null, "error: cannot find `{nitc}` given by --nitc.")
+				abort
+			end
+			return nitc
+		end
+
+		nitc = "NITC".environ
+		if nitc != "" then
+			if not nitc.file_exists then
+				fatal_error(null, "error: cannot find `{nitc}` given by NITC.")
+				abort
+			end
+			return nitc
+		end
+
 		var nit_dir = nit_dir
-		var nitc = nit_dir/"bin/nitc"
+		nitc = nit_dir/"bin/nitc"
 		if not nitc.file_exists then
-			fatal_error(null, "Error: cannot find nitc. Set envvar NIT_DIR.")
+			fatal_error(null, "Error: cannot find nitc. Set envvar NIT_DIR or NITC or use the --nitc option.")
 			abort
 		end
 		return nitc

--- a/src/testing/testing_base.nit
+++ b/src/testing/testing_base.nit
@@ -68,4 +68,28 @@ redef class ToolContext
 		end
 		return nitc
 	end
+
+	# Execute a system command in a more safe context than `Sys::system`.
+	fun safe_exec(command: String): Int
+	do
+		info(command, 2)
+		var real_command = """
+bash -c "
+ulimit -f {{{ulimit_file}}} 2> /dev/null
+ulimit -t {{{ulimit_usertime}}} 2> /dev/null
+{{{command}}}
+"
+"""
+		return system(real_command)
+	end
+
+	# The maximum size (in KB) of files written by a command executed trough `safe_exec`
+	#
+	# Default: 64MB
+	var ulimit_file = 65536 is writable
+
+	# The maximum amount of cpu time (in seconds) for a command executed trough `safe_exec`
+	#
+	# Default: 10 CPU minute
+	var ulimit_usertime = 600 is writable
 end

--- a/src/testing/testing_base.nit
+++ b/src/testing/testing_base.nit
@@ -34,4 +34,18 @@ redef class ToolContext
 		if dir == null then return ".nitunit"
 		return dir
 	end
+
+	# Search the `nitc` compiler to use
+	#
+	# If not `nitc` is suitable, then prints an error and quit.
+	fun find_nitc: String
+	do
+		var nit_dir = nit_dir
+		var nitc = nit_dir/"bin/nitc"
+		if not nitc.file_exists then
+			fatal_error(null, "Error: cannot find nitc. Set envvar NIT_DIR.")
+			abort
+		end
+		return nitc
+	end
 end

--- a/src/testing/testing_doc.nit
+++ b/src/testing/testing_doc.nit
@@ -159,12 +159,13 @@ class NitUnitExecutor
 			toolcontext.info("Execute doc-unit {du.testcase.attrs["name"]} in {file} {i}", 1)
 			var res2 = toolcontext.safe_exec("{file.to_program_name}.bin {i} >'{file}.out1' 2>&1 </dev/null")
 
-			var msg
 			f = new FileReader.open("{file}.out1")
 			var n2
 			n2 = new HTMLTag("system-err")
 			tc.add n2
-			msg = f.read_all
+			var content = f.read_all
+			var msg = content.trunc(8192).filter_nonprintable
+			n2.append(msg)
 			f.close
 
 			n2 = new HTMLTag("system-out")
@@ -173,9 +174,9 @@ class NitUnitExecutor
 
 			if res2 != 0 then
 				var ne = new HTMLTag("error")
-				ne.attr("message", msg)
+				ne.attr("message", "Runtime error")
 				tc.add ne
-				toolcontext.warning(du.mdoc.location, "error", "ERROR: {tc.attrs["classname"]}.{tc.attrs["name"]} (in {file}): {msg}")
+				toolcontext.warning(du.mdoc.location, "error", "ERROR: {tc.attrs["classname"]}.{tc.attrs["name"]} (in {file}): Runtime error\n{msg}")
 				toolcontext.modelbuilder.failed_entities += 1
 			end
 			toolcontext.check_errors
@@ -209,12 +210,13 @@ class NitUnitExecutor
 			res2 = toolcontext.safe_exec("{file.to_program_name}.bin >'{file}.out1' 2>&1 </dev/null")
 		end
 
-		var msg
 		f = new FileReader.open("{file}.out1")
 		var n2
 		n2 = new HTMLTag("system-err")
 		tc.add n2
-		msg = f.read_all
+		var content = f.read_all
+		var msg = content.trunc(8192).filter_nonprintable
+		n2.append(msg)
 		f.close
 
 		n2 = new HTMLTag("system-out")
@@ -224,15 +226,15 @@ class NitUnitExecutor
 
 		if res != 0 then
 			var ne = new HTMLTag("failure")
-			ne.attr("message", msg)
+			ne.attr("message", "Compilation Error")
 			tc.add ne
-			toolcontext.warning(du.mdoc.location, "failure", "FAILURE: {tc.attrs["classname"]}.{tc.attrs["name"]} (in {file}): {msg}")
+			toolcontext.warning(du.mdoc.location, "failure", "FAILURE: {tc.attrs["classname"]}.{tc.attrs["name"]} (in {file}):\n{msg}")
 			toolcontext.modelbuilder.failed_entities += 1
 		else if res2 != 0 then
 			var ne = new HTMLTag("error")
-			ne.attr("message", msg)
+			ne.attr("message", "Runtime Error")
 			tc.add ne
-			toolcontext.warning(du.mdoc.location, "error", "ERROR: {tc.attrs["classname"]}.{tc.attrs["name"]} (in {file}): {msg}")
+			toolcontext.warning(du.mdoc.location, "error", "ERROR: {tc.attrs["classname"]}.{tc.attrs["name"]} (in {file}):\n{msg}")
 			toolcontext.modelbuilder.failed_entities += 1
 		end
 		toolcontext.check_errors

--- a/src/testing/testing_doc.nit
+++ b/src/testing/testing_doc.nit
@@ -268,12 +268,7 @@ class NitUnitExecutor
 	# Can terminate the program if the compiler is not found
 	private fun compile_unitfile(file: String): Int
 	do
-		var nit_dir = toolcontext.nit_dir
-		var nitc = nit_dir/"bin/nitc"
-		if not nitc.file_exists then
-			toolcontext.error(null, "Error: cannot find nitc. Set envvar NIT_DIR.")
-			toolcontext.check_errors
-		end
+		var nitc = toolcontext.find_nitc
 		var opts = new Array[String]
 		if mmodule != null then
 			opts.add "-I {mmodule.filepath.dirname}"

--- a/src/testing/testing_doc.nit
+++ b/src/testing/testing_doc.nit
@@ -157,7 +157,7 @@ class NitUnitExecutor
 			toolcontext.modelbuilder.unit_entities += 1
 			i += 1
 			toolcontext.info("Execute doc-unit {du.testcase.attrs["name"]} in {file} {i}", 1)
-			var res2 = sys.system("{file.to_program_name}.bin {i} >>'{file}.out1' 2>&1 </dev/null")
+			var res2 = toolcontext.safe_exec("{file.to_program_name}.bin {i} >'{file}.out1' 2>&1 </dev/null")
 
 			var msg
 			f = new FileReader.open("{file}.out1")
@@ -206,7 +206,7 @@ class NitUnitExecutor
 		var res = compile_unitfile(file)
 		var res2 = 0
 		if res == 0 then
-			res2 = sys.system("{file.to_program_name}.bin >>'{file}.out1' 2>&1 </dev/null")
+			res2 = toolcontext.safe_exec("{file.to_program_name}.bin >'{file}.out1' 2>&1 </dev/null")
 		end
 
 		var msg
@@ -274,7 +274,7 @@ class NitUnitExecutor
 			opts.add "-I {mmodule.filepath.dirname}"
 		end
 		var cmd = "{nitc} --ignore-visibility --no-color '{file}' {opts.join(" ")} >'{file}.out1' 2>&1 </dev/null -o '{file}.bin'"
-		var res = sys.system(cmd)
+		var res = toolcontext.safe_exec(cmd)
 		return res
 	end
 end

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -183,12 +183,7 @@ class TestSuite
 	# Compile all `test_cases` cases in one file.
 	fun compile do
 		# find nitc
-		var nit_dir = toolcontext.nit_dir
-		var nitc = nit_dir/"bin/nitc"
-		if not nitc.file_exists then
-			toolcontext.error(null, "Error: cannot find nitc. Set envvar NIT_DIR.")
-			toolcontext.check_errors
-		end
+		var nitc = toolcontext.find_nitc
 		# compile test suite
 		var file = test_file
 		var module_file = mmodule.location.file

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -259,6 +259,25 @@ class TestCase
 			toolcontext.warning(loc, "failure",
 			   "ERROR: {method_name} (in file {test_file}.nit): {msg}")
 			toolcontext.modelbuilder.failed_tests += 1
+		else
+			var mmodule = test_method.mclassdef.mmodule
+			var file = mmodule.filepath
+			if file != null then
+				var sav = file.dirname / mmodule.name + ".sav" / test_method.name + ".res"
+				if sav.file_exists then
+					toolcontext.info("Diff output with {sav}", 1)
+					res = toolcontext.safe_exec("diff -u --label 'expected:{sav}' --label 'got:{res_name}.out1' '{sav}' '{res_name}.out1' > '{res_name}.diff' 2>&1 </dev/null")
+					if res != 0 then
+						msg = "Diff\n" + "{res_name}.diff".to_path.read_all
+						error = msg
+						toolcontext.warning(loc, "failure",
+						"ERROR: {method_name} (in file {test_file}.nit): {msg}")
+						toolcontext.modelbuilder.failed_tests += 1
+					end
+				else
+					toolcontext.info("No diff: {sav} not found", 2)
+				end
+			end
 		end
 		toolcontext.check_errors
 	end

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -194,7 +194,7 @@ class TestSuite
 		end
 		var include_dir = module_file.filename.dirname
 		var cmd = "{nitc} --no-color '{file}.nit' -I {include_dir} -o '{file}.bin' > '{file}.out' 2>&1 </dev/null"
-		var res = sys.system(cmd)
+		var res = toolcontext.safe_exec(cmd)
 		var f = new FileReader.open("{file}.out")
 		var msg = f.read_all
 		f.close
@@ -248,7 +248,7 @@ class TestCase
 		var method_name = test_method.name
 		var test_file = test_suite.test_file
 		var res_name = "{test_file}_{method_name.escape_to_c}"
-		var res = sys.system("{test_file}.bin {method_name} > '{res_name}.out1' 2>&1 </dev/null")
+		var res = toolcontext.safe_exec("{test_file}.bin {method_name} > '{res_name}.out1' 2>&1 </dev/null")
 		var f = new FileReader.open("{res_name}.out1")
 		var msg = f.read_all
 		f.close

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -277,14 +277,14 @@ class TestCase
 		tc.attr("classname", "nitunit." + mclassdef.mmodule.full_name + "." + mclassdef.mclass.full_name)
 		tc.attr("name", test_method.mproperty.full_name)
 		if was_exec then
-			tc.add  new HTMLTag("system-err")
-			var n = new HTMLTag("system-out")
-			n.append "out"
+			tc.add  new HTMLTag("system-out")
+			var n = new HTMLTag("system-err")
 			tc.add n
 			var error = self.error
 			if error != null then
+				n.append error.trunc(8192).filter_nonprintable
 				n = new HTMLTag("error")
-				n.attr("message", error.to_s)
+				n.attr("message", "Runtime Error")
 				tc.add n
 			end
 		end

--- a/tests/sav/nitunit_args1.res
+++ b/tests/sav/nitunit_args1.res
@@ -1,6 +1,8 @@
-test_nitunit.nit:20,1--22,0: ERROR: nitunit.test_nitunit::test_nitunit.test_nitunit::X.<class> (in .nitunit/test_nitunit-2.nit): Runtime error: Assert failed (.nitunit/test_nitunit-2.nit:5)
+test_nitunit.nit:20,1--22,0: ERROR: nitunit.test_nitunit::test_nitunit.test_nitunit::X.<class> (in .nitunit/test_nitunit-2.nit):
+Runtime error: Assert failed (.nitunit/test_nitunit-2.nit:5)
 
-test_nitunit.nit:23,2--25,0: FAILURE: nitunit.test_nitunit::test_nitunit.test_nitunit::X.test_nitunit::X::foo (in .nitunit/test_nitunit-3.nit): .nitunit/test_nitunit-3.nit:5,8--27: Error: method or variable `undefined_identifier` unknown in `Sys`.
+test_nitunit.nit:23,2--25,0: FAILURE: nitunit.test_nitunit::test_nitunit.test_nitunit::X.test_nitunit::X::foo (in .nitunit/test_nitunit-3.nit):
+.nitunit/test_nitunit-3.nit:5,8--27: Error: method or variable `undefined_identifier` unknown in `Sys`.
 
 test_test_nitunit.nit:36,2--40,4: ERROR: test_foo1 (in file .nitunit/gen_test_test_nitunit.nit): Runtime error: Assert failed (test_test_nitunit.nit:39)
 
@@ -10,9 +12,9 @@ Entities: 27; Documented ones: 3; With nitunits: 3; Failures: 2
 TestSuites:
 Class suites: 1; Test Cases: 3; Failures: 1
 <testsuites><testsuite package="test_nitunit::test_nitunit"><testcase classname="nitunit.test_nitunit::test_nitunit.&lt;module&gt;" name="&lt;module&gt;"><system-err></system-err><system-out>assert true
-</system-out></testcase><testcase classname="nitunit.test_nitunit::test_nitunit.test_nitunit::X" name="&lt;class&gt;"><system-err></system-err><system-out>assert false
-</system-out><error message="Runtime error: Assert failed (.nitunit&#47;test_nitunit-2.nit:5)
-"></error></testcase><testcase classname="nitunit.test_nitunit::test_nitunit.test_nitunit::X" name="test_nitunit::X::foo"><system-err></system-err><system-out>assert undefined_identifier
-</system-out><failure message=".nitunit&#47;test_nitunit-3.nit:5,8--27: Error: method or variable `undefined_identifier` unknown in `Sys`.
-"></failure></testcase></testsuite><testsuite package="test_test_nitunit"><testcase classname="nitunit.test_test_nitunit::test_test_nitunit.test_test_nitunit::TestX" name="test_test_nitunit::TestX::test_foo"><system-err></system-err><system-out>out</system-out></testcase><testcase classname="nitunit.test_test_nitunit::test_test_nitunit.test_test_nitunit::TestX" name="test_test_nitunit::TestX::test_foo1"><system-err></system-err><system-out>out</system-out><error message="Runtime error: Assert failed (test_test_nitunit.nit:39)
-"></error></testcase><testcase classname="nitunit.test_test_nitunit::test_test_nitunit.test_test_nitunit::TestX" name="test_test_nitunit::TestX::test_foo2"><system-err></system-err><system-out>out</system-out></testcase></testsuite></testsuites>
+</system-out></testcase><testcase classname="nitunit.test_nitunit::test_nitunit.test_nitunit::X" name="&lt;class&gt;"><system-err>Runtime error: Assert failed (.nitunit&#47;test_nitunit-2.nit:5)
+</system-err><system-out>assert false
+</system-out><error message="Runtime Error"></error></testcase><testcase classname="nitunit.test_nitunit::test_nitunit.test_nitunit::X" name="test_nitunit::X::foo"><system-err>.nitunit&#47;test_nitunit-3.nit:5,8--27: Error: method or variable `undefined_identifier` unknown in `Sys`.
+</system-err><system-out>assert undefined_identifier
+</system-out><failure message="Compilation Error"></failure></testcase></testsuite><testsuite package="test_test_nitunit"><testcase classname="nitunit.test_test_nitunit::test_test_nitunit.test_test_nitunit::TestX" name="test_test_nitunit::TestX::test_foo"><system-out></system-out><system-err></system-err></testcase><testcase classname="nitunit.test_test_nitunit::test_test_nitunit.test_test_nitunit::TestX" name="test_test_nitunit::TestX::test_foo1"><system-out></system-out><system-err>Runtime error: Assert failed (test_test_nitunit.nit:39)
+</system-err><error message="Runtime Error"></error></testcase><testcase classname="nitunit.test_test_nitunit::test_test_nitunit.test_test_nitunit::TestX" name="test_test_nitunit::TestX::test_foo2"><system-out></system-out><system-err></system-err></testcase></testsuite></testsuites>

--- a/tests/sav/nitunit_args6.res
+++ b/tests/sav/nitunit_args6.res
@@ -1,5 +1,6 @@
 test_nitunit3/README.md:7,3--5: Syntax Error: unexpected malformed character '\]. To suppress this message, enclose the block with a fence tagged `nitish` or `raw` (see `man nitdoc`).
-test_nitunit3/README.md:1,0--13,0: ERROR: nitunit.test_nitunit3>.<group> (in .nitunit/test_nitunit3-0.nit): Runtime error: Assert failed (.nitunit/test_nitunit3-0.nit:7)
+test_nitunit3/README.md:1,0--13,0: ERROR: nitunit.test_nitunit3>.<group> (in .nitunit/test_nitunit3-0.nit): Runtime error
+Runtime error: Assert failed (.nitunit/test_nitunit3-0.nit:7)
 
 DocUnits:
 Entities: 2; Documented ones: 2; With nitunits: 3; Failures: 2
@@ -7,8 +8,8 @@ Entities: 2; Documented ones: 2; With nitunits: 3; Failures: 2
 TestSuites:
 No test cases found
 Class suites: 0; Test Cases: 0; Failures: 0
-<testsuites><testsuite package="test_nitunit3&gt;"><testcase classname="nitunit.test_nitunit3&gt;" name="&lt;group&gt;"><failure message="test_nitunit3&#47;README.md:7,3--5: Syntax Error: unexpected malformed character &#39;\]."></failure><system-err></system-err><system-out>assert false
+<testsuites><testsuite package="test_nitunit3&gt;"><testcase classname="nitunit.test_nitunit3&gt;" name="&lt;group&gt;"><failure message="test_nitunit3&#47;README.md:7,3--5: Syntax Error: unexpected malformed character &#39;\]."></failure><system-err>Runtime error: Assert failed (.nitunit&#47;test_nitunit3-0.nit:7)
+</system-err><system-out>assert false
 assert true
-</system-out><error message="Runtime error: Assert failed (.nitunit&#47;test_nitunit3-0.nit:7)
-"></error></testcase></testsuite><testsuite package="test_nitunit3::test_nitunit3"><testcase classname="nitunit.test_nitunit3::test_nitunit3.&lt;module&gt;" name="&lt;module&gt;"><system-err></system-err><system-out>assert true
+</system-out><error message="Runtime error"></error></testcase></testsuite><testsuite package="test_nitunit3::test_nitunit3"><testcase classname="nitunit.test_nitunit3::test_nitunit3.&lt;module&gt;" name="&lt;module&gt;"><system-err></system-err><system-out>assert true
 </system-out></testcase></testsuite><testsuite></testsuite></testsuites>

--- a/tests/sav/nitunit_args7.res
+++ b/tests/sav/nitunit_args7.res
@@ -1,4 +1,5 @@
-test_nitunit_md.md:1,0--15,0: ERROR: nitunit.<file>.test_nitunit_md.md:1,0--15,0 (in .nitunit/file-0.nit): Runtime error: Assert failed (.nitunit/file-0.nit:8)
+test_nitunit_md.md:1,0--15,0: ERROR: nitunit.<file>.test_nitunit_md.md:1,0--15,0 (in .nitunit/file-0.nit): Runtime error
+Runtime error: Assert failed (.nitunit/file-0.nit:8)
 
 DocUnits:
 Entities: 1; Documented ones: 1; With nitunits: 1; Failures: 1
@@ -6,8 +7,8 @@ Entities: 1; Documented ones: 1; With nitunits: 1; Failures: 1
 TestSuites:
 No test cases found
 Class suites: 0; Test Cases: 0; Failures: 0
-<testsuites><testsuite package="test_nitunit_md.md:1,0--15,0"><testcase classname="nitunit.&lt;file&gt;" name="test_nitunit_md.md:1,0--15,0"><system-err></system-err><system-out>var a = 1
+<testsuites><testsuite package="test_nitunit_md.md:1,0--15,0"><testcase classname="nitunit.&lt;file&gt;" name="test_nitunit_md.md:1,0--15,0"><system-err>Runtime error: Assert failed (.nitunit&#47;file-0.nit:8)
+</system-err><system-out>var a = 1
 assert 1 == 1
 assert false
-</system-out><error message="Runtime error: Assert failed (.nitunit&#47;file-0.nit:8)
-"></error></testcase></testsuite></testsuites>
+</system-out><error message="Runtime error"></error></testcase></testsuite></testsuites>

--- a/tests/sav/nitunit_args9.res
+++ b/tests/sav/nitunit_args9.res
@@ -3,15 +3,9 @@ Tested method
 After Test
 Runtime error: Assert failed (test_nitunit4/test_nitunit4_base.nit:31)
 
-diff: missing operand after 'expected:'
-diff: Try 'diff --help' for more information.
-test_nitunit4/test_nitunit4.nit:28,2--30,4: ERROR: test_bar (in file .nitunit/gen_test_nitunit4.nit): Diff
-
-diff: missing operand after 'expected:'
-diff: Try 'diff --help' for more information.
 test_nitunit4/test_nitunit4.nit:32,2--34,4: ERROR: test_baz (in file .nitunit/gen_test_nitunit4.nit): Diff
---- expected: test_nitunit4/test_baz.res
-+++ got: .nitunit/gen_test_nitunit4_test_baz.out1
+--- expected:test_nitunit4/test_nitunit4.sav/test_baz.res
++++ got:.nitunit/gen_test_nitunit4_test_baz.out1
 @@ -1 +1,3 @@
 -Bad result file
 +Before Test
@@ -23,15 +17,14 @@ No doc units found
 Entities: 12; Documented ones: 0; With nitunits: 0; Failures: 0
 
 TestSuites:
-Class suites: 1; Test Cases: 3; Failures: 3
+Class suites: 1; Test Cases: 3; Failures: 2
 <testsuites><testsuite package="test_nitunit4&gt;"></testsuite><testsuite package="test_nitunit4::nitunit4"></testsuite><testsuite package="test_nitunit4"><testcase classname="nitunit.test_nitunit4::test_nitunit4.test_nitunit4::TestTestSuite" name="test_nitunit4::TestTestSuite::test_foo"><system-out></system-out><system-err>Before Test
 Tested method
 After Test
 Runtime error: Assert failed (test_nitunit4&#47;test_nitunit4_base.nit:31)
-</system-err><error message="Runtime Error"></error></testcase><testcase classname="nitunit.test_nitunit4::test_nitunit4.test_nitunit4::TestTestSuite" name="test_nitunit4::TestTestSuite::test_bar"><system-out></system-out><system-err>Diff
-</system-err><error message="Runtime Error"></error></testcase><testcase classname="nitunit.test_nitunit4::test_nitunit4.test_nitunit4::TestTestSuite" name="test_nitunit4::TestTestSuite::test_baz"><system-out></system-out><system-err>Diff
---- expected: test_nitunit4&#47;test_baz.res
-+++ got: .nitunit&#47;gen_test_nitunit4_test_baz.out1
+</system-err><error message="Runtime Error"></error></testcase><testcase classname="nitunit.test_nitunit4::test_nitunit4.test_nitunit4::TestTestSuite" name="test_nitunit4::TestTestSuite::test_bar"><system-out></system-out><system-err></system-err></testcase><testcase classname="nitunit.test_nitunit4::test_nitunit4.test_nitunit4::TestTestSuite" name="test_nitunit4::TestTestSuite::test_baz"><system-out></system-out><system-err>Diff
+--- expected:test_nitunit4&#47;test_nitunit4.sav&#47;test_baz.res
++++ got:.nitunit&#47;gen_test_nitunit4_test_baz.out1
 @@ -1 +1,3 @@
 -Bad result file
 +Before Test

--- a/tests/sav/nitunit_args9.res
+++ b/tests/sav/nitunit_args9.res
@@ -1,16 +1,40 @@
-test_nitunit4/test_nitunit4.nit:22,2--25,4: ERROR: test_foo (in file .nitunit/gen_test_nitunit4.nit): Before Test
+test_nitunit4/test_nitunit4.nit:22,2--26,4: ERROR: test_foo (in file .nitunit/gen_test_nitunit4.nit): Before Test
 Tested method
 After Test
 Runtime error: Assert failed (test_nitunit4/test_nitunit4_base.nit:31)
 
+diff: missing operand after 'expected:'
+diff: Try 'diff --help' for more information.
+test_nitunit4/test_nitunit4.nit:28,2--30,4: ERROR: test_bar (in file .nitunit/gen_test_nitunit4.nit): Diff
+
+diff: missing operand after 'expected:'
+diff: Try 'diff --help' for more information.
+test_nitunit4/test_nitunit4.nit:32,2--34,4: ERROR: test_baz (in file .nitunit/gen_test_nitunit4.nit): Diff
+--- expected: test_nitunit4/test_baz.res
++++ got: .nitunit/gen_test_nitunit4_test_baz.out1
+@@ -1 +1,3 @@
+-Bad result file
++Before Test
++Tested method
++After Test
+
 DocUnits:
 No doc units found
-Entities: 10; Documented ones: 0; With nitunits: 0; Failures: 0
+Entities: 12; Documented ones: 0; With nitunits: 0; Failures: 0
 
 TestSuites:
-Class suites: 1; Test Cases: 1; Failures: 1
+Class suites: 1; Test Cases: 3; Failures: 3
 <testsuites><testsuite package="test_nitunit4&gt;"></testsuite><testsuite package="test_nitunit4::nitunit4"></testsuite><testsuite package="test_nitunit4"><testcase classname="nitunit.test_nitunit4::test_nitunit4.test_nitunit4::TestTestSuite" name="test_nitunit4::TestTestSuite::test_foo"><system-out></system-out><system-err>Before Test
 Tested method
 After Test
 Runtime error: Assert failed (test_nitunit4&#47;test_nitunit4_base.nit:31)
+</system-err><error message="Runtime Error"></error></testcase><testcase classname="nitunit.test_nitunit4::test_nitunit4.test_nitunit4::TestTestSuite" name="test_nitunit4::TestTestSuite::test_bar"><system-out></system-out><system-err>Diff
+</system-err><error message="Runtime Error"></error></testcase><testcase classname="nitunit.test_nitunit4::test_nitunit4.test_nitunit4::TestTestSuite" name="test_nitunit4::TestTestSuite::test_baz"><system-out></system-out><system-err>Diff
+--- expected: test_nitunit4&#47;test_baz.res
++++ got: .nitunit&#47;gen_test_nitunit4_test_baz.out1
+@@ -1 +1,3 @@
+-Bad result file
++Before Test
++Tested method
++After Test
 </system-err><error message="Runtime Error"></error></testcase></testsuite><testsuite package="test_nitunit4::test_nitunit4"></testsuite><testsuite></testsuite><testsuite package="test_nitunit4::test_nitunit4_base"></testsuite><testsuite></testsuite></testsuites>

--- a/tests/sav/nitunit_args9.res
+++ b/tests/sav/nitunit_args9.res
@@ -9,8 +9,8 @@ Entities: 10; Documented ones: 0; With nitunits: 0; Failures: 0
 
 TestSuites:
 Class suites: 1; Test Cases: 1; Failures: 1
-<testsuites><testsuite package="test_nitunit4&gt;"></testsuite><testsuite package="test_nitunit4::nitunit4"></testsuite><testsuite package="test_nitunit4"><testcase classname="nitunit.test_nitunit4::test_nitunit4.test_nitunit4::TestTestSuite" name="test_nitunit4::TestTestSuite::test_foo"><system-err></system-err><system-out>out</system-out><error message="Before Test
+<testsuites><testsuite package="test_nitunit4&gt;"></testsuite><testsuite package="test_nitunit4::nitunit4"></testsuite><testsuite package="test_nitunit4"><testcase classname="nitunit.test_nitunit4::test_nitunit4.test_nitunit4::TestTestSuite" name="test_nitunit4::TestTestSuite::test_foo"><system-out></system-out><system-err>Before Test
 Tested method
 After Test
 Runtime error: Assert failed (test_nitunit4&#47;test_nitunit4_base.nit:31)
-"></error></testcase></testsuite><testsuite package="test_nitunit4::test_nitunit4"></testsuite><testsuite></testsuite><testsuite package="test_nitunit4::test_nitunit4_base"></testsuite><testsuite></testsuite></testsuites>
+</system-err><error message="Runtime Error"></error></testcase></testsuite><testsuite package="test_nitunit4::test_nitunit4"></testsuite><testsuite></testsuite><testsuite package="test_nitunit4::test_nitunit4_base"></testsuite><testsuite></testsuite></testsuites>

--- a/tests/test_nitunit4/test_nitunit4.nit
+++ b/tests/test_nitunit4/test_nitunit4.nit
@@ -22,5 +22,14 @@ class TestTestSuite
 	fun test_foo do
 		print "Tested method"
 		assert before
+		before = false
+	end
+
+	fun test_bar do
+		print "Tested method"
+	end
+
+	fun test_baz do
+		print "Tested method"
 	end
 end

--- a/tests/test_nitunit4/test_nitunit4.sav/test_bar.res
+++ b/tests/test_nitunit4/test_nitunit4.sav/test_bar.res
@@ -1,0 +1,3 @@
+Before Test
+Tested method
+After Test

--- a/tests/test_nitunit4/test_nitunit4.sav/test_baz.res
+++ b/tests/test_nitunit4/test_nitunit4.sav/test_baz.res
@@ -1,0 +1,1 @@
+Bad result file

--- a/tests/test_nitunit4/test_nitunit4_base.nit
+++ b/tests/test_nitunit4/test_nitunit4_base.nit
@@ -28,6 +28,6 @@ class SuperTestSuite
 
 	redef fun after_test do
 		print "After Test"
-		assert false
+		assert before
 	end
 end


### PR DESCRIPTION
The point of this serie is to make nitunit more usable and make it more sexy than tests.sh (or ad hoc test scripts) for libraries and programs.

## Highlight

* black box tests with .res files
* --nitc of NITC to locate a specific binary to use
* testcases are executed with some ulimits (to limit timeouts)
* the XML generated is more robust

## Black Box Testing

Sometimes, it is easier to validate a `TestCase` by comparing its output with a text file containing the expected result.

For each TestCase `test_bar` of a TestSuite `test_mod.nit`, if the corresponding file `test_mod.sav/test_bar.res` exists, then the output of the test is compared with the file.

The `diff(1)` command is used to perform the comparison.
The test is failed if non-zero is returned by `diff`.

~~~nit
module test_mod is test_suite
class TestFoo
        fun test_bar do
                print "Hello!"
        end
end
~~~

Where `test_mod.sav/test_bar.res` contains

~~~raw
Hello!
~~~

## Option `--nitc`

nitc compiler to use.

By default, nitunit tries to locate the `nitc` program with the environment variable `NITC` or heuristics.
The option is used to indicate a specific nitc binary.
