### PR TITLE
nitunit: testsuites are explicit

### DIFF
--- a/contrib/nitrpg/src/test_helper.nit
+++ b/contrib/nitrpg/src/test_helper.nit
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Test tools for NitRPG.
-module test_helper is test_suite
+module test_helper
 
 import test_suite
 import game

--- a/share/man/nitunit.md
+++ b/share/man/nitunit.md
@@ -129,12 +129,12 @@ This flag can be used by libraries and program to prevent (or limit) the executi
 
 ## Working with `TestSuites`
 
-TestSuites are Nit files that define a set of `TestSuite`s for a particular
-module.
+TestSuites are Nit modules that define a set of TestCases.
 
-The test suite’s module must be called `test_` followed by the name of the
-module to test. So for the module `foo.nit` the test suite will be called
-`test_foo.nit`.
+A test suite is a module that uses the annotation `is test_suite`.
+
+It is common that a test suite focuses on testing a single module.
+In this case, the name of the test_suite is often `test_foo.nit` where `foo.nit` is the tested module.
 
 The structure of a test suite is the following:
 
@@ -320,9 +320,6 @@ Does not compile and run tests.
 Only run test case with name that match pattern.
 
 Examples: `TestFoo`, `TestFoo*`, `TestFoo::test_foo`, `TestFoo::test_foo*`, `test_foo`, `test_foo*`
-
-### `-t`, `--target-file`
-Specify test suite location.
 
 ### `--autosav`
 Automatically create/update .res files for black box testing.

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -700,7 +700,7 @@ redef class ModelBuilder
 		if decl != null then
 			var decl_name = decl.n_name.n_id.text
 			if decl_name != mmodule.name then
-				error(decl.n_name, "Error: module name mismatch; declared {decl_name} file named {mmodule.name}.")
+				warning(decl.n_name, "module-name-mismatch", "Error: module name mismatch; declared {decl_name} file named {mmodule.name}.")
 			end
 		end
 

--- a/src/nitunit.nit
+++ b/src/nitunit.nit
@@ -20,7 +20,7 @@ import testing
 
 var toolcontext = new ToolContext
 
-toolcontext.option_context.add_option(toolcontext.opt_full, toolcontext.opt_output, toolcontext.opt_dir, toolcontext.opt_noact, toolcontext.opt_pattern, toolcontext.opt_file, toolcontext.opt_autosav, toolcontext.opt_gen_unit, toolcontext.opt_gen_force, toolcontext.opt_gen_private, toolcontext.opt_gen_show, toolcontext.opt_nitc)
+toolcontext.option_context.add_option(toolcontext.opt_full, toolcontext.opt_output, toolcontext.opt_dir, toolcontext.opt_noact, toolcontext.opt_pattern, toolcontext.opt_autosav, toolcontext.opt_gen_unit, toolcontext.opt_gen_force, toolcontext.opt_gen_private, toolcontext.opt_gen_show, toolcontext.opt_nitc)
 toolcontext.tooldescription = "Usage: nitunit [OPTION]... <file.nit>...\nExecutes the unit tests from Nit source files."
 
 toolcontext.process_options(args)
@@ -29,10 +29,6 @@ var args = toolcontext.option_context.rest
 if toolcontext.opt_gen_unit.value then
 	if toolcontext.opt_pattern.value != null then
 		print "Option --pattern cannot be used with --gen-suite"
-		exit(0)
-	end
-	if toolcontext.opt_file.value != null then
-		print "Option --target-file cannot be used with --gen-suite"
 		exit(0)
 	end
 else

--- a/src/nitunit.nit
+++ b/src/nitunit.nit
@@ -92,7 +92,8 @@ end
 
 for m in mmodules do
 	page.add modelbuilder.test_markdown(m)
-	page.add modelbuilder.test_unit(m)
+	var ts = modelbuilder.test_unit(m)
+	if ts != null then page.add ts
 end
 
 var file = toolcontext.opt_output.value

--- a/src/testing/testing_doc.nit
+++ b/src/testing/testing_doc.nit
@@ -274,7 +274,7 @@ class NitUnitExecutor
 		if mmodule != null then
 			opts.add "-I {mmodule.filepath.dirname}"
 		end
-		var cmd = "{nitc} --ignore-visibility --no-color '{file}' {opts.join(" ")} >'{file}.out1' 2>&1 </dev/null -o '{file}.bin'"
+		var cmd = "{nitc} --ignore-visibility --no-color -q '{file}' {opts.join(" ")} >'{file}.out1' 2>&1 </dev/null -o '{file}.bin'"
 		var res = toolcontext.safe_exec(cmd)
 		return res
 	end

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -20,8 +20,6 @@ import html
 private import annotation
 
 redef class ToolContext
-	# -- target-file
-	var opt_file = new OptionString("Specify test suite location", "-t", "--target-file")
 	# --pattern
 	var opt_pattern = new OptionString("Only run test case with name that match pattern", "-p", "--pattern")
 	# --autosav

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -210,7 +210,7 @@ class TestSuite
 			return
 		end
 		var include_dir = module_file.filename.dirname
-		var cmd = "{nitc} --no-color '{file}.nit' -I {include_dir} -o '{file}.bin' > '{file}.out' 2>&1 </dev/null"
+		var cmd = "{nitc} --no-color -q '{file}.nit' -I {include_dir} -o '{file}.bin' > '{file}.out' 2>&1 </dev/null"
 		var res = toolcontext.safe_exec(cmd)
 		var f = new FileReader.open("{file}.out")
 		var msg = f.read_all

--- a/tests/nitunit.args
+++ b/tests/nitunit.args
@@ -1,4 +1,4 @@
-test_nitunit.nit --no-color -o $WRITE
+test_nitunit.nit test_test_nitunit.nit --no-color -o $WRITE
 test_nitunit.nit --gen-suite --only-show
 test_nitunit.nit --gen-suite --only-show --private
 test_nitunit2.nit --no-color -o $WRITE

--- a/tests/sav/nitunit_args1.res
+++ b/tests/sav/nitunit_args1.res
@@ -22,7 +22,7 @@
 
 [OK] test_test_nitunit$TestX$test_foo2
 
-Docunits: Entities: 27; Documented ones: 4; With nitunits: 4; Failures: 3
+Docunits: Entities: 34; Documented ones: 6; With nitunits: 4; Failures: 3
 Test suites: Classes: 1; Test Cases: 3; Failures: 1
 [FAILURE] 4/7 tests failed.
 `nitunit.out` is not removed for investigation.
@@ -32,5 +32,5 @@ Test suites: Classes: 1; Test Cases: 3; Failures: 1
 </system-out></testcase><testcase classname="nitunit.test_nitunit::test_nitunit.test_nitunit::X" name="test_nitunit::X::foo"><failure>Compilation error in nitunit.out&#47;test_nitunit-3.nit</failure><system-err>nitunit.out&#47;test_nitunit-3.nit:5,8--27: Error: method or variable `undefined_identifier` unknown in `Sys`.
 </system-err><system-out>assert undefined_identifier
 </system-out></testcase><testcase classname="nitunit.test_nitunit::test_nitunit.test_nitunit::X" name="test_nitunit::X::foo1"><failure>Syntax Error: unexpected operator &#39;!&#39;.</failure><system-out>assert !@#$%^&amp;*()
-</system-out></testcase></testsuite><testsuite package="test_test_nitunit"><testcase classname="nitunit.test_test_nitunit::test_test_nitunit.test_test_nitunit::TestX" name="test_test_nitunit::TestX::test_foo"><system-err></system-err></testcase><testcase classname="nitunit.test_test_nitunit::test_test_nitunit.test_test_nitunit::TestX" name="test_test_nitunit::TestX::test_foo1"><error>Runtime Error in file nitunit.out&#47;gen_test_test_nitunit.nit</error><system-err>Runtime error: Assert failed (test_test_nitunit.nit:39)
+</system-out></testcase></testsuite><testsuite package="test_test_nitunit::test_test_nitunit"></testsuite><testsuite package="test_test_nitunit"><testcase classname="nitunit.test_test_nitunit::test_test_nitunit.test_test_nitunit::TestX" name="test_test_nitunit::TestX::test_foo"><system-err></system-err></testcase><testcase classname="nitunit.test_test_nitunit::test_test_nitunit.test_test_nitunit::TestX" name="test_test_nitunit::TestX::test_foo1"><error>Runtime Error in file nitunit.out&#47;gen_test_test_nitunit.nit</error><system-err>Runtime error: Assert failed (test_test_nitunit.nit:39)
 </system-err></testcase><testcase classname="nitunit.test_test_nitunit::test_test_nitunit.test_test_nitunit::TestX" name="test_test_nitunit::TestX::test_foo2"><system-err></system-err></testcase></testsuite></testsuites>

--- a/tests/sav/nitunit_args4.res
+++ b/tests/sav/nitunit_args4.res
@@ -19,4 +19,4 @@ end
 </system-out></testcase><testcase classname="nitunit.test_nitunit2::test_nitunit2.core::Sys" name="test_nitunit2::test_nitunit2::Sys::foo3"><system-err></system-err><system-out>var a = 1
 assert a == 1
 assert a == 1
-</system-out></testcase></testsuite><testsuite></testsuite></testsuites>
+</system-out></testcase></testsuite></testsuites>

--- a/tests/sav/nitunit_args5.res
+++ b/tests/sav/nitunit_args5.res
@@ -9,4 +9,4 @@ Test suites: Classes: 0; Test Cases: 0
 <testsuites><testsuite package="test_doc2::test_doc2"><testcase classname="nitunit.test_doc2::test_doc2.core::Sys" name="test_doc2::test_doc2::Sys::foo1"><system-err></system-err><system-out>assert true # tested
 </system-out></testcase><testcase classname="nitunit.test_doc2::test_doc2.core::Sys" name="test_doc2::test_doc2::Sys::foo2"><system-err></system-err><system-out>assert true # tested
 </system-out></testcase><testcase classname="nitunit.test_doc2::test_doc2.core::Sys" name="test_doc2::test_doc2::Sys::foo3"><system-err></system-err><system-out>assert true # tested
-</system-out></testcase></testsuite><testsuite></testsuite></testsuites>
+</system-out></testcase></testsuite></testsuites>

--- a/tests/sav/nitunit_args6.res
+++ b/tests/sav/nitunit_args6.res
@@ -19,4 +19,4 @@ Test suites: Classes: 0; Test Cases: 0
 assert true
 </system-out></testcase><testcase classname="nitunit.test_nitunit3&gt;" name="&lt;group&gt;#2"><failure>Syntax Error: unexpected malformed character &#39;\].</failure><system-out>;&#39;\][]
 </system-out></testcase></testsuite><testsuite package="test_nitunit3::test_nitunit3"><testcase classname="nitunit.test_nitunit3::test_nitunit3.&lt;module&gt;" name="&lt;module&gt;"><system-err></system-err><system-out>assert true
-</system-out></testcase></testsuite><testsuite></testsuite></testsuites>
+</system-out></testcase></testsuite></testsuites>

--- a/tests/sav/nitunit_args8.res
+++ b/tests/sav/nitunit_args8.res
@@ -13,4 +13,4 @@ Test suites: Classes: 0; Test Cases: 0
 <testsuites><testsuite package="test_doc3::test_doc3"><testcase classname="nitunit.test_doc3::test_doc3.core::Sys" name="test_doc3::test_doc3::Sys::foo1"><failure>Syntax Error: unexpected identifier &#39;garbage&#39;.</failure><system-out> *garbage*
 </system-out></testcase><testcase classname="nitunit.test_doc3::test_doc3.core::Sys" name="test_doc3::test_doc3::Sys::foo2"><failure>Syntax Error: unexpected identifier &#39;garbage&#39;.</failure><system-out>*garbage*
 </system-out></testcase><testcase classname="nitunit.test_doc3::test_doc3.core::Sys" name="test_doc3::test_doc3::Sys::foo3"><failure>Syntax Error: unexpected identifier &#39;garbage&#39;.</failure><system-out>*garbage*
-</system-out></testcase></testsuite><testsuite></testsuite></testsuites>
+</system-out></testcase></testsuite></testsuites>

--- a/tests/sav/nitunit_args9.res
+++ b/tests/sav/nitunit_args9.res
@@ -28,11 +28,14 @@
 	After Test
 
 
+==== Test-suite of module test_nitunit4::test_nitunit4_base | tests: 0
+==== Test-suite of module test_nitunit4::test_nitunit4_base | tests: 0
+
 Docunits: Entities: 13; Documented ones: 0; With nitunits: 0
-Test suites: Classes: 1; Test Cases: 4; Failures: 3
+Test suites: Classes: 2; Test Cases: 4; Failures: 3
 [FAILURE] 3/4 tests failed.
 `nitunit.out` is not removed for investigation.
-<testsuites><testsuite package="test_nitunit4&gt;"></testsuite><testsuite package="test_nitunit4::nitunit4"></testsuite><testsuite package="test_nitunit4"><testcase classname="nitunit.test_nitunit4::test_nitunit4.test_nitunit4::TestTestSuite" name="test_nitunit4::TestTestSuite::test_foo"><error>Runtime Error in file nitunit.out&#47;gen_test_nitunit4.nit</error><system-err>Before Test
+<testsuites><testsuite package="test_nitunit4&gt;"></testsuite><testsuite package="test_nitunit4::nitunit4"></testsuite><testsuite package="test_nitunit4::test_nitunit4"></testsuite><testsuite package="test_nitunit4"><testcase classname="nitunit.test_nitunit4::test_nitunit4.test_nitunit4::TestTestSuite" name="test_nitunit4::TestTestSuite::test_foo"><error>Runtime Error in file nitunit.out&#47;gen_test_nitunit4.nit</error><system-err>Before Test
 Tested method
 After Test
 Runtime error: Assert failed (test_nitunit4&#47;test_nitunit4_base.nit:31)
@@ -50,4 +53,4 @@ After Test
 </system-err></testcase><testcase classname="nitunit.test_nitunit4::test_nitunit4.test_nitunit4::TestTestSuite" name="test_nitunit4::TestTestSuite::test_sav_conflict"><error>Conflicting expected output: test_nitunit4&#47;test_nitunit4.sav&#47;test_sav_conflict.res, test_nitunit4&#47;sav&#47;test_sav_conflict.res and test_nitunit4&#47;test_sav_conflict.res all exist</error><system-err>Before Test
 Tested method
 After Test
-</system-err></testcase></testsuite><testsuite package="test_nitunit4::test_nitunit4"></testsuite><testsuite></testsuite><testsuite package="test_nitunit4::test_nitunit4_base"></testsuite><testsuite></testsuite></testsuites>
+</system-err></testcase></testsuite><testsuite package="test_nitunit4::test_nitunit4_base"></testsuite><testsuite package="test_nitunit4_base"></testsuite></testsuites>


### PR DESCRIPTION
nitunit do no more try to be clever and find test-suites.

Previously, `nitunit foo.nit` caused the execution of the test suite `test_foo.nit` if it exist.
This behavior had some drawbacks:

* the test suite must follow a strict naming convention `test_*`
* the test suite must be in the same directory
* there must a an associated module. no way to create a test-suite out of thin air
* nitunit do nothing if you give the test suite instead of the module
* `-t` used to precise the location of the test suite did not work with more than one module

The proposed solution is to remove all this test-suite association with a module and asks the used to use the test-suite instead.

    nitunit test_foo.nit

Because nitunit in intended to work with more than one module, there is basically no change for client that do

    nitunit .