### PR TITLE
calculator: nicer Android adaptation with API 21 + variant

### DIFF
--- a/examples/calculator/Makefile
+++ b/examples/calculator/Makefile
@@ -26,13 +26,14 @@ bin/scientific.apk: $(shell ${NITLS} -M src/scientific src/android_calculator.ni
 
 android-release: $(shell ${NITLS} -M src/scientific src/android_calculator.nit) ${NITC} android/res/drawable-hdpi/icon.png
 	mkdir -p bin
-	${NITC} -o bin/calculator.apk src/scientific -m src/android_calculator.nit --release
+	${NITC} -o bin/calculator.apk src/android_calculator.nit --release
+	${NITC} -o bin/scientific.apk src/scientific -m src/android_calculator.nit --release
 
 android/res/drawable-hdpi/icon.png: art/icon.svg ../../contrib/inkscape_tools/bin/svg_to_icons
 	mkdir -p android/res
 	../../contrib/inkscape_tools/bin/svg_to_icons art/icon.svg --android --out android/res/
 
-src/scientific/android/res/drawable-hdpi/icon.png: art/icon_sci.svg ../../contrib/inkscape_tools/bin/svg_to_icons
+src/scientific/android/res/drawable-hdpi/icon.png: art/icon-sci.svg ../../contrib/inkscape_tools/bin/svg_to_icons
 	mkdir -p src/scientific/android/res
 	../../contrib/inkscape_tools/bin/svg_to_icons art/icon-sci.svg --android --out src/scientific/android/res/
 

--- a/examples/calculator/Makefile
+++ b/examples/calculator/Makefile
@@ -18,29 +18,29 @@ bin/scientific: $(shell ${NITLS} -M scientific linux) ${NITC}
 # * scientific vs non-scientific
 # * android API 21+ vs under 21
 
-android: bin/calculator.apk bin/scientific.apk bin/calculator21.apk bin/scientific21.apk
+android: bin/calculator14.apk bin/scientific14.apk bin/calculator21.apk bin/scientific21.apk
 
-bin/calculator.apk: $(shell ${NITLS} -M src/android_calculator.nit) ${NITC} android/res/drawable-hdpi/icon.png
+bin/calculator14.apk: $(shell ${NITLS} -M src/android14.nit) ${NITC} android/res/drawable-hdpi/icon.png
 	mkdir -p bin
-	${NITC} -o $@ src/android_calculator.nit -D debug
+	${NITC} -o $@ src/android14.nit -D debug
 
 bin/calculator21.apk: $(shell ${NITLS} -M src/android21) ${NITC} android/res/drawable-hdpi/icon.png
 	mkdir -p bin
 	${NITC} -o $@ src/android21 -D debug
 
-bin/scientific.apk: $(shell ${NITLS} -M src/scientific src/android_calculator.nit) ${NITC} src/scientific/android/res/drawable-hdpi/icon.png
+bin/scientific14.apk: $(shell ${NITLS} -M src/scientific src/android14.nit) ${NITC} src/scientific/android/res/drawable-hdpi/icon.png
 	mkdir -p bin
-	${NITC} -o $@ src/scientific -m src/android_calculator.nit -D debug
+	${NITC} -o $@ src/scientific -m src/android14.nit -D debug
 
 bin/scientific21.apk: $(shell ${NITLS} -M src/scientific src/android21) ${NITC} src/scientific/android/res/drawable-hdpi/icon.png
 	mkdir -p bin
 	${NITC} -o $@ src/scientific -m src/android21 -D debug
 
-android-release: $(shell ${NITLS} -M src/scientific src/android_calculator.nit) ${NITC} android/res/drawable-hdpi/icon.png
+android-release: $(shell ${NITLS} -M src/scientific src/android14.nit) ${NITC} android/res/drawable-hdpi/icon.png
 	mkdir -p bin
-	${NITC} -o bin/calculator.apk src/android_calculator.nit --release
+	${NITC} -o bin/calculator14.apk src/android14.nit --release
 	${NITC} -o bin/calculator21.apk src/android21 --release
-	${NITC} -o bin/scientific.apk src/scientific -m src/android_calculator.nit --release
+	${NITC} -o bin/scientific14.apk src/scientific -m src/android14.nit --release
 	${NITC} -o bin/scientific21.apk src/scientific -m src/android21 --release
 
 android/res/drawable-hdpi/icon.png: art/icon.svg ../../contrib/inkscape_tools/bin/svg_to_icons
@@ -54,8 +54,8 @@ src/scientific/android/res/drawable-hdpi/icon.png: art/icon-sci.svg ../../contri
 ../../contrib/inkscape_tools/bin/svg_to_icons:
 	make -C ../../contrib/inkscape_tools/
 
-android-install: bin/calculator.apk
-	adb install -r bin/calculator.apk
+android-install: bin/calculator14.apk
+	adb install -r bin/calculator14.apk
 
 # ---
 # iOS

--- a/examples/calculator/Makefile
+++ b/examples/calculator/Makefile
@@ -13,21 +13,35 @@ bin/scientific: $(shell ${NITLS} -M scientific linux) ${NITC}
 
 # ---
 # Android
+#
+# There are 4 versions, combining 2 variations:
+# * scientific vs non-scientific
+# * android API 21+ vs under 21
 
-android: bin/calculator.apk bin/scientific.apk
+android: bin/calculator.apk bin/scientific.apk bin/calculator21.apk bin/scientific21.apk
 
 bin/calculator.apk: $(shell ${NITLS} -M src/android_calculator.nit) ${NITC} android/res/drawable-hdpi/icon.png
 	mkdir -p bin
 	${NITC} -o $@ src/android_calculator.nit -D debug
 
+bin/calculator21.apk: $(shell ${NITLS} -M src/android21) ${NITC} android/res/drawable-hdpi/icon.png
+	mkdir -p bin
+	${NITC} -o $@ src/android21 -D debug
+
 bin/scientific.apk: $(shell ${NITLS} -M src/scientific src/android_calculator.nit) ${NITC} src/scientific/android/res/drawable-hdpi/icon.png
 	mkdir -p bin
 	${NITC} -o $@ src/scientific -m src/android_calculator.nit -D debug
 
+bin/scientific21.apk: $(shell ${NITLS} -M src/scientific src/android21) ${NITC} src/scientific/android/res/drawable-hdpi/icon.png
+	mkdir -p bin
+	${NITC} -o $@ src/scientific -m src/android21 -D debug
+
 android-release: $(shell ${NITLS} -M src/scientific src/android_calculator.nit) ${NITC} android/res/drawable-hdpi/icon.png
 	mkdir -p bin
 	${NITC} -o bin/calculator.apk src/android_calculator.nit --release
+	${NITC} -o bin/calculator21.apk src/android21 --release
 	${NITC} -o bin/scientific.apk src/scientific -m src/android_calculator.nit --release
+	${NITC} -o bin/scientific21.apk src/scientific -m src/android21 --release
 
 android/res/drawable-hdpi/icon.png: art/icon.svg ../../contrib/inkscape_tools/bin/svg_to_icons
 	mkdir -p android/res

--- a/examples/calculator/android/res/values/color.xml
+++ b/examples/calculator/android/res/values/color.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2014 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<resources>
+
+    <!-- Default background color for the status bar. -->
+    <color name="calculator_accent_color">#00BCD4</color>
+
+    <!-- Color to indicate an error has occured. -->
+    <color name="calculator_error_color">#F40056</color>
+
+    <!-- Background color of the calculator display. -->
+    <color name="display_background_color">#FFF</color>
+
+    <!-- Text color for the formula in the calculator display. -->
+    <color name="display_formula_text_color">#8A000000</color>
+
+    <!-- Text color for the result in the calculator display. -->
+    <color name="display_result_text_color">#6C000000</color>
+
+    <!-- Background color for the numeric pad. -->
+    <color name="pad_numeric_background_color">#434343</color>
+
+    <!-- Background color for the operator pad. -->
+    <color name="pad_operator_background_color">#636363</color>
+
+    <!-- Background color for the advanced pad. -->
+    <color name="pad_advanced_background_color">#1DE9B6</color>
+
+    <!-- Text color for a button in a pad. -->
+    <color name="pad_button_text_color">#FFF</color>
+
+    <!-- Text color for a button in the advanced pad. -->
+    <color name="pad_button_advanced_text_color">#91000000</color>
+
+    <!-- Ripple color when a button is pressed in a pad. -->
+    <color name="pad_button_ripple_color">#33FFFFFF</color>
+
+    <!-- Ripple color when a button is pressed in a pad. -->
+    <color name="pad_button_advanced_ripple_color">#1A000000</color>
+
+</resources>

--- a/examples/calculator/org.nitlanguage.scientific_calculator.txt
+++ b/examples/calculator/org.nitlanguage.scientific_calculator.txt
@@ -1,0 +1,10 @@
+Categories:Nit
+License:Apache2
+Web Site:http://nitlanguage.org
+Source Code:http://nitlanguage.org/nit.git/tree/HEAD:/examples/calculator
+Issue Tracker:https://github.com/nitlang/nit/issues
+
+Summary:A Scientific Calculator
+Description:
+10 digits, 16 operations, hours of fun.
+.

--- a/examples/calculator/package.ini
+++ b/examples/calculator/package.ini
@@ -9,4 +9,4 @@ git=https://github.com/nitlang/nit.git
 git.directory=examples/calculator/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
-apk=http://nitlanguage.org/fdroid/apk/calculator.apk
+apk=http://nitlanguage.org/fdroid/apk/calculator21.apk

--- a/examples/calculator/src/android14.nit
+++ b/examples/calculator/src/android14.nit
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Aesthetic adaptations for Android
-module android_calculator
+# Aesthetic adaptations for Android for API 14+
+module android14
 
 import calculator
 import android

--- a/examples/calculator/src/android21/android/res/values/styles.xml
+++ b/examples/calculator/src/android21/android/res/values/styles.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2014 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <style name="CalculatorTheme" parent="@android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:colorPrimary">@color/calculator_accent_color</item>
+        <item name="android:navigationBarColor">@color/calculator_accent_color</item>
+        <item name="android:statusBarColor">@color/calculator_accent_color</item>
+        <item name="android:windowContentOverlay">@null</item>
+    </style>
+
+    <style name="DisplayEditTextStyle" parent="@android:style/Widget.Material.Light.EditText">
+        <item name="android:background">@android:color/transparent</item>
+        <item name="android:cursorVisible">false</item>
+        <item name="android:fontFamily">sans-serif-light</item>
+        <item name="android:includeFontPadding">false</item>
+        <item name="android:gravity">bottom|end</item>
+    </style>
+
+    <style name="PadButtonStyle" parent="@android:style/Widget.Material.Light.Button.Borderless">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:fontFamily">sans-serif-light</item>
+        <item name="android:gravity">center</item>
+        <item name="android:includeFontPadding">false</item>
+        <item name="android:minWidth">0dip</item>
+        <item name="android:minHeight">0dip</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textColor">@color/pad_button_text_color</item>
+    </style>
+
+    <style name="PadLayoutStyle">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">match_parent</item>
+    </style>
+</resources>

--- a/examples/calculator/src/android21/android21.nit
+++ b/examples/calculator/src/android21/android21.nit
@@ -20,7 +20,7 @@ module android21 is
 	app_files
 end
 
-import android_calculator
+import android14
 
 redef class TextInput
 	init do

--- a/examples/calculator/src/android21/android21.nit
+++ b/examples/calculator/src/android21/android21.nit
@@ -1,0 +1,50 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Aesthetic adaptations for Android Lollypop (API 21)
+module android21 is
+	android_api_min 21
+	android_api_target 21
+	android_manifest_activity """android:theme="@style/CalculatorTheme" """
+	app_files
+end
+
+import android_calculator
+
+redef class TextInput
+	init do
+		set_android_style(native, app.native_activity)
+		super
+	end
+
+	# Deactivate the virtual keyboard and set the text style from XML resources
+	private fun set_android_style(java_edit_text: NativeEditText, activity: NativeActivity)
+	in "Java" `{
+		java_edit_text.setShowSoftInputOnFocus(false);
+		java_edit_text.setTextAppearance(activity, R.style.DisplayEditTextStyle);
+	`}
+end
+
+redef class Button
+	init do
+		set_text_style(native, app.native_activity)
+		super
+	end
+
+	# Set the text style from XML resources
+	private fun set_text_style(java_button: NativeButton, activity: NativeActivity)
+	in "Java" `{
+		java_button.setTextAppearance(activity, R.style.PadButtonStyle);
+	`}
+end

--- a/examples/calculator/src/android_calculator.nit
+++ b/examples/calculator/src/android_calculator.nit
@@ -19,18 +19,46 @@ import calculator
 import android
 
 redef class Button
-	init do set_android_style(native, (text or else "?").is_int)
+	init do set_android_style(native, app.native_activity,
+	                          (text or else "?").is_int,
+	                          ["+","-","×","C","÷","=","."].has(text))
 
-	private fun set_android_style(java_button: NativeButton, is_number: Bool)
+	# Set color and text style
+	private fun set_android_style(java_button: NativeButton, activity: NativeActivity,
+		is_number: Bool, is_basic_op: Bool)
 	in "Java" `{
-		// Flatten the background and use a different color for digit buttons
-		int color = is_number? android.graphics.Color.DKGRAY: android.graphics.Color.TRANSPARENT;
-		java_button.setBackgroundColor(color);
+		// Set color
+		int back_color_id = 0;
+		if (is_number)
+			back_color_id = R.color.pad_numeric_background_color;
+		else if (is_basic_op)
+			back_color_id = R.color.pad_operator_background_color;
+		else {
+			back_color_id = R.color.pad_advanced_background_color;
 
-		// Center the label on both horizontal and vertical axes
+			int text_color = activity.getResources().getColor(R.color.pad_button_advanced_text_color);
+			java_button.setTextColor(text_color);
+		}
+		java_button.setBackgroundResource(back_color_id);
+
+		// Center label, use lowercase and make text bigger
 		java_button.setGravity(android.view.Gravity.CENTER);
-
-		// Set lowercase text to correctly display constants like e and π
 		java_button.setAllCaps(false);
+		java_button.setTextSize(android.util.TypedValue.COMPLEX_UNIT_FRACTION, 100.0f);
+	`}
+end
+
+redef class TextInput
+	init do set_android_style(native, app.native_activity)
+
+	# Set text style and hide cursor
+	private fun set_android_style(java_edit_text: NativeEditText, activity: NativeActivity)
+	in "Java" `{
+		java_edit_text.setBackgroundResource(R.color.display_background_color);
+		java_edit_text.setTextColor(
+			activity.getResources().getColor(R.color.display_formula_text_color));
+		java_edit_text.setTextSize(android.util.TypedValue.COMPLEX_UNIT_FRACTION, 120.0f);
+		java_edit_text.setCursorVisible(false);
+		java_edit_text.setGravity(android.view.Gravity.CENTER_VERTICAL | android.view.Gravity.END);
 	`}
 end


### PR DESCRIPTION
Improve the look of the Android variant for the calculator using style resources from the AOSP calculator. Also intro another variant for Android API 21+ which changes the font and deactivates the virtual keyboard.

This should also fix the calculator missing from our f-droid repository. However, I don't know yet how f-droid handles more than one APK per package...

For an idea of the result, you can take a look at the 6 different resulting calculators alongside the latest AOSP calculator: http://xymus.net/pub/calcs.pdf