### PR TITLE
Improve (and fix) Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,8 @@ doc/nitc/index.html: bin/nitdoc bin/nitls
 		--piwik-site-id "3"
 
 man:
-	$(MAKE) -C share/man
+	# Setup PATH to find nitc
+	PATH=$$PWD/bin:$$PATH $(MAKE) -C share/man
 
 clean:
 	rm -rf -- doc/stdlib doc/nitc || true

--- a/misc/docker/Dockerfile
+++ b/misc/docker/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 	&& rm -rf /var/lib/apt/lists/*
 
 # Clone and compile
-RUN git clone https://github.com/nitlang/nit.git /root/nit \
-	&& cd /root/nit \
+RUN git clone https://github.com/nitlang/nit.git /nit \
+	&& cd /nit \
 	&& make \
 	&& . misc/nit_env.sh install \
 	# Clean and reduce size
@@ -30,6 +30,6 @@ RUN git clone https://github.com/nitlang/nit.git /root/nit \
 	&& ccache -C \
 	&& rm -rf .git
 
-ENV NIT_DIR /root/nit
+ENV NIT_DIR /nit
 ENV PATH $NIT_DIR/bin:$PATH
 WORKDIR $NIT_DIR

--- a/misc/docker/README.md
+++ b/misc/docker/README.md
@@ -24,8 +24,8 @@ You can use these images to build then run your programs.
 
 ~~~
 host$ docker run -ti nitlang/nit
-root@ce9b671dd9fc:/root/nit# nitc examples/hello_world.nit
-root@ce9b671dd9fc:/root/nit# ./hello_world
+root@ce9b671dd9fc:/nit# nitc examples/hello_world.nit
+root@ce9b671dd9fc:/nit# ./hello_world
 hello world
 ~~~
 
@@ -37,11 +37,11 @@ In your Dockerfile, write something like:
 FROM nitlang/nit
 
 # Create a workdir
-RUN mkdir -p /root/work
-WORKDIR /root/work
+RUN mkdir -p /work
+WORKDIR /work
 
-# Copy the source code in /root/work/
-COPY . /root/work/
+# Copy the source code in /work/
+COPY . /work/
 
 # Compile
 RUN nitc src/hello.nit --dir . \

--- a/misc/docker/full/Dockerfile
+++ b/misc/docker/full/Dockerfile
@@ -63,7 +63,7 @@ ENV ANDROID_NDK /opt/android-ndk
 ENV PATH $PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$ANDROID_NDK
 
 # Run tests
-RUN cd /root/nit/tests \
+RUN cd /nit/tests \
 	# Basic tests
 	&& ./testfull.sh || true \
 	&& rm -rf out/ alt/*.nit \
@@ -71,6 +71,3 @@ RUN cd /root/nit/tests \
 	&& ../bin/nitunit ../lib ../contrib || true \
 	&& rm -rf .nitunit \
 	&& ccache -C
-
-WORKDIR /root/nit
-ENTRYPOINT [ "bash" ]

--- a/misc/docker/hello/Dockerfile
+++ b/misc/docker/hello/Dockerfile
@@ -1,11 +1,11 @@
 FROM nitlang/nit
 
 # Create a workdir
-RUN mkdir -p /root/work
-WORKDIR /root/work
+RUN mkdir -p /work
+WORKDIR /work
 
-# Copy the source code in /root/work/
-COPY . /root/work/
+# Copy the source code in /work/
+COPY . /work/
 
 # Compile
 RUN nitc src/hello.nit --dir . \


### PR DESCRIPTION
#2181 broke the initial bootstrap because nitc was not found to build nitmd thus failed the `make man`

This PR also cleanup the dockerfiles so the root/ directory is not more used (this cause issue for non-root users)