### PR TITLE
Popcorn: use_before, use_after

### DIFF
--- a/lib/popcorn/examples/middlewares/example_advanced_logger.nit
+++ b/lib/popcorn/examples/middlewares/example_advanced_logger.nit
@@ -48,7 +48,7 @@ class HelloHandler
 end
 
 var app = new App
-app.use("/*", new RequestTimeHandler)
+app.use_before("/*", new RequestTimeHandler)
 app.use("/", new HelloHandler)
-app.use("/*", new LogHandler)
+app.use_after("/*", new LogHandler)
 app.listen("localhost", 3000)

--- a/lib/popcorn/examples/middlewares/example_simple_logger.nit
+++ b/lib/popcorn/examples/middlewares/example_simple_logger.nit
@@ -30,6 +30,6 @@ end
 
 
 var app = new App
-app.use("/*", new LogHandler)
+app.use_before("/*", new LogHandler)
 app.use("/", new HelloHandler)
 app.listen("localhost", 3000)

--- a/lib/popcorn/pop_handlers.nit
+++ b/lib/popcorn/pop_handlers.nit
@@ -317,6 +317,10 @@ class Router
 
 	redef fun handle(route, uri, req, res) do
 		if not route.match(uri) then return
+		handle_in(route, uri, req, res)
+	end
+
+	private fun handle_in(route: AppRoute, uri: String, req: HttpRequest, res: HttpResponse) do
 		for hroute, handler in handlers do
 			handler.handle(hroute, route.uri_root(uri), req, res)
 			if res.sent then break

--- a/lib/popcorn/pop_handlers.nit
+++ b/lib/popcorn/pop_handlers.nit
@@ -311,14 +311,7 @@ class Router
 	#
 	# Route paths are matched in registration order.
 	fun use(path: String, handler: Handler) do
-		var route
-		if handler isa Router or handler isa StaticHandler then
-			route = new AppGlobRoute(path)
-		else if path.has_suffix("*") then
-			route = new AppGlobRoute(path)
-		else
-			route = new AppParamRoute(path)
-		end
+		var route = build_route(handler, path)
 		handlers[route] = handler
 	end
 
@@ -327,6 +320,16 @@ class Router
 		for hroute, handler in handlers do
 			handler.handle(hroute, route.uri_root(uri), req, res)
 			if res.sent then break
+		end
+	end
+
+	private fun build_route(handler: Handler, path: String): AppRoute do
+		if handler isa Router or handler isa StaticHandler then
+			return new AppGlobRoute(path)
+		else if path.has_suffix("*") then
+			return new AppGlobRoute(path)
+		else
+			return new AppParamRoute(path)
 		end
 	end
 end

--- a/lib/popcorn/popcorn.nit
+++ b/lib/popcorn/popcorn.nit
@@ -48,11 +48,18 @@ redef class App
 	redef fun answer(req, uri) do
 		uri = uri.simplify_path
 		var res = new HttpResponse(404)
+		for route, handler in pre_handlers do
+			handler.handle(route, uri, req, res)
+		end
 		for route, handler in handlers do
 			handler.handle(route, uri, req, res)
+			if res.sent then break
 		end
 		if not res.sent then
 			res.send(error_tpl(res.status_code, res.status_message), 404)
+		end
+		for route, handler in post_handlers do
+			handler.handle(route, uri, req, res)
 		end
 		res.session = req.session
 		return res

--- a/lib/popcorn/tests/res/test_example_static_multiple.res
+++ b/lib/popcorn/tests/res/test_example_static_multiple.res
@@ -28,13 +28,6 @@ alert("Hello World!");
 </html>
 
 [Client] curl -s localhost:*****/
-Warning: Headers already sent!
-<!DOCTYPE html>
-<html>
-	<body>
-		<h1>Another Index</h1>
-	</body>
-</html>
 <!DOCTYPE html>
 <html>
 	<body>

--- a/lib/popcorn/tests/test_example_advanced_logger.nit
+++ b/lib/popcorn/tests/test_example_advanced_logger.nit
@@ -28,9 +28,9 @@ class TestClient
 end
 
 var app = new App
-app.use("/*", new RequestTimeHandler)
+app.use_before("/*", new RequestTimeHandler)
 app.use("/", new HelloHandler)
-app.use("/*", new LogHandler)
+app.use_after("/*", new LogHandler)
 
 var host = test_host
 var port = test_port

--- a/lib/popcorn/tests/test_example_simple_logger.nit
+++ b/lib/popcorn/tests/test_example_simple_logger.nit
@@ -28,7 +28,7 @@ class TestClient
 end
 
 var app = new App
-app.use("/*", new LogHandler)
+app.use_before("/*", new LogHandler)
 app.use("/", new HelloHandler)
 
 var host = test_host


### PR DESCRIPTION
This PR introduce two changes in the popcorn request-response cycle:
* Introduce placeholders `use_before` and `use_after` to force handler execution before or after each request. This makes the life of developer easier when using a lot of routers/routers.
* Break response cycle if a between (between as between before and after) handler gives a response then call after_handler. This encourage the use of middleware into `use_before` and `use_after` and avoid requests sent twice. Bonus the api makes more sense like this.