### PR TITLE
android: click event on button release, better errors and safer `JavaString::to_s`

### DIFF
--- a/lib/android/ui/ui.nit
+++ b/lib/android/ui/ui.nit
@@ -330,11 +330,13 @@ redef class NativeButton
 		final int final_sender_object = sender_object;
 		Button_incr_ref(final_sender_object);
 
-		return new android.widget.Button(context){
+		return new android.widget.Button(context) {
 			@Override
 			public boolean onTouchEvent(android.view.MotionEvent event) {
-				if(event.getAction() == android.view.MotionEvent.ACTION_DOWN) {
+				if (event.getAction() == android.view.MotionEvent.ACTION_UP) {
 					Button_on_click(final_sender_object);
+					return true;
+				} else if (event.getAction() == android.view.MotionEvent.ACTION_DOWN) {
 					return true;
 				}
 				return false;

--- a/lib/java/ffi_support.nit
+++ b/lib/java/ffi_support.nit
@@ -29,8 +29,9 @@ redef class Sys
 	private var jvm_cache: nullable JavaVM = null
 	private var jni_env_cache: nullable JniEnv = null
 
-	# Default Java Virtual Machine to use (will be instantiated using
-	# `create_default_jvm` if not already set)
+	# Default Java Virtual Machine to use
+	#
+	# Instantiated using `create_default_jvm` if not already set.
 	fun jvm: JavaVM
 	do
 		if jvm_cache == null then create_default_jvm
@@ -110,7 +111,11 @@ extern class JavaString in "Java" `{ java.lang.String `}
 		return nit_cstr;
 	`}
 
-	redef fun to_s do return to_cstring.to_s
+	redef fun to_s
+	do
+		if is_java_null then return "<{inspect_head}:null>"
+		return to_cstring.to_s
+	end
 end
 
 redef class NativeString
@@ -188,7 +193,7 @@ redef extern class JavaObject
 	# Use Java's `toString` for any `JavaObject`
 	redef fun to_s
 	do
-		if is_java_null then return super
+		if is_java_null then return "<{inspect_head}:null>"
 		return to_java_string.to_s
 	end
 end


### PR DESCRIPTION
Some small tweaks to the Android support:

* `JavaString::to_s` used to crash (at the JNI level) if the associated Java string was null. This was a counterintuitive behavior when the Nit object is non-nullable. This PR prevents this error by returning something similar to the default `Object::to_s` when the underlying Java value is null (for `JavaString` and others). This makes it crash proof, but one should still check if `JavaString::is_java_null` before using the value returned by `to_s` when an actual string is expected.

* Some Java exceptions raised by the Android implementation of `http_get` do not have a message. This PR looks through the causes of such exceptions to find the first available message.

* Also, fix `on_click & ButtonPressEvent` to be raised only when a button is released (instead of at the initial touch).