### PR TITLE
Beef up github merge

### DIFF
--- a/contrib/github_merge.nit
+++ b/contrib/github_merge.nit
@@ -36,7 +36,8 @@ redef class GithubCurl
 		var pr = get_and_check("https://api.github.com/repos/{repo}/pulls/{number}")
 		var prm = pr.json_as_map
 		var sha = prm["head"].json_as_map["sha"].to_s
-		var statuses = get_and_check("https://api.github.com/repos/{repo}/statuses/{sha}")
+		var statuses = get_and_check("https://api.github.com/repos/{repo}/commits/{sha}/status")
+		statuses = statuses.json_as_map
 		prm["statuses"] = statuses
 		print "{prm["title"].to_s}: by {prm["user"].json_as_map["login"].to_s} (# {prm["number"].to_s})"
 		var mergeable = prm["mergeable"]
@@ -45,11 +46,18 @@ redef class GithubCurl
 		else
 			print "\tmergeable: unknown"
 		end
-		var st = prm["statuses"].json_as_a
-		if not st.is_empty then
-			print "\tstatus: {st[0].json_as_map["state"].to_s}"
-		else
+		var state = statuses["state"]
+		if state == null then
 			print "\tstatus: not tested"
+		else
+			print "\tstatus: {state}"
+			var sts = statuses["statuses"].json_as_a
+			for st in sts do
+				st = st.json_as_map
+				var ctx = st["context"].to_s
+				state = st["state"].to_s
+				print "\tstatus {ctx}: {state}"
+			end
 		end
 		return prm
 	end

--- a/contrib/github_merge.nit
+++ b/contrib/github_merge.nit
@@ -122,6 +122,10 @@ for arg in args do
 		print "Commit {sha} not in local repository; did you fetch github?"
 		return
 	end
+	if system("git merge-base --is-ancestor {sha} HEAD") == 0 then
+		print "Is already merged."
+		continue
+	end
 	if system("git merge --no-ff --no-commit {sha}") != 0 then
 		system("cp mergemsg `git rev-parse --git-dir`/MERGE_MSG")
 		print "Problem during merge... Let's do the commit manually."

--- a/contrib/github_merge.nit
+++ b/contrib/github_merge.nit
@@ -92,16 +92,19 @@ end
 
 var curl = new GithubCurl(auth, "Merge-o-matic (nitlang/nit)")
 
-if args.length != 1 then
+if args.is_empty then
 	# Without args, list `ok_will_merge`
 	var x = curl.get_and_check("https://api.github.com/repos/nitlang/nit/issues?labels=ok_will_merge")
 	for y in x.json_as_a do
 		var number = y.json_as_map["number"].as(Int)
 		curl.getpr(number)
 	end
-else
+	return
+end
+
+for arg in args do
 	# With a arg, merge the PR
-	var number = args.first.to_i
+	var number = arg.to_i
 	var pr = curl.getpr(number)
 	var revs = curl.getrev(pr)
 

--- a/contrib/github_merge.nit
+++ b/contrib/github_merge.nit
@@ -91,8 +91,9 @@ var opt_repo = new OptionString("Repository (e.g. nitlang/nit)", "-r", "--repo")
 var opt_auth = new OptionString("OAuth token", "--auth")
 var opt_query = new OptionString("Query to get issues (e.g. label=ok_will_merge)", "-q", "--query")
 var opt_keepgoing = new OptionBool("Skip merge conflicts", "-k", "--keep-going")
+var opt_all = new OptionBool("Merge all", "-a", "--all")
 var opts = new OptionContext
-opts.add_option(opt_repo, opt_auth, opt_query, opt_keepgoing)
+opts.add_option(opt_repo, opt_auth, opt_query, opt_all, opt_keepgoing)
 
 opts.parse(sys.args)
 var args = opts.rest
@@ -113,11 +114,16 @@ var curl = new GithubCurl(auth, "Merge-o-matic (nitlang/nit)")
 if args.is_empty then
 	# Without args, list `ok_will_merge`
 	var x = curl.get_and_check("https://api.github.com/repos/{repo}/issues?{query}")
+	var list = new Array[String]
 	for y in x.json_as_a do
 		var number = y.json_as_map["number"].as(Int)
-		curl.getpr(repo, number)
+		var pr = curl.getpr(repo, number)
+		if pr == null then continue
+		list.add number.to_s
 	end
-	return
+
+	if not opt_all.value then return
+	args = list
 end
 
 for arg in args do

--- a/contrib/github_merge.nit
+++ b/contrib/github_merge.nit
@@ -28,8 +28,11 @@ end
 
 redef class GithubCurl
 	# Get a given pull request (PR)
-	fun getpr(repo: String, number: Int): JsonObject
+	fun getpr(repo: String, number: Int): nullable JsonObject
 	do
+		var ir = get_and_check("https://api.github.com/repos/{repo}/issues/{number}")
+		var irm = ir.json_as_map
+		if not irm.has_key("pull_request") then return null
 		var pr = get_and_check("https://api.github.com/repos/{repo}/pulls/{number}")
 		var prm = pr.json_as_map
 		var sha = prm["head"].json_as_map["sha"].to_s
@@ -121,6 +124,10 @@ for arg in args do
 	# With a arg, merge the PR
 	var number = arg.to_i
 	var pr = curl.getpr(repo, number)
+	if pr == null then
+		print "Not a PR: {number}"
+		return
+	end
 	var revs = curl.getrev(repo, pr)
 
 	var mergemsg = new Template


### PR DESCRIPTION
The tool was fragile, crappy, and very limited.
Now it is still fragile, crappy but less limited.

A lot of new features:

* can work on other repositories than nitlang/nit
* can choose what query to list (eg label)
* fixed status info, and we can filter on it also
* can merge automatically
* and ~~much~~ some more.

All these improvement are used to enable the automatic construction of a `next` branch based on PR with some characteristics.