### PR TITLE
lib/github: make `PullRef::repo` nullable.

### DIFF
--- a/lib/github/api.nit
+++ b/lib/github/api.nit
@@ -768,8 +768,10 @@ class PullRef
 	# User pointed by `self`.
 	var user: User is writable
 
-	# Repo pointed by `self`.
-	var repo: Repo is writable
+	# Repo pointed by `self` (if any).
+	#
+	# A `null` value means the `repo` was deleted.
+	var repo: nullable Repo is writable
 end
 
 # A Github label.


### PR DESCRIPTION
Since repos can be deleted, the reference can be null.

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>