### PR TITLE
src/model: fix mdoc_or_fallback for MClasses and MProperties

### DIFF
--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -555,6 +555,8 @@ class MClass
 
 	# Is `self` and abstract class?
 	var is_abstract: Bool is lazy do return kind == abstract_kind
+
+	redef fun mdoc_or_fallback do return intro.mdoc_or_fallback
 end
 
 
@@ -1962,6 +1964,8 @@ abstract class MProperty
 	redef var name
 
 	redef var location
+
+	redef fun mdoc_or_fallback do return intro.mdoc_or_fallback
 
 	# The canonical name of the property.
 	#

--- a/tests/sav/test_model_visitor_args2.res
+++ b/tests/sav/test_model_visitor_args2.res
@@ -116,26 +116,26 @@ names::n3$::n1::P1	MClassDef	names/n3.nit:29,1--35,3	a refinement of a subclass 
 names::n3$::n1::P1$A::a	MMethodDef	names/n3.nit:31,2--32,19	a refinement (3 distinct modules)
 names::n3$::n1::P1$::n0::P::p	MMethodDef	names/n3.nit:33,2--34,19	a refinement (3 distinct modules)
 names::n0	MModule	names/n0.nit:15,1--67,3	Root module
-names::Object	MClass	names/n0.nit:20,1--22,3	
+names::Object	MClass	names/n0.nit:20,1--22,3	Root interface
 names$Object	MClassDef	names/n0.nit:20,1--22,3	Root interface
 names::Object::init	MMethod	names/n0.nit:20,1--22,3	
 names$Object$init	MMethodDef	names/n0.nit:20,1--22,3	
-names::A	MClass	names/n0.nit:24,1--31,3	
+names::A	MClass	names/n0.nit:24,1--31,3	A public class
 names$A	MClassDef	names/n0.nit:24,1--31,3	A public class
-names::A::a	MMethod	names/n0.nit:26,2--27,13	
+names::A::a	MMethod	names/n0.nit:26,2--27,13	A public method in a public class
 names$A$a	MMethodDef	names/n0.nit:26,2--27,13	A public method in a public class
-names::n0::A::z	MMethod	names/n0.nit:29,2--30,21	
+names::n0::A::z	MMethod	names/n0.nit:29,2--30,21	A private method in a public class
 names$A$z	MMethodDef	names/n0.nit:29,2--30,21	A private method in a public class
-names::A0	MClass	names/n0.nit:33,1--46,3	
+names::A0	MClass	names/n0.nit:33,1--46,3	A public subclass in the same module
 names$A0	MClassDef	names/n0.nit:33,1--46,3	A public subclass in the same module
 names$A0$A::a	MMethodDef	names/n0.nit:38,2--39,19	Redefinition it the same module of a public method
 names$A0$::n0::A::z	MMethodDef	names/n0.nit:41,2--42,19	Redefinition it the same module of a private method
 names$A0$::n0::P::p	MMethodDef	names/n0.nit:44,2--45,19	Redefinition it the same module of a private method
-names::n0::P	MClass	names/n0.nit:48,1--52,3	
+names::n0::P	MClass	names/n0.nit:48,1--52,3	A private class
 names::n0$P	MClassDef	names/n0.nit:48,1--52,3	A private class
-names::n0::P::p	MMethod	names/n0.nit:50,2--51,13	
+names::n0::P::p	MMethod	names/n0.nit:50,2--51,13	A private method in a private class
 names::n0$P$p	MMethodDef	names/n0.nit:50,2--51,13	A private method in a private class
-names::n0::P0	MClass	names/n0.nit:54,1--67,3	
+names::n0::P0	MClass	names/n0.nit:54,1--67,3	A private subclass introduced in the same module
 names::n0$P0	MClassDef	names/n0.nit:54,1--67,3	A private subclass introduced in the same module
 names::n0$P0$A::a	MMethodDef	names/n0.nit:59,2--60,19	Redefinition it the same module of a public method
 names::n0$P0$::n0::A::z	MMethodDef	names/n0.nit:62,2--63,19	Redefinition it the same module of a private method
@@ -144,13 +144,13 @@ names::n1	MModule	names/n1.nit:15,1--90,3	Second module
 names::n1$A	MClassDef	names/n1.nit:20,1--30,3	A refinement of a class
 names::n1$A$a	MMethodDef	names/n1.nit:22,2--23,19	A refinement in the same class
 names::n1$A$z	MMethodDef	names/n1.nit:25,2--26,19	A refinement in the same class
-names::n1::A::b	MMethod	names/n1.nit:28,2--29,13	
+names::n1::A::b	MMethod	names/n1.nit:28,2--29,13	A public method introduced in a refinement
 names::n1$A$b	MMethodDef	names/n1.nit:28,2--29,13	A public method introduced in a refinement
 names::n1$A0	MClassDef	names/n1.nit:32,1--42,3	A refinement of a subclass
 names::n1$A0$A::a	MMethodDef	names/n1.nit:34,2--35,19	A refinement+redefinition
 names::n1$A0$::n0::A::z	MMethodDef	names/n1.nit:37,2--38,19	A refinement+redefinition
 names::n1$A0$::n0::P::p	MMethodDef	names/n1.nit:40,2--41,19	A refinement+redefinition
-names::A1	MClass	names/n1.nit:44,1--57,3	
+names::A1	MClass	names/n1.nit:44,1--57,3	A subclass introduced in a submodule
 names$A1	MClassDef	names/n1.nit:44,1--57,3	A subclass introduced in a submodule
 names$A1$A::a	MMethodDef	names/n1.nit:49,2--50,19	A redefinition in a subclass from a different module
 names$A1$::n0::A::z	MMethodDef	names/n1.nit:52,2--53,19	A redefinition in a subclass from a different module
@@ -161,20 +161,20 @@ names::n1$::n0::P0	MClassDef	names/n1.nit:65,1--75,3	A refinement of a subclass
 names::n1$::n0::P0$A::a	MMethodDef	names/n1.nit:67,2--68,19	A refinement+redefinition
 names::n1$::n0::P0$::n0::A::z	MMethodDef	names/n1.nit:70,2--71,19	A refinement+redefinition
 names::n1$::n0::P0$::n0::P::p	MMethodDef	names/n1.nit:73,2--74,19	A refinement+redefinition
-names::n1::P1	MClass	names/n1.nit:77,1--90,3	
+names::n1::P1	MClass	names/n1.nit:77,1--90,3	A private subclass introduced in a different module
 names::n1$P1	MClassDef	names/n1.nit:77,1--90,3	A private subclass introduced in a different module
 names::n1$P1$A::a	MMethodDef	names/n1.nit:82,2--83,19	A redefinition in a subclass from a different module
 names::n1$P1$::n0::A::z	MMethodDef	names/n1.nit:85,2--86,19	A redefinition in a subclass from a different module
 names::n1$P1$::n0::P::p	MMethodDef	names/n1.nit:88,2--89,19	A redefinition in a subclass from a different module
 names::n2	MModule	names/n2.nit:15,1--33,3	A alternative second module, used to make name conflicts
 names::n2$A	MClassDef	names/n2.nit:20,1--27,3	A refinement of a class
-names::n2::A::b	MMethod	names/n2.nit:22,2--23,13	
+names::n2::A::b	MMethod	names/n2.nit:22,2--23,13	Name conflict? A second public method
 names::n2$A$b	MMethodDef	names/n2.nit:22,2--23,13	Name conflict? A second public method
-names::n2::A::z	MMethod	names/n2.nit:25,2--26,13	
+names::n2::A::z	MMethod	names/n2.nit:25,2--26,13	Name conflict? A second private method
 names::n2$A$z	MMethodDef	names/n2.nit:25,2--26,13	Name conflict? A second private method
-names::n2::P	MClass	names/n2.nit:29,1--33,3	
+names::n2::P	MClass	names/n2.nit:29,1--33,3	Name conflict? A second private class
 names::n2$P	MClassDef	names/n2.nit:29,1--33,3	Name conflict? A second private class
-names::n2::P::p	MMethod	names/n2.nit:31,2--32,13	
+names::n2::P::p	MMethod	names/n2.nit:31,2--32,13	Name conflict? A private method in an homonym class.
 names::n2$P$p	MMethodDef	names/n2.nit:31,2--32,13	Name conflict? A private method in an homonym class.
 names1	MPackage	names1.nit	An alternative second module in a distinct package
 names1>	MGroup	names1.nit	An alternative second module in a distinct package
@@ -182,13 +182,13 @@ names1::names1	MModule	names1.nit:15,1--90,3	An alternative second module in a d
 names1::names1$names::A	MClassDef	names1.nit:20,1--30,3	A refinement of a class
 names1::names1$names::A$a	MMethodDef	names1.nit:22,2--23,19	A refinement in the same class
 names1::names1$names::A$z	MMethodDef	names1.nit:25,2--26,19	A refinement in the same class
-names1::names1::A::b	MMethod	names1.nit:28,2--29,13	
+names1::names1::A::b	MMethod	names1.nit:28,2--29,13	A public method introduced in a refinement
 names1::names1$names::A$b	MMethodDef	names1.nit:28,2--29,13	A public method introduced in a refinement
 names1::names1$names::A0	MClassDef	names1.nit:32,1--42,3	A refinement of a subclass
 names1::names1$names::A0$names::A::a	MMethodDef	names1.nit:34,2--35,19	A refinement+redefinition
 names1::names1$names::A0$names::n0::A::z	MMethodDef	names1.nit:37,2--38,19	A refinement+redefinition
 names1::names1$names::A0$names::n0::P::p	MMethodDef	names1.nit:40,2--41,19	A refinement+redefinition
-names1::A1	MClass	names1.nit:44,1--57,3	
+names1::A1	MClass	names1.nit:44,1--57,3	A subclass introduced in a submodule
 names1$A1	MClassDef	names1.nit:44,1--57,3	A subclass introduced in a submodule
 names1$A1$names::A::a	MMethodDef	names1.nit:49,2--50,19	A redefinition in a subclass from a different module
 names1$A1$names::n0::A::z	MMethodDef	names1.nit:52,2--53,19	A redefinition in a subclass from a different module
@@ -199,7 +199,7 @@ names1::names1$names::n0::P0	MClassDef	names1.nit:65,1--75,3	A refinement of a s
 names1::names1$names::n0::P0$names::A::a	MMethodDef	names1.nit:67,2--68,19	A refinement+redefinition
 names1::names1$names::n0::P0$names::n0::A::z	MMethodDef	names1.nit:70,2--71,19	A refinement+redefinition
 names1::names1$names::n0::P0$names::n0::P::p	MMethodDef	names1.nit:73,2--74,19	A refinement+redefinition
-names1::names1::P1	MClass	names1.nit:77,1--90,3	
+names1::names1::P1	MClass	names1.nit:77,1--90,3	A private subclass introduced in a different module
 names1::names1$P1	MClassDef	names1.nit:77,1--90,3	A private subclass introduced in a different module
 names1::names1$P1$names::A::a	MMethodDef	names1.nit:82,2--83,19	A redefinition in a subclass from a different module
 names1::names1$P1$names::n0::A::z	MMethodDef	names1.nit:85,2--86,19	A redefinition in a subclass from a different module


### PR DESCRIPTION
Specify `mdoc_or_fallback` behavior in MClass and MProperty (return intro mdoc)

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>