### PR TITLE
nitcorn: support the special address 0.0.0.0

### DIFF
--- a/lib/nitcorn/nitcorn.nit
+++ b/lib/nitcorn/nitcorn.nit
@@ -25,26 +25,27 @@
 # Basic usage example:
 # ~~~~
 # class MyAction
-# 	super Action
+#     super Action
 #
-# 	redef fun answer(http_request, turi)
-# 	do
-# 		var response = new HttpResponse(200)
-# 		response.body = """
-# 		<!DOCTYPE html>
-# 		<head>
-# 			<meta charset="utf-8">
-# 			<title>Hello World</title>
-# 		</head>
-# 		<body>
-# 			<p>Hello World</p>
-# 		</body>
-# 		</html>"""
-# 		return response
-# 	end
+#     redef fun answer(http_request, turi)
+#     do
+#         var response = new HttpResponse(200)
+#         response.body = """
+# <!DOCTYPE html>
+# <head>
+#     <meta charset="utf-8">
+#     <title>Hello World</title>
+# </head>
+# <body>
+#     <p>Hello World</p>
+# </body>
+# </html>"""
+#         return response
+#     end
 # end
 #
-# var vh = new VirtualHost("localhost:80")
+# # Listen to port 8080 on all interfaces
+# var vh = new VirtualHost("0.0.0.0:8080")
 #
 # # Serve index.html with our custom handler
 # vh.routes.add new Route("/index.html", new MyAction)

--- a/lib/nitcorn/reactor.nit
+++ b/lib/nitcorn/reactor.nit
@@ -201,8 +201,15 @@ redef class Interfaces
 	redef fun add(e)
 	do
 		super
-		var config = vh.server_config
-		if config != null then sys.listen_on(e, config.factory)
+		var config = virtual_host.server_config
+		if config != null then register_and_listen(e, config)
+	end
+
+	# Indirection to `listen_on` and check if this targets all addresses
+	private fun register_and_listen(e: Interface, config: ServerConfig)
+	do
+		listen_on(e, config.factory)
+		if e.name == "0.0.0.0" or e.name == "::0" then config.default_virtual_host = virtual_host
 	end
 
 	# TODO remove
@@ -212,7 +219,7 @@ redef class VirtualHosts
 	redef fun add(e)
 	do
 		super
-		for i in e.interfaces do sys.listen_on(i, config.factory)
+		for i in e.interfaces do e.interfaces.register_and_listen(i, config)
 	end
 
 	# TODO remove

--- a/lib/nitcorn/server_config.nit
+++ b/lib/nitcorn/server_config.nit
@@ -82,7 +82,7 @@ class Interfaces
 	super Array[Interface]
 
 	# Back reference to the associtated `VirtualHost`
-	var vh: VirtualHost
+	var virtual_host: VirtualHost
 
 	# Add an `Interface` described by `text` formatted as `interface.name.com:port`
 	fun add_from_string(text: String)

--- a/lib/nitcorn/server_config.nit
+++ b/lib/nitcorn/server_config.nit
@@ -25,7 +25,7 @@ class ServerConfig
 	var virtual_hosts = new VirtualHosts(self)
 
 	# Default `VirtualHost` to respond to requests not handled by any of the `virtual_hosts`
-	var default_virtual_host: nullable VirtualHost = null
+	var default_virtual_host: nullable VirtualHost = null is writable
 end
 
 # A `VirtualHost` configuration


### PR DESCRIPTION
This PR automates assigning virtual hosts on `0.0.0.0` as the `default_virtual_host`, a fallback for all request not intercepted by other virtual hosts.

It is an imperfect temporary solution as the virtual host on 0.0.0.0:80 may receive requests from other ports, and there can be only one functional virtual host on all interfaces. A better solution would involve rewriting  `ConnectionListener::bind_to` and splitting it up in many services to keep the address and socket associated to a virtual host.