### PR TITLE
new class MErrorType to handle buggy types

### DIFF
--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -1407,8 +1407,10 @@ class MVirtualType
 
 	redef fun model do return self.mproperty.intro_mclassdef.mmodule.model
 
-	redef fun lookup_bound(mmodule: MModule, resolved_receiver: MType): MType
+	redef fun lookup_bound(mmodule, resolved_receiver)
 	do
+		# There is two possible invalid cases: the vt does not exists in resolved_receiver or the bound is broken
+		if not resolved_receiver.has_mproperty(mmodule, mproperty) then return new MErrorType(model)
 		return lookup_single_definition(mmodule, resolved_receiver).bound or else new MErrorType(model)
 	end
 
@@ -1570,7 +1572,8 @@ class MParameterType
 				return res
 			end
 		end
-		abort
+		# Cannot found `self` in `resolved_receiver`
+		return new MErrorType(model)
 	end
 
 	# A PT is fixed when:

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -1054,6 +1054,12 @@ abstract class MType
 	# In case of conflicts or inconsistencies in the model, the method returns a `MErrorType`.
 	fun lookup_fixed(mmodule: MModule, resolved_receiver: MType): MType do return self
 
+	# Is the type a `MErrorType` or contains an `MErrorType`?
+	#
+	# `MErrorType` are used in result with conflict or inconsistencies.
+	#
+	fun is_ok: Bool do return true
+
 	# Can the type be resolved?
 	#
 	# In order to resolve open types, the formal types must make sence.
@@ -1350,6 +1356,12 @@ class MGenericType
 			if not t.can_resolve_for(mtype, anchor, mmodule) then return false
 		end
 		return true
+	end
+
+	redef fun is_ok
+	do
+		for t in arguments do if not t.is_ok then return false
+		return super
 	end
 
 
@@ -1671,6 +1683,8 @@ abstract class MProxyType
 		return self.mtype.can_resolve_for(mtype, anchor, mmodule)
 	end
 
+	redef fun is_ok do return mtype.is_ok
+
 	redef fun lookup_fixed(mmodule, resolved_receiver)
 	do
 		var t = mtype.lookup_fixed(mmodule, resolved_receiver)
@@ -1813,6 +1827,7 @@ end
 # The error type can de used to denote things that are conflicting or inconsistent.
 #
 # Some methods on types can return a `MErrorType` to denote a broken or a conflicting result.
+# Use `is_ok` to check if a type is (or contains) a `MErrorType` .
 class MErrorType
 	super MType
 	redef var model
@@ -1822,6 +1837,7 @@ class MErrorType
 	redef fun need_anchor do return false
 	redef fun resolve_for(mtype, anchor, mmodule, cleanup_virtual) do return self
 	redef fun can_resolve_for(mtype, anchor, mmodule) do return true
+	redef fun is_ok do return false
 
 	redef fun collect_mclassdefs(mmodule) do return new HashSet[MClassDef]
 

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -111,7 +111,7 @@ redef class ModelBuilder
 				if not check_virtual_types_circularity(npropdef, mpropdef.mproperty, mclassdef.bound_mtype, mclassdef.mmodule) then
 					# Invalidate the bound
 					mpropdef.is_broken = true
-					mpropdef.bound = new MBottomType(mclassdef.mmodule.model)
+					mpropdef.bound = new MErrorType(mclassdef.mmodule.model)
 				end
 			end
 			for npropdef in nclassdef2.n_propdefs do
@@ -383,6 +383,8 @@ redef class ModelBuilder
 		else if mtype isa MNullType then
 			# nothing to do.
 		else if mtype isa MBottomType then
+			# nothing to do.
+		else if mtype isa MErrorType then
 			# nothing to do.
 		else
 			node.debug "Unexpected type {mtype}"

--- a/src/rapid_type_analysis.nit
+++ b/src/rapid_type_analysis.nit
@@ -313,7 +313,7 @@ class RapidTypeAnalysis
 				if not ot.can_resolve_for(t, t, mainmodule) then continue
 				var rt = ot.anchor_to(mainmodule, t)
 				if live_types.has(rt) then continue
-				if not is_valid_type(rt) then continue
+				if not rt.is_legal_in(mainmodule) then continue
 				if not check_depth(rt) then continue
 				#print "{ot}/{t} -> {rt}"
 				live_types.add(rt)
@@ -330,22 +330,12 @@ class RapidTypeAnalysis
 			for t in live_types do
 				if not ot.can_resolve_for(t, t, mainmodule) then continue
 				var rt = ot.anchor_to(mainmodule, t)
-				if not is_valid_type(rt) then continue
+				if not rt.is_legal_in(mainmodule) then continue
 				live_cast_types.add(rt)
 				#print "  {ot}/{t} -> {rt}"
 			end
 		end
 		#print "cast MType {live_cast_types.length}: {live_cast_types.join(", ")}"
-	end
-
-	# Quick and dirty check that a forced type resolution gives a legal type
-	# TODO: move up in the model and kill `can_resolve_for`
-	private fun is_valid_type(mtype: MType): Bool
-	do
-		if mtype isa MGenericType then
-			return mtype.is_subtype(mainmodule, null, mtype.mclass.intro.bound_mtype)
-		end
-		return true
 	end
 
 	private fun check_depth(mtype: MClassType): Bool

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -117,7 +117,7 @@ private class TypeVisitor
 			#node.debug("Unsafe typing: expected {sup}, got {sub}")
 			return sup
 		end
-		if sup isa MBottomType then return null # Skip error
+		if sup isa MErrorType then return null # Skip error
 		if sub.need_anchor then
 			var u = anchor_to(sub)
 			self.modelbuilder.error(node, "Type Error: expected `{sup}`, got `{sub}: {u}`.")


### PR DESCRIPTION
This is a small cleanup of some part of the code of the model.
The main improvement is the addition of a `MErrorType` class and two somewhat related services `MType::is_ok` and `MType::is_legal_in`.

Beside a better model and better services, this changeset clean the quickfix introduced in RTA (see #2245 )
There should be no change in the overall performance.