### PR TITLE
Generalize MEntity visibility

### DIFF
--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -30,6 +30,15 @@ import mdoc
 import ordered_tree
 private import more_collections
 
+redef class MEntity
+	# The visibility of the MEntity.
+	#
+	# MPackages, MGroups and MModules are always public.
+	# The visibility of `MClass` and `MProperty` is defined by the keyword used.
+	# `MClassDef` and `MPropDef` return the visibility of `MClass` and `MProperty`.
+	fun visibility: MVisibility do return public_visibility
+end
+
 redef class Model
 	# All known classes
 	var mclasses = new Array[MClass]
@@ -465,7 +474,7 @@ class MClass
 
 	# The visibility of the class
 	# In Nit, the visibility of a class cannot evolve in refinements
-	var visibility: MVisibility
+	redef var visibility
 
 	init
 	do
@@ -592,6 +601,8 @@ class MClassDef
 	var bound_mtype: MClassType
 
 	redef var location: Location
+
+	redef fun visibility do return mclass.visibility
 
 	# Internal name combining the module and the class
 	# Example: "mymodule$MyClass"
@@ -1988,7 +1999,7 @@ abstract class MProperty
 	end
 
 	# The visibility of the property
-	var visibility: MVisibility
+	redef var visibility
 
 	# Is the property usable as an initializer?
 	var is_autoinit = false is writable
@@ -2254,6 +2265,8 @@ abstract class MPropDef
 	var mproperty: MPROPERTY
 
 	redef var location: Location
+
+	redef fun visibility do return mproperty.visibility
 
 	init
 	do

--- a/src/model/model_json.nit
+++ b/src/model/model_json.nit
@@ -59,6 +59,7 @@ redef class MEntity
 		obj["class_name"] = class_name
 		obj["full_name"] = full_name
 		obj["mdoc"] = mdoc_or_fallback
+		obj["visibility"] = visibility
 		var modifiers = new JsonArray
 		for modifier in collect_modifiers do
 			modifiers.add modifier
@@ -114,7 +115,6 @@ redef class MPackage
 
 	redef fun json do
 		var obj = super
-		obj["visibility"] = public_visibility
 		if ini != null then
 			obj["ini"] = new JsonObject.from(ini.as(not null).to_map)
 		end
@@ -127,7 +127,6 @@ end
 redef class MGroup
 	redef fun json do
 		var obj = super
-		obj["visibility"] = public_visibility
 		obj["is_root"] = is_root
 		obj["mpackage"] = to_mentity_ref(mpackage)
 		obj["default_mmodule"] = to_mentity_ref(default_mmodule)
@@ -142,7 +141,6 @@ redef class MModule
 	redef fun json do
 		var obj = super
 		obj["location"] = location
-		obj["visibility"] = public_visibility
 		obj["mpackage"] = to_mentity_ref(mpackage)
 		obj["mgroup"] = to_mentity_ref(mgroup)
 		obj["intro_mclasses"] = to_mentity_refs(intro_mclasses)
@@ -154,7 +152,6 @@ end
 redef class MClass
 	redef fun json do
 		var obj = super
-		obj["visibility"] = visibility
 		var arr = new JsonArray
 		for mparameter in mparameters do arr.add mparameter
 		obj["mparameters"] = arr
@@ -169,7 +166,6 @@ end
 redef class MClassDef
 	redef fun json do
 		var obj = super
-		obj["visibility"] = mclass.visibility
 		obj["location"] = location
 		obj["is_intro"] = is_intro
 		var arr = new JsonArray
@@ -186,7 +182,6 @@ end
 redef class MProperty
 	redef fun json do
 		var obj = super
-		obj["visibility"] = visibility
 		obj["intro"] = to_mentity_ref(intro)
 		obj["intro_mclassdef"] = to_mentity_ref(intro_mclassdef)
 		obj["mpropdefs"] = to_mentity_refs(mpropdefs)
@@ -223,7 +218,6 @@ end
 redef class MPropDef
 	redef fun json do
 		var obj = super
-		obj["visibility"] = mproperty.visibility
 		obj["location"] = location
 		obj["is_intro"] = is_intro
 		obj["mclassdef"] = to_mentity_ref(mclassdef)

--- a/src/model/model_json.nit
+++ b/src/model/model_json.nit
@@ -60,6 +60,7 @@ redef class MEntity
 		obj["full_name"] = full_name
 		obj["mdoc"] = mdoc_or_fallback
 		obj["visibility"] = visibility
+		obj["location"] = location
 		var modifiers = new JsonArray
 		for modifier in collect_modifiers do
 			modifiers.add modifier
@@ -140,7 +141,6 @@ end
 redef class MModule
 	redef fun json do
 		var obj = super
-		obj["location"] = location
 		obj["mpackage"] = to_mentity_ref(mpackage)
 		obj["mgroup"] = to_mentity_ref(mgroup)
 		obj["intro_mclasses"] = to_mentity_refs(intro_mclasses)
@@ -166,7 +166,6 @@ end
 redef class MClassDef
 	redef fun json do
 		var obj = super
-		obj["location"] = location
 		obj["is_intro"] = is_intro
 		var arr = new JsonArray
 		for mparameter in mclass.mparameters do arr.add mparameter
@@ -218,7 +217,6 @@ end
 redef class MPropDef
 	redef fun json do
 		var obj = super
-		obj["location"] = location
 		obj["is_intro"] = is_intro
 		obj["mclassdef"] = to_mentity_ref(mclassdef)
 		obj["mproperty"] = to_mentity_ref(mproperty)

--- a/src/model/model_visitor.nit
+++ b/src/model/model_visitor.nit
@@ -144,7 +144,10 @@ redef class MEntity
 	# See the specific implementation in the subclasses.
 	fun visit_all(v: ModelVisitor) do end
 
-	private fun accept_visibility(min_visibility: nullable MVisibility): Bool do return true
+	private fun accept_visibility(min_visibility: nullable MVisibility): Bool do
+		if min_visibility == null then return true
+		return visibility >= min_visibility
+	end
 end
 
 redef class Model
@@ -183,13 +186,6 @@ redef class MModule
 	end
 end
 
-redef class MClass
-	redef fun accept_visibility(min_visibility) do
-		if min_visibility == null then return true
-		return visibility >= min_visibility
-	end
-end
-
 redef class MClassDef
 	# Visit all the classes and class definitions of the module.
 	#
@@ -201,24 +197,5 @@ redef class MClassDef
 			if x.is_intro then v.enter_visit(x.mproperty)
 			v.enter_visit(x)
 		end
-	end
-
-	redef fun accept_visibility(min_visibility) do
-		if min_visibility == null then return true
-		return mclass.visibility >= min_visibility
-	end
-end
-
-redef class MProperty
-	redef fun accept_visibility(min_visibility) do
-		if min_visibility == null then return true
-		return visibility >= min_visibility
-	end
-end
-
-redef class MPropDef
-	redef fun accept_visibility(min_visibility) do
-		if min_visibility == null then return true
-		return mproperty.visibility >= min_visibility
 	end
 end


### PR DESCRIPTION
Proposal to generalize the visibility concept to all the MEntities:
* packages, groups and modules are always public
* classes depend on the signature, classdefs return the class visibility (shortcut)
* properties depend on the signature, propdefs return the property visibility (shortcut)
Other exotic MEntities are always public.

This PR makes the changes in model and update `model_json` as PoC for the gain of the generalization.