### PR TITLE
nitweb: better namespaces

### DIFF
--- a/share/nitweb/directives/entity/defcard.html
+++ b/share/nitweb/directives/entity/defcard.html
@@ -1,24 +1,13 @@
-<div class='card card-xl' ng-class='{active: focus.full_name == definition.full_name}'>
+<div class='card card-xl' ng-class='{active: isActive()}'>
 	<div class='card-body'>
-		<h5 class='text-muted'>
+		<h5>
 			<span ng-if='definition.is_intro'>
-				<span class='glyphicon glyphicon-plus' /> Introduction</span>
+				<span class='text-muted glyphicon glyphicon-plus' title='introduction' />
+				<entity-namespace namespace='definition.namespace' />
 			</span>
 			<span ng-if='!definition.is_intro'>
-				<span class='glyphicon glyphicon-asterisk' /> Redefinition</span>
-			</span>
-			<span ng-if='definition.mclass'>
-				of <entity-link mentity='definition.mclass' />
-			</span>
-			<span ng-if='definition.mproperty'>
-				of <entity-link mentity='definition.mproperty' />
-			</span>
-			<span ng-if='definition.mclassdef'>
-				in <entity-link mentity='definition.mmodule' />
-				:: <entity-link mentity='definition.mclassdef' />
-			</span>
-			<span ng-if='!definition.mclassdef'>
-				in <entity-link mentity='definition.mmodule' />
+				<span class='text-muted glyphicon glyphicon-asterisk' title='redefinition' />
+				<entity-namespace namespace='definition.namespace' />
 			</span>
 			<div class='btn-bar'>
 				<button class='btn btn-link' aria-expanded='false'
@@ -31,7 +20,7 @@
 		</h5>
 		<div id='{{codeId}}' class='collapse'>
 			<pre ng-bind-html='code' />
+			<entity-location mentity='definition' />
 		</div>
-		<entity-location mentity='definition' />
 	</div>
 </div>

--- a/share/nitweb/directives/entity/namespace.html
+++ b/share/nitweb/directives/entity/namespace.html
@@ -1,13 +1,10 @@
-<span ng-if='mentity.mpackage'>
-	<entity-link mentity='mentity.mpackage' /> ::
+<span ng-repeat='part in namespace track by $index'>
+	<span ng-if='isArray(part)'>
+		<entity-namespace namespace='part' />
+	</span>
+	<span ng-if='isObject(part)'>
+		<entity-link mentity='part' />
+	</span>
+	<span ng-if='isString(part)'>
+	<span>{{part}}</span>
 </span>
-<span ng-if='mentity.mmodule'>
-	<entity-link mentity='mentity.mmodule' /> ::
-</span>
-<span ng-if='mentity.intro_mclassdef'>
-	<entity-link mentity='mentity.intro_mclassdef' /> ::
-</span>
-<span ng-if='mentity.mclassdef'>
-	<entity-link mentity='mentity.mclassdef' /> ::
-</span>
-{{mentity.name}}

--- a/share/nitweb/javascripts/entities.js
+++ b/share/nitweb/javascripts/entities.js
@@ -108,9 +108,20 @@
 			return {
 				restrict: 'E',
 				scope: {
-					mentity: '='
+					namespace: '='
 				},
-				templateUrl: '/directives/entity/namespace.html'
+				templateUrl: '/directives/entity/namespace.html',
+				link: function ($scope, element, attrs) {
+					$scope.isObject = function(obj) {
+						return typeof obj === 'object';
+					};
+					$scope.isArray = function(obj) {
+						return Array.isArray(obj);
+					};
+					$scope.isString = function(obj) {
+						return typeof obj === 'string';
+					};
+				}
 			};
 		})
 
@@ -213,6 +224,11 @@
 				templateUrl: '/directives/entity/defcard.html',
 				link: function ($scope, element, attrs) {
 					$scope.codeId = 'code_' + $scope.definition.full_name.replace(/[^a-zA-Z0-9]/g, '_');
+
+					$scope.isActive = function() {
+						return $scope.focus.full_name == $scope.definition.full_name;
+					}
+
 					$scope.loadCardCode = function() {
 						if(!$scope.code) {
 							Model.loadEntityCode($scope.definition.full_name,

--- a/share/nitweb/javascripts/entities.js
+++ b/share/nitweb/javascripts/entities.js
@@ -248,6 +248,8 @@
 							}
 						}
 					};
+
+					if($scope.isActive()) $scope.loadCardCode();
 				}
 			};
 		}])

--- a/share/nitweb/views/doc.html
+++ b/share/nitweb/views/doc.html
@@ -11,7 +11,7 @@
 
 	<div class='page-header'>
 		<h2><entity-signature mentity='mentity' /></h2>
-		<entity-namespace mentity='mentity' />
+		<entity-namespace namespace='mentity.namespace' />
 	</div>
 	<div ng-switch='mentity.class_name'>
 		<div ng-switch-when='MPackage'>

--- a/src/model/mmodule.nit
+++ b/src/model/mmodule.nit
@@ -75,7 +75,7 @@ class MModule
 	super MConcern
 
 	# The model considered
-	redef var model: Model
+	redef var model
 
 	# The group of module in the package if any
 	var mgroup: nullable MGroup
@@ -98,9 +98,9 @@ class MModule
 	end
 
 	# The short name of the module
-	redef var name: String
+	redef var name
 
-	redef var location: Location is writable
+	redef var location is writable
 
 	# Alias for `name`
 	redef fun to_s do return self.name
@@ -144,7 +144,7 @@ class MModule
 
 	# Return the name of the global C identifier associated to `self`.
 	# This name is used to prefix files and other C identifiers associated with `self`.
-	redef var c_name: String is lazy do
+	redef var c_name is lazy do
 		var g = mgroup
 		var res
 		if g != null and g.mpackage.name != name then

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -603,7 +603,7 @@ class MClassDef
 	# ENSURE: `bound_mtype.mclass == self.mclass`
 	var bound_mtype: MClassType
 
-	redef var location: Location
+	redef var location
 
 	redef fun visibility do return mclass.visibility
 

--- a/src/model/mpackage.nit
+++ b/src/model/mpackage.nit
@@ -25,14 +25,14 @@ class MPackage
 	super MConcern
 
 	# The name of the package
-	redef var name: String
+	redef var name
 
 	redef fun full_name do return name
 
 	redef var c_name = name.to_cmangle is lazy
 
 	# The model of the package
-	redef var model: Model
+	redef var model
 
 	redef var location
 
@@ -55,8 +55,11 @@ class MPackage
 
 	redef fun mdoc_or_fallback
 	do
+		var mdoc = self.mdoc
 		if mdoc != null then return mdoc
-		return root.mdoc_or_fallback
+		var root = self.root
+		if root != null then return root.mdoc_or_fallback
+		return null
 	end
 end
 
@@ -66,7 +69,7 @@ class MGroup
 
 	# The name of the group
 	# empty name for a default group in a single-module package
-	redef var name: String
+	redef var name
 
 	redef var location
 


### PR DESCRIPTION
Before this PR, the namespace composition (adding html things to the MEntity::full_name) was handled by Angular. Namespaces are a pain in the nit to generate, even more when you don't have access to the model... So the solution was to delegate that work to the API.

With this PR, nitweb attach a Namespace object to each MEntity so Angular knows how to render it.
The idea is pretty simple, a namespace is an array of either:

* a string for "::", "$" ...
* an mentity reference like `Array`
* another namespace for recursive definitions

Demo is here: http://nitweb.moz-code.org/

Some examples:

* `core`: http://nitweb.moz-code.org/doc/core
* `core>`: http://nitweb.moz-code.org/doc/core>
* `core::core`: http://nitweb.moz-code.org/doc/core::core
* `core::Array`: http://nitweb.moz-code.org/doc/core::Array
* `core::Array::from`: http://nitweb.moz-code.org/doc/core::Array::from
