### PR TITLE
nitunit: import frontend

### DIFF
--- a/src/nitunit.nit
+++ b/src/nitunit.nit
@@ -16,9 +16,11 @@
 # see `testing/README`
 module nitunit
 
+import frontend
 import testing
 
 var toolcontext = new ToolContext
+toolcontext.keep_going = true
 
 toolcontext.option_context.add_option(toolcontext.opt_full, toolcontext.opt_output, toolcontext.opt_dir, toolcontext.opt_noact, toolcontext.opt_pattern, toolcontext.opt_autosav, toolcontext.opt_gen_unit, toolcontext.opt_gen_force, toolcontext.opt_gen_private, toolcontext.opt_gen_show, toolcontext.opt_nitc)
 toolcontext.tooldescription = "Usage: nitunit [OPTION]... <file.nit>...\nExecutes the unit tests from Nit source files."

--- a/tests/sav/nitunit_args9.res
+++ b/tests/sav/nitunit_args9.res
@@ -1,3 +1,4 @@
+test_nitunit4/test_bad_comp.nit:27,10--19: Error: method or variable `bad_method` unknown in `TestSuiteBadComp`.
 test_nitunit4/test_bad_comp2.nit:19,7--22: Error: a class named `test_nitunit4::TestSuiteBadComp` is already defined in module `test_bad_comp` at test_nitunit4/test_bad_comp.nit:19,1--29,3.
 ==== Test-suite of module test_nitunit4::test_bad_comp | tests: 2
 [KO] test_nitunit4$TestSuiteBadComp$test_good


### PR DESCRIPTION
So the tests can use annotations and other things introduced in compiler phases.

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>