### PR TITLE
nitcatalog: count warnings per 1000 lines of code (w/kloc)

### DIFF
--- a/src/catalog.nit
+++ b/src/catalog.nit
@@ -235,6 +235,9 @@ class Catalog
 	# Number of warnings and advices
 	var warnings = new Counter[MPackage]
 
+	# Number of warnings per 1000 lines of code (w/kloc)
+	var warnings_per_kloc = new Counter[MPackage]
+
 	# Documentation score (between 0 and 100)
 	var documentation_score = new Counter[MPackage]
 
@@ -406,6 +409,9 @@ class Catalog
 		self.loc[mpackage] = loc
 		self.errors[mpackage] = errors
 		self.warnings[mpackage] = warnings
+		if loc > 0 then
+			self.warnings_per_kloc[mpackage] = warnings * 1000 / loc
+		end
 		var documentation_score =  (100.0 * doc_score / entity_score).to_i
 		self.documentation_score[mpackage] = documentation_score
 

--- a/src/nitcatalog.nit
+++ b/src/nitcatalog.nit
@@ -320,7 +320,7 @@ redef class Catalog
 		if errors > 0 then
 			res.add "<li>{errors} errors</li>\n"
 		end
-		res.add "<li>{warnings[mpackage]} warnings</li>\n"
+		res.add "<li>{warnings[mpackage]} warnings ({warnings_per_kloc[mpackage]}/kloc)</li>\n"
 		res.add "<li>{documentation_score[mpackage]}% documented</li>\n"
 		res.add "</ul>\n"
 
@@ -485,6 +485,7 @@ redef class Catalog
 		res.add "<th data-field=\"score\" data-sortable=\"true\">score</th>\n"
 		res.add "<th data-field=\"errors\" data-sortable=\"true\">errors</th>\n"
 		res.add "<th data-field=\"warnings\" data-sortable=\"true\">warnings</th>\n"
+		res.add "<th data-field=\"warnings_per_kloc\" data-sortable=\"true\">w/kloc</th>\n"
 		res.add "<th data-field=\"doc\" data-sortable=\"true\">doc</th>\n"
 		res.add "</tr></thead>"
 		for p in mpackages do
@@ -507,6 +508,7 @@ redef class Catalog
 			res.add "<td>{score[p]}</td>"
 			res.add "<td>{errors[p]}</td>"
 			res.add "<td>{warnings[p]}</td>"
+			res.add "<td>{warnings_per_kloc[p]}</td>"
 			res.add "<td>{documentation_score[p]}</td>"
 			res.add "</tr>\n"
 		end

--- a/tests/sav/nitcatalog_args1.res
+++ b/tests/sav/nitcatalog_args1.res
@@ -75,7 +75,7 @@
 </ul>
 <h3>Quality</h3>
 <ul class="box">
-<li>28 warnings</li>
+<li>28 warnings (63/kloc)</li>
 <li>93% documented</li>
 </ul>
 <h3>Tags</h3>


### PR DESCRIPTION
The raw number of warnings is not that useful.
Number of warnings per 1000 lines of code make it more semantic.

Signed-off-by: Jean Privat <jean@pryen.org>