### PR TITLE
Nitweb errors

### DIFF
--- a/share/nitweb/javascripts/nitweb.js
+++ b/share/nitweb/javascripts/nitweb.js
@@ -54,7 +54,7 @@
 				controllerAs: 'entityCtrl'
 			})
 			.otherwise({
-				redirectTo: '/'
+				templateUrl: 'views/error.html'
 			});
 		$locationProvider.html5Mode(true);
 	});

--- a/share/nitweb/views/error.html
+++ b/share/nitweb/views/error.html
@@ -1,0 +1,6 @@
+<div class='container-fluid'>
+	<div class='page-header'>
+		<h2>404 Not found</h2>
+		<p>The page you requested does not exist.</p>
+	</div>
+</div>

--- a/src/nitweb.nit
+++ b/src/nitweb.nit
@@ -85,7 +85,7 @@ private class NitwebPhase
 
 		app.use_before("/*", new SessionInit)
 		app.use_before("/*", new RequestClock)
-		app.use("/api", new NitwebAPIRouter(config))
+		app.use("/api", new APIRouter(config))
 		app.use("/login", new GithubLogin(config.github_client_id))
 		app.use("/oauth", new GithubOAuthCallBack(config.github_client_id, config.github_client_secret))
 		app.use("/logout", new GithubLogout)
@@ -93,29 +93,6 @@ private class NitwebPhase
 		app.use_after("/*", new ConsoleLog)
 
 		app.listen(config.app_host, config.app_port)
-	end
-end
-
-# Group all api handlers in one router.
-class NitwebAPIRouter
-	super APIRouter
-
-	init do
-		use("/catalog", new APICatalogRouter(config))
-		use("/list", new APIList(config))
-		use("/search", new APISearch(config))
-		use("/random", new APIRandom(config))
-		use("/entity/:id", new APIEntity(config))
-		use("/code/:id", new APIEntityCode(config))
-		use("/uml/:id", new APIEntityUML(config))
-		use("/linearization/:id", new APIEntityLinearization(config))
-		use("/defs/:id", new APIEntityDefs(config))
-		use("/feedback/", new APIFeedbackRouter(config))
-		use("/inheritance/:id", new APIEntityInheritance(config))
-		use("/graph/", new APIGraphRouter(config))
-		use("/docdown/", new APIDocdown(config))
-		use("/metrics/", new APIMetricsRouter(config))
-		use("/user", new GithubUser)
 	end
 end
 

--- a/src/web/api_catalog.nit
+++ b/src/web/api_catalog.nit
@@ -40,16 +40,14 @@ redef class NitwebConfig
 	end
 end
 
-# Group all api handlers in one router.
-class APICatalogRouter
-	super APIRouter
-
-	init do
-		use("/highlighted", new APICatalogHighLighted(config))
-		use("/required", new APICatalogMostRequired(config))
-		use("/bytags", new APICatalogByTags(config))
-		use("/contributors", new APICatalogContributors(config))
-		use("/stats", new APICatalogStats(config))
+redef class APIRouter
+	redef init do
+		super
+		use("/catalog/highlighted", new APICatalogHighLighted(config))
+		use("/catalog/required", new APICatalogMostRequired(config))
+		use("/catalog/bytags", new APICatalogByTags(config))
+		use("/catalog/contributors", new APICatalogContributors(config))
+		use("/catalog/stats", new APICatalogStats(config))
 	end
 end
 

--- a/src/web/api_docdown.nit
+++ b/src/web/api_docdown.nit
@@ -20,6 +20,13 @@ intrude import doc_down
 intrude import markdown::wikilinks
 import doc_commands
 
+redef class APIRouter
+	redef init do
+		super
+		use("/docdown/", new APIDocdown(config))
+	end
+end
+
 # Docdown handler accept docdown as POST data and render it as HTML
 class APIDocdown
 	super APIHandler

--- a/src/web/api_feedback.nit
+++ b/src/web/api_feedback.nit
@@ -23,12 +23,10 @@ redef class NitwebConfig
 	var stars: MongoCollection is lazy do return db.collection("stars")
 end
 
-# Group all api handlers in one router
-class APIFeedbackRouter
-	super APIRouter
-
-	init do
-		use("/stars/:id", new APIStars(config))
+redef class APIRouter
+	redef init do
+		super
+		use("/feedback/stars/:id", new APIStars(config))
 	end
 end
 

--- a/src/web/api_feedback.nit
+++ b/src/web/api_feedback.nit
@@ -36,28 +36,21 @@ class APIStars
 
 	redef fun get(req, res) do
 		var mentity = mentity_from_uri(req, res)
-		if mentity == null then
-			res.error 404
-			return
-		end
-
+		if mentity == null then return
 		res.json mentity_ratings(mentity)
 	end
 
 	redef fun post(req, res) do
 		var mentity = mentity_from_uri(req, res)
-		if mentity == null then
-			res.error 404
-			return
-		end
+		if mentity == null then return
 		var obj = req.body.parse_json
 		if not obj isa JsonObject then
-			res.error 400
+			res.api_error(400, "Expected a JSON object")
 			return
 		end
 		var rating = obj["rating"]
 		if not rating isa Int then
-			res.error 400
+			res.api_error(400, "Expected a key `rating`")
 			return
 		end
 

--- a/src/web/api_graph.nit
+++ b/src/web/api_graph.nit
@@ -31,13 +31,10 @@ class APIInheritanceGraph
 	super APIHandler
 
 	redef fun get(req, res) do
+		var mentity = mentity_from_uri(req, res)
+		if mentity == null then return
 		var pdepth = req.int_arg("pdepth")
 		var cdepth = req.int_arg("cdepth")
-		var mentity = mentity_from_uri(req, res)
-		if mentity == null then
-			res.error 404
-			return
-		end
 		var g = new InheritanceGraph(mentity, view)
 		res.send g.draw(pdepth, cdepth).to_svg
 	end

--- a/src/web/api_graph.nit
+++ b/src/web/api_graph.nit
@@ -19,12 +19,10 @@ import web_base
 import dot
 import uml
 
-# Group all api handlers in one router.
-class APIGraphRouter
-	super APIRouter
-
+redef class APIRouter
 	init do
-		use("/inheritance/:id", new APIInheritanceGraph(config))
+		super
+		use("/graph/inheritance/:id", new APIInheritanceGraph(config))
 	end
 end
 

--- a/src/web/api_metrics.nit
+++ b/src/web/api_metrics.nit
@@ -17,12 +17,10 @@ module api_metrics
 import web_base
 import metrics
 
-# Group all api handlers in one router.
-class APIMetricsRouter
-	super APIRouter
-
-	init do
-		use("/structural/:id", new APIStructuralMetrics(config))
+redef class APIRouter
+	redef init do
+		super
+		use("/metrics/structural/:id", new APIStructuralMetrics(config))
 	end
 end
 

--- a/src/web/api_metrics.nit
+++ b/src/web/api_metrics.nit
@@ -69,13 +69,10 @@ class APIStructuralMetrics
 
 	redef fun get(req, res) do
 		var mentity = mentity_from_uri(req, res)
-		if mentity == null then
-			res.error 404
-			return
-		end
+		if mentity == null then return
 		var metrics = mentity.collect_metrics(self)
 		if metrics == null then
-			res.error 404
+			res.api_error(404, "No metric for mentity `{mentity.full_name}`")
 			return
 		end
 		res.json metrics

--- a/src/web/api_model.nit
+++ b/src/web/api_model.nit
@@ -143,10 +143,7 @@ class APIEntityInheritance
 
 	redef fun get(req, res) do
 		var mentity = mentity_from_uri(req, res)
-		if mentity == null then
-			res.error 404
-			return
-		end
+		if mentity == null then return
 		res.json mentity.hierarchy_poset(view)[mentity]
 	end
 end
@@ -159,13 +156,10 @@ class APIEntityLinearization
 
 	redef fun get(req, res) do
 		var mentity = mentity_from_uri(req, res)
-		if mentity == null then
-			res.error 404
-			return
-		end
+		if mentity == null then return
 		var lin = mentity.collect_linearization(config.mainmodule)
 		if lin == null then
-			res.error 404
+			res.api_error(404, "No linearization for mentity `{mentity.full_name}`")
 			return
 		end
 		res.json new JsonArray.from(lin)
@@ -180,6 +174,7 @@ class APIEntityDefs
 
 	redef fun get(req, res) do
 		var mentity = mentity_from_uri(req, res)
+		if mentity == null then return
 		var arr = new JsonArray
 		if mentity isa MModule then
 			for mclassdef in mentity.mclassdefs do arr.add mclassdef
@@ -190,7 +185,7 @@ class APIEntityDefs
 		else if mentity isa MProperty then
 			for mpropdef in mentity.mpropdefs do arr.add mpropdef
 		else
-			res.error 404
+			res.api_error(404, "No definition list for mentity `{mentity.full_name}`")
 			return
 		end
 		res.json arr
@@ -218,6 +213,7 @@ class APIEntityUML
 
 	redef fun get(req, res) do
 		var mentity = mentity_from_uri(req, res)
+		if mentity == null then return
 		var dot
 		if mentity isa MClassDef then mentity = mentity.mclass
 		if mentity isa MClass then
@@ -227,7 +223,7 @@ class APIEntityUML
 			var uml = new UMLModel(view, mentity)
 			dot = uml.generate_package_uml.write_to_string
 		else
-			res.error 404
+			res.api_error(404, "No UML for mentity `{mentity.full_name}`")
 			return
 		end
 		res.send render_dot(dot)
@@ -245,7 +241,7 @@ class APIEntityCode
 		if mentity == null then return
 		var source = render_source(mentity)
 		if source == null then
-			res.error 404
+			res.api_error(404, "No code for mentity `{mentity.full_name}`")
 			return
 		end
 		res.send source

--- a/src/web/api_model.nit
+++ b/src/web/api_model.nit
@@ -18,6 +18,21 @@ import web_base
 import highlight
 import uml
 
+redef class APIRouter
+	redef init do
+		super
+		use("/list", new APIList(config))
+		use("/search", new APISearch(config))
+		use("/random", new APIRandom(config))
+		use("/entity/:id", new APIEntity(config))
+		use("/code/:id", new APIEntityCode(config))
+		use("/uml/:id", new APIEntityUML(config))
+		use("/linearization/:id", new APIEntityLinearization(config))
+		use("/defs/:id", new APIEntityDefs(config))
+		use("/inheritance/:id", new APIEntityInheritance(config))
+	end
+end
+
 # List all mentities.
 #
 # MEntities can be filtered on their kind using the `k` parameter.

--- a/src/web/web.nit
+++ b/src/web/web.nit
@@ -23,5 +23,19 @@ import api_metrics
 import api_feedback
 
 redef class APIRouter
-	redef init do super
+	redef init do
+		super
+		use("/*", new APIErrorHandler(config)) # catch 404 errors
+	end
+end
+
+# Error handler user to catch non resolved request by the API
+#
+# Displays a JSON formatted 404 error.
+class APIErrorHandler
+	super APIHandler
+
+	redef fun all(req, res) do
+		res.api_error(404, "Not found")
+	end
 end

--- a/src/web/web.nit
+++ b/src/web/web.nit
@@ -21,3 +21,7 @@ import api_graph
 import api_docdown
 import api_metrics
 import api_feedback
+
+redef class APIRouter
+	redef init do super
+end

--- a/src/web/web_base.nit
+++ b/src/web/web_base.nit
@@ -72,12 +72,12 @@ abstract class APIHandler
 	fun mentity_from_uri(req: HttpRequest, res: HttpResponse): nullable MEntity do
 		var id = req.param("id")
 		if id == null then
-			res.error 400
+			res.api_error(400, "Expected mentity full name")
 			return null
 		end
 		var mentity = find_mentity(view, id)
 		if mentity == null then
-			res.error 404
+			res.api_error(404, "MEntity `{id}` not found")
 		end
 		return mentity
 	end
@@ -89,6 +89,42 @@ class APIRouter
 
 	# App config
 	var config: NitwebConfig
+end
+
+redef class HttpResponse
+
+	# Return an HTTP error response with `status`
+	#
+	# Like the rest of the API, errors are formated as JSON:
+	# ~~~json
+	# { "status": 404, "message": "Not found" }
+	# ~~~
+	fun api_error(status: Int, message: String) do
+		json(new APIError(status, message), status)
+	end
+end
+
+# An error returned by the API.
+#
+# Can be serialized to json.
+class APIError
+	super Jsonable
+
+	# Reponse status
+	var status: Int
+
+	# Response error message
+	var message: String
+
+	# Json Object for this error
+	var json: JsonObject is lazy do
+		var obj = new JsonObject
+		obj["status"] = status
+		obj["message"] = message
+		return obj
+	end
+
+	redef fun to_json do return json.to_json
 end
 
 redef class MEntity

--- a/src/web/web_base.nit
+++ b/src/web/web_base.nit
@@ -106,7 +106,7 @@ end
 class APIRouter
 	super Router
 
-	# App config.
+	# App config
 	var config: NitwebConfig
 end
 

--- a/src/web/web_base.nit
+++ b/src/web/web_base.nit
@@ -38,8 +38,8 @@ class NitwebConfig
 	var modelbuilder: ModelBuilder
 end
 
-# Specific nitcorn Action that uses a Model
-class ModelHandler
+# Specific handler for the nitweb API.
+abstract class APIHandler
 	super Handler
 
 	# App config.
@@ -50,25 +50,6 @@ class ModelHandler
 		if full_name == null then return null
 		return model.mentity_by_full_name(full_name.from_percent_encoding)
 	end
-
-	# Init the model view from the `req` uri parameters.
-	fun init_model_view(req: HttpRequest): ModelView do
-		var view = new ModelView(config.model)
-		var show_private = req.bool_arg("private") or else false
-		if not show_private then view.min_visibility = protected_visibility
-
-		view.include_fictive = req.bool_arg("fictive") or else false
-		view.include_empty_doc = req.bool_arg("empty-doc") or else true
-		view.include_test_suite = req.bool_arg("test-suite") or else false
-		view.include_attribute = req.bool_arg("attributes") or else true
-
-		return view
-	end
-end
-
-# Specific handler for nitweb API.
-abstract class APIHandler
-	super ModelHandler
 
 	# The JSON API does not filter anything by default.
 	#
@@ -126,7 +107,7 @@ redef class MEntity
 	end
 
 	# Get the full json repesentation of `self` with MEntityRefs resolved.
-	fun api_json(handler: ModelHandler): JsonObject do return json
+	fun api_json(handler: APIHandler): JsonObject do return json
 end
 
 redef class MEntityRef


### PR DESCRIPTION
Better error handling for the nitweb API:

* the API catches all unmatched `/api/*` requests and display a JSON error. Example here: http://nitweb.moz-code.org/api/foo
* better error messages (in JSON) for all API handlers. One example here: http://nitweb.moz-code.org/api/entity/foo

Also one change in the frontend that displays 404 not found pages: http://nitweb.moz-code.org/foo