### PR TITLE
Update xymus.net to activate the full API for the mobile client

### DIFF
--- a/contrib/xymus_net/.gitignore
+++ b/contrib/xymus_net/.gitignore
@@ -1,0 +1,1 @@
+xymus.net

--- a/contrib/xymus_net/Makefile
+++ b/contrib/xymus_net/Makefile
@@ -1,0 +1,9 @@
+all: xymus.net
+
+xymus.net: ../benitlux/src/server/benitlux_restful.nit $(shell ../../bin/nitls -M xymus_net.nit)
+	../../bin/nitc -o $@ xymus_net.nit
+
+../benitlux/src/server/benitlux_restful.nit:
+	make -C ../benitlux src/server/benitlux_restful.nit
+
+pre-build: ../benitlux/src/server/benitlux_restful.nit

--- a/contrib/xymus_net/README.md
+++ b/contrib/xymus_net/README.md
@@ -1,0 +1,5 @@
+Web server source and config of xymus.net
+
+This module acts also as an example to merge multiple `nitcorn` projects into one server.
+
+See the server online at http://xymus.net/.

--- a/contrib/xymus_net/package.ini
+++ b/contrib/xymus_net/package.ini
@@ -1,0 +1,11 @@
+[package]
+name=xymus_net
+tags=web,example
+maintainer=Alexis Laferrière <alexis.laf@xymus.net>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/xymus.net/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/xymus.net/
+homepage=http://xymus.net/
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/xymus_net/xymus_net.nit
+++ b/contrib/xymus_net/xymus_net.nit
@@ -1,6 +1,6 @@
 # This file is part of NIT ( http://www.nitlanguage.org ).
 #
-# Copyright 2014-2015 Alexis Laferrière <alexis.laf@xymus.net>
+# Copyright 2014-2016 Alexis Laferrière <alexis.laf@xymus.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/nitcorn/README.md
+++ b/lib/nitcorn/README.md
@@ -26,7 +26,8 @@ and the FFI enables calling services in different languages.
 A minimal example follows with a custom `Action` and using `FileServer`.
 
 More general examples are available at `lib/nitcorn/examples/`.
-It includes the configuration of `http://xymus.net/` which merges many other _nitcorn_ applications.
+For an example of a larger project merging many _nitcorn_ applications into one server,
+take a look at the configuration of `http://xymus.net/` at `../contrib/xymus_net/xymus_net.nit`.
 
 Larger projects using _nitcorn_ can be found in the `contrib/` folder:
 * _opportunity_ is a meetup planner heavily based on _nitcorn_.

--- a/lib/nitcorn/examples/Makefile
+++ b/lib/nitcorn/examples/Makefile
@@ -2,10 +2,6 @@ all: bin/restful_annot
 	mkdir -p bin/
 	../../../bin/nitc --dir bin src/nitcorn_hello_world.nit src/simple_file_server.nit
 
-xymus.net:
-	mkdir -p bin/
-	../../../bin/nitc --dir bin/ src/xymus_net.nit
-
 pre-build: src/restful_annot_gen.nit
 src/restful_annot_gen.nit:
 	../../../bin/nitrestful -o $@ src/restful_annot.nit

--- a/lib/nitcorn/examples/src/xymus_net.nit
+++ b/lib/nitcorn/examples/src/xymus_net.nit
@@ -23,6 +23,7 @@ import privileges
 # Use actions defined by contribs
 import tnitter
 import benitlux::benitlux_controller
+import benitlux::benitlux_restful
 import opportunity::opportunity_controller
 import nitiwiki::wiki_edit
 
@@ -173,6 +174,7 @@ var vps_vh = new VirtualHost("vps.xymus.net:80")
 var tnitter_vh = new VirtualHost("tnitter.xymus.net:80")
 var pep8_vh = new VirtualHost("pep8.xymus.net:80")
 var benitlux_vh = new VirtualHost("benitlux.xymus.net:80")
+var benitlux_admin_vh = new VirtualHost("localhost:8081")
 
 var factory = new HttpFactory.and_libevent
 factory.config.virtual_hosts.add default_vh
@@ -180,6 +182,7 @@ factory.config.virtual_hosts.add vps_vh
 factory.config.virtual_hosts.add tnitter_vh
 factory.config.virtual_hosts.add pep8_vh
 factory.config.virtual_hosts.add benitlux_vh
+factory.config.virtual_hosts.add benitlux_admin_vh
 
 # Ports are open, drop to a low-privileged user if we are root
 var user_group = new UserGroup("nitcorn", "nitcorn")
@@ -227,6 +230,8 @@ benitlux_vh.routes.add new Route("/rest/", benitlux_rest)
 benitlux_vh.routes.add new Route("/push/", benitlux_push)
 benitlux_vh.routes.add new Route("/static/", shared_file_server)
 benitlux_vh.routes.add new Route(null, benitlux_sub)
+
+benitlux_admin_vh.routes.add new Route(null, new BenitluxAdminAction(benitlux_db))
 
 # Opportunity service
 var opportunity = new OpportunityWelcome

--- a/tests/listfull.sh
+++ b/tests/listfull.sh
@@ -9,7 +9,6 @@ ls -1 -- "%s\n" "$@" \
 	../examples/*/src/*_android.nit \
 	../examples/*/src/*_linux.nit \
 	../examples/*/src/*_null.nit \
-	../examples/nitcorn/src/*.nit \
 	../lib/*/examples/*.nit \
 	../lib/*/examples/*/*.nit \
 	../contrib/friendz/src/solver_cmd.nit \


### PR DESCRIPTION
This PR activates full support for the Benilux mobile app on the [xymus.net](xymus.net) production server. It was missing only the RESTful API code which is generated by nitrestful, and the admin interface.

A future PR will update the HTML interface with info on the app, or it will drop the hard coded content of the Benitlux page/views in favor of local content.