### PR TITLE
Int::is_pow2

### DIFF
--- a/lib/core/math.nit
+++ b/lib/core/math.nit
@@ -169,6 +169,16 @@ redef class Int
 		end
 		return res
 	end
+
+	# Is `self` a power of two ?
+	#
+	# ~~~nit
+	# assert not 3.is_pow2
+	# assert 2.is_pow2
+	# assert 1.is_pow2
+	# assert not 0.is_pow2
+	# ~~~
+	fun is_pow2: Bool do return self != 0 and (self & self - 1) == 0
 end
 
 redef class Byte


### PR DESCRIPTION
Simple addition to `core`, the `is_pow2` method on Int tells whether an integer is a power of two.