### PR TITLE
app::audio: remove deprecated services and other minor improvements

### DIFF
--- a/contrib/mnit_test/src/test_audio.nit
+++ b/contrib/mnit_test/src/test_audio.nit
@@ -22,10 +22,10 @@ import android::audio
 
 redef class App
 	# Sound
-	var soundsp: Sound
+	var soundsp: Sound is noinit
 
 	# Music
-	var soundmp: Music
+	var soundmp: Music is noinit
 
 	# Sound
 	var easy_soundsp = new Sound("testsound")
@@ -47,8 +47,8 @@ redef class App
 		super
 		default_mediaplayer.looping = true
 		if test_assets then
-			soundsp = load_sound("testsound.og")
-			soundmp = load_music("xylofon.og")
+			soundsp = new Sound("testsound.og")
+			soundmp = new Music("xylofon.og")
 			soundmp.play
 		end
 		if test_ressources then

--- a/lib/android/audio.nit
+++ b/lib/android/audio.nit
@@ -527,7 +527,7 @@ redef class Sound
 		if is_loaded then return
 		var retval_resources = app.default_soundpool.load_name_rid(app.resource_manager, app.native_activity, self.name.strip_extension)
 		if retval_resources == -1 then
-			self.error = new Error("failed to load" + self.name)
+			self.error = new Error("Failed to load " + self.name)
 			var nam = app.asset_manager.open_fd(self.name)
 			if nam.is_java_null then
 				self.error = new Error("Failed to get file descriptor for " + self.name)
@@ -549,6 +549,9 @@ redef class Sound
 			self.soundpool.error = null
 		end
 		is_loaded = true
+
+		var error = error
+		if error != null then print_error error
 	end
 
 	redef fun play do
@@ -613,6 +616,9 @@ redef class Music
 			self.media_player.error = null
 		end
 		is_loaded = true
+
+		var error = error
+		if error != null then print_error error
 	end
 
 	redef fun play do

--- a/lib/android/audio.nit
+++ b/lib/android/audio.nit
@@ -293,12 +293,12 @@ class SoundPool
 		return nsoundpool.play(id, left_volume, right_volume, priority, looping, rate)
 	end
 
-	# Load a sound by its name in the resources, the sound must be in the `res/raw` folder
-	fun load_name(resource_manager: ResourcesManager, context: NativeActivity, sound: String): Sound do
-		var id = resource_manager.raw_id(sound)
+	# Load a sound by its `name` in the resources, the sound must be in the `res/raw` folder
+	fun load_name(resource_manager: ResourcesManager, context: NativeActivity, name: String): Sound do
+		var id = resource_manager.raw_id(name)
 		var resval = nsoundpool.load_id(context, id, priority)
 		if  resval == -1 then
-			self.error = new Error("Unable to load sound from resources : " + sound)
+			self.error = new Error("Unable to load sound from resources: " + name)
 			return new Sound.priv_init(null, -1, self, self.error)
 		else
 			return new Sound.priv_init(null, resval, self, null)

--- a/lib/android/audio.nit
+++ b/lib/android/audio.nit
@@ -658,30 +658,6 @@ redef class App
 		App_native_activity(self).setVolumeControlStream(AudioManager.STREAM_MUSIC);
 	`}
 
-	# Retrieves a sound with a soundpool in the `assets` folder using its name.
-	# Used to play short songs, can play multiple sounds simultaneously
-	redef fun load_sound(path) do
-		var fd = asset_manager.open_fd(path)
-		if not fd.is_java_null then
-			return add_to_sounds(default_soundpool.load_asset_fd(fd)).as(Sound)
-		else
-			var error = new Error("Failed to load Sound {path}")
-			return new Sound.priv_init(null, -1, default_soundpool, error)
-		end
-	end
-
-	# Retrieves a music with a media player in the `assets` folder using its name.
-	# Used to play long sounds or musics, can't play multiple sounds simultaneously
-	redef fun load_music(path) do
-		var fd = asset_manager.open_fd(path)
-		if not fd.is_java_null then
-			return add_to_sounds(default_mediaplayer.data_source_fd(fd)).as(Music)
-		else
-			var error = new Error("Failed to load music {path}")
-			return new Music.priv_init(null, default_mediaplayer, error)
-		end
-	end
-
 	# Same as `load_sound` but load the sound from the `res/raw` folder
 	fun load_sound_from_res(sound_name: String): Sound do
 		return add_to_sounds(default_soundpool.load_name(resource_manager,self.native_activity, sound_name)).as(Sound)

--- a/lib/android/audio.nit
+++ b/lib/android/audio.nit
@@ -498,7 +498,7 @@ redef class PlayableAudio
 	# Used when the app pause all sounds or resume all sounds
 	var paused: Bool = false
 
-	redef init do add_to_sounds(self)
+	redef init do sounds.add self
 end
 
 redef class Sound
@@ -666,12 +666,16 @@ redef class App
 
 	# Same as `load_sound` but load the sound from the `res/raw` folder
 	fun load_sound_from_res(sound_name: String): Sound do
-		return add_to_sounds(default_soundpool.load_name(resource_manager,self.native_activity, sound_name)).as(Sound)
+		var sound = default_soundpool.load_name(resource_manager,self.native_activity, sound_name)
+		sys.sounds.add sound
+		return sound
 	end
 
 	# Same as `load_music` but load the sound from the `res/raw` folder
 	fun load_music_from_res(music: String): Music do
-		return add_to_sounds(default_mediaplayer.load_sound(resource_manager.raw_id(music), self.native_activity)).as(Music)
+		var sound = default_mediaplayer.load_sound(resource_manager.raw_id(music), self.native_activity)
+		sys.sounds.add sound
+		return sound
 	end
 
 	redef fun on_pause do
@@ -710,10 +714,4 @@ redef class Sys
 	# Sounds handled by the application, when you load a sound, it's added to this list.
 	# This array is used in `pause` and `resume`
 	private var sounds = new Array[PlayableAudio]
-
-	# Factorizes `sounds.add` to use it in `load_music`, `load_sound`, `load_music_from_res` and `load_sound_from_res`
-	private fun add_to_sounds(sound: PlayableAudio): PlayableAudio do
-		sounds.add(sound)
-		return sound
-	end
 end

--- a/lib/android/audio.nit
+++ b/lib/android/audio.nit
@@ -280,7 +280,7 @@ class SoundPool
 		var resval = nsoundpool.load_path(path.to_java_string, priority)
 		sys.jni_env.pop_local_frame
 		if  resval == -1 then
-			self.error = new Error("Unable to load sound from path : " + path)
+			self.error = new Error("Unable to load sound from path: " + path)
 			return new Sound.priv_init(null, -1, self, self.error)
 		else
 			return new Sound.priv_init(null, resval, self, null)
@@ -525,16 +525,16 @@ redef class Sound
 
 	redef fun load do
 		if is_loaded then return
-		var retval_resources = app.default_soundpool.load_name_rid(app.resource_manager, app.native_activity, self.name.strip_extension)
+		var retval_resources = app.default_soundpool.load_name_rid(app.resource_manager, app.native_activity, path.strip_extension)
 		if retval_resources == -1 then
-			self.error = new Error("Failed to load " + self.name)
-			var nam = app.asset_manager.open_fd(self.name)
+			self.error = new Error("Failed to load " + path)
+			var nam = app.asset_manager.open_fd(path)
 			if nam.is_java_null then
-				self.error = new Error("Failed to get file descriptor for " + self.name)
+				self.error = new Error("Failed to get file descriptor for " + path)
 			else
 				var retval_assets = app.default_soundpool.load_asset_fd_rid(nam)
 				if retval_assets == -1 then
-					self.error = new Error("Failed to load" + self.name)
+					self.error = new Error("Failed to load " + path)
 				else
 					self.soundpool_id = retval_assets
 					self.soundpool = app.default_soundpool
@@ -594,12 +594,12 @@ redef class Music
 
 	redef fun load do
 		if is_loaded then return
-		var mp_sound_resources = app.default_mediaplayer.load_sound(app.resource_manager.raw_id(self.name.strip_extension), app.native_activity)
+		var mp_sound_resources = app.default_mediaplayer.load_sound(app.resource_manager.raw_id(path.strip_extension), app.native_activity)
 		if mp_sound_resources.error != null then
 			self.error = mp_sound_resources.error
-			var nam = app.asset_manager.open_fd(self.name)
+			var nam = app.asset_manager.open_fd(path)
 			if nam.is_java_null then
-				self.error = new Error("Failed to get file descriptor for " + self.name)
+				self.error = new Error("Failed to get file descriptor for " + path)
 			else
 				var mp_sound_assets = app.default_mediaplayer.data_source_fd(nam)
 				if mp_sound_assets.error != null then

--- a/lib/app/audio.nit
+++ b/lib/app/audio.nit
@@ -64,12 +64,3 @@ end
 class Music
 	super PlayableAudio
 end
-
-redef class App
-
-	# Load a sound
-	fun load_sound(name: String): Sound is abstract
-
-	# Load a music
-	fun load_music(name: String): Music is abstract
-end

--- a/lib/app/audio.nit
+++ b/lib/app/audio.nit
@@ -14,13 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# App audio abstraction
-# Default behaviour is loading the audio from the `assets` folder of the project with its name and extension
-# Platforms implementations can modify this comportement
+# Services to load and play `Sound` and `Music` from the assets folder
 #
-# Once the application has started (after `App.setup`)
-# use `App.load_sound` to get a sound
-# then `Sound.play` to play it
+# Get a handle to a sound using `new Sound` or `new Music` at any time.
+# Call `load` at or after `App::on_create` or leave it to be loaded
+# on demand by the first call to `play`.
 module audio
 
 import app_base
@@ -36,31 +34,31 @@ abstract class PlayableAudio
 	# Name of this playable audio
 	var name: String
 
-	# Error which is not null if an error happened
+	# Last error on this sound, if any
 	var error: nullable Error = null is writable
 
-	# Is this already loaded ?
+	# Is `self` already loaded?
 	protected var is_loaded = false is writable
 
 	# Load this playable audio
 	fun load is abstract
 
-	# Plays the sound
+	# Play the sound
 	fun play is abstract
 
-	# Pauses the sound
+	# Pause the sound
 	fun pause is abstract
 
-	# Resumes the sound
+	# Resume the sound
 	fun resume is abstract
 end
 
-# Abstraction of a short sound
+# Short sound
 class Sound
 	super PlayableAudio
 end
 
-# Abstraction of a long song, that can bee looped
+# Long sound that can bee looped
 class Music
 	super PlayableAudio
 end

--- a/lib/app/audio.nit
+++ b/lib/app/audio.nit
@@ -31,8 +31,8 @@ import android::audio is conditional(android)
 # Abstraction of a playable Audio
 abstract class PlayableAudio
 
-	# Name of this playable audio
-	var name: String
+	# Path to the audio file in the assets folder
+	var path: String
 
 	# Last error on this sound, if any
 	var error: nullable Error = null is writable

--- a/lib/linux/audio.nit
+++ b/lib/linux/audio.nit
@@ -50,15 +50,3 @@ redef class Music
 	redef fun pause do end
 	redef fun resume do end
 end
-
-redef class App
-	redef fun load_sound(name)
-	do
-		return new Sound(name)
-	end
-
-	redef fun load_music(name)
-	do
-		return new Music(name)
-	end
-end

--- a/lib/linux/audio.nit
+++ b/lib/linux/audio.nit
@@ -14,20 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Linux audio services
+# Linux audio implementation
 module audio
 
 import app::audio
 import linux
 
-# Simple audio asset
 redef class Sound
 
 	redef fun play do
-		if name.has_suffix(".wav") then
-			sys.system "aplay -q {app.assets_dir}{name} &"
-		else if name.has_suffix(".mp3") then
-			sys.system "mpg123 -q {app.assets_dir}{name} &"
+		if path.has_suffix(".wav") then
+			sys.system "aplay -q {app.assets_dir}{path} &"
+		else if path.has_suffix(".mp3") then
+			sys.system "mpg123 -q {app.assets_dir}{path} &"
 		end
 	end
 
@@ -39,10 +38,10 @@ end
 redef class Music
 
 	redef fun play do
-		if name.has_suffix(".wav") then
-			sys.system "aplay -q {app.assets_dir}{name} &"
-		else if name.has_suffix(".mp3") then
-			sys.system "mpg123 -q {app.assets_dir}{name} &"
+		if path.has_suffix(".wav") then
+			sys.system "aplay -q {app.assets_dir}{path} &"
+		else if path.has_suffix(".mp3") then
+			sys.system "mpg123 -q {app.assets_dir}{path} &"
 		end
 	end
 


### PR DESCRIPTION
This PR removes the old `load_sound` and `load_music` services, they were replaced by lazy loading services a while back. The new services are more in line with the other asset loading services from `gamnit`.

There are also other general but minor improvements: doc updates, better names for a param and an attribute, less warnings, less casts, more consistent error messages and easier debugging.