### PR TITLE
Filter isa adaptation

### DIFF
--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -1666,11 +1666,15 @@ redef class AIsaExpr
 
 		var variable = self.n_expr.its_variable
 		if variable != null then
-			#var orig = self.n_expr.mtype
+			var orig = self.n_expr.mtype
 			#var from = if orig != null then orig.to_s else "invalid"
 			#var to = if mtype != null then mtype.to_s else "invalid"
 			#debug("adapt {variable}: {from} -> {to}")
-			self.after_flow_context.when_true.set_var(v, variable, mtype)
+
+			# Do not adapt if there is no information gain (i.e. adapt to a supertype)
+			if mtype == null or orig == null or not v.is_subtype(orig, mtype) then
+				self.after_flow_context.when_true.set_var(v, variable, mtype)
+			end
 		end
 
 		self.mtype = v.type_bool(self)

--- a/tests/sav/base_classid.res
+++ b/tests/sav/base_classid.res
@@ -1,6 +1,7 @@
 base_classid.nit:47,2--8: Warning: expression is already a `A`.
 base_classid.nit:48,2--9: Warning: expression is already a `A`.
 base_classid.nit:49,2--8: Warning: expression is already a `A` since it is a `B`.
+base_classid.nit:52,2--8: Warning: expression is already a `B`.
 true
 true
 true

--- a/tests/sav/base_isa3.res
+++ b/tests/sav/base_isa3.res
@@ -1,12 +1,20 @@
 base_isa3.nit:59,8--14: Warning: expression is already a `A` since it is a `B`.
+base_isa3.nit:60,8--14: Warning: expression is already a `B`.
 base_isa3.nit:64,8--14: Warning: expression is already a `A` since it is a `C`.
+base_isa3.nit:66,8--14: Warning: expression is already a `C`.
 base_isa3.nit:69,8--14: Warning: expression is already a `A` since it is a `D`.
+base_isa3.nit:71,8--14: Warning: expression is already a `C` since it is a `D`.
+base_isa3.nit:72,8--14: Warning: expression is already a `D`.
 base_isa3.nit:73,8--14: Warning: expression is already a `E` since it is a `D`.
-base_isa3.nit:74,8--14: Warning: expression is already a `E`.
-base_isa3.nit:75,8--14: Warning: expression is already a `E`.
-base_isa3.nit:76,8--14: Warning: expression is already a `E`.
+base_isa3.nit:74,8--14: Warning: expression is already a `E` since it is a `D`.
+base_isa3.nit:75,8--14: Warning: expression is already a `E` since it is a `D`.
+base_isa3.nit:76,8--14: Warning: expression is already a `E` since it is a `D`.
 base_isa3.nit:79,8--14: Warning: expression is already a `A` since it is a `E`.
+base_isa3.nit:81,8--14: Warning: expression is already a `E`.
 base_isa3.nit:84,8--14: Warning: expression is already a `A` since it is a `F`.
+base_isa3.nit:85,8--14: Warning: expression is already a `E` since it is a `F`.
+base_isa3.nit:86,8--14: Warning: expression is already a `F`.
 base_isa3.nit:87,8--14: Warning: expression is already a `G` since it is a `F`.
 base_isa3.nit:91,8--14: Warning: expression is already a `A` since it is a `G`.
+base_isa3.nit:93,8--14: Warning: expression is already a `G`.
 true

--- a/tests/sav/base_isa_gen1.res
+++ b/tests/sav/base_isa_gen1.res
@@ -1,4 +1,7 @@
 base_isa_gen1.nit:62,8--14: Warning: expression is already a `A` since it is a `F`.
+base_isa_gen1.nit:63,8--14: Warning: expression is already a `C` since it is a `F`.
 base_isa_gen1.nit:65,8--30: Warning: expression is already a `D[Object, Object]` since it is a `G[Object]`.
 base_isa_gen1.nit:66,8--30: Warning: expression is already a `D[Object, Object]` since it is a `E[F]`.
+base_isa_gen1.nit:67,8--25: Warning: expression is already a `D[A, Object]` since it is a `E[F]`.
+base_isa_gen1.nit:69,8--25: Warning: expression is already a `D[F, Object]` since it is a `E[F]`.
 true

--- a/tests/sav/base_isa_gen2.res
+++ b/tests/sav/base_isa_gen2.res
@@ -1,5 +1,10 @@
 base_isa_gen2.nit:39,8--22: Warning: expression is already a `A[Object]`.
 base_isa_gen2.nit:41,8--22: Warning: expression is already a `A[Object]` since it is a `B[Object]`.
+base_isa_gen2.nit:42,8--22: Warning: expression is already a `B[Object]`.
 base_isa_gen2.nit:44,8--22: Warning: expression is already a `A[Object]` since it is a `C[Object]`.
+base_isa_gen2.nit:46,8--22: Warning: expression is already a `C[Object]`.
 base_isa_gen2.nit:48,8--22: Warning: expression is already a `A[Object]` since it is a `D[Object, Object]`.
+base_isa_gen2.nit:49,8--22: Warning: expression is already a `B[Object]` since it is a `D[Object, Object]`.
+base_isa_gen2.nit:50,8--22: Warning: expression is already a `C[Object]` since it is a `D[Object, Object]`.
+base_isa_gen2.nit:51,8--30: Warning: expression is already a `D[Object, Object]`.
 true

--- a/tests/sav/base_isa_gen4.res
+++ b/tests/sav/base_isa_gen4.res
@@ -1,4 +1,5 @@
 base_isa_gen4.nit:34,8--15: Warning: expression is already a `A` since it is a `B[Canard]`.
+base_isa_gen4.nit:35,8--23: Warning: expression is already a `B[Canard]`.
 base_isa_gen4.nit:36,8--23: Warning: expression is already a `B[Animal]` since it is a `B[Canard]`.
 base_isa_gen4.nit:40,8--26: Warning: expression is already a `B[B[Canard]]`.
 base_isa_gen4.nit:42,8--26: Warning: expression is already a `B[B[Animal]]` since it is a `B[B[Canard]]`.

--- a/tests/sav/base_isa_gen5.res
+++ b/tests/sav/base_isa_gen5.res
@@ -1,4 +1,5 @@
 base_isa_gen5.nit:39,8--15: Warning: expression is already a `A` since it is a `B[Canard]`.
+base_isa_gen5.nit:40,8--23: Warning: expression is already a `B[Canard]`.
 base_isa_gen5.nit:41,8--23: Warning: expression is already a `B[Animal]` since it is a `B[Canard]`.
 base_isa_gen5.nit:46,8--26: Warning: expression is already a `B[B[Canard]]`.
 base_isa_gen5.nit:48,8--26: Warning: expression is already a `B[B[Animal]]` since it is a `B[B[Canard]]`.

--- a/tests/sav/base_isa_nullable1.res
+++ b/tests/sav/base_isa_nullable1.res
@@ -1,6 +1,7 @@
 base_isa_nullable1.nit:39,8--15: Warning: expression is already a `A` since it is a `B[Integer]`.
+base_isa_nullable1.nit:40,8--24: Warning: expression is already a `B[Integer]`.
 base_isa_nullable1.nit:41,8--25: Warning: expression is already a `B[Discrete]` since it is a `B[Integer]`.
 base_isa_nullable1.nit:46,8--27: Warning: expression is already a `B[B[Integer]]`.
 base_isa_nullable1.nit:48,8--28: Warning: expression is already a `B[B[Discrete]]` since it is a `B[B[Integer]]`.
-base_isa_nullable1.nit:50,8--34: Warning: expression is already a `B[nullable Discrete]` since it is a `B[Discrete]`.
+base_isa_nullable1.nit:50,8--34: Warning: expression is already a `B[nullable Discrete]` since it is a `B[Integer]`.
 true

--- a/tests/sav/base_isa_nullable2.res
+++ b/tests/sav/base_isa_nullable2.res
@@ -1,5 +1,5 @@
 base_isa_nullable2.nit:27,8--23: Warning: expression is already a `nullable A` since it is a `A`.
 base_isa_nullable2.nit:29,8--31: Warning: expression is already a `nullable B[Object]` since it is a `B[Object]`.
-base_isa_nullable2.nit:30,8--40: Warning: expression is already a `nullable B[nullable Object]` since it is a `nullable B[Object]`.
+base_isa_nullable2.nit:30,8--40: Warning: expression is already a `nullable B[nullable Object]` since it is a `B[Object]`.
 base_isa_nullable2.nit:33,8--31: Warning: expression is already a `C[nullable Object]`.
 true

--- a/tests/sav/nitce/base_isa_gen1.res
+++ b/tests/sav/nitce/base_isa_gen1.res
@@ -1,4 +1,7 @@
 base_isa_gen1.nit:62,8--14: Warning: expression is already a `A` since it is a `F`.
+base_isa_gen1.nit:63,8--14: Warning: expression is already a `C` since it is a `F`.
 base_isa_gen1.nit:65,8--30: Warning: expression is already a `D[Object, Object]` since it is a `G[Object]`.
 base_isa_gen1.nit:66,8--30: Warning: expression is already a `D[Object, Object]` since it is a `E[F]`.
+base_isa_gen1.nit:67,8--25: Warning: expression is already a `D[A, Object]` since it is a `E[F]`.
+base_isa_gen1.nit:69,8--25: Warning: expression is already a `D[F, Object]` since it is a `E[F]`.
 Runtime error: Assert failed (base_isa_gen1.nit:68)

--- a/tests/sav/nitce/base_isa_gen4.res
+++ b/tests/sav/nitce/base_isa_gen4.res
@@ -1,4 +1,5 @@
 base_isa_gen4.nit:34,8--15: Warning: expression is already a `A` since it is a `B[Canard]`.
+base_isa_gen4.nit:35,8--23: Warning: expression is already a `B[Canard]`.
 base_isa_gen4.nit:36,8--23: Warning: expression is already a `B[Animal]` since it is a `B[Canard]`.
 base_isa_gen4.nit:40,8--26: Warning: expression is already a `B[B[Canard]]`.
 base_isa_gen4.nit:42,8--26: Warning: expression is already a `B[B[Animal]]` since it is a `B[B[Canard]]`.

--- a/tests/sav/nitce/base_isa_gen5.res
+++ b/tests/sav/nitce/base_isa_gen5.res
@@ -1,4 +1,5 @@
 base_isa_gen5.nit:39,8--15: Warning: expression is already a `A` since it is a `B[Canard]`.
+base_isa_gen5.nit:40,8--23: Warning: expression is already a `B[Canard]`.
 base_isa_gen5.nit:41,8--23: Warning: expression is already a `B[Animal]` since it is a `B[Canard]`.
 base_isa_gen5.nit:46,8--26: Warning: expression is already a `B[B[Canard]]`.
 base_isa_gen5.nit:48,8--26: Warning: expression is already a `B[B[Animal]]` since it is a `B[B[Canard]]`.

--- a/tests/sav/nitce/base_isa_nullable1.res
+++ b/tests/sav/nitce/base_isa_nullable1.res
@@ -1,6 +1,7 @@
 base_isa_nullable1.nit:39,8--15: Warning: expression is already a `A` since it is a `B[Integer]`.
+base_isa_nullable1.nit:40,8--24: Warning: expression is already a `B[Integer]`.
 base_isa_nullable1.nit:41,8--25: Warning: expression is already a `B[Discrete]` since it is a `B[Integer]`.
 base_isa_nullable1.nit:46,8--27: Warning: expression is already a `B[B[Integer]]`.
 base_isa_nullable1.nit:48,8--28: Warning: expression is already a `B[B[Discrete]]` since it is a `B[B[Integer]]`.
-base_isa_nullable1.nit:50,8--34: Warning: expression is already a `B[nullable Discrete]` since it is a `B[Discrete]`.
+base_isa_nullable1.nit:50,8--34: Warning: expression is already a `B[nullable Discrete]` since it is a `B[Integer]`.
 Runtime error: Assert failed (base_isa_nullable1.nit:42)

--- a/tests/sav/nitce/base_isa_nullable2.res
+++ b/tests/sav/nitce/base_isa_nullable2.res
@@ -1,5 +1,5 @@
 base_isa_nullable2.nit:27,8--23: Warning: expression is already a `nullable A` since it is a `A`.
 base_isa_nullable2.nit:29,8--31: Warning: expression is already a `nullable B[Object]` since it is a `B[Object]`.
-base_isa_nullable2.nit:30,8--40: Warning: expression is already a `nullable B[nullable Object]` since it is a `nullable B[Object]`.
+base_isa_nullable2.nit:30,8--40: Warning: expression is already a `nullable B[nullable Object]` since it is a `B[Object]`.
 base_isa_nullable2.nit:33,8--31: Warning: expression is already a `C[nullable Object]`.
 Runtime error: Assert failed (base_isa_nullable2.nit:32)


### PR DESCRIPTION
`isa` used to always adapt a local variable, even if there was strict information loss (a warning was shown but the adaptation was effective).

This caused issues for the adaptive typing system since there was no way to retrieve the original type information.

~~~nit
var a: A
a = new B
# a is now a B
if a isa A then
   # warning, but a is now a A
else
  # nothing here, so a is still a B
end
# merge type information of both branches: a isa A or B, thus a isa A
~~~

The change is now that `a isa A` still cause a warning but not more do the adaptation.
Thus in the *then* branch, `a` is still a `B`.
Thus in the merge at the end of the `if`, `a` remains a `B`.

close #2202 