### PR TITLE
Android: import the R class

### DIFF
--- a/contrib/benitlux/src/client/android.nit
+++ b/contrib/benitlux/src/client/android.nit
@@ -126,8 +126,7 @@ redef class ItemView
 	init do set_backgroud(native, app.native_context)
 
 	private fun set_backgroud(view: NativeView, context: NativeContext) in "Java" `{
-		int color = context.getResources().getIdentifier("item_background", "color", context.getPackageName());
-		view.setBackgroundResource(color);
+		view.setBackgroundResource(R.color.item_background);
 	`}
 end
 
@@ -141,9 +140,6 @@ end
 
 private fun native_notify(context: NativeService, id: Int, title, content: JavaString)
 in "Java" `{
-	int icon = context.getResources().getIdentifier(
-		"notif", "drawable", context.getPackageName());
-
 	android.app.Notification.BigTextStyle style =
 		new android.app.Notification.BigTextStyle();
 	style.bigText(content);
@@ -156,7 +152,7 @@ in "Java" `{
 	android.app.Notification notif = new android.app.Notification.Builder(context)
 		.setContentTitle(title)
 		.setContentText(content)
-		.setSmallIcon(icon)
+		.setSmallIcon(R.drawable.notif)
 		.setAutoCancel(true)
 		.setOngoing(false)
 		.setStyle(style)
@@ -225,8 +221,7 @@ redef class BeerView
 				rating.setRating(final_rating);
 
 				// Header bar
-				int icon = final_context.getResources().getIdentifier("notif", "drawable", final_context.getPackageName());
-				dialog_builder.setIcon(icon);
+				dialog_builder.setIcon(R.drawable.notif);
 				dialog_builder.setTitle(final_title);
 
 				// Rating control

--- a/contrib/benitlux/src/client/android.nit
+++ b/contrib/benitlux/src/client/android.nit
@@ -123,9 +123,9 @@ redef class SectionTitle
 end
 
 redef class ItemView
-	init do set_backgroud(native, app.native_context)
+	init do set_background(native, app.native_context)
 
-	private fun set_backgroud(view: NativeView, context: NativeContext) in "Java" `{
+	private fun set_background(view: NativeView, context: NativeContext) in "Java" `{
 		view.setBackgroundResource(R.color.item_background);
 	`}
 end

--- a/src/ffi/java.nit
+++ b/src/ffi/java.nit
@@ -193,8 +193,8 @@ end
 redef class MModule
 	private var callbacks_used_from_java = new ForeignCallbackSet
 
-	# Pure java class source file
-	private var java_file: nullable JavaClassTemplate = null
+	# Java source file extracted from user FFI code with generated structure
+	var java_file: nullable JavaClassTemplate = null
 
 	# Set up the templates of the Java implementation class
 	private fun ensure_java_files

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -104,6 +104,12 @@ class AndroidToolchain
 		dir = compile_dir
 		if not dir.file_exists then dir.mkdir
 
+		# Insert an importation of the generated R class to all Java files from the FFI
+		for mod in compiler.mainmodule.in_importation.greaters do
+			var java_ffi_file = mod.java_file
+			if java_ffi_file != null then java_ffi_file.add "import {app_package}.R;"
+		end
+
 		# compile normal C files
 		super
 
@@ -240,7 +246,7 @@ $(call import-module,android/native_app_glue)
 
 		### Link to png sources
 		# libpng is not available on Android NDK
-		# FIXME make obtionnal when we have alternatives to mnit
+		# FIXME make optional when we have alternatives to mnit
 		var nit_dir = toolcontext.nit_dir
 		var share_dir =  nit_dir/"share/"
 		if not share_dir.file_exists then


### PR DESCRIPTION
The R class is generated by the Android toolchain and acts as a static way to identify resources in Java code. The ID of each values from the `android/res` folder is sorted in a category and accessible through a static field. An example of a generated R class is shown at the bottom of this description.

This PR import the R class in all Java classes generated from the Java FFI. This creates a similar effect as having the R class in the same package. Previously, the user could not reliably import the R class manually as the package name changes between the debug and release version.

~~~
/* AUTO-GENERATED FILE.  DO NOT MODIFY.
 *
 * This class was automatically generated by the
 * aapt tool from the resource data it found.  It
 * should not be modified by hand.
 */

package net.xymus.benitlux_debug;

public final class R {
    public static final class attr {
    }
    public static final class color {
        public static final int item_background=0x7f050000;
    }
    public static final class drawable {
        public static final int ic_launcher=0x7f020000;
        public static final int icon=0x7f020001;
        public static final int notif=0x7f020002;
    }
    public static final class layout {
        public static final int main=0x7f030000;
    }
    public static final class string {
        public static final int app_name=0x7f040000;
    }
}

~~~