### PR TITLE
`mendel_metrics`: Fix documentation

### DIFF
--- a/src/metrics/mendel_metrics.nit
+++ b/src/metrics/mendel_metrics.nit
@@ -38,9 +38,9 @@
 # * replacers that have less redefinitions that call super than not calling it
 #
 # For more details see
-#  Mendel: A Model, Metrics and Rules to Understan Class Hierarchies
-#  S. Denier and Y. Gueheneuc
-#  in Proceedings of the 16th IEEE International Conference on Program Comprehension (OCPC'08)
+# “Mendel: A Model, Metrics and Rules to Understand Class Hierarchies,”
+# by S. Denier and Y. Gueheneuc,
+# in *Proceedings of the 16th IEEE International Conference on Program Comprehension* (OCPC'08).
 module mendel_metrics
 
 import metrics_base

--- a/src/metrics/mendel_metrics.nit
+++ b/src/metrics/mendel_metrics.nit
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The mndel model helps to understand class hierarchies
+# The Mendel model helps to understand class hierarchies.
 #
 # It provides metrics to extract interesting classes:
 #


### PR DESCRIPTION
Some minor fixes for the documentation of the `mendel_metrics` module.