### PR TITLE
toolcontext: introduce --share-dir

### DIFF
--- a/share/man/nitdoc.md
+++ b/share/man/nitdoc.md
@@ -66,8 +66,8 @@ Also generate private API.
 
 ## CUSTOMIZATION
 
-### `--sharedir`
-Directory containing nitdoc assets.
+### `--share-dir`
+Directory containing tools assets.
 
 By default `$NIT_DIR/share/nitdoc/` is used.
 

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -31,9 +31,6 @@ redef class ToolContext
 	var opt_source = new OptionString("Format to link source code (%f for filename, " +
 		"%l for first line, %L for last line)", "--source")
 
-	# Directory where the CSS and JS is stored.
-	var opt_sharedir = new OptionString("Directory containing nitdoc assets", "--sharedir")
-
 	# Use a shareurl instead of copy shared files.
 	#
 	# This is usefull if you don't want to store the Nitdoc templates with your
@@ -77,7 +74,7 @@ redef class ToolContext
 		super
 
 		option_context.add_option(
-			opt_source, opt_sharedir, opt_shareurl, opt_custom_title,
+			opt_source, opt_share_dir, opt_shareurl, opt_custom_title,
 			opt_custom_footer, opt_custom_intro, opt_custom_brand,
 			opt_github_upstream, opt_github_base_sha1, opt_github_gitdir,
 			opt_piwik_tracker, opt_piwik_site_id,
@@ -120,15 +117,7 @@ class RenderHTMLPhase
 		var output_dir = ctx.output_dir
 		if not output_dir.file_exists then output_dir.mkdir
 		# locate share dir
-		var sharedir = ctx.opt_sharedir.value
-		if sharedir == null then
-			var dir = ctx.nit_dir
-			sharedir = dir/"share/nitdoc"
-			if not sharedir.file_exists then
-				print "Error: cannot locate nitdoc share files. Uses --sharedir or envvar NIT_DIR"
-				abort
-			end
-		end
+		var sharedir = ctx.share_dir / "nitdoc"
 		# copy shared files
 		if ctx.opt_shareurl.value == null then
 			sys.system("cp -r -- {sharedir.to_s.escape_to_sh}/* {output_dir.to_s.escape_to_sh}/")

--- a/src/toolcontext.nit
+++ b/src/toolcontext.nit
@@ -374,6 +374,9 @@ class ToolContext
 	# Option --nit-dir
 	var opt_nit_dir = new OptionString("Base directory of the Nit installation", "--nit-dir")
 
+	# Option --share-dir
+	var opt_share_dir = new OptionString("Directory containing tools assets", "--share-dir")
+
 	# Option --help
 	var opt_help = new OptionBool("Show Help (This screen)", "-h", "-?", "--help")
 
@@ -541,6 +544,20 @@ The Nit language documentation and the source code of its tools and libraries ma
 
 	# The identified root directory of the Nit package
 	var nit_dir: String is noinit
+
+	# Shared files directory.
+	#
+	# Most often `nit/share/`.
+	var share_dir: String is lazy do
+		var sharedir = opt_share_dir.value
+		if sharedir == null then
+			sharedir = nit_dir / "share"
+			if not sharedir.file_exists then
+				fatal_error(null, "Fatal Error: cannot locate shared files directory in {sharedir}. Uses --share-dir to define it's location.")
+			end
+		end
+		return sharedir
+	end
 
 	private fun compute_nit_dir: String
 	do


### PR DESCRIPTION
So other tools than nitdoc can use it.

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>