### PR TITLE
tests: add sav/Darwin/test_loader_args5.res

### DIFF
--- a/tests/sav/Darwin/test_loader_args5.res
+++ b/tests/sav/Darwin/test_loader_args5.res
@@ -1,0 +1,32 @@
+Error: cannot find module `/lib`.
+Error: cannot find module `/fail`.
+Error: `sublib` is not a Nit source file.
+Error: cannot find module `/lib`.
+Error: cannot find module `/fail`.
+/lib: module?
+	nothing
+/lib: group?
+	nothing
+  model: mpackages=0 mmodules=0
+  mb: identified modules=0; parsed modules=0
+/fail: module?
+	nothing
+/fail: group?
+	nothing
+  model: mpackages=0 mmodules=0
+  mb: identified modules=0; parsed modules=0
+sublib: module?
+	Error: `sublib` is not a Nit package.
+sublib: group?
+	nothing
+  model: mpackages=0 mmodules=0
+  mb: identified modules=0; parsed modules=0
+scan_full found 3 modules
+  model: mpackages=2 mmodules=3
+  mb: identified modules=3; parsed modules=0
+parse found 0 modules
+  model: mpackages=2 mmodules=3
+  mb: identified modules=3; parsed modules=0
+parse_full found 3 modules
+  model: mpackages=2 mmodules=3
+  mb: identified modules=3; parsed modules=3


### PR DESCRIPTION
because /lib does not exists

Signed-off-by: Jean Privat <jean@pryen.org>