### PR TITLE
nitcorn: handle SIGINT and SIGTERM

### DIFF
--- a/lib/libevent.nit
+++ b/lib/libevent.nit
@@ -65,16 +65,16 @@ in "C" `{
 	{
 		ConnectionFactory_accept_connection(ctx, listener, fd, addrin, socklen);
 	}
+#endif
 
+#ifdef EventCallback_incr_ref
 	// Callback forwarded to 'EventCallback.callback'
 	static void signal_cb(evutil_socket_t fd, short events, void *data)
 	{
 		EventCallback handler = data;
 		EventCallback_callback(handler, events);
 	}
-
 #endif
-
 `}
 
 # Structure to hold information and state for a Libevent dispatch loop.

--- a/lib/libevent.nit
+++ b/lib/libevent.nit
@@ -85,16 +85,15 @@ extern class NativeEventBase `{ struct event_base * `}
 	# Event dispatching loop
 	#
 	# This loop will run the event base until either there are no more added
-	# events, or until something calls `exit_loop`.
+	# events, or until something calls `loopexit`.
 	fun dispatch `{ event_base_dispatch(self); `}
 
 	# Exit the event loop
 	#
 	# TODO support timer
-	fun exit_loop `{ event_base_loopexit(self, NULL); `}
+	fun loopexit `{ event_base_loopexit(self, NULL); `}
 
-	# Destroy this instance
-	fun destroy `{ event_base_free(self); `}
+	redef fun free `{ event_base_free(self); `}
 end
 
 # Spawned to manage a specific connection

--- a/lib/nitcorn/nitcorn.nit
+++ b/lib/nitcorn/nitcorn.nit
@@ -62,3 +62,4 @@ module nitcorn
 import reactor
 import file_server
 import sessions
+import signal_handler

--- a/lib/nitcorn/reactor.nit
+++ b/lib/nitcorn/reactor.nit
@@ -148,7 +148,7 @@ class HttpFactory
 			event_base.dispatch
 		end
 
-		event_base.destroy
+		event_base.free
 	end
 end
 

--- a/lib/nitcorn/signal_handler.nit
+++ b/lib/nitcorn/signal_handler.nit
@@ -1,0 +1,39 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Handle SIGINT and SIGTERM to close the server after all active events
+module signal_handler
+
+import reactor
+
+redef class HttpFactory
+	super EventCallback
+
+	private var signal_handlers: Array[NativeEvSignal] = [
+		new NativeEvSignal(event_base, 2, self), # SIGINT
+		new NativeEvSignal(event_base, 15, self) # SIGTERM
+		] is lazy
+
+	redef fun run
+	do
+		for handler in signal_handlers do handler.add
+		super
+	end
+
+	redef fun callback(events)
+	do
+		event_base.loopexit
+		for handler in signal_handlers do handler.del
+	end
+end

--- a/lib/signals.nit
+++ b/lib/signals.nit
@@ -164,7 +164,8 @@ interface SignalHandler
 
 			nit_signals_list[signal].safely = safely;
 
-			nit_SignalHandler_receive_signal = SignalHandler_receive_signal;
+			nit_SignalHandler_receive_signal =
+				(void (*)(void*, long))&SignalHandler_receive_signal;
 		}
 	`}
 


### PR DESCRIPTION
Intercept SIGINT and SIGTERM to close the server cleanly. The first signal request a clean exit from libevent, so it waits to complete the active events before closing. The second signal reverts to the default signal handler and quits instantly. 

Fix #2294.