### PR TITLE
opportunity: official docker image

### DIFF
--- a/contrib/opportunity/docker/Dockerfile
+++ b/contrib/opportunity/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM nitlang/nit
+RUN apt-get update && apt-get install gettext libevent-dev libsqlite3-dev -y
+WORKDIR /nit/contrib/opportunity
+RUN sed -i 's/localhost/0.0.0.0/' src/opportunity_web.nit \
+	&& make \
+	# Move the database to the directory db. Add a symlink since its name is hard-coded in the application :(
+	&& mkdir -p db/ \
+	&& touch db/opportunity \
+	&& ln -s db/opportunity .
+EXPOSE 8080
+VOLUME /nit/contrib/opportunity/db/
+CMD bin/opportunity_web 0.0.0.0:8080

--- a/contrib/opportunity/src/opportunity_web.nit
+++ b/contrib/opportunity/src/opportunity_web.nit
@@ -21,6 +21,10 @@ import privileges
 
 var iface = "localhost:8080"
 
+if args.not_empty then
+	iface = args.first
+end
+
 var vh = new VirtualHost(iface)
 vh.routes.add new Route("/rest/", new OpportunityRESTAction)
 vh.routes.add new Route("/static/", new FileServer("art"))


### PR DESCRIPTION
Now that nitcorn can listen on any interface, why not having lightweight standalone web applications?

How to build?
1. install docker
2. cd nit/contrib/opportunity/docker
3. docker build --tag opportunity .

How to run?
1. docker run -d -p 8080:8080 --name  opportunity opportunity
2. xdg-open http://localhost:8080
3. docker stop opportunity

or just get it from the [hub](https://hub.docker.com/r/nitlang/opportunity/tags/)
1. docker run -d -p 8080:8080 --name opportunity nitlang/opportunity
