### PR TITLE
libevent: force closing connections on error to fix file descriptors leak

### DIFF
--- a/lib/libevent.nit
+++ b/lib/libevent.nit
@@ -164,7 +164,7 @@ class Connection
 	do
 		if events & bev_event_error != 0 or events & bev_event_eof != 0 then
 			if events & bev_event_error != 0 then print_error "Error from bufferevent"
-			close
+			force_close
 			return true
 		end
 


### PR DESCRIPTION
The libevent wrapper did not always free and close connections on errors. These are expected errors, like when a file download is cancelled half-way through or when a push connection expires. This recently caused xymus.net to crash due to the exhaustion of file descriptors available to the process.