### PR TITLE
Nitcorn PUT

### DIFF
--- a/lib/nitcorn/http_request.nit
+++ b/lib/nitcorn/http_request.nit
@@ -146,7 +146,7 @@ class HttpRequestParser
 		end
 
 		# POST args
-		if http_request.method == "POST" then
+		if http_request.method == "POST" or http_request.method == "PUT" then
 			http_request.body = body
 			var lines = body.split_with('&')
 			for line in lines do if not line.trim.is_empty then

--- a/lib/nitcorn/http_request.nit
+++ b/lib/nitcorn/http_request.nit
@@ -155,8 +155,6 @@ class HttpRequestParser
 					var decoded = parts[1].replace('+', " ").from_percent_encoding
 					http_request.post_args[parts[0]] = decoded
 					http_request.all_args[parts[0]] = decoded
-				else
-					print "POST Error: {line} format error on {line}"
 				end
 			end
 		end


### PR DESCRIPTION
This PR does two things:

* The first, maybe controversial, but I removed the warning printed by nitcorn on bad post format. The reason is, I am posting a lot of raw json object to my APIs (like github and other APIs work) and I'm getting this warning a lot.

The right thing to do should be to check the format depending on the request type. But the code seem old, I'm not sure I want to rewrite it.

* Second thing: parsing body when receiving PUT requests.

Review: @xymus 