### PR TITLE
lib/core: Renamed `Text::bytelen` to `Text::byte_length`

### DIFF
--- a/lib/base64.nit
+++ b/lib/base64.nit
@@ -163,7 +163,7 @@ redef class String
 	# If using the default padding character `=`, see `encode_base64`.
 	fun encode_base64(padding: nullable Byte): String
 	do
-		return to_cstring.encode_base64(bytelen, padding).to_s
+		return to_cstring.encode_base64(byte_length, padding).to_s
 	end
 
 	# Decodes the receiver string to base64 using a custom padding character.
@@ -171,6 +171,6 @@ redef class String
 	# Default padding character `=`
 	fun decode_base64(padding : nullable Byte) : String
 	do
-		return to_cstring.decode_base64(bytelen, padding).to_s
+		return to_cstring.decode_base64(byte_length, padding).to_s
 	end
 end

--- a/lib/binary/binary.nit
+++ b/lib/binary/binary.nit
@@ -107,7 +107,7 @@ redef abstract class Writer
 	# Compared to `write_string`, this method supports null bytes in `text`.
 	fun write_block(text: Text)
 	do
-		write_int64 text.bytelen
+		write_int64 text.byte_length
 		write text
 	end
 

--- a/lib/cocoa/foundation.nit
+++ b/lib/cocoa/foundation.nit
@@ -51,7 +51,7 @@ end
 
 redef class Text
 	# Get a `NSString` from `self`
-	fun to_nsstring: NSString do return to_cstring.to_nsstring(bytelen)
+	fun to_nsstring: NSString do return to_cstring.to_nsstring(byte_length)
 end
 
 # Wrapper of byte buffers

--- a/lib/core/bytes.nit
+++ b/lib/core/bytes.nit
@@ -456,7 +456,7 @@ class Bytes
 	# Appends the bytes of `s` to `selftextextt`
 	fun append_text(s: Text) do
 		for i in s.substrings do
-			append_ns(i.fast_cstring, i.bytelen)
+			append_ns(i.fast_cstring, i.byte_length)
 		end
 	end
 
@@ -712,7 +712,7 @@ redef class Text
 	# assert "String".to_bytes == [83u8, 116u8, 114u8, 105u8, 110u8, 103u8]
 	# ~~~
 	fun to_bytes: Bytes do
-		var b = new Bytes.with_capacity(bytelen)
+		var b = new Bytes.with_capacity(byte_length)
 		append_to_bytes b
 		return b
 	end
@@ -730,7 +730,7 @@ redef class Text
 	fun append_to_bytes(b: Bytes) do
 		for s in substrings do
 			var from = if s isa FlatString then s.first_byte else 0
-			b.append_ns_from(s.items, s.bytelen, from)
+			b.append_ns_from(s.items, s.byte_length, from)
 		end
 	end
 
@@ -757,7 +757,7 @@ redef class Text
 	#     assert "a b c".hexdigest_to_bytes.hexdigest == "0ABC"
 	fun hexdigest_to_bytes: Bytes do
 		var b = bytes
-		var max = bytelen
+		var max = byte_length
 
 		var dlength = 0 # Number of hex digits
 		var pos = 0
@@ -795,7 +795,7 @@ redef class Text
 	#
 	#     assert "&lt;STRING&#47;&rt;".hexdigest == "266C743B535452494E47262334373B2672743B"
 	fun hexdigest: String do
-		var ln = bytelen
+		var ln = byte_length
 		var outns = new NativeString(ln * 2)
 		var oi = 0
 		for i in [0 .. ln[ do
@@ -815,7 +815,7 @@ redef class Text
 	#     assert "\\x41\\x42\\x43".unescape_to_bytes.chexdigest == "\\x41\\x42\\x43"
 	#     assert "B\\n\\x41\\u0103D3".unescape_to_bytes.chexdigest == "\\x42\\x0A\\x41\\xF0\\x90\\x8F\\x93"
 	fun unescape_to_bytes: Bytes do
-		var res = new Bytes.with_capacity(self.bytelen)
+		var res = new Bytes.with_capacity(self.byte_length)
 		var was_slash = false
 		var i = 0
 		while i < length do
@@ -886,7 +886,7 @@ redef class Text
 	fun binarydigest_to_bytes: Bytes
 	do
 		var b = bytes
-		var max = bytelen
+		var max = byte_length
 
 		# Count bits
 		var bitlen = 0
@@ -930,7 +930,7 @@ end
 redef class FlatText
 	redef fun append_to_bytes(b) do
 		var from = if self isa FlatString then first_byte else 0
-		b.append_ns_from(items, bytelen, from)
+		b.append_ns_from(items, byte_length, from)
 	end
 end
 

--- a/lib/core/codecs/iso8859_1.nit
+++ b/lib/core/codecs/iso8859_1.nit
@@ -40,7 +40,7 @@ private class ISO88591Codec
 	end
 
 	redef fun encode_string(s) do
-		var ns = new Bytes.with_capacity(s.bytelen)
+		var ns = new Bytes.with_capacity(s.byte_length)
 		add_string_to(s, ns)
 		return ns
 	end

--- a/lib/core/codecs/utf8.nit
+++ b/lib/core/codecs/utf8.nit
@@ -41,14 +41,14 @@ private class UTF8Codec
 	end
 
 	redef fun encode_string(s) do
-		var buf = new Bytes.with_capacity(s.bytelen)
+		var buf = new Bytes.with_capacity(s.byte_length)
 		add_string_to(s, buf)
 		return buf
 	end
 
 	redef fun add_string_to(s, b) do
 		s.append_to_bytes(b)
-		return s.bytelen
+		return s.byte_length
 	end
 
 	redef fun is_valid_char(ns, len) do
@@ -73,7 +73,7 @@ private class UTF8Codec
 		if rit == ns then
 			var nns = new NativeString(len)
 			rit.copy_to(nns, len, 0, 0)
-			return nns.to_s_full(ret.bytelen, ret.length)
+			return nns.to_s_full(ret.byte_length, ret.length)
 		end
 		return ret
 	end

--- a/lib/core/file.nit
+++ b/lib/core/file.nit
@@ -858,7 +858,7 @@ redef class Text
 
 	private fun write_native_to(s: FileWriter)
 	do
-		for i in substrings do s.write_native(i.to_cstring, 0, i.bytelen)
+		for i in substrings do s.write_native(i.to_cstring, 0, i.byte_length)
 	end
 end
 
@@ -1285,7 +1285,7 @@ end
 redef class FlatString
 	redef fun write_native_to(s)
 	do
-		s.write_native(items, first_byte, bytelen)
+		s.write_native(items, first_byte, byte_length)
 	end
 
 	redef fun file_extension do

--- a/lib/core/fixed_ints.nit
+++ b/lib/core/fixed_ints.nit
@@ -902,7 +902,7 @@ redef class Text
 	#     assert not "Not an Int".is_int
 	#     assert not "-".is_int
 	fun is_int: Bool do
-		if bytelen == 0 then return false
+		if byte_length == 0 then return false
 		var s = remove_all('_')
 		var pos = 0
 		var len = s.length

--- a/lib/core/re.nit
+++ b/lib/core/re.nit
@@ -368,7 +368,7 @@ class Regex
 
 		# Actually execute
 		var cstr = text.to_cstring
-		var rets = cstr.to_s_with_length(text.bytelen)
+		var rets = cstr.to_s_with_length(text.byte_length)
 		var bytefrom = cstr.char_to_byte_index_cached(charfrom, 0, 0)
 		var subcstr = cstr.fast_cstring(bytefrom)
 		var eflags = gather_eflags
@@ -428,7 +428,7 @@ class Regex
 		# Actually execute
 		var cstr = text.to_cstring
 		var subcstr = cstr
-		var rets = cstr.to_s_with_length(text.bytelen)
+		var rets = cstr.to_s_with_length(text.byte_length)
 		var eflags = gather_eflags
 		var eflags_or_notbol = eflags | flag_notbol
 		var native_match = self.native_match

--- a/lib/core/stream.nit
+++ b/lib/core/stream.nit
@@ -198,7 +198,7 @@ abstract class Reader
 		var rets = ""
 		var pos = 0
 		var str = s.items.clean_utf8(slen)
-		slen = str.bytelen
+		slen = str.byte_length
 		var sits = str.items
 		var remsp = slen
 		while pos < slen do
@@ -211,10 +211,10 @@ abstract class Reader
 				break
 			end
 			var st = sits.find_beginning_of_char_at(pos + chunksz - 1)
-			var bytelen = st - pos
-			rets += new FlatString.with_infos(sits, bytelen, pos)
+			var byte_length = st - pos
+			rets += new FlatString.with_infos(sits, byte_length, pos)
 			pos = st
-			remsp -= bytelen
+			remsp -= byte_length
 		end
 		if rets isa Concat then return rets.balance
 		return rets
@@ -732,5 +732,5 @@ class StringReader
 		return new Bytes(nns, nslen, nslen)
 	end
 
-	redef fun eof do return cursor >= source.bytelen
+	redef fun eof do return cursor >= source.byte_length
 end

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -50,9 +50,9 @@ abstract class Text
 
 	# Number of bytes in `self`
 	#
-	#     assert "12345".bytelen == 5
-	#     assert "あいうえお".bytelen == 15
-	fun bytelen: Int is abstract
+	#     assert "12345".byte_length == 5
+	#     assert "あいうえお".byte_length == 15
+	fun byte_length: Int is abstract
 
 	# Create a substring.
 	#
@@ -844,7 +844,7 @@ abstract class Text
 	#     assert "%c3%a9%e3%81%82%e3%81%84%e3%81%86".from_percent_encoding == "éあいう"
 	fun from_percent_encoding: String
 	do
-		var len = bytelen
+		var len = byte_length
 		var has_percent = false
 		for c in chars do
 			if c == '%' then
@@ -1181,7 +1181,7 @@ abstract class FlatText
 
 	redef var length = 0
 
-	redef var bytelen = 0
+	redef var byte_length = 0
 
 	redef fun output
 	do
@@ -1226,11 +1226,11 @@ private abstract class StringByteView
 
 	redef fun is_empty do return target.is_empty
 
-	redef fun length do return target.bytelen
+	redef fun length do return target.byte_length
 
 	redef fun iterator do return self.iterator_from(0)
 
-	redef fun reverse_iterator do return self.reverse_iterator_from(target.bytelen - 1)
+	redef fun reverse_iterator do return self.reverse_iterator_from(target.byte_length - 1)
 end
 
 # Immutable sequence of characters.
@@ -2187,7 +2187,7 @@ redef class NativeString
 	# use only when the data has already been verified as valid UTF-8.
 	fun to_s_unsafe(length: nullable Int): String is abstract
 
-	# Get a `String` from the raw `bytelen` bytes at `self` with `unilen` Unicode characters
+	# Get a `String` from the raw `byte_length` bytes at `self` with `unilen` Unicode characters
 	#
 	# The created `String` points to the data at `self`.
 	# This method should be used when `self` was allocated by the Nit GC,
@@ -2197,13 +2197,13 @@ redef class NativeString
 	# use only when the data has already been verified as valid UTF-8.
 	#
 	# SEE: `abstract_text::Text` for more info on the difference
-	# between `Text::bytelen` and `Text::length`.
-	fun to_s_full(bytelen, unilen: Int): String is abstract
+	# between `Text::byte_length` and `Text::length`.
+	fun to_s_full(byte_length, unilen: Int): String is abstract
 
 	# Copies the content of `src` to `self`
 	#
-	# NOTE: `self` must be large enough to withold `self.bytelen` bytes
-	fun fill_from(src: Text) do src.copy_to_native(self, src.bytelen, 0, 0)
+	# NOTE: `self` must be large enough to withold `self.byte_length` bytes
+	fun fill_from(src: Text) do src.copy_to_native(self, src.byte_length, 0, 0)
 end
 
 redef class NativeArray[E]

--- a/lib/core/text/native.nit
+++ b/lib/core/text/native.nit
@@ -268,23 +268,23 @@ extern class NativeString `{ char* `}
 		return endpos
 	end
 
-	# Number of UTF-8 characters in `self` starting at `from`, for a length of `bytelen`
-	fun utf8_length(from, bytelen: Int): Int is intern do
+	# Number of UTF-8 characters in `self` starting at `from`, for a length of `byte_length`
+	fun utf8_length(from, byte_length: Int): Int is intern do
 		var st = from
 		var ln = 0
-		while bytelen > 0 do
-			while bytelen >= 4 do
+		while byte_length > 0 do
+			while byte_length >= 4 do
 				var i = fetch_4_chars(st)
 				if i & 0x80808080 != 0 then break
-				bytelen -= 4
+				byte_length -= 4
 				st += 4
 				ln += 4
 			end
-			if bytelen == 0 then break
+			if byte_length == 0 then break
 			var cln = length_of_char_at(st)
 			st += cln
 			ln += 1
-			bytelen -= cln
+			byte_length -= cln
 		end
 		return ln
 	end

--- a/lib/csv/csv.nit
+++ b/lib/csv/csv.nit
@@ -20,7 +20,7 @@ redef class Text
 	private fun escape_to_csv(sep_char, delim_char: Char, eol: String): String do
 		var add_sp = chars_to_escape_csv(sep_char, delim_char, eol)
 		if add_sp == 0 then return to_s
-		var bf = new Buffer.with_cap(add_sp + bytelen)
+		var bf = new Buffer.with_cap(add_sp + byte_length)
 		bf.add '"'
 		for i in [0 .. length[ do
 			var c = self[i]
@@ -67,7 +67,7 @@ redef class Text
 	private fun unescape_csv(delim_char: Char): String do
 		var to_un = chars_to_unescape_csv(delim_char)
 		if to_un == 0 then return to_s
-		var buf = new Buffer.with_cap(bytelen - to_un)
+		var buf = new Buffer.with_cap(byte_length - to_un)
 		var pos = 0
 		var ln = length
 		while pos < ln do

--- a/lib/json/static.nit
+++ b/lib/json/static.nit
@@ -139,7 +139,7 @@ redef class Text
 	#     assert "\\nEscape\\t\\n".json_to_nit_string == "\nEscape\t\n"
 	#     assert "\\u0041zu\\uD800\\uDFD3".json_to_nit_string == "Azu𐏓"
 	protected fun json_to_nit_string: String do
-		var res = new FlatBuffer.with_capacity(bytelen)
+		var res = new FlatBuffer.with_capacity(byte_length)
 		var i = 0
 		var ln = self.length
 		while i < ln do
@@ -188,7 +188,7 @@ redef class Text
 	#     "\"\\t\\\"http://example.com\\\"\\r\\n\\u0000\\\\\""
 	# ~~~
 	redef fun to_json do
-		var b = new FlatBuffer.with_capacity(bytelen)
+		var b = new FlatBuffer.with_capacity(byte_length)
 		append_json(b)
 		return b.to_s
 	end

--- a/lib/libevent.nit
+++ b/lib/libevent.nit
@@ -161,7 +161,7 @@ class Connection
 	redef fun write(str)
 	do
 		if close_requested then return
-		native_buffer_event.write(str.to_cstring, str.bytelen)
+		native_buffer_event.write(str.to_cstring, str.byte_length)
 	end
 
 	redef fun write_byte(byte)

--- a/lib/nitcorn/http_response.nit
+++ b/lib/nitcorn/http_response.nit
@@ -46,7 +46,7 @@ class HttpResponse
 		# Set the content length if not already set
 		if not header.keys.has("Content-Length") then
 			# Size of the body
-			var len = body.bytelen
+			var len = body.byte_length
 
 			# Size of included files
 			for path in files do

--- a/lib/ropes_debug.nit
+++ b/lib/ropes_debug.nit
@@ -53,14 +53,14 @@ end
 redef class FlatString
 	redef fun internal_to_dot: String
 	do
-		return "n{object_id} [label=\"FlatString\\nlength = {length}\\nbytelen = {bytelen}\\nfirst_byte = {first_byte}\\nlast_byte = {last_byte}\\nText = {self.escape_to_dot}\"];\n"
+		return "n{object_id} [label=\"FlatString\\nlength = {length}\\nbyte_length = {byte_length}\\nfirst_byte = {first_byte}\\nlast_byte = {last_byte}\\nText = {self.escape_to_dot}\"];\n"
 	end
 end
 
 redef class FlatBuffer
 	redef fun internal_to_dot: String
 	do
-		return "n{object_id} [label=\"FlatBuffer\\nbytelen = {bytelen}\\nlength = {length}\\ncapacity = {capacity}\\nText = {escape_to_dot}\"];\n"
+		return "n{object_id} [label=\"FlatBuffer\\nbyte_length = {byte_length}\\nlength = {length}\\ncapacity = {capacity}\\nText = {escape_to_dot}\"];\n"
 	end
 end
 

--- a/lib/sha1.nit
+++ b/lib/sha1.nit
@@ -247,7 +247,7 @@ redef class String
 	#     import base64
 	#     assert "The quick brown fox jumps over the lazy dog".sha1 == [0x2Fu8, 0xD4u8, 0xE1u8, 0xC6u8, 0x7Au8, 0x2Du8, 0x28u8, 0xFCu8, 0xEDu8, 0x84u8, 0x9Eu8, 0xE1u8, 0xBBu8, 0x76u8, 0xE7u8, 0x39u8, 0x1Bu8, 0x93u8, 0xEBu8, 0x12u8]
 	fun sha1: Bytes do
-		return new Bytes(to_cstring.sha1_intern(bytelen), 20, 20)
+		return new Bytes(to_cstring.sha1_intern(byte_length), 20, 20)
 	end
 
 	# Computes the SHA1 of the receiver.

--- a/lib/text_stat.nit
+++ b/lib/text_stat.nit
@@ -53,10 +53,10 @@ redef class Sys
 	var index_len = new Counter[Int]
 
 	# Length (bytes) of the FlatString created by lib
-	var str_bytelen = new Counter[Int]
+	var str_byte_length = new Counter[Int]
 
-	# Counter of the times `bytelen` is called on FlatString
-	var bytelen_call = new Counter[String]
+	# Counter of the times `byte_length` is called on FlatString
+	var byte_length_call = new Counter[String]
 
 	# Counter of the times `bytepos` is called on each type of receiver
 	var position_call = new Counter[String]
@@ -98,8 +98,8 @@ Allocations, by type:
 			printn "\n"
 		end
 
-		print "Calls to bytelen for each type:"
-		for k, v in bytelen_call do
+		print "Calls to byte_length for each type:"
+		for k, v in byte_length_call do
 			print "\t{k} = {v}"
 		end
 
@@ -120,7 +120,7 @@ Allocations, by type:
 		index_len.print_content
 
 		print "Byte length of the FlatStrings created:"
-		str_bytelen.print_content
+		str_byte_length.print_content
 	end
 
 	redef fun run do
@@ -139,8 +139,8 @@ redef class Concat
 		sys.concat_allocations += 1
 	end
 
-	redef fun bytelen do
-		sys.bytelen_call.inc "Concat"
+	redef fun byte_length do
+		sys.byte_length_call.inc "Concat"
 		return super
 	end
 
@@ -221,8 +221,8 @@ redef class RopeBuffer
 		sys.ropebuf_allocations += 1
 	end
 
-	redef fun bytelen do
-		sys.bytelen_call.inc "RopeBuffer"
+	redef fun byte_length do
+		sys.byte_length_call.inc "RopeBuffer"
 		return super
 	end
 
@@ -258,8 +258,8 @@ redef class FlatBuffer
 		super
 	end
 
-	redef fun bytelen do
-		sys.bytelen_call.inc "FlatBuffer"
+	redef fun byte_length do
+		sys.byte_length_call.inc "FlatBuffer"
 		return super
 	end
 
@@ -301,8 +301,8 @@ redef class FlatString
 		super
 	end
 
-	redef fun bytelen do
-		sys.bytelen_call.inc "FlatString"
+	redef fun byte_length do
+		sys.byte_length_call.inc "FlatString"
 		return super
 	end
 
@@ -328,7 +328,7 @@ redef class FlatString
 		var l = length_cache
 		if l != null then return l
 		sys.length_cache_miss.inc "FlatString"
-		if bytelen == 0 then return 0
+		if byte_length == 0 then return 0
 		var st = first_byte
 		var its = items
 		var ln = 0
@@ -348,7 +348,7 @@ redef class FlatString
 end
 
 redef class ASCIIFlatString
-	redef init full_data(items, bytelen, from, length)
+	redef init full_data(items, byte_length, from, length)
 	do
 		super
 		sys.asciiflatstr_allocations += 1
@@ -357,7 +357,7 @@ redef class ASCIIFlatString
 end
 
 redef class UnicodeFlatString
-	redef init full_data(items, bytelen, from, length)
+	redef init full_data(items, byte_length, from, length)
 	do
 		super
 		sys.uniflatstr_allocations += 1

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -1652,9 +1652,9 @@ abstract class AbstractCompilerVisitor
 		var native_mtype = mmodule.native_string_type
 		var nat = self.new_var(native_mtype)
 		self.add("{nat} = \"{string.escape_to_c}\";")
-		var bytelen = self.int_instance(string.bytelen)
+		var byte_length = self.int_instance(string.byte_length)
 		var unilen = self.int_instance(string.length)
-		self.add("{res} = {self.send(self.get_property("to_s_full", native_mtype), [nat, bytelen, unilen]).as(not null)};")
+		self.add("{res} = {self.send(self.get_property("to_s_full", native_mtype), [nat, byte_length, unilen]).as(not null)};")
 		self.add("{name} = {res};")
 		self.add("\}")
 		return res

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -319,10 +319,10 @@ class NaiveInterpreter
 	# Return a new native string initialized with `txt`
 	fun native_string_instance(txt: String): Instance
 	do
-		var instance = native_string_instance_len(txt.bytelen+1)
+		var instance = native_string_instance_len(txt.byte_length+1)
 		var val = instance.val
-		val[txt.bytelen] = 0u8
-		txt.to_cstring.copy_to(val, txt.bytelen, 0, 0)
+		val[txt.byte_length] = 0u8
+		txt.to_cstring.copy_to(val, txt.byte_length, 0, 0)
 
 		return instance
 	end
@@ -352,7 +352,7 @@ class NaiveInterpreter
 	fun string_instance(txt: String): Instance
 	do
 		var nat = native_string_instance(txt)
-		var res = self.send(self.force_get_primitive_method("to_s_full", nat.mtype), [nat, self.int_instance(txt.bytelen), self.int_instance(txt.length)])
+		var res = self.send(self.force_get_primitive_method("to_s_full", nat.mtype), [nat, self.int_instance(txt.byte_length), self.int_instance(txt.length)])
 		assert res != null
 		return res
 	end

--- a/tests/bench_string_super.nit
+++ b/tests/bench_string_super.nit
@@ -23,4 +23,4 @@ while i < n do
 	s = "Je dis «{s}» et redis «{s}» et trois fois de plus : «{s}{s}{s}».\n"
 	i = i + 1
 end
-print s.bytelen
+print s.byte_length

--- a/tests/bench_string_tos.nit
+++ b/tests/bench_string_tos.nit
@@ -23,4 +23,4 @@ while i < n do
 	s = ["Je dis «", s, "» et redis «", s, "» et trois fois de plus : «", s, s, s, "».\n"].plain_to_s
 	i = i + 1
 end
-print(s.bytelen)
+print(s.byte_length)

--- a/tests/sav/test_text_stat.res
+++ b/tests/sav/test_text_stat.res
@@ -12,7 +12,7 @@ Allocations, by type:
 Calls to length, by type:
 	FlatString = 19
 Indexed accesses, by type:
-Calls to bytelen for each type:
+Calls to byte_length for each type:
 	FlatString = 48
 Calls to position for each type:
 Calls to bytepos for each type:

--- a/tests/test_buffer_unicode.nit
+++ b/tests/test_buffer_unicode.nit
@@ -46,7 +46,7 @@ for i in fb.chars.reverse_iterator do
 	l -= 1
 end
 
-l = fb.bytelen - 1
+l = fb.byte_length - 1
 
 for i in fb.bytes.reverse_iterator do
 	print "Byte {l} = {i}"

--- a/tests/test_copy_to_native.nit
+++ b/tests/test_copy_to_native.nit
@@ -23,6 +23,6 @@ var str: String = base_str
 #alt1 str = new Concat(base_str, base_str)
 #alt2 str = new Concat(base_str, base_str.substring_from(2))
 
-var copy_len = (str.bytelen - 4).min(9)
+var copy_len = (str.byte_length - 4).min(9)
 str.copy_to_native(ons, copy_len, 4, 0)
 print ons.to_s_with_length(copy_len)

--- a/tests/test_nativestring_fill_from.nit
+++ b/tests/test_nativestring_fill_from.nit
@@ -21,7 +21,7 @@ var cpstr: Text = src_s
 #alt2 cpstr = new FlatBuffer.from(src_s)
 #alt3 cpstr = cpstr.substring(1, 5)
 
-var ns = new NativeString(cpstr.bytelen)
+var ns = new NativeString(cpstr.byte_length)
 ns.fill_from(cpstr)
 
-print ns.to_s_with_length(cpstr.bytelen)
+print ns.to_s_with_length(cpstr.byte_length)


### PR DESCRIPTION
As one famous man once said: "Je vous ai compris!".

So, I understood that some of us (@xymus, @ppepos, @BlackMinou, etc.) did not like the `bytelen` name, since it was not that explicit.
Well, its days are numbered and it is replaced by the longer but more explicit `byte_length`.