### PR TITLE
gamnit: fix field of view issues

### DIFF
--- a/contrib/action_nitro/src/action_nitro.nit
+++ b/contrib/action_nitro/src/action_nitro.nit
@@ -132,7 +132,7 @@ redef class App
 		iss_model.load
 
 		# Setup cameras
-		world_camera.reset_height 40.0
+		world_camera.reset_height 60.0
 		ui_camera.reset_height 1080.0
 
 		# Register particle systems

--- a/lib/gamnit/cameras.nit
+++ b/lib/gamnit/cameras.nit
@@ -185,7 +185,7 @@ class EulerCamera
 		var near_height = (field_of_view_y/2.0).tan * near
 		var cross_screen_to_near = near_height / (display.height.to_f/2.0)
 		var cross_near_to_target = (position.z - target_z) / near
-		var mod = cross_screen_to_near * cross_near_to_target * 1.72 # FIXME drop the magic number
+		var mod = cross_screen_to_near * cross_near_to_target
 
 		var wx = position.x + (x.to_f-display.width.to_f/2.0) * mod
 		var wy = position.y - (y.to_f-display.height.to_f/2.0) * mod

--- a/lib/gamnit/cameras.nit
+++ b/lib/gamnit/cameras.nit
@@ -133,7 +133,7 @@ class EulerCamera
 		view = view * rotation_matrix
 
 		# Use a projection matrix with a depth
-		var projection = new Matrix.perspective(pi*field_of_view_y/2.0,
+		var projection = new Matrix.perspective(field_of_view_y,
 			display.aspect_ratio, near, far)
 
 		return view * projection


### PR DESCRIPTION
Erroneous code at creation of the perspective matrix caused a wider than requested frustum and field of view. This caused issues in other gamnit code:

* The service `camera_to_world` had to multiply the result by 1.72 to correct the deformation.
* In `asteronits`, the world was not filling the screen, only part of it.
* In general, it created a cool but not desired wide angle lens / fisheye effect.

After the fix, some clients might have to widen the requested visible area, usually set with `reset_height`. We may have to lower the default `field_of_view_y` as it is a bit high.