### PR TITLE
libevent: improve "Error from bufferevent" with socket error code and name

### DIFF
--- a/lib/libevent.nit
+++ b/lib/libevent.nit
@@ -242,6 +242,18 @@ fun bev_event_timeout: Int `{ return BEV_EVENT_TIMEOUT; `}
 # connect operation finished.
 fun bev_event_connected: Int `{ return BEV_EVENT_CONNECTED; `}
 
+# Global error code for the last socket operation on the calling thread
+#
+# Not idempotent on all platforms.
+fun evutil_socket_error: Int `{
+	return EVUTIL_SOCKET_ERROR();
+`}
+
+# Convert an error code from `evutil_socket_error` to a string
+fun evutil_socket_error_to_string(error_code: Int): NativeString `{
+	return evutil_socket_error_to_string(error_code);
+`}
+
 # ---
 # Options that can be specified when creating a `NativeBufferEvent`
 
@@ -384,16 +396,9 @@ extern class ConnectionListener `{ struct evconnlistener * `}
 
 	# Callback method on listening error
 	fun error_callback do
-		var cstr = socket_error
-		sys.stderr.write "libevent error: '{cstr}'"
+		var cstr = evutil_socket_error_to_string(evutil_socket_error)
+		print_error "libevent error: '{cstr}'"
 	end
-
-	# Error with sockets
-	fun socket_error: NativeString `{
-		// TODO move to Nit and maybe NativeEventBase
-		int err = EVUTIL_SOCKET_ERROR();
-		return evutil_socket_error_to_string(err);
-	`}
 end
 
 # Factory to listen on sockets and create new `Connection`

--- a/lib/libevent.nit
+++ b/lib/libevent.nit
@@ -163,7 +163,17 @@ class Connection
 	fun event_callback(events: Int): Bool
 	do
 		if events & bev_event_error != 0 or events & bev_event_eof != 0 then
-			if events & bev_event_error != 0 then print_error "Error from bufferevent"
+			if events & bev_event_error != 0 then
+				var sock_err = evutil_socket_error
+				# Ignore some normal errors and print the others for debugging
+				if sock_err == 110 then
+					# Connection timed out (ETIMEDOUT)
+				else if sock_err == 104 then
+					# Connection reset by peer (ECONNRESET)
+				else
+					print_error "libevent error event: {evutil_socket_error_to_string(sock_err)} ({sock_err})"
+				end
+			end
 			force_close
 			return true
 		end


### PR DESCRIPTION
This PR improves what is logged on callbacks reporting an error on a socket. It prints the error code and string from the last socket error. Some errors are ignored: ETIMEDOUT and ECONNRESET.

In the future, we may want to add more expected errors to the list, ignore all of them or let the client chose with a list, I don't know. Note that `event_callback` can be specialized by the clients, so they have access to this too.