### PR TITLE
examples/fibonacci: fix fibonacci function

### DIFF
--- a/examples/fibonacci.nit
+++ b/examples/fibonacci.nit
@@ -21,13 +21,8 @@ redef class Int
 	# Calculate the self-th element of the fibonacci sequence.
 	fun fibonacci: Int
 	do
-		if self == 0 then
-			return 0
-		else if self < 3 then
-			return 1
-		else
-			return (self-2).fibonacci + (self-1).fibonacci
-		end
+		if self < 2 then return self
+		return (self-2).fibonacci + (self-1).fibonacci
 	end
 end
 

--- a/examples/fibonacci.nit
+++ b/examples/fibonacci.nit
@@ -21,12 +21,14 @@ redef class Int
 	# Calculate the self-th element of the fibonacci sequence.
 	fun fibonacci: Int
 	do
-		if self < 2 then
+		if self == 0 then
+			return 0
+		else if self < 3 then
 			return 1
 		else
 			return (self-2).fibonacci + (self-1).fibonacci
 		end
-	end 
+	end
 end
 
 # Print usage and exit.


### PR DESCRIPTION
In the fibonacci example, all values were off by one because the first element of the fibonacci sequence is 0, not 1. Now the fibonacci example also includes and example usage of `else if`.
