### PR TITLE
Tools use model index

### DIFF
--- a/lib/core/README.md
+++ b/lib/core/README.md
@@ -4,43 +4,43 @@ Core classes and methods used by default by Nit programs and libraries.
 
 ## Core Basic Types and Operations
 
-[[doc:kernel]]
+[[doc: kernel]]
 
 ### Object
 
-[[doc:Object]]
+[[doc: Object]]
 
 #### Equality
 
-[[doc:Object::==]]
-[[doc:Object::!=]]
-[[doc:Object::hash]]
-[[doc:Object::is_same_instance]]
-[[doc:Object::object_id]]
+[[doc: core::Object::==]]
+[[doc: core::Object::!=]]
+[[doc: core::Object::hash]]
+[[doc: core::Object::is_same_instance]]
+[[doc: core::Object::object_id]]
 
 #### Debuging
 
-[[doc:Object::output]]
-[[doc:Object::output_class_name]]
-[[doc:Object::is_same_type]]
+[[doc: core::Object::output]]
+[[doc: core::Object::output_class_name]]
+[[doc: core::Object::is_same_type]]
 
 ### Sys
 
-[[doc:Sys]]
+[[doc: Sys]]
 
 #### Program Execution
 
-[[doc:Sys::main]]
-[[doc:Sys::run]]
+[[doc: core::Sys::main]]
+[[doc: core::Sys::run]]
 
 ### Other
 
-[[list:kernel]]
+[[list: kernel]]
 
 ## Core Collections
 
-[[doc:collection]]
+[[doc: collection]]
 
 ## String and Text manipulation
 
-[[doc:text]]
+[[doc: text]]

--- a/lib/github/README.md
+++ b/lib/github/README.md
@@ -8,7 +8,7 @@ This module provides a Nit object oriented interface to access the Github api.
 
 ### Authentification
 
-[[doc: GithubAPI::auth]]
+[[doc: auth]]
 
 Token can also be recovered from user config with `get_github_oauth`.
 
@@ -28,7 +28,7 @@ Token can also be recovered from user config with `get_github_oauth`.
 
 ### Other data
 
-[[list: api]]
+[[list: github::api]]
 
 ### Advanced uses
 
@@ -38,11 +38,11 @@ Token can also be recovered from user config with `get_github_oauth`.
 
 #### Custom requests
 
-[[doc: GithubAPI::get]]
+[[doc: github::GithubAPI::get]]
 
 #### Change the user agent
 
-[[doc: GithubAPI::user_agent]]
+[[doc: github::GithubAPI::user_agent]]
 
 #### Debugging
 

--- a/lib/nlp/README.md
+++ b/lib/nlp/README.md
@@ -33,41 +33,41 @@ For ease of use, this wrapper introduce a Nit model to handle CoreNLP XML result
 
 [[doc: NLPDocument]]
 
-[[doc: NLPDocument::from_xml]]
-[[doc: NLPDocument::from_xml_file]]
-[[doc: NLPDocument::sentences]]
+[[doc: nlp::NLPDocument::from_xml]]
+[[doc: nlp::NLPDocument::from_xml_file]]
+[[doc: nlp::NLPDocument::sentences]]
 
 ### NLPSentence
 
 [[doc: NLPSentence]]
 
-[[doc: NLPSentence::tokens]]
+[[doc: nlp::NLPSentence::tokens]]
 
 ### NLPToken
 
 [[doc: NLPToken]]
 
-[[doc: NLPToken::word]]
-[[doc: NLPToken::lemma]]
-[[doc: NLPToken::pos]]
+[[doc: nlp::NLPToken::word]]
+[[doc: nlp::NLPToken::lemma]]
+[[doc: nlp::NLPToken::pos]]
 
 ### NLP Processor
 
 [[doc: NLPProcessor]]
 
-[[doc: NLPProcessor::java_cp]]
+[[doc: nlp::NLPProcessor::java_cp]]
 
-[[doc: NLPProcessor::process]]
-[[doc: NLPProcessor::process_file]]
-[[doc: NLPProcessor::process_files]]
+[[doc: nlp::NLPProcessor::process]]
+[[doc: nlp::NLPProcessor::process_file]]
+[[doc: nlp::NLPProcessor::process_files]]
 
 ## Vector Space Model
 
 [[doc: NLPVector]]
 
-[[doc: NLPDocument::vector]]
+[[doc: vector]]
 
-[[doc: NLPVector::cosine_similarity]]
+[[doc: nlp::NLPVector::cosine_similarity]]
 
 ## NitNLP binary
 

--- a/src/model/model_views.nit
+++ b/src/model/model_views.nit
@@ -125,33 +125,12 @@ class ModelView
 		v.include_test_suite = self.include_test_suite
 	end
 
-	# Searches MEntities that match `name`.
-	fun mentities_by_name(name: String): Array[MEntity] do
-		var res = new Array[MEntity]
-		for mentity in mentities do if mentity.name == name then res.add mentity
-		return res
-	end
-
 	# Searches the MEntity that matches `full_name`.
 	fun mentity_by_full_name(full_name: String): nullable MEntity do
 		for mentity in mentities do
 			if mentity.full_name == full_name then return mentity
 		end
 		return null
-	end
-
-	# Looks up a MEntity by its full `namespace`.
-	#
-	# Usefull when `mentities_by_name` returns conflicts.
-	#
-	# Namespaces must be of the form `package::core::module::Class::prop`.
-	fun mentities_by_namespace(namespace: String): Array[MEntity] do
-		var v = new LookupNamespaceVisitor(namespace)
-		init_visitor(v)
-		for mpackage in mpackages do
-			v.enter_visit(mpackage)
-		end
-		return v.results
 	end
 
 	# Build an concerns tree with from `self`

--- a/tests/sav/nitx_args1.res
+++ b/tests/sav/nitx_args1.res
@@ -1,13 +1,9 @@
 
-[1m[32m# 2 result(s) for 'comment: A'[m[m
+[1m[34m# [m[m[1m[34mA[m[m
+[1m[30mclass A[m[m
 
- [1m[32mC[m[m [1m[34mA[m[m
-   [1m[30mbase_simple3::A[m[m
-   class A
-   [30mbase_simple3.nit:29,1--32,3[m
+    [1m[32mclass A[m[m
+    [1m[30mbase_simple3.nit:29,1--32,3[m[m
 
- [1m[32mC[m[m [1m[34mA[m[m
-   [1m[30mbase_simple3::base_simple3::A[m[m
-   class A
-   [30mbase_simple3.nit:29,1--32,3[m
+
 

--- a/tests/sav/nitx_args2.res
+++ b/tests/sav/nitx_args2.res
@@ -1,13 +1,9 @@
 
-[1m[32m# 2 result(s) for 'comment: foo'[m[m
+[1m[34m# [m[m[1m[34mfoo[m[m
+[1m[30mfun foo[m[m
 
- [1m[32mF[m[m [1m[34mfoo[m[m
-   [1m[30mbase_simple3::Sys::foo[m[m
-   fun foo
-   [30mbase_simple3.nit:49,1--19[m
+    [1m[32mfun foo[m[m
+    [1m[30mbase_simple3.nit:49,1--19[m[m
 
- [1m[32mF[m[m [1m[34mfoo[m[m
-   [1m[30mbase_simple3::base_simple3::Sys::foo[m[m
-   fun foo
-   [30mbase_simple3.nit:49,1--19[m
+
 

--- a/tests/sav/nitx_args3.res
+++ b/tests/sav/nitx_args3.res
@@ -1,18 +1,9 @@
 
-[1m[32m# 3 result(s) for 'comment: base_simple3'[m[m
+[1m[34m# [m[m[1m[34mbase_simple3[m[m
+[1m[30mpackage base_simple3[m[m
 
- [1m[32mP[m[m [1m[34mbase_simple3[m[m
-   [1m[30mbase_simple3[m[m
-   package base_simple3
-   [30mbase_simple3.nit:17,1--66,13[m
+    [1m[32mpackage base_simple3[m[m
+    [1m[30mbase_simple3.nit:17,1--66,13[m[m
 
- [1m[32mG[m[m [1m[34mbase_simple3[m[m
-   [1m[30mbase_simple3[m[m
-   group base_simple3
-   [30mbase_simple3.nit:17,1--66,13[m
 
- [1m[32mM[m[m [1m[34mbase_simple3[m[m
-   [1m[30mbase_simple3::base_simple3[m[m
-   module base_simple3
-   [30mbase_simple3.nit:17,1--66,13[m
 


### PR DESCRIPTION
Add `model_index` inside `model_view` so importing `model_index` automatically provide an index within the view. Also migrate documentation tools to model index.

### nitx

Model index is used to search mentities in commands (like `Array`, or `doc: Array`)
Improvement: nitx can no suggest entities if nothing was found.

### nitdoc

Model index is used to render doc commands in README files (like `[[list: Array]]`, or `[[graph: Array]]`)

Improvements:
* user can use `name` or `full_name` to locate entities
* nitdoc check and suggest errors
* nitdoc check and display short name conflicts


### nitweb

Model index is used to render doc down inputs and benefits now from the same improvements than nitdoc (but with a different implementation).

Futur PR will migrate the quick search engine.