### PR TITLE
json::serialization: fix reading attributes from non-objects

### DIFF
--- a/lib/json/serialization.nit
+++ b/lib/json/serialization.nit
@@ -290,7 +290,14 @@ class JsonDeserializer
 
 	redef fun deserialize_attribute(name, static_type)
 	do
-		assert not path.is_empty # This is an internal error, abort
+		if path.is_empty then
+			# The was a parsing error or the root is not an object
+			if not root isa Error then
+				errors.add new Error("Deserialization Error: parsed JSON value is not an object.")
+			end
+			return null
+		end
+
 		var current = path.last
 
 		if not current.keys.has(name) then


### PR DESCRIPTION
This error could arise when parsing invalid JSON strings (or non-object JSON values) and skipping the call to `deserialize`.

See @privat comment in #2291.