### PR TITLE
Make HttpRequest and Response serializable

### DIFF
--- a/lib/nitcorn/http_request.nit
+++ b/lib/nitcorn/http_request.nit
@@ -35,9 +35,6 @@ class HttpRequest
 	# Method of this request (GET or POST)
 	var method: String
 
-	# The host targetter by this request (usually the server)
-	var host: String
-
 	# The full URL requested by the client (including the `query_string`)
 	var url: String
 

--- a/lib/nitcorn/http_request.nit
+++ b/lib/nitcorn/http_request.nit
@@ -21,9 +21,12 @@
 module http_request
 
 import core
+import serialization
 
 # A request received over HTTP, is build by `HttpRequestParser`
 class HttpRequest
+	serialize
+
 	private init is old_style_init do end
 
 	# HTTP protocol version

--- a/lib/nitcorn/http_response.nit
+++ b/lib/nitcorn/http_response.nit
@@ -19,8 +19,11 @@
 # Provides the `HttpResponse` class and `http_status_codes`
 module http_response
 
+import serialization
+
 # A response to send over HTTP
 class HttpResponse
+	serialize
 
 	# HTTP protocol version
 	var http_version = "HTTP/1.0" is writable


### PR DESCRIPTION
This PR makes HTTP requests and responses serializable.

I had a hard time with deserialization because of the `host` attribute that is never initialized, I removed it. Let's see what is crashing.