### PR TITLE
Nitweb clean

### DIFF
--- a/share/nitweb/directives/entity/card.html
+++ b/share/nitweb/directives/entity/card.html
@@ -1,11 +1,42 @@
 <div class='card'>
-	<div class='card-left text-center'>
-		<entity-tag mentity='mentity' />
-	</div>
 	<div class='card-body'>
-		<h5 class='card-heading'>
-			<entity-signature mentity='mentity'/>
-		</h5>
-		<span class='synopsis' ng-bind-html='mentity.mdoc.html_synopsis' />
+		<div class='pull-right'>
+			<div class='dropdown'>
+				<button class='btn btn-link dropdown-toggle' type='button' data-toggle='dropdown'>
+					<span class='glyphicon glyphicon-chevron-down'></span>
+				</button>
+				<ul class='dropdown-menu dropdown-menu-right'>
+					<li ng-class='currentTab == "signature" ? "active" : ""'>
+						<a ng-click='currentTab = "signature"'>Signature</a>
+					</li>
+					<li ng-class='currentTab == "doc" ? "active" : ""'>
+						<a ng-click='currentTab = "doc"'>Doc</a>
+					</li>
+					<li ng-class='currentTab == "grade" ? "active" : ""'>
+						<a ng-click='currentTab = "grade"'>Grade</a>
+					</li>
+				</ul>
+			</div>
+		</div>
+		<div class='tab-content'>
+			<div id='{{mentity.html_id}}-signature' class='tab-pane'
+			  ng-class='currentTab == "signature" ? "active" : ""'>
+				<div class='pull-left text-center'>
+					<entity-tag mentity='mentity' />
+				</div>
+				<h5 class='card-heading'>
+					<entity-signature mentity='mentity'/>
+				</h5>
+				<span class='synopsis' ng-bind-html='mentity.mdoc.html_synopsis' />
+			</div>
+			<div id='{{mentity.html_id}}-doc' class='tab-pane'
+			  ng-class='currentTab == "doc" ? "active" : ""'>
+				<entity-doc mentity='mentity' />
+			</div>
+			<div id='{{mentity.html_id}}-grade' class='tab-pane'
+			  ng-class='currentTab == "grade" ? "active" : ""'>
+				<entity-rating mentity='mentity'>
+			</div>
+		</div>
 	</div>
 </div>

--- a/share/nitweb/directives/entity/card.html
+++ b/share/nitweb/directives/entity/card.html
@@ -13,7 +13,7 @@
 						<a ng-click='currentTab = "doc"'>Doc</a>
 					</li>
 					<li ng-class='currentTab == "grade" ? "active" : ""'>
-						<a ng-click='currentTab = "grade"'>Grade</a>
+						<a ng-click='loadEntityStars(); currentTab = "grade"'>Grade</a>
 					</li>
 				</ul>
 			</div>
@@ -35,7 +35,7 @@
 			</div>
 			<div id='{{mentity.html_id}}-grade' class='tab-pane'
 			  ng-class='currentTab == "grade" ? "active" : ""'>
-				<entity-rating mentity='mentity'>
+				<entity-rating mentity='mentity' ratings='ratings'>
 			</div>
 		</div>
 	</div>

--- a/share/nitweb/directives/entity/doc.html
+++ b/share/nitweb/directives/entity/doc.html
@@ -1,29 +1,6 @@
-<div class='card' ng-if='mentity.mdoc'>
-	<div class='card-body'>
-		<div class='pull-right'>
-			<div class='dropdown'>
-				<button class='btn btn-link dropdown-toggle' type='button' data-toggle='dropdown'>
-					<span class='glyphicon glyphicon-chevron-down'></span>
-				</button>
-				<ul class='dropdown-menu dropdown-menu-right'>
-					<li ng-class='currentTab == "doc" ? "active" : ""'>
-						<a ng-click='currentTab = "doc"'>Doc</a>
-					</li>
-					<li ng-class='currentTab == "grade" ? "active" : ""'>
-						<a ng-click='currentTab = "grade"'>Grade</a>
-					</li>
-				</ul>
-			</div>
-		</div>
-		<div class='tab-content'>
-			<div id='{{mentity.html_id}}-doc' class='tab-pane'
-			  ng-class='currentTab == "doc" ? "active" : ""'>
-				<div ng-bind-html='mentity.mdoc.html_documentation'></div>
-			</div>
-			<div id='{{mentity.html_id}}-grade' class='tab-pane'
-			  ng-class='currentTab == "grade" ? "active" : ""'>
-				<entity-rating mentity='mentity'>
-			</div>
-		</div>
-	</div>
+<div ng-if='mentity.mdoc'>
+	<div ng-bind-html='mentity.mdoc.html_documentation'></div>
+</div>
+<div ng-if='!mentity.mdoc'>
+	<i class='text-muted'>No documentation for this entity.</i>
 </div>

--- a/share/nitweb/directives/entity/doc.html
+++ b/share/nitweb/directives/entity/doc.html
@@ -1,8 +1,29 @@
 <div class='card' ng-if='mentity.mdoc'>
 	<div class='card-body'>
 		<div class='pull-right'>
-			<entity-rating mentity='mentity' />
+			<div class='dropdown'>
+				<button class='btn btn-link dropdown-toggle' type='button' data-toggle='dropdown'>
+					<span class='glyphicon glyphicon-chevron-down'></span>
+				</button>
+				<ul class='dropdown-menu dropdown-menu-right'>
+					<li ng-class='currentTab == "doc" ? "active" : ""'>
+						<a ng-click='currentTab = "doc"'>Doc</a>
+					</li>
+					<li ng-class='currentTab == "grade" ? "active" : ""'>
+						<a ng-click='currentTab = "grade"'>Grade</a>
+					</li>
+				</ul>
+			</div>
 		</div>
-		<div ng-bind-html='mentity.mdoc.html_documentation'></div>
+		<div class='tab-content'>
+			<div id='{{mentity.html_id}}-doc' class='tab-pane'
+			  ng-class='currentTab == "doc" ? "active" : ""'>
+				<div ng-bind-html='mentity.mdoc.html_documentation'></div>
+			</div>
+			<div id='{{mentity.html_id}}-grade' class='tab-pane'
+			  ng-class='currentTab == "grade" ? "active" : ""'>
+				<entity-rating mentity='mentity'>
+			</div>
+		</div>
 	</div>
 </div>

--- a/share/nitweb/directives/entity/graph.html
+++ b/share/nitweb/directives/entity/graph.html
@@ -1,0 +1,1 @@
+<div class='graph' ng-bind-html='graph'></div>

--- a/share/nitweb/index.html
+++ b/share/nitweb/index.html
@@ -28,12 +28,19 @@
 		<nav class='navbar navbar-default navbar-fixed-top'>
 			<div class='container-fluid'>
 				<div class='col-xs-3'>
-					<div class='navbar-header'>
+					<ul class='nav navbar-nav'>
+						<li class='dropdown'>
+							<a class='btn btn-link dropdown-toggle' type='button' data-toggle='dropdown'>
+								<span class='glyphicon glyphicon-menu-hamburger' />
+							</a>
+							<ul class='dropdown-menu'>
+								<li><a href='/docdown'>DocDown</a></li>
+							</ul>
+						</li>
+					</ul>
+					<div class='navbar-header dropdown'>
 						<a class='navbar-brand' ng-href='/'>Nitdoc</a>
 					</div>
-					<ul class="nav navbar-nav">
-						<li><a href="/docdown?edit=true">DocDown</a></li>
-					</ul>
 				</div>
 				<div class='col-xs-7'>
 					<form ng-controller='SearchCtrl as searchCtrl' >

--- a/share/nitweb/javascripts/entities.js
+++ b/share/nitweb/javascripts/entities.js
@@ -90,10 +90,7 @@
 				scope: {
 					mentity: '='
 				},
-				templateUrl: '/directives/entity/doc.html',
-				link: function ($scope, element, attrs) {
-					$scope.currentTab = 'doc';
-				}
+				templateUrl: '/directives/entity/doc.html'
 			};
 		})
 
@@ -154,10 +151,14 @@
 			return {
 				restrict: 'E',
 				scope: {
-					mentity: '='
+					mentity: '=',
+					defaultTab: '@'
 				},
 				replace: true,
-				templateUrl: '/directives/entity/card.html'
+				templateUrl: '/directives/entity/card.html',
+				link: function ($scope, element, attrs) {
+					$scope.currentTab = $scope.defaultTab ? $scope.defaultTab : 'signature';
+				}
 			};
 		})
 

--- a/share/nitweb/javascripts/entities.js
+++ b/share/nitweb/javascripts/entities.js
@@ -138,6 +138,18 @@
 			};
 		})
 
+		.directive('entityGraph', function() {
+			return {
+				restrict: 'E',
+				scope: {
+					mentity: '=',
+					graph: '='
+				},
+				replace: true,
+				templateUrl: '/directives/entity/graph.html'
+			};
+		})
+
 		.directive('entityCard', function() {
 			return {
 				restrict: 'E',

--- a/share/nitweb/javascripts/entities.js
+++ b/share/nitweb/javascripts/entities.js
@@ -90,7 +90,10 @@
 				scope: {
 					mentity: '='
 				},
-				templateUrl: '/directives/entity/doc.html'
+				templateUrl: '/directives/entity/doc.html',
+				link: function ($scope, element, attrs) {
+					$scope.currentTab = 'doc';
+				}
 			};
 		})
 

--- a/share/nitweb/stylesheets/nitweb.css
+++ b/share/nitweb/stylesheets/nitweb.css
@@ -45,11 +45,13 @@ a {
 	padding: 15px;
 }
 
-.card-left, .card>.pull-left {
+.card-left, .card .pull-left {
 	float: left;
+	padding: 0 15px 15px 0;
 }
-.card-right, .card>.pull-right {
+.card-right, .card .pull-right {
 	float: right;
+	padding: 0 0 15px 15px;
 }
 
 .card-list {

--- a/share/nitweb/stylesheets/nitweb.css
+++ b/share/nitweb/stylesheets/nitweb.css
@@ -29,8 +29,6 @@ a {
 	border: 1px solid #1E9431;
 }
 
-.card, .card-body { overflow: hidden; }
-
 .card-heading {
     margin-top: 0;
     margin-bottom: 5px;
@@ -43,23 +41,15 @@ a {
 	box-shadow: 0 -1px 0 #e5e5e5,0 0 2px rgba(0,0,0,.12),0 2px 4px rgba(0,0,0,.24);
 }
 
-.card-body {
-    padding: 15px;
-    width: 10000px;
-}
-
-.card-body, .card-right, .card-left {
-    display: table-cell;
-    vertical-align: top;
+.card-body, .card-left, .card-right {
+	padding: 15px;
 }
 
 .card-left, .card>.pull-left {
-    padding: 15px;
-	padding-right: 0px;
+	float: left;
 }
 .card-right, .card>.pull-right {
-    padding: 15px;
-	padding-left: 0px;
+	float: right;
 }
 
 .card-list {
@@ -160,7 +150,8 @@ entity-list:hover .btn-filter {
 
 .search-results {
 	position: absolute;
-	right: 0;
+	right: 15px;
+	left: 15px;
 }
 
 .search-results .card.active {

--- a/share/nitweb/views/class.html
+++ b/share/nitweb/views/class.html
@@ -59,7 +59,7 @@
 	<div role='tabpanel' class='tab-pane fade' id='graph'>
 		<div class='card'>
 			<div class='card-body text-center'>
-				<div class='graph' ng-bind-html='graph'></div>
+				<entity-graph mentity='mentity' graph='graph' />
 			</div>
 		</div>
 	</div>

--- a/share/nitweb/views/class.html
+++ b/share/nitweb/views/class.html
@@ -28,7 +28,7 @@
 
 <div class='tab-content'>
 	<div role='tabpanel' class='tab-pane fade in active' id='doc'>
-		<entity-doc mentity='mentity'/>
+		<entity-card mentity='mentity' default-tab='doc'/>
 
 		<entity-list list-title='Parents'
 			list-entities='mentity.parents'

--- a/share/nitweb/views/group.html
+++ b/share/nitweb/views/group.html
@@ -32,7 +32,7 @@
 	<div role='tabpanel' class='tab-pane fade' id='graph'>
 		<div class='card'>
 			<div class='card-body text-center'>
-				<div class='graph' ng-bind-html='graph'></div>
+				<entity-graph mentity='mentity' graph='graph' />
 			</div>
 		</div>
 	</div>

--- a/share/nitweb/views/group.html
+++ b/share/nitweb/views/group.html
@@ -18,7 +18,7 @@
 
 <div class='tab-content'>
 	<div role='tabpanel' class='tab-pane fade in active' id='doc'>
-		<entity-doc mentity='mentity'/>
+		<entity-card mentity='mentity' default-tab='doc'/>
 
 		<entity-list list-title='Parent group' list-entities='[mentity.parent]'
 			list-object-filter='{}' ng-if='mentity.parent' />

--- a/share/nitweb/views/module.html
+++ b/share/nitweb/views/module.html
@@ -55,7 +55,7 @@
 	<div class='tab-pane fade' id='graph'>
 		<div class='card'>
 			<div class='card-body text-center'>
-				<div class='graph' ng-bind-html='graph'></div>
+				<entity-graph mentity='mentity' graph='graph' />
 			</div>
 		</div>
 	</div>

--- a/share/nitweb/views/module.html
+++ b/share/nitweb/views/module.html
@@ -28,7 +28,7 @@
 
 <div class='tab-content'>
 	<div role='tabpanel' class='tab-pane fade in active' id='doc'>
-		<entity-doc mentity='mentity'/>
+		<entity-card mentity='mentity' default-tab='doc'/>
 
 		<entity-list list-title='Imported modules' list-entities='mentity.imports'
 			list-object-filter='{}' />

--- a/share/nitweb/views/package.html
+++ b/share/nitweb/views/package.html
@@ -18,7 +18,7 @@
 
 <div class='tab-content'>
 	<div role='tabpanel' class='tab-pane fade in active' id='doc'>
-		<entity-doc mentity='mentity'/>
+		<entity-card mentity='mentity' default-tab='doc'/>
 
 		<entity-list list-title='Groups' list-entities='mentity.mgroups'
 			list-object-filter='{}' />

--- a/share/nitweb/views/package.html
+++ b/share/nitweb/views/package.html
@@ -26,7 +26,7 @@
 	<div role='tabpanel' class='tab-pane fade' id='graph'>
 		<div class='card'>
 			<div class='card-body text-center'>
-				<div class='graph' ng-bind-html='graph'></div>
+				<entity-graph mentity='mentity' graph='graph' />
 			</div>
 		</div>
 	</div>

--- a/share/nitweb/views/property.html
+++ b/share/nitweb/views/property.html
@@ -13,7 +13,7 @@
 
 <div class='tab-content'>
 	<div role='tabpanel' class='tab-pane fade in active' id='doc'>
-		<entity-doc mentity='mentity'/>
+		<entity-card mentity='mentity' default-tab='doc'/>
 	</div>
 	<div role='tabpanel' class='tab-pane fade' id='linearization'>
 		<entity-linearization

--- a/src/web/api_feedback.nit
+++ b/src/web/api_feedback.nit
@@ -16,29 +16,8 @@
 module api_feedback
 
 import web_base
-import mongodb
 
 redef class NitwebConfig
-
-	# MongoDB uri used for data persistence.
-	#
-	# * key: `mongo.uri`
-	# * default: `mongodb://localhost:27017/`
-	var mongo_uri: String is lazy do
-		return value_or_default("mongo.uri", "mongodb://localhost:27017/")
-	end
-
-	# MongoDB DB used for data persistence.
-	#
-	# * key: `mongo.db`
-	# * default: `nitweb`
-	var mongo_db: String is lazy do return value_or_default("mongo.db", "nitweb")
-
-	# Mongo instance
-	var mongo: MongoClient is lazy do return new MongoClient(mongo_uri)
-
-	# Database instance
-	var db: MongoDb is lazy do return mongo.database(mongo_db)
 
 	# MongoDB collection used to store stars.
 	var stars: MongoCollection is lazy do return db.collection("stars")

--- a/src/web/web_base.nit
+++ b/src/web/web_base.nit
@@ -20,10 +20,13 @@ import model::model_json
 import doc_down
 import popcorn
 import popcorn::pop_config
+import popcorn::pop_repos
 
 # Nitweb config file.
 class NitwebConfig
 	super AppConfig
+
+	redef var default_db_name = "nitweb"
 
 	# Model to use.
 	var model: Model


### PR DESCRIPTION
Cleans some misc part of Nitweb. Notable fact, replace the hover on cards by a dropdown menu with caret.

Can be seen here: http://nitweb.moz-code.org/doc/core::array

For now, the dropdown menu allows the user to swtich between signature and documentation. More contextual options in the future.

This looks quirk with the stars rating (left untouched in the new dropdown system) so still need the mouse over. Since the next PR rewrite this part, I will let this as it is.
We load the stars only when the dropdown is selected so we gain some perfs on the home page.

This PR is based on #2265 