### PR TITLE
rta: do not analyze abstract methods

### DIFF
--- a/src/rapid_type_analysis.nit
+++ b/src/rapid_type_analysis.nit
@@ -255,6 +255,8 @@ class RapidTypeAnalysis
 				add_cast(paramtype)
 			end
 
+			if mmethoddef.is_abstract then continue
+
 			var npropdef = modelbuilder.mpropdef2node(mmethoddef)
 
 			if npropdef isa AClassdef then


### PR DESCRIPTION
Just stop visiting abstract methods. This make RTA more robust when there is not body