### PR TITLE
Less randomness and race conditions in tests

### DIFF
--- a/contrib/nitrpg/src/test_helper.nit
+++ b/contrib/nitrpg/src/test_helper.nit
@@ -57,7 +57,8 @@ abstract class NitrpgTestHelper
 
 	# Gen a test db with a random name (to avoid race conditions).
 	fun gen_test_db: MongoDb do
-		var db_name = "test_nitrpg_{get_time}_{1000.rand}"
+		var testid = "NIT_TESTING_ID".environ.to_i
+		var db_name = "test_nitrpg_{testid}"
 		var db = load_db(db_name)
 		test_dbs.add db
 		return db

--- a/lib/core/exec.nit
+++ b/lib/core/exec.nit
@@ -324,6 +324,9 @@ redef class Sys
 	do
 		return command.to_cstring.system
 	end
+
+	# The pid of the program
+	fun pid: Int `{ return getpid(); `}
 end
 
 redef class NativeString

--- a/share/man/nitunit.md
+++ b/share/man/nitunit.md
@@ -312,6 +312,29 @@ Only display the skeleton, do not write any file.
 
 Indicate the specific Nit compiler executable to use. See `--nitc`.
 
+### `NIT_TESTING`
+
+The environment variable `NIT_TESTING` is set to `true` during the execution of program tests.
+Some libraries of programs can use it to produce specific reproducible results; or just to exit their executions.
+
+Unit-tests may unset this environment variable to retrieve the original behavior of such piece of software.
+
+### `SRAND`
+
+In order to maximize reproducibility, `SRAND` is set to 0.
+This make the pseudo-random generator no random at all.
+See `Sys::srand` for details.
+
+To retrieve the randomness, unit-tests may unset this environment variable then call `srand`.
+
+### `NIT_TESTING_ID`
+
+Parallel executions can cause some race collisions on named resources (e.g. DB table names).
+To solve this issue, `NIT_TESTING_ID` is initialized with a distinct integer identifier that can be used to give unique names to resources.
+
+Note: `rand` is not a recommended way to get a distinct identifier because its randomness is disabled by default. See `SRAND`.
+
+
 # SEE ALSO
 
 The Nit language documentation and the source code of its tools and libraries may be downloaded from <http://nitlanguage.org>

--- a/src/nitunit.nit
+++ b/src/nitunit.nit
@@ -64,6 +64,8 @@ if toolcontext.opt_gen_unit.value then
 end
 
 "NIT_TESTING".setenv("true")
+"NIT_TESTING_ID".setenv(pid.to_s)
+"SRAND".setenv("0")
 
 var test_dir = toolcontext.test_dir
 test_dir.mkdir

--- a/tests/test_nitcorn.nit
+++ b/tests/test_nitcorn.nit
@@ -17,8 +17,8 @@ import pthreads
 
 redef class Sys
 	var iface: String is lazy do
-		srand
-		return "localhost:{10000+20000.rand}"
+		var testid = "NIT_TESTING_ID".environ.to_i
+		return "localhost:{10000+testid}"
 	end
 
 	var fs_path: String = getcwd / "../lib/nitcorn/examples/www/hello_world/dir" is lazy

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -21,6 +21,8 @@
 export LANG=C
 export LC_ALL=C
 export NIT_TESTING=true
+# Use the pid as a collision prevention
+export NIT_TESTING_ID=$$
 export NIT_SRAND=0
 
 unset NIT_DIR


### PR DESCRIPTION
Parallel executions can cause some race collisions on named resources (e.g. DB table names).

To solve this issue, `tests.sh` and `nitunit` initialize  `NIT_TESTING_ID` with a distinct integer identifier that can be used to give unique names to resources. 

`rand` is not a recommended way to get a distinct identifier because its randomness is disabled by default.