### PR TITLE
Native Windows bootstrap

### DIFF
--- a/lib/core/environ.nit
+++ b/lib/core/environ.nit
@@ -58,7 +58,13 @@ end
 
 redef class NativeString
 	private fun get_environ: NativeString `{ return getenv(self); `}
-	private fun setenv(value: NativeString) `{ setenv(self, value, 1); `}
+	private fun setenv(value: NativeString) `{
+#ifdef _WIN32
+		_putenv_s(self, value);
+#else
+		setenv(self, value, 1);
+#endif
+	`}
 end
 
 redef class Sys

--- a/lib/core/exec.nit
+++ b/lib/core/exec.nit
@@ -337,10 +337,12 @@ redef class NativeString
 	# See the posix function system(3).
 	fun system: Int `{
 		int status = system(self);
+#ifndef _WIN32
 		if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT) {
 			// system exited on SIGINT: in my opinion the user wants the main to be discontinued
 			kill(getpid(), SIGINT);
 		}
+#endif
 		return status;
 	`}
 end

--- a/lib/core/file.nit
+++ b/lib/core/file.nit
@@ -1372,7 +1372,13 @@ redef class NativeString
 		return stat_element;
 	`}
 
-	private fun file_mkdir(mode: Int): Bool `{ return !mkdir(self, mode); `}
+	private fun file_mkdir(mode: Int): Bool `{
+#ifdef _WIN32
+		return !mkdir(self);
+#else
+		return !mkdir(self, mode);
+#endif
+	`}
 
 	private fun rmdir: Bool `{ return !rmdir(self); `}
 

--- a/lib/core/kernel.nit
+++ b/lib/core/kernel.nit
@@ -1073,3 +1073,12 @@ interface Task
 	# Main method of this task
 	fun main do end
 end
+
+# Is this program currently running in a Windows OS?
+fun is_windows: Bool `{
+#ifdef _WIN32
+	return 1;
+#else
+	return 0;
+#endif
+`}

--- a/lib/core/text/native.nit
+++ b/lib/core/text/native.nit
@@ -22,6 +22,9 @@ in "C" `{
 	#include <libkern/OSByteOrder.h>
 	#define be32toh(x) OSSwapBigToHostInt32(x)
 #endif
+#ifdef _WIN32
+	#define be32toh(val) _byteswap_ulong(val)
+#endif
 
 #ifdef __pnacl__
 	#define be16toh(val) (((val) >> 8) | ((val) << 8))

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -510,7 +510,7 @@ endif
 		self.toolcontext.info(command, 2)
 
 		var res
-		if self.toolcontext.verbose_level >= 3 then
+		if self.toolcontext.verbose_level >= 3 or is_windows then
 			res = sys.system("{command} 2>&1")
 		else
 			res = sys.system("{command} 2>&1 >/dev/null")

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -665,6 +665,9 @@ abstract class AbstractCompiler
 		self.header.add_decl("	#include <libkern/OSByteOrder.h>")
 		self.header.add_decl("	#define be32toh(x) OSSwapBigToHostInt32(x)")
 		self.header.add_decl("#endif")
+		self.header.add_decl("#ifdef _WIN32")
+		self.header.add_decl("	#define be32toh(val) _byteswap_ulong(val)")
+		self.header.add_decl("#endif")
 		self.header.add_decl("#ifdef __pnacl__")
 		self.header.add_decl("	#define be16toh(val) (((val) >> 8) | ((val) << 8))")
 		self.header.add_decl("	#define be32toh(val) ((be16toh((val) << 16) | (be16toh((val) >> 16))))")
@@ -878,11 +881,17 @@ extern void nitni_global_ref_decr( struct nitni_ref *ref );
 		v.add_decl("\}")
 
 		v.add_decl("void sig_handler(int signo)\{")
+		v.add_decl "#ifdef _WIN32"
+		v.add_decl "PRINT_ERROR(\"Caught signal : %s\\n\", signo);"
+		v.add_decl "#else"
 		v.add_decl("PRINT_ERROR(\"Caught signal : %s\\n\", strsignal(signo));")
+		v.add_decl "#endif"
 		v.add_decl("show_backtrace();")
 		# rethrows
 		v.add_decl("signal(signo, SIG_DFL);")
+		v.add_decl "#ifndef _WIN32"
 		v.add_decl("kill(getpid(), signo);")
+		v.add_decl "#endif"
 		v.add_decl("\}")
 
 		v.add_decl("void fatal_exit(int status) \{")
@@ -908,7 +917,9 @@ extern void nitni_global_ref_decr( struct nitni_ref *ref );
 		v.add("signal(SIGTERM, sig_handler);")
 		v.add("signal(SIGSEGV, sig_handler);")
 		v.add "#endif"
+		v.add "#ifndef _WIN32"
 		v.add("signal(SIGPIPE, SIG_IGN);")
+		v.add "#endif"
 
 		v.add("glob_argc = argc; glob_argv = argv;")
 		v.add("catchStack.cursor = -1;")

--- a/tests/sav/nituml_args3.res
+++ b/tests/sav/nituml_args3.res
@@ -16,7 +16,7 @@ Object [
 ]
 
 Sys [
- label = "{Sys||+ main()\l+ run()\l+ errno(): Int\l+ exit(exit_value: Int)\l}"
+ label = "{Sys||+ main()\l+ run()\l+ errno(): Int\l+ exit(exit_value: Int)\l+ is_windows(): Bool\l}"
 ]
 Object -> Sys [dir=back arrowtail=open style=dashed];
 

--- a/tests/sav/nituml_args4.res
+++ b/tests/sav/nituml_args4.res
@@ -16,7 +16,7 @@ Object [
 ]
 
 Sys [
- label = "{Sys||+ main()\l+ run()\l+ errno(): Int\l+ exit(exit_value: Int)\l}"
+ label = "{Sys||+ main()\l+ run()\l+ errno(): Int\l+ exit(exit_value: Int)\l+ is_windows(): Bool\l}"
 ]
 Object -> Sys [dir=back arrowtail=open style=dashed];
 


### PR DESCRIPTION
This PR tweaks and hacks the core lib and the compiler to get a working bootstrap on Windows. After a regen of c_src, one could clone the repo and build c_src/nitc.exe using GCC on Windows with mingw or similar. There's a procedure using msys2 at <https://github.com/nitlang/nitlanguage/blob/master/pages/windows.mdwn>.

To achieve basic Windows compatibility, I applied the following algorithm:
1. For a missing C function, if there is an equivalent in `<windows.h>`, use an alternative static C implementation.
2. If it's a difference in a Nit only method, (like the path separator) add an alternative implementation selected at runtime.
3. If the difference spawns across more than one Nit method/class. Deactivate the code for Windows, replace by a no-op, and wait for a later fix hiding platform implementations behind an abstract API. Alternatively, we could use many `#ifdef` and keep the differences on the C side.

There are still a lot of issues:
* `c_src/nitc` can compile `hello_world` and `src/nitc.nit`. `hello_world` behaves as expected, but `src/nitc.nit` does not, there's some problems at parsing. (Maybe with the line endings.)
* The compiler hangs randomly. This may be related to different blocking behavior when reading files, or a local setup issue.
* I did not find a compatible GNU libregex, a solution is to use libboost regex. This could be declared in `lib/core/re.nit`, however would need to tweak some annotations and ensure that they work in nith. (`ldflags("-lmboost_regex-mt")@windows`)
* `poll` and `Process` related features must be replaced/implemented for Windows.
* There's a few warnings from the C compiler to check/silence.