### PR TITLE
app.nit: propagate events (such as a button press) to the parents of the control

### DIFF
--- a/contrib/benitlux/src/client/features/debug.nit
+++ b/contrib/benitlux/src/client/features/debug.nit
@@ -24,7 +24,7 @@ redef class UserWindow
 	private var layout_debug = new VerticalLayout(parent=layout)
 
 	private var lbl_debug_title = new Label(parent=layout_debug,
-		text="Debug options".t)
+		text="Debug options".t, size=1.5)
 
 	private var but_test_notif = new Button(parent=layout_debug,
 		text="Test notifications".t)
@@ -37,15 +37,6 @@ redef class UserWindow
 
 	private var but_test_menu = new Button(parent=layout_debug,
 		text="Test menu diff".t)
-
-	init
-	do
-		lbl_debug_title.size = 1.5
-
-		for c in [but_test_notif, but_test_checkin, but_test_checkout, but_test_menu] do
-			c.observers.add self
-		end
-	end
 
 	redef fun on_event(event)
 	do

--- a/contrib/benitlux/src/client/features/push.nit
+++ b/contrib/benitlux/src/client/features/push.nit
@@ -180,7 +180,7 @@ redef class UserWindow
 	private var layout_push_options = new VerticalLayout(parent=layout)
 
 	private var lbl_push_options_title = new Label(parent=layout_push_options,
-		text="Notifications options".t)
+		text="Notifications options".t, size=1.5)
 
 	private var chk_notify_on_new_beers = new CheckBox(parent=layout_push_options,
 		text="Notify when there are new beers".t)
@@ -194,14 +194,9 @@ redef class UserWindow
 
 	init
 	do
-		lbl_push_options_title.size = 1.5
 		chk_notify_on_new_beers.is_checked = app.notify_on_new_beers
 		chk_notify_menu_daily.is_checked = app.notify_menu_daily
 		chk_notify_on_checkins.is_checked = app.notify_on_checkins
-
-		for c in [chk_notify_menu_daily, chk_notify_on_new_beers, chk_notify_on_checkins] do
-			c.observers.add self
-		end
 	end
 
 	redef fun on_event(event)

--- a/contrib/benitlux/src/client/ios.nit
+++ b/contrib/benitlux/src/client/ios.nit
@@ -27,7 +27,6 @@ redef class HomeWindow
 	do
 		title = "Benitlux"
 		update_checkin_text
-		checkin_button.observers.add self
 	end
 
 	# TODO hide when not logged in

--- a/contrib/benitlux/src/client/views/beer_views.nit
+++ b/contrib/benitlux/src/client/views/beer_views.nit
@@ -63,7 +63,6 @@ class BeerView
 		for i in [1..5] do
 			var but = new StarButton(beer_info.beer, i, i <= rating, parent=l_stars)
 			but.size = 1.5
-			but.observers.add self
 			star_buttons.add but
 		end
 	end

--- a/contrib/benitlux/src/client/views/home_views.nit
+++ b/contrib/benitlux/src/client/views/home_views.nit
@@ -79,13 +79,6 @@ class HomeWindow
 	#private var news_button = new Button(parent=news_header, text="Open website") # TODO
 	private var news_label = new Label(parent=layout_news, text="Bière en cask le jeudi!")
 
-	init
-	do
-		for c in [but_login, but_preferences, beer_button, social_button] do
-			c.observers.add self
-		end
-	end
-
 	redef fun on_resume do refresh
 
 	# Refresh content of this page

--- a/contrib/benitlux/src/client/views/social_views.nit
+++ b/contrib/benitlux/src/client/views/social_views.nit
@@ -36,10 +36,6 @@ class SocialWindow
 
 	init
 	do
-		for c in [but_search, but_followed, but_followers] do
-			c.observers.add self
-		end
-
 		# Load friends and suggestions
 		(new ListUsersAction(self, "rest/friends?token={app.token}&n=16")).start
 	end
@@ -108,7 +104,6 @@ class PeopleView
 			# Show unfollow button if not on the home screen
 			if not home_window_mode or not user_and_following.following then
 				var but = new FollowButton(user.id, user_and_following.following, user_and_following.followed, parent=layout_top_line)
-				but.observers.add self
 			end
 		end
 

--- a/contrib/benitlux/src/client/views/user_views.nit
+++ b/contrib/benitlux/src/client/views/user_views.nit
@@ -60,11 +60,7 @@ class UserWindow
 		but_logout.enabled = app.user != null
 	end
 
-	init
-	do
-		but_logout.observers.add self
-		refresh
-	end
+	init do refresh
 
 	redef fun on_event(event)
 	do
@@ -127,13 +123,6 @@ class SignupWindow
 	private var txt_email = new TextInput(parent=email_line)
 
 	private var but_signup = new Button(parent=layout_register, text="Signup".t)
-
-	init
-	do
-		for c in [but_login, but_signup] do
-			c.observers.add self
-		end
-	end
 
 	redef fun on_event(event)
 	do

--- a/examples/calculator/src/calculator.nit
+++ b/examples/calculator/src/calculator.nit
@@ -75,7 +75,6 @@ class CalculatorWindow
 
 			for op in row do
 				var but = new Button(parent=row_layout, text=op)
-				but.observers.add self
 				buttons[op] = but
 			end
 		end

--- a/examples/calculator/src/scientific_calculator.nit
+++ b/examples/calculator/src/scientific_calculator.nit
@@ -30,7 +30,6 @@ redef class CalculatorWindow
 
 			for op in row do
 				var but = new Button(parent=row_layout, text=op)
-				but.observers.add self
 				buttons[op] = but
 			end
 		end

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -107,10 +107,16 @@ class Control
 
 	# Direct parent `Control` in the control tree
 	#
+	# The parents (direct and indirect) receive all events from `self`,
+	# like the `observers`.
+	#
 	# If `null` then `self` is at the root of the tree, or not yet attached.
 	var parent: nullable CompositeControl = null is private writable(set_parent)
 
 	# Direct parent `Control` in the control tree
+	#
+	# The parents (direct and indirect) receive all events from `self`,
+	# like the `observers`.
 	#
 	# Setting `parent` calls `remove` on the old parent and `add` on the new one.
 	fun parent=(parent: nullable CompositeControl)
@@ -124,12 +130,25 @@ class Control
 
 		set_parent parent
 	end
+
+	# Also notify the parents (both direct and indirect)
+	redef fun notify_observers(event)
+	do
+		super
+
+		var p = parent
+		while p != null do
+			p.on_event event
+			p = p.parent
+		end
+	end
 end
 
 # A `Control` grouping other controls
 class CompositeControl
 	super Control
 
+	# Child controls composing this control
 	protected var items = new Array[Control]
 
 	# Add `item` as a child of `self`

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -211,7 +211,7 @@ abstract class TextView
 	# depending on the customization options of each platform.
 	# For consistent results, it is recommended to use only on instances
 	# of `Label` and `size` should be either 0.0, 0.5 or 1.0.
-	fun align=(center: nullable Float) is autoinit do end
+	fun align=(align: nullable Float) is autoinit do end
 end
 
 # A control for the user to enter custom `text`


### PR DESCRIPTION
UI events, such as a button press or a check box toggle, were only sent to the observers of a control, and the control itself. For this reason, every button was watched by the window or some other container.

Propagating the events to the parents (direct and indirect) reaches the window and all of its containers. This allows for more modular code and components, and it removes the need for manually declaring the window as an observer.