### PR TITLE
Java FFI: Improve documentation of `java` and `jvm`

### DIFF
--- a/examples/calculator/src/calculator.nit
+++ b/examples/calculator/src/calculator.nit
@@ -14,7 +14,7 @@
 
 # Portable calculator UI
 module calculator is
-app_name "app.nit Calc."
+	app_name "app.nit Calc."
 	app_version(0, 1, git_revision)
 	app_namespace "org.nitlanguage.calculator"
 

--- a/lib/android/dalvik.nit
+++ b/lib/android/dalvik.nit
@@ -29,11 +29,8 @@ redef class App
 	fun native_context: NativeContext do return native_activity
 end
 
-extern class JavaClassLoader in "Java" `{java.lang.ClassLoader`}
-	super JavaObject
-end
-
 redef class Sys
+
 	# We cannot create a JVM on Android
 	#
 	# This method is not reachable on this platform anyway.
@@ -43,7 +40,9 @@ redef class Sys
 	redef fun jni_env do return jvm.attach_current_thread
 
 	private var class_loader: nullable JavaObject = null
+
 	private var class_loader_method: nullable JMethodID = null
+
 	redef fun load_jclass(name)
 	do
 		var class_loader = self.class_loader

--- a/lib/android/wifi.nit
+++ b/lib/android/wifi.nit
@@ -146,13 +146,13 @@ extern class NativeScanResult in "Java" `{ android.net.wifi.ScanResult `}
 end
 
 # Java list of `NativeScanResult`
-extern class NativeListOfScanResult in "Java" `{ java.util.List `}
+extern class NativeListOfScanResult in "Java" `{ java.util.List<android.net.wifi.ScanResult> `}
 
 	# Number of elements in this list
 	fun length: Int in "Java" `{ return self.size();`}
 
 	# Element at `index`
 	fun [](index: Int): NativeScanResult in "Java" `{
-		return ((java.util.List<android.net.wifi.ScanResult>)self).get((int)index);
+		return self.get((int)index);
 	`}
 end

--- a/lib/java/base.nit
+++ b/lib/java/base.nit
@@ -66,7 +66,9 @@ redef class Sys
 		assert jvm != null else print "JVM creation failed"
 
 		self.jvm = jvm
-		self.jni_env = builder.jni_env.as(not null)
+		assert not jvm.address_is_null
+		self.jni_env = jvm.env
+		assert not jni_env.address_is_null
 	end
 
 	# Get a Java class by its name from the current `jni_env`

--- a/lib/java/collections.nit
+++ b/lib/java/collections.nit
@@ -28,7 +28,7 @@
 # ~~~
 module collections
 
-import base
+import ffi_support
 
 # Java primitive array
 #

--- a/lib/java/ffi_support.nit
+++ b/lib/java/ffi_support.nit
@@ -20,7 +20,7 @@
 # `Sys::create_default_jvm` and supply your own JVM object. You can manage
 # multiple java thread by switching the current environment in a redef
 # of `Sys::jni_env`, and multiple JVM using `Sys::jvm`.
-module base is
+module ffi_support is
 	cflags "-I $(JAVA_HOME)/include/ -I $(JAVA_HOME)/include/linux/"
 	ldflags "-L $(JNI_LIB_PATH) -ljvm"
 	new_annotation extra_java_files

--- a/lib/java/ffi_support.nit
+++ b/lib/java/ffi_support.nit
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Supporting services for the FFI with Java
+# Core supporting services for the FFI with Java
 #
-# This modules relies on `Sys::jvm`, `Sys::jni_env` and
-# `Sys::create_default_jvm` to get a handle on a JVM. You can adapt the
-# behavior of the FFI and services in this module by redefing
-# `Sys::create_default_jvm` and supply your own JVM object. You can manage
-# multiple java thread by switching the current environment in a redef
-# of `Sys::jni_env`, and multiple JVM using `Sys::jvm`.
+# This module *must* be imported by modules using the Java FFI.
+# Some might prefer to import the whole `java` package as it provides
+# other useful services.
 module ffi_support is
 	cflags "-I $(JAVA_HOME)/include/ -I $(JAVA_HOME)/include/linux/"
 	ldflags "-L $(JNI_LIB_PATH) -ljvm"

--- a/lib/java/io.nit
+++ b/lib/java/io.nit
@@ -19,7 +19,7 @@
 # This module is used by `android::assets_and_resources` and `android::audio`.
 module io
 
-import base
+import ffi_support
 
 in "Java" `{
 	import java.io.File;

--- a/lib/java/java.nit
+++ b/lib/java/java.nit
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Supporting services for the FFI with Java
+# Supporting services for the FFI with Java and to access Java libraries
 #
 # This modules relies on `Sys::jvm`, `Sys::jni_env` and
 # `Sys::create_default_jvm` to get a handle on a JVM. You can adapt the
@@ -21,9 +21,8 @@
 # multiple java thread by switching the current environment in a redef
 # of `Sys::jni_env`, and multiple JVM using `Sys::jvm`.
 #
-# The module `jvm` gives more control over the JVM instances and wraps
-# most of JNI functions. You can use it to further customize the behavior
-# of your code.
+# See also, the module `jvm` to control the JVM instances and access JNI functions.
+# You can use it to further customize the behavior of your code.
 module java
 
 import ffi_support

--- a/lib/java/java.nit
+++ b/lib/java/java.nit
@@ -26,5 +26,5 @@
 # of your code.
 module java
 
-import base
+import ffi_support
 import collections

--- a/lib/jvm.nit
+++ b/lib/jvm.nit
@@ -17,12 +17,15 @@
 
 # Java Virtual Machine invocation API and others services from the JNI C API
 #
-# Users of this module and the Java FFI, on desktop computers, must define two environment variables:
+# Users of this module and the Java FFI, on desktop computers, must define three environment variables:
 # * `JAVA_HOME` points to the installation folder of the target Java VM.
 #   This folder should contain the JNI header file `include/jni.h`.
 #   e.g. `/usr/lib/jvm/default-java` on Debian Jessie.
 # * `JNI_LIB_PATH` points to the folder with `libjvm.so`.
 #   e.g. `/usr/lib/jvm/default-java/jre/lib/amd64/server/` on Debian Jessie.
+# * `LD_LIBRARY_PATH` has the path to the folder with `libjvm.so`.
+#   It's the same value as `JNI_LIB_PATH` but `LD_LIBRARY_PATH` is a colon separated list
+#   which may contain other paths.
 #
 # See: http://docs.oracle.com/javase/1.5.0/docs/guide/jni/spec/jniTOC.html
 module jvm is

--- a/tests/test_jvm.nit
+++ b/tests/test_jvm.nit
@@ -43,11 +43,10 @@ builder.options.add "-Djava.class.path=."
 #alt1#builder.options.clear
 #alt1#builder.options.add "-Djava.class.path=/tmp/"
 var jvm = builder.create_jvm
-var env = builder.jni_env
-assert env != null
+assert jvm != null
 
-# Test JavaVM::env
-assert not jvm.env.address_is_null
+var env = jvm.env
+assert not env.address_is_null
 
 print "---------------------Test 1----------------------"
 # get the class


### PR DESCRIPTION
This PR improves the documentation of the modules related to the Java FFI: `java` and `jvm`. Besides the doc itself, the name of the module `java::base` has been changed to the more meaningful `java::ffi_support`.

As a bonus, the JVM API is simplified a bit, there's one less unused class in the Android modules and a few other details have been fixed.