### PR TITLE
pkgconfig annotation: improve error on missing dev package

### DIFF
--- a/src/ffi/pkgconfig.nit
+++ b/src/ffi/pkgconfig.nit
@@ -80,7 +80,7 @@ class PkgconfigPhase
 			proc_exist.wait
 			status = proc_exist.status
 			if status == 1 then
-				modelbuilder.error(nat, "Error: package `{pkg}` unknown by `pkg-config`, make sure the development package is be installed.")
+				modelbuilder.error(nat, "Error: dev package for `{pkg}` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.")
 				return
 			else if status != 0 then
 				modelbuilder.error(nat, "Error: something went wrong calling `pkg-config`, make sure it is correctly installed.")

--- a/tests/sav/Darwin/todo
+++ b/tests/sav/Darwin/todo
@@ -1,7 +1,7 @@
 fatal error: 'endian.h' file not found
-Error: package `glesv1_cm` unknown by `pkg-config`, make sure the development package is be installed
-Error: package `glesv2` unknown by `pkg-config`, make sure the development package is be installed
-Error: package `egl` unknown by `pkg-config`, make sure the development package is be installed
-Error: package `ncurses` unknown by `pkg-config`, make sure the development package is be installed
-Error: package `x11` unknown by `pkg-config`, make sure the development package is be installed
+Error: dev package for `glesv1_cm` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.
+Error: dev package for `glesv2` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.
+Error: dev package for `egl` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.
+Error: dev package for `ncurses` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.
+Error: dev package for `x11` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.
 fatal error: 'libintl.h' file not found

--- a/tests/sav/error_annot_pkgconfig_alt1.res
+++ b/tests/sav/error_annot_pkgconfig_alt1.res
@@ -1,1 +1,1 @@
-alt/error_annot_pkgconfig_alt1.nit:18,38--61: Error: package `missing-lib` unknown by `pkg-config`, make sure the development package is be installed.
+alt/error_annot_pkgconfig_alt1.nit:18,38--61: Error: dev package for `missing-lib` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.


### PR DESCRIPTION
This is an attempt to improve the error message on a missing development package. The current error stumps everyone on the first occurrence. The new version puts an emphasis on three things:
- it needs the _dev_ package, 
- a possible solution by mentioning apt-get and brew,  and
- that it may be a problem with pkg-config itself. 

I chose to mention apt-get and brew as I consider that they are the best known package manager on Linux and macOS.. 
