### PR TITLE
nitweb: add `code` tab for modules, classdefs and propdefs.

### DIFF
--- a/share/nitweb/directives/entity/defcard.html
+++ b/share/nitweb/directives/entity/defcard.html
@@ -1,0 +1,26 @@
+<div class='card card-xl' ng-class='{active: focus.full_name == definition.full_name}'>
+	<div class='card-body'>
+		<h5 class='text-muted'>
+			<span ng-if='definition.is_intro'>
+				<span class='glyphicon glyphicon-plus' /> Introduction</span>
+			</span>
+			<span ng-if='!definition.is_intro'>
+				<span class='glyphicon glyphicon-asterisk' /> Redefinition</span>
+			</span>
+			<span ng-if='definition.mclass'>
+				of <entity-link mentity='definition.mclass' />
+			</span>
+			<span ng-if='definition.mproperty'>
+				of <entity-link mentity='definition.mproperty' />
+			</span>
+			<span ng-if='definition.mclassdef'>
+				in <entity-link mentity='definition.mmodule' />
+				:: <entity-link mentity='definition.mclassdef' />
+			</span>
+			<span ng-if='!definition.mclassdef'>
+				in <entity-link mentity='definition.mmodule' />
+			</span>
+		</h5>
+		<entity-location mentity='definition' />
+	</div>
+</div>

--- a/share/nitweb/directives/entity/linearization.html
+++ b/share/nitweb/directives/entity/linearization.html
@@ -1,0 +1,11 @@
+<div class='entity-list' ng-if='listEntities.length'>
+	<h3>{{listTitle}}</h3>
+	<div class='card-list'>
+		<div ng-repeat='def in listEntities'>
+			<entity-def definition='def' focus='listFocus' />
+			<h4 ng-if='!$last' class='text-muted text-center'>
+				<span class='glyphicon glyphicon-chevron-up'></span>
+			</h4>
+		</div>
+	</div>
+</div>

--- a/share/nitweb/javascripts/entities.js
+++ b/share/nitweb/javascripts/entities.js
@@ -126,4 +126,43 @@
 				}
 			};
 		})
+
+		.directive('entityLinearization', function() {
+			return {
+				restrict: 'E',
+				scope: {
+					listEntities: '=',
+					listTitle: '@',
+					listFocus: '='
+				},
+				templateUrl: '/directives/entity/linearization.html'
+			};
+		})
+
+		.directive('entityDef', ['Model', function(Model, Code) {
+			return {
+				restrict: 'E',
+				scope: {
+					definition: '=',
+					focus: '='
+				},
+				link: function ($scope, element, attrs) {
+					$scope.$watch("definition", function() {
+						/*.loadEntityDefs($scope.definition.full_name,
+							function(data) {
+								$scope.mentity = data;
+							}, function(err) {
+								$scope.error = err;
+							});
+						Model.loadEntityCode($scope.definition.full_name,
+							function(data) {
+								$scope.code = data;
+							}, function(err) {
+								$scope.error = err;
+							});*/
+					});
+				},
+				templateUrl: '/directives/entity/defcard.html'
+			};
+		}])
 })();

--- a/share/nitweb/javascripts/entities.js
+++ b/share/nitweb/javascripts/entities.js
@@ -19,6 +19,15 @@
 		.module('entities', ['ui', 'model'])
 
 		.controller('EntityCtrl', ['Model', '$routeParams', '$scope', function(Model, $routeParams, $scope) {
+			this.loadEntityLinearization = function() {
+				Model.loadEntityLinearization($routeParams.id,
+					function(data) {
+						$scope.linearization = data;
+					}, function(err) {
+						$scope.error = err;
+					});
+			};
+
 			Model.loadEntity($routeParams.id,
 				function(data) {
 					$scope.mentity = data;

--- a/share/nitweb/javascripts/entities.js
+++ b/share/nitweb/javascripts/entities.js
@@ -28,6 +28,15 @@
 					});
 			};
 
+			this.loadEntityCode = function() {
+				Model.loadEntityCode($routeParams.id,
+					function(data) {
+						$scope.code = data;
+					}, function(err) {
+						$scope.code = err;
+					});
+			};
+
 			Model.loadEntity($routeParams.id,
 				function(data) {
 					$scope.mentity = data;

--- a/share/nitweb/javascripts/model.js
+++ b/share/nitweb/javascripts/model.js
@@ -35,6 +35,12 @@
 						.error(cbErr);
 				},
 
+				loadEntityCode: function(id, cb, cbErr) {
+					$http.get(apiUrl + '/code/' + id)
+						.success(cb)
+						.error(cbErr);
+				},
+
 				search: function(q, n, cb, cbErr) {
 					$http.get(apiUrl + '/search?q=' + q + '&n=' + n)
 						.success(cb)

--- a/share/nitweb/javascripts/model.js
+++ b/share/nitweb/javascripts/model.js
@@ -29,6 +29,12 @@
 						.error(cbErr);
 				},
 
+				loadEntityLinearization: function(id, cb, cbErr) {
+					$http.get(apiUrl + '/linearization/' + id)
+						.success(cb)
+						.error(cbErr);
+				},
+
 				search: function(q, n, cb, cbErr) {
 					$http.get(apiUrl + '/search?q=' + q + '&n=' + n)
 						.success(cb)

--- a/share/nitweb/views/class.html
+++ b/share/nitweb/views/class.html
@@ -5,7 +5,7 @@
 	</div>
 
 	<ul class='nav nav-tabs'>
-		<li class='active'>
+		<li role='presentation' class='active'>
 			<a data-toggle='tab' data-target='#doc'>
 				<span class='glyphicon glyphicon-book'/> Doc
 			</a>
@@ -18,7 +18,7 @@
 	</ul>
 
 	<div class='tab-content'>
-		<div class='tab-pane fade in active' id='doc'>
+		<div role='tabpanel' class='tab-pane fade in active' id='doc'>
 			<entity-doc mentity='mentity.intro'/>
 
 			<entity-list list-title='Parents'

--- a/share/nitweb/views/class.html
+++ b/share/nitweb/views/class.html
@@ -10,6 +10,11 @@
 				<span class='glyphicon glyphicon-book'/> Doc
 			</a>
 		</li>
+		<li role='presentation'>
+			<a data-toggle='tab' role='tab' data-target='#linearization' aria-controls='linearization' ng-click='entityCtrl.loadEntityLinearization()'>
+				<span class='glyphicon glyphicon-arrow-down'/> Linearization
+			</a>
+		</li>
 	</ul>
 
 	<div class='tab-content'>
@@ -31,6 +36,12 @@
 			<entity-list list-title='Redefined properties'
 				list-entities='mentity.redef_mproperties'
 				list-object-filter='{is_init: "!true"}' />
+		</div>
+		<div role='tabpanel' class='tab-pane fade' id='linearization'>
+			<entity-linearization
+				list-title='Class definitions'
+				list-entities='linearization'
+				list-focus='mentity.intro' />
 		</div>
 	</div>
 </div>

--- a/share/nitweb/views/classdef.html
+++ b/share/nitweb/views/classdef.html
@@ -17,6 +17,11 @@
 				<span class='glyphicon glyphicon-arrow-down'/> Linearization
 			</a>
 		</li>
+		<li role='presentation'>
+			<a data-toggle='tab' data-target='#code' ng-click="entityCtrl.loadEntityCode()">
+				<span class='glyphicon glyphicon-console'/> Code
+			</a>
+		</li>
 	</ul>
 
 	<div class='tab-content'>
@@ -25,6 +30,14 @@
 				list-title='Class definitions'
 				list-entities='linearization'
 				list-focus='mentity' />
+		</div>
+		<div role='tabpanel' class='tab-pane fade' id='code'>
+			<div class='card'>
+				<div class='card-body'>
+					<pre ng-bind-html='code' />
+					<entity-location mentity='mentity' />
+				</div>
+			</div>
 		</div>
 	</div>
 </div>

--- a/share/nitweb/views/classdef.html
+++ b/share/nitweb/views/classdef.html
@@ -1,4 +1,4 @@
-<div class='container-fluid'>
+<div class='container-fluid' ng-init='entityCtrl.loadEntityLinearization()'>
 	<div class='page-header'>
 		<h2><entity-signature mentity='mentity'/></h2>
 		<entity-link mentity='mentity.mpackage' />
@@ -12,5 +12,19 @@
 				<span class='glyphicon glyphicon-chevron-left'/> Go to class
 			</a>
 		</li>
+		<li role='presentation' class='active'>
+			<a data-toggle='tab' role='tab' data-target='#linearization' aria-controls='linearization'>
+				<span class='glyphicon glyphicon-arrow-down'/> Linearization
+			</a>
+		</li>
 	</ul>
+
+	<div class='tab-content'>
+		<div role='tabpanel' class='tab-pane fade in active' id='linearization'>
+			<entity-linearization
+				list-title='Class definitions'
+				list-entities='linearization'
+				list-focus='mentity' />
+		</div>
+	</div>
 </div>

--- a/share/nitweb/views/classdef.html
+++ b/share/nitweb/views/classdef.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<ul class='nav nav-tabs' role='tablist'>
-		<li class='warning'>
+		<li role='presentation' class='warning'>
 			<a ng-href='{{mentity.mclass.web_url}}'>
 				<span class='glyphicon glyphicon-chevron-left'/> Go to class
 			</a>

--- a/share/nitweb/views/module.html
+++ b/share/nitweb/views/module.html
@@ -10,6 +10,11 @@
 				<span class='glyphicon glyphicon-book'/> Doc
 			</a>
 		</li>
+		<li>
+			<a data-toggle='tab' data-target='#code' ng-click="entityCtrl.loadEntityCode()">
+				<span class='glyphicon glyphicon-console'/> Code
+			</a>
+		</li>
 	</ul>
 
 	<div class='tab-content'>
@@ -25,6 +30,14 @@
 			<entity-list list-title='Class redefinitions' list-entities='mentity.redef_mclassdefs'
 				list-object-filter='{}' />
 
+		</div>
+		<div class='tab-pane fade' id='code'>
+			<div class='card'>
+				<div class='card-body'>
+					<pre ng-bind-html='code' />
+					<entity-location mentity='mentity' />
+				</div>
+			</div>
 		</div>
 	</div>
 </div>

--- a/share/nitweb/views/propdef.html
+++ b/share/nitweb/views/propdef.html
@@ -18,6 +18,11 @@
 				<span class='glyphicon glyphicon-arrow-down'/> Linearization
 			</a>
 		</li>
+		<li role='presentation'>
+			<a data-toggle='tab' data-target='#code' ng-click="entityCtrl.loadEntityCode()">
+				<span class='glyphicon glyphicon-console'/> Code
+			</a>
+		</li>
 	</ul>
 
 	<div class='tab-content'>
@@ -26,6 +31,14 @@
 				list-title='Class definitions'
 				list-entities='linearization'
 				list-focus='mentity' />
+		</div>
+		<div role='tabpanel' class='tab-pane fade' id='code'>
+			<div class='card'>
+				<div class='card-body'>
+					<pre ng-bind-html='code' />
+					<entity-location mentity='mentity' />
+				</div>
+			</div>
 		</div>
 	</div>
 </div>

--- a/share/nitweb/views/propdef.html
+++ b/share/nitweb/views/propdef.html
@@ -1,5 +1,4 @@
-<div class='container-fluid'>
-
+<div class='container-fluid' ng-init='entityCtrl.loadEntityLinearization()'>
 	<div class='page-header'>
 		<h2><entity-signature mentity='mentity'/></h2>
 		<entity-link mentity='mentity.mpackage' />
@@ -14,5 +13,19 @@
 				<span class='glyphicon glyphicon-chevron-left'/> Go to property
 			</a>
 		</li>
+		<li role='presentation' class='active'>
+			<a data-toggle='tab' role='tab' data-target='#linearization' aria-controls='linearization'>
+				<span class='glyphicon glyphicon-arrow-down'/> Linearization
+			</a>
+		</li>
 	</ul>
+
+	<div class='tab-content'>
+		<div role='tabpanel' class='tab-pane fade in active' id='linearization'>
+			<entity-linearization
+				list-title='Class definitions'
+				list-entities='linearization'
+				list-focus='mentity' />
+		</div>
+	</div>
 </div>

--- a/share/nitweb/views/propdef.html
+++ b/share/nitweb/views/propdef.html
@@ -8,7 +8,7 @@
 	</div>
 
 	<ul class='nav nav-tabs'>
-		<li class='warning'>
+		<li role='presentation' class='warning'>
 			<a href='{{mentity.mproperty.web_url}}'>
 				<span class='glyphicon glyphicon-chevron-left'/> Go to property
 			</a>

--- a/share/nitweb/views/property.html
+++ b/share/nitweb/views/property.html
@@ -13,11 +13,22 @@
 				<span class='glyphicon glyphicon-book'/> Doc
 			</a>
 		</li>
+		<li role='presentation'>
+			<a data-toggle='tab' role='tab' data-target='#linearization' aria-controls='linearization' ng-click='entityCtrl.loadEntityLinearization()'>
+				<span class='glyphicon glyphicon-arrow-down'/> Linearization
+			</a>
+		</li>
 	</ul>
 
 	<div class='tab-content'>
 		<div role='tabpanel' class='tab-pane fade in active' id='doc'>
 			<entity-doc mentity='mentity.intro'/>
+		</div>
+		<div role='tabpanel' class='tab-pane fade' id='linearization'>
+			<entity-linearization
+				list-title='Class definitions'
+				list-entities='linearization'
+				list-focus='mentity.intro' />
 		</div>
 	</div>
 </div>

--- a/share/nitweb/views/property.html
+++ b/share/nitweb/views/property.html
@@ -8,7 +8,7 @@
 	</div>
 
 	<ul class='nav nav-tabs'>
-		<li class='active'>
+		<li role='presentation' class='active'>
 			<a data-toggle='tab' data-target='#doc'>
 				<span class='glyphicon glyphicon-book'/> Doc
 			</a>

--- a/src/nitweb.nit
+++ b/src/nitweb.nit
@@ -100,6 +100,7 @@ class APIRouter
 		use("/entity/:id", new APIEntity(model, mainmodule))
 		use("/code/:id", new APIEntityCode(model, mainmodule, modelbuilder))
 		use("/uml/:id", new APIEntityUML(model, mainmodule))
+		use("/linearization/:id", new APIEntityLinearization(model, mainmodule))
 	end
 end
 

--- a/src/web/model_api.nit
+++ b/src/web/model_api.nit
@@ -120,6 +120,26 @@ class APIEntity
 	end
 end
 
+# Linearize super definitions of a MClassDef or a MPropDef if any.
+#
+# Example: `GET /entity/core::Array/linearization`
+class APIEntityLinearization
+	super APIHandler
+
+	redef fun get(req, res) do
+		var mentity = mentity_from_uri(req, res)
+		if mentity == null then
+			res.error 404
+			return
+		end
+		var lin = mentity.collect_linearization(mainmodule)
+		if lin == null then
+			res.error 404
+			return
+		end
+		res.json new JsonArray.from(lin)
+	end
+end
 
 # Return a UML representation of MEntity.
 #


### PR DESCRIPTION
Interesting demos:
* http://nitweb.moz-code.org/module/array_debug::array_debug
* http://nitweb.moz-code.org/classdef/core$Array
* http://nitweb.moz-code.org/propdef/core::abstract_text$Object$to_s

Only the two last commits are relevant since the rest belongs to #2170 