### PR TITLE
StatementRow::map

### DIFF
--- a/lib/sqlite3/sqlite3.nit
+++ b/lib/sqlite3/sqlite3.nit
@@ -155,6 +155,17 @@ class StatementRow
 	# Statement linked to `self`
 	var statement: Statement
 
+	# Maps the column name to its value
+	fun map: Map[String, nullable Sqlite3Data]
+	do
+		var ret = new ArrayMap[String, nullable Sqlite3Data]
+		for i in [0 .. length[ do
+			var st = self[i]
+			ret[st.name] = st.value
+		end
+		return ret
+	end
+
 	# Number of entries in this row
 	#
 	# require: `self.statement.is_open`

--- a/tests/sav/test_sqlite3_nity.res
+++ b/tests/sav/test_sqlite3_nity.res
@@ -8,5 +8,19 @@ uname: Guillaume
 pass: xxx
 activated: 1
 perc: 88.8
+
+Map test:
+
+####
+uname = Bob
+pass = zzz
+activated = 1
+perc = 77.7
+####
+uname = Guillaume
+pass = xxx
+activated = 1
+perc = 88.8
+
 true
 false

--- a/tests/test_sqlite3_nity.nit
+++ b/tests/test_sqlite3_nity.nit
@@ -58,6 +58,17 @@ for row in db.select("* FROM users") do
 	print row[3].to_f
 end
 
+print "\nMap test:\n"
+
+for row in db.select("* FROM users") do
+	var m = row.map
+	print "####"
+	for k, v in m do
+		print "{k} = {v or else "nil"}"
+	end
+end
+print ""
+
 print db.is_open
 db.close
 print db.is_open


### PR DESCRIPTION
I thought this was lacking from the API, so now when dealing with a StatementRow, one can get a map from column name to column value.

NOTE: This is not lazy since Sqlite re-uses the StatementRow for each row returned when a select statement is sent to the database.