### PR TITLE
Mkdir fix

### DIFF
--- a/lib/core/file.nit
+++ b/lib/core/file.nit
@@ -1216,14 +1216,20 @@ redef class String
 			path.add('/')
 		end
 		var error: nullable Error = null
-		for d in dirs do
+		for i in [0 .. dirs.length - 1[ do
+			var d = dirs[i]
 			if d.is_empty then continue
 			path.append(d)
 			path.add('/')
-			var res = path.to_s.to_cstring.file_mkdir(mode)
+			if path.file_exists then continue
+			var res = path.to_cstring.file_mkdir(mode)
 			if not res and error == null then
 				error = new IOError("Cannot create directory `{path}`: {sys.errno.strerror}")
 			end
+		end
+		var res = self.to_cstring.file_mkdir(mode)
+		if not res and error == null then
+			error = new IOError("Cannot create directory `{path}`: {sys.errno.strerror}")
 		end
 		return error
 	end

--- a/lib/core/file.nit
+++ b/lib/core/file.nit
@@ -888,12 +888,12 @@ redef class Text
 	do
 		for i in substrings do s.write_native(i.to_cstring, 0, i.byte_length)
 	end
+
+	# return true if a file with this names exists
+	fun file_exists: Bool do return to_cstring.file_exists
 end
 
 redef class String
-	# return true if a file with this names exists
-	fun file_exists: Bool do return to_cstring.file_exists
-
 	# The status of a file. see POSIX stat(2).
 	fun file_stat: nullable FileStat
 	do


### PR DESCRIPTION
Calling `String::mkdir` on a path might produce errors when part of the path already existed.

This PR fixes this behaviour.