### PR TITLE
app.nit: update AsyncHttpRequest API, add examples and a simple implementation

### DIFF
--- a/contrib/benitlux/src/client/base.nit
+++ b/contrib/benitlux/src/client/base.nit
@@ -90,9 +90,9 @@ end
 class BenitluxHttpRequest
 	super AsyncHttpRequest
 
-	redef fun rest_server_uri do return benitlux_rest_server_uri
+	redef fun uri_root do return benitlux_rest_server_uri
 
-	redef var rest_action
+	redef var uri_tail
 
 	redef fun on_fail(error)
 	do
@@ -104,7 +104,7 @@ class BenitluxHttpRequest
 			# This could be a deserialization error,
 			# it may be related to an outdated client.
 			# Report to user.
-			print_error "Request Error: {rest_server_uri / rest_action} with {error}"
+			print_error "Request Error: {uri} with {error}"
 			app.feedback "Request Error: {error}"
 		end
 	end
@@ -134,7 +134,7 @@ end
 class WindowHttpRequest
 	super BenitluxHttpRequest
 
-	autoinit window, rest_action
+	autoinit window, uri_tail
 
 	# Type of the related `window`
 	type W: Window

--- a/contrib/benitlux/src/client/features/checkins.nit
+++ b/contrib/benitlux/src/client/features/checkins.nit
@@ -109,7 +109,7 @@ end
 class MenuHttpRequest
 	super BenitluxHttpRequest
 
-	redef fun on_load(data)
+	redef fun on_load(data, status)
 	do
 		if not data isa Array[BeerAndRatings] then
 			on_fail new Error("Server sent unexpected data {data or else "null"}")

--- a/contrib/benitlux/src/client/features/push.nit
+++ b/contrib/benitlux/src/client/features/push.nit
@@ -68,7 +68,7 @@ class PushHttpRequest
 		t.start
 	end
 
-	redef fun on_load(data)
+	redef fun on_load(data, status)
 	do
 		if app.user == null then return
 

--- a/contrib/benitlux/src/client/views/beer_views.nit
+++ b/contrib/benitlux/src/client/views/beer_views.nit
@@ -219,7 +219,7 @@ end
 class ReviewAction
 	super WindowHttpRequest
 
-	redef fun on_load(res)
+	redef fun on_load(res, status)
 	do
 		if intercept_error(res) then return
 	end
@@ -231,7 +231,7 @@ class ListBeersAction
 
 	redef type W: BeersWindow
 
-	redef fun on_load(beers)
+	redef fun on_load(beers, status)
 	do
 		window.layout.remove window.list_beers
 		window.list_beers = new ListLayout(parent=window.layout)

--- a/contrib/benitlux/src/client/views/home_views.nit
+++ b/contrib/benitlux/src/client/views/home_views.nit
@@ -150,7 +150,7 @@ class ListDiffAction
 
 	redef type W: HomeWindow
 
-	redef fun on_load(beers)
+	redef fun on_load(beers, status)
 	do
 		window.layout_beers.remove window.beer_list
 		window.beer_list = new VerticalLayout(parent=window.layout_beers)
@@ -181,7 +181,7 @@ class HomeListPeopleAction
 
 	redef type W: HomeWindow
 
-	redef fun on_load(users)
+	redef fun on_load(users, status)
 	do
 		window.layout_social.remove window.social_list
 		window.social_list = new VerticalLayout(parent=window.layout_social)
@@ -200,7 +200,7 @@ class CheckTokenAction
 
 	redef type W: HomeWindow
 
-	redef fun on_load(res) do intercept_error(res)
+	redef fun on_load(res, status) do intercept_error(res)
 end
 
 # Today's date as a `String`

--- a/contrib/benitlux/src/client/views/social_views.nit
+++ b/contrib/benitlux/src/client/views/social_views.nit
@@ -160,7 +160,7 @@ class ListUsersAction
 
 	init do affected_views.add_all([window.but_search, window.but_followed, window.but_followers])
 
-	redef fun on_load(users)
+	redef fun on_load(users, status)
 	do
 		window.layout.remove window.list_search
 		window.list_search = new ListLayout(parent=window.layout)
@@ -179,7 +179,7 @@ class FollowAction
 	private var button: FollowButton
 	init do affected_views.add(button)
 
-	redef fun on_load(res)
+	redef fun on_load(res, status)
 	do
 		if intercept_error(res) then return
 	end

--- a/contrib/benitlux/src/client/views/user_views.nit
+++ b/contrib/benitlux/src/client/views/user_views.nit
@@ -194,7 +194,7 @@ class LoginOrSignupAction
 
 	init do affected_views.add_all([window.but_login, window.but_signup])
 
-	redef fun on_load(res)
+	redef fun on_load(res, status)
 	do
 		if intercept_error(res) then return
 

--- a/contrib/tnitter/src/tnitter_app.nit
+++ b/contrib/tnitter/src/tnitter_app.nit
@@ -100,9 +100,9 @@ abstract class AsyncTnitterRequest
 
 	private var window: TnitterWindow
 
-	redef fun rest_server_uri do return tnitter_server_uri
+	redef fun uri_root do return tnitter_server_uri
 
-	redef var rest_action
+	redef var uri_tail
 
 	# Should this request be delayed by `request_delay_on_error` seconds?
 	fun after_error(value: Bool) is autoinit do if value then delay = request_delay_on_error
@@ -120,11 +120,11 @@ end
 class ListPostRequest
 	super AsyncTnitterRequest
 
-	redef fun on_load(posts)
+	redef fun on_load(posts, status)
 	do
 		# Deal with server-side errors
 		if posts isa Error then
-			print_error "Server Error: '{posts.message}' from '{rest_server_uri / rest_action}'"
+			print_error "Server Error: '{posts.message}' from '{uri}'"
 			return
 		end
 
@@ -141,7 +141,7 @@ class ListPostRequest
 
 	redef fun on_fail(error)
 	do
-		print "Warning: Request {rest_server_uri/rest_action} failed with {error}"
+		print "Warning: Request {uri} failed with {error}"
 		window.request_full_list_on_error
 	end
 end

--- a/lib/app/README.md
+++ b/lib/app/README.md
@@ -128,7 +128,8 @@ end
 The module `app::http_request` provides services to execute asynchronous HTTP request.
 The class `AsyncHttpRequest` hides the complex parallel logic and
 lets the user implement methods acting only on the UI thread.
-See the documentation of `AsyncHttpRequest` for more information.
+See the documentation of `AsyncHttpRequest` for more information and
+the full example at `examples/http_request_example.nit`.
 
 # Metadata annotations
 

--- a/lib/app/examples/.gitignore
+++ b/lib/app/examples/.gitignore
@@ -1,0 +1,3 @@
+http_request_example
+http_request_example.apk
+http_request_example.app

--- a/lib/app/examples/Makefile
+++ b/lib/app/examples/Makefile
@@ -1,0 +1,10 @@
+all: http_request_example
+
+http_request_example: $(shell nitls -M http_request_example.nit linux)
+	nitc http_request_example.nit -m linux
+
+http_request_example.apk: $(shell nitls -M http_request_example.nit android)
+	nitc http_request_example.nit -m android
+
+http_request_example.app: $(shell nitls -M http_request_example.nit ios)
+	nitc http_request_example.nit -m ios

--- a/lib/app/examples/http_request_example.nit
+++ b/lib/app/examples/http_request_example.nit
@@ -1,0 +1,86 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example for the `app::http_request` main service `AsyncHttpRequest`
+module http_request_example
+
+import app::ui
+import app::http_request
+
+# Simple asynchronous HTTP request to http://example.com/ displaying feedback to the window
+class MyHttpRequest
+	super AsyncHttpRequest
+
+	# Back reference to the window to show feedback to the user
+	var win: HttpRequestClientWindow
+
+	# ---
+	# Config the request
+
+	redef fun uri do return "http://example.com/"
+	redef fun deserialize_json do return false
+
+	# ---
+	# Customize callbacks
+
+	redef fun before
+	do
+		win.label_response.text = "Sending request..."
+
+		# Disable button to prevent double requests
+		win.button_request.enabled = false
+	end
+
+	redef fun on_load(data, status)
+	do win.label_response.text = "Received response code {status} with {data.as(Text).byte_length} bytes"
+
+	redef fun on_fail(error)
+	do win.label_response.text = "Connection error: {error}"
+
+	redef fun after do win.button_request.enabled = true
+end
+
+# Simpe window with a label and a button
+class HttpRequestClientWindow
+	super Window
+
+	# Root layout
+	var layout = new VerticalLayout(parent=self)
+
+	# Button to send request
+	var button_request = new Button(parent=layout, text="Press to send HTTP request")
+
+	# Label displaying feedback to user
+	var label_response = new Label(parent=layout, text="No response yet.")
+
+	init do button_request.observers.add self
+
+	redef fun on_event(event)
+	do
+		if event isa ButtonPressEvent and event.sender == button_request then
+			# Prepare and send request
+			var request = new MyHttpRequest(self)
+			request.start
+		end
+	end
+end
+
+redef class App
+	redef fun on_create
+	do
+		# Create the main window
+		push_window new HttpRequestClientWindow
+		super
+	end
+end

--- a/lib/app/http_request.nit
+++ b/lib/app/http_request.nit
@@ -97,6 +97,7 @@ abstract class AsyncHttpRequest
 			return null
 		end
 
+		app.run_on_ui_thread new RestRunnableJoin(self)
 
 		return null
 	end
@@ -180,4 +181,10 @@ private class RestRunnableOnFail
 		sender_thread.on_fail(error)
 		sender_thread.after
 	end
+end
+
+private class RestRunnableJoin
+	super HttpRequestTask
+
+	redef fun main do sender_thread.join
 end

--- a/lib/app/http_request.nit
+++ b/lib/app/http_request.nit
@@ -89,11 +89,11 @@ abstract class AsyncHttpRequest
 			if deserializer.errors.not_empty then
 				app.run_on_ui_thread new RestRunnableOnFail(self, deserializer.errors.first)
 			else
-				app.run_on_ui_thread new RestRunnableOnLoad(self, res)
+				app.run_on_ui_thread new RestRunnableOnLoad(self, res, rep.code)
 			end
 		else
 			# Return text data
-			app.run_on_ui_thread new RestRunnableOnLoad(self, rep.value)
+			app.run_on_ui_thread new RestRunnableOnLoad(self, rep.value, rep.code)
 			return null
 		end
 
@@ -111,7 +111,7 @@ abstract class AsyncHttpRequest
 	# In this case, `result` may be any deserialized object.
 	#
 	# Otherwise, if `not deserialize_json`, `result` contains the content of the response as a `String`.
-	fun on_load(result: nullable Object) do end
+	fun on_load(result: nullable Object, http_status_code: Int) do end
 
 	# Invoked when the HTTP request has failed and no data was received or deserialization failed
 	fun on_fail(error: Error) do print_error "HTTP request '{uri}' failed with: {error}"
@@ -164,9 +164,11 @@ private class RestRunnableOnLoad
 
 	var res: nullable Object
 
+	var code: Int
+
 	redef fun main
 	do
-		sender_thread.on_load(res)
+		sender_thread.on_load(res, code)
 		sender_thread.after
 	end
 end

--- a/lib/app/http_request.nit
+++ b/lib/app/http_request.nit
@@ -44,6 +44,8 @@ end
 # * `on_load`
 # * `on_fail`
 # * `after`
+#
+# See full example at `examples/http_request_example.nit`.
 abstract class AsyncHttpRequest
 	super Thread
 

--- a/lib/app/http_request.nit
+++ b/lib/app/http_request.nit
@@ -122,6 +122,23 @@ abstract class AsyncHttpRequest
 	fun after do end
 end
 
+# Minimal implementation of `AsyncHttpRequest` where `uri` is an attribute
+#
+# Prints on communication errors and when the server returns an HTTP status code not in the 200s.
+#
+# ~~~
+# var request = new SimpleAsyncHttpRequest("http://example.com")
+# request.start
+# ~~~
+class SimpleAsyncHttpRequest
+	super AsyncHttpRequest
+
+	redef var uri
+
+	redef fun on_load(data, status) do if status < 200 or status >= 299
+	then print_error "HTTP request '{uri}' received HTTP status code: {status}"
+end
+
 redef class Text
 	# Execute an HTTP GET request synchronously at the URI `self`
 	#


### PR DESCRIPTION
This PR updates the API of `AsyncHttpRequest`, using more general names for methods and adding a new variation point `uri`. The useful `uri_root` and `uri_tail` are still available as they are more practical to factorize code in real programs. Also provide the `http_status_code` to callbacks when the request succeeded.

Fix a few bugs: correct the ordering of the callback to the UI thread, and join the thread from the UI thread after request is completed.
 
Intro the new `SimpleAsyncHttpRequest` which prints feedback to the console on errors. It can be used when the response from the server is ignored, or as a quick and dirty first version in the prototype.