### PR TITLE
nitcorn: decode GET args from percent encoding

### DIFF
--- a/contrib/benitlux/src/client/views/social_views.nit
+++ b/contrib/benitlux/src/client/views/social_views.nit
@@ -66,7 +66,7 @@ class SocialWindow
 		var query = txt_query.text
 		if query == null or query.is_empty then return
 
-		var res = "rest/search?token={app.token}&query={query}&offset=0"
+		var res = "rest/search?token={app.token}&query={query.to_percent_encoding}&offset=0"
 		(new ListUsersAction(self, res)).start
 	end
 

--- a/contrib/benitlux/src/client/views/user_views.nit
+++ b/contrib/benitlux/src/client/views/user_views.nit
@@ -146,7 +146,7 @@ class SignupWindow
 
 				if sender == but_login then
 					feedback "Logging in...".t
-					(new LoginOrSignupAction(self, "rest/login?name={name}&pass={pass.pass_hash}")).start
+					(new LoginOrSignupAction(self, "rest/login?name={name.to_percent_encoding}&pass={pass.pass_hash}")).start
 				else if sender == but_signup then
 					if pass != txt_pass2.text then
 						feedback "Passwords do not match.".t
@@ -160,7 +160,7 @@ class SignupWindow
 					end
 
 					feedback "Signing up...".t
-					(new LoginOrSignupAction(self, "rest/signup?name={name}&pass={pass.pass_hash}&email={email}")).start
+					(new LoginOrSignupAction(self, "rest/signup?name={name.to_percent_encoding}&pass={pass.pass_hash}&email={email.to_percent_encoding}")).start
 				end
 			end
 		end

--- a/contrib/shibuqam/examples/shibuqamoauth.nit
+++ b/contrib/shibuqam/examples/shibuqamoauth.nit
@@ -174,17 +174,6 @@ import popcorn
 import shibuqam
 import json
 
-redef class HttpRequest
-	# percent decoded get or post parameter.
-	fun dec_param(name: String): nullable String
-	do
-		var res = get_args.get_or_null(name)
-		if res == null then res = post_args.get_or_null(name)
-		if res == null then return null
-		return res.from_percent_encoding
-	end
-end
-
 class AuthHandler
 	super Handler
 
@@ -232,8 +221,8 @@ class AuthHandler
 		# GET means a Authorization Request from the user-agent
 
 		# Get the `redirect_uri` parameter, we use it to identify the client
-		var redir = http_request.dec_param("redir")
-		if redir == null then redir = http_request.dec_param("redirect_uri")
+		var redir = http_request.string_arg("redir")
+		if redir == null then redir = http_request.string_arg("redirect_uri")
 		if redir == null then
 			response.send("No redirect_uri.", 400)
 			return
@@ -246,7 +235,7 @@ class AuthHandler
 		end
 
 		# Get the state, we use it to avoid CSRF attacks
-		var state = http_request.dec_param("state")
+		var state = http_request.string_arg("state")
 		var res = redir + "?"
 
 		# If we are here, the reverse proxy did the authentication
@@ -281,7 +270,7 @@ class AuthHandler
 
 		expiration
 
-		var code = http_request.dec_param("code")
+		var code = http_request.string_arg("code")
 		if code == null then
 			print "POST: no code"
 			return

--- a/lib/nitcorn/http_request.nit
+++ b/lib/nitcorn/http_request.nit
@@ -239,7 +239,10 @@ class HttpRequestParser
 			for param in get_args do
 				var key_value = param.split_with("=")
 				if key_value.length < 2 then continue
-				query_strings[key_value[0]] = key_value[1]
+
+				var key = key_value[0].from_percent_encoding
+				var value = key_value[1].from_percent_encoding
+				query_strings[key] = value
 			end
 		end
 

--- a/tests/sav/test_nitcorn.res
+++ b/tests/sav/test_nitcorn.res
@@ -26,6 +26,11 @@ POST args: i:0123, s:asdf
 Method: GET, URI: /simple_answer, trailing: /
 Cookie: i:0123, s:asdf
 
+[Client] curl -s localhost:*****/simple_answer --get --data-urlencode 's=b b'
+[Response] Simple answer
+Method: GET, URI: /simple_answer, trailing: /
+GET args: s:b b
+
 [Client] curl -s localhost:*****/params_answer/0123/asdf
 [Response] Simple answer
 Method: GET, URI: /params_answer/0123/asdf, trailing: /

--- a/tests/test_nitcorn.nit
+++ b/tests/test_nitcorn.nit
@@ -86,6 +86,7 @@ class ClientThread
 		system "curl -s '{iface}/simple_answer?i=0123&s=asdf'"
 		system "curl -s {iface}/simple_answer --data 'i=0123&s=asdf'"
 		system "curl -s {iface}/simple_answer --cookie 'i=0123; s=asdf'"
+		system "curl -s {iface}/simple_answer --get --data-urlencode 's=b b'"
 
 		system "curl -s {iface}/params_answer/0123/asdf"
 		system "curl -s {iface}/params_answer/0123/"


### PR DESCRIPTION
While POST data was decoded from percent encoding, GET args were not. Some clients (`shibuqam`) manually decoded that args while others (`benitlux`) hung on requests with spaces.

There is still an issue in the HTTP request parsing where request URL with a space are broken. I'm not fixing this right away because there is no current issue associated to this problem and I have a larger rewrite of nitcorn in the works that will solve this.