### PR TITLE
iOS: fix compilation problems, warnings and the Benitlux ios-release rule

### DIFF
--- a/contrib/benitlux/Makefile
+++ b/contrib/benitlux/Makefile
@@ -79,7 +79,9 @@ bin/proto.app: $(shell nitls -M src/client/ios_proto.nit) ios/AppIcon.appiconset
 
 ios-release: $(shell nitls -M src/client/ios.nit) ios/AppIcon.appiconset/Contents.json
 	mkdir -p bin/
-	nitc -o bin/benitlux.app src/client/ios.nit -D benitlux_rest_server_uri=http://$(SERVER)/
+	nitc -o bin/benitlux.app src/client/ios.nit \
+		-D benitlux_rest_server_uri=http://xymus.net/benitlux/ --release \
+		--compile-dir nit_compile
 
 ios/AppIcon.appiconset/Contents.json: art/icon.svg
 	mkdir -p ios

--- a/lib/md5.nit
+++ b/lib/md5.nit
@@ -508,7 +508,7 @@ redef class NativeString
 		int di;
 
 		md5_init(&state);
-		md5_append(&state, (const md5_byte_t *)self, strlen(self));
+		md5_append(&state, (const md5_byte_t *)self, (int)strlen(self));
 		md5_finish(&state, digest);
 
 		for (di = 0; di < 16; ++di)

--- a/lib/pthreads/pthreads.nit
+++ b/lib/pthreads/pthreads.nit
@@ -128,7 +128,7 @@ private extern class NativePthread in "C" `{ pthread_t * `}
 
 	fun equal(other: NativePthread): Bool `{ return pthread_equal(*self, *other); `}
 
-	fun kill(signal: Int) `{ pthread_kill(*self, signal); `}
+	fun kill(signal: Int) `{ pthread_kill(*self, (int)signal); `}
 end
 
 private extern class NativePthreadAttr in "C" `{ pthread_attr_t * `}

--- a/src/platform/ios.nit
+++ b/src/platform/ios.nit
@@ -175,7 +175,14 @@ private class IOSToolchain
 		toolcontext.exec_and_check(args, "iOS project error")
 
 		# Move compiled app to destination
-		if outfile.file_exists then outfile.rmdir
+		if outfile.file_exists then
+			var error = outfile.rmdir
+			if error != null then
+				print_error error
+				exit 1
+			end
+		end
+
 		args = ["mv", "{ios_project_root}/build/Debug-iphonesimulator/{project_name}.app", outfile]
 		toolcontext.exec_and_check(args, "iOS project error")
 	end

--- a/src/platform/ios.nit
+++ b/src/platform/ios.nit
@@ -168,7 +168,7 @@ private class IOSToolchain
 		# TODO support more than the iPhone and the simulator.
 		var compile_mode = if release then "Release" else "Debug"
 		var args = ["sh", "-c", "cd {ios_project_root}; " +
-			"xcodebuild -target '{project_name}' " +
+			"xcodebuild -quiet -target '{project_name}' " +
 			"-destination 'platform=iOS Simulator,name=iPhone' " +
 			"-configuration {compile_mode} " +
 			 "ONLY_ACTIVE_ARCH=NO "+

--- a/src/platform/ios.nit
+++ b/src/platform/ios.nit
@@ -166,10 +166,11 @@ private class IOSToolchain
 		# Compile with `xcodebuild`
 		#
 		# TODO support more than the iPhone and the simulator.
+		var compile_mode = if release then "Release" else "Debug"
 		var args = ["sh", "-c", "cd {ios_project_root}; " +
 			"xcodebuild -target '{project_name}' " +
 			"-destination 'platform=iOS Simulator,name=iPhone' " +
-			"-configuration {if release then "Release" else "Debug"} " +
+			"-configuration {compile_mode} " +
 			 "ONLY_ACTIVE_ARCH=NO "+
 			"-sdk iphonesimulator build"]
 		toolcontext.exec_and_check(args, "iOS project error")
@@ -183,7 +184,7 @@ private class IOSToolchain
 			end
 		end
 
-		args = ["mv", "{ios_project_root}/build/Debug-iphonesimulator/{project_name}.app", outfile]
+		args = ["mv", "{ios_project_root}/build/{compile_mode}-iphonesimulator/{project_name}.app", outfile]
 		toolcontext.exec_and_check(args, "iOS project error")
 	end
 end

--- a/src/toolcontext.nit
+++ b/src/toolcontext.nit
@@ -340,7 +340,7 @@ class ToolContext
 		proc_which.wait
 		var res = proc_which.status
 		if res != 0 then
-			print "{error}: executable \"{prog}\" not found"
+			print_error "{error}: executable \"{prog}\" not found"
 			exit 1
 		end
 
@@ -349,7 +349,7 @@ class ToolContext
 		proc.wait
 		res = proc.status
 		if res != 0 then
-			print "{error}: execution of \"{prog} {args.join(" ")}\" failed"
+			print_error "{error}: execution of \"{prog} {args.join(" ")}\" failed"
 			exit 1
 		end
 	end

--- a/tests/Darwin.skip
+++ b/tests/Darwin.skip
@@ -7,3 +7,4 @@ mpi
 emscripten
 ui_test
 readline
+postgres

--- a/tests/sav/hello_ios.res
+++ b/tests/sav/hello_ios.res
@@ -5,4 +5,6 @@ out/hello_ios.bin/LaunchScreen.storyboardc/01J-lp-oVM-view-Ze5-6b-2t3.nib
 out/hello_ios.bin/LaunchScreen.storyboardc/Info.plist
 out/hello_ios.bin/LaunchScreen.storyboardc/UIViewController-01J-lp-oVM.nib
 out/hello_ios.bin/PkgInfo
+out/hello_ios.bin/_CodeSignature
+out/hello_ios.bin/_CodeSignature/CodeResources
 out/hello_ios.bin/hello_ios

--- a/tests/sav/test_platform_ios.res
+++ b/tests/sav/test_platform_ios.res
@@ -5,4 +5,6 @@ out/test_platform_ios.bin/LaunchScreen.storyboardc/01J-lp-oVM-view-Ze5-6b-2t3.ni
 out/test_platform_ios.bin/LaunchScreen.storyboardc/Info.plist
 out/test_platform_ios.bin/LaunchScreen.storyboardc/UIViewController-01J-lp-oVM.nib
 out/test_platform_ios.bin/PkgInfo
+out/test_platform_ios.bin/_CodeSignature
+out/test_platform_ios.bin/_CodeSignature/CodeResources
 out/test_platform_ios.bin/test_platform_ios


### PR DESCRIPTION
General fixes for the iOS support:
* Report errors on `rmdir`, this depends on the fix #2309.
* Fix release mode compilation, the path to the binary was wrong.
* Fix the ios-release rule of Benitlux to use the release mode, contact the right server, and keep the generated files to use from XCode.
* Finally silence the normal output of `xcodebuild`. This looks like a new feature of XCode 8!
* Fixed a few warnings raised by clang.