### PR TITLE
modelize_class: Remove an unnecessary pre-condition

### DIFF
--- a/src/modelize/modelize_class.nit
+++ b/src/modelize/modelize_class.nit
@@ -308,7 +308,6 @@ redef class ModelBuilder
 	end
 
 	# Build the classes of the module `nmodule`.
-	# REQUIRE: classes of imported modules are already build. (let `phase` do the job)
 	private fun build_classes(nmodule: AModule)
 	do
 		# Force building recursively


### PR DESCRIPTION
`build_classes` calls itself recursively on imported modules. So, there is no point to specify that imported modules must be processed first.

Signed-off-by: Jean-Christophe Beaupré <jcbrinfo@users.noreply.github.com>