### PR TITLE
lib/core: Push rope maxlen to 512 instead of 64

### DIFF
--- a/lib/core/text/ropes.nit
+++ b/lib/core/text/ropes.nit
@@ -58,7 +58,7 @@ intrude import flat
 #
 # Its purpose is to limit the depth of the `Rope` (this
 # improves performance when accessing/iterating).
-fun maxlen: Int do return 64
+fun maxlen: Int do return 512
 
 # String using a tree-based representation with leaves as `FlatStrings`
 private abstract class Rope


### PR DESCRIPTION
As discussed in my thesis, 512 bytes/leaf is a nice compromise for most uses of Ropes, therefore, the current threshold is updated to better reflect this.