### PR TITLE
lib/github: update unit test for change in Github API behavior

### DIFF
--- a/lib/github/api.nit
+++ b/lib/github/api.nit
@@ -466,7 +466,7 @@ class GithubAPI
 	#     assert repo != null
 	#     var comment = api.load_commit_comment(repo, 8982707)
 	#     assert comment.user.login == "Morriar"
-	#     assert comment.body == "For testing purposes..."
+	#     assert comment.body == "For testing purposes...\n"
 	#     assert comment.commit_id == "7eacb86d1e24b7e72bc9ac869bf7182c0300ceca"
 	fun load_commit_comment(repo: Repo, id: Int): nullable CommitComment do
 		return load_from_github("/repos/{repo.full_name}/comments/{id}").as(nullable CommitComment)


### PR DESCRIPTION
Update a Github API unit test for recent changes in the remote API behavior. I couldn't find any information on this change, so it may also be a temporary problem.

This commit was originally in #2326.