### PR TITLE
nitunit: set NIT_TESTING_PATH

### DIFF
--- a/share/man/nitunit.md
+++ b/share/man/nitunit.md
@@ -274,6 +274,23 @@ fun after_module do
 end
 ~~~~
 
+## Accessing the test suite environment
+
+The `NIT_TESTING_PATH` environment variable contains the current test suite
+file path.
+Nitunit define this variable before the execution of each test suite.
+It can be used to access files based on the current test_suite location:
+
+~~~
+class TestWithPath
+	super TestSuite
+
+    fun test_suite_path do
+        assert "NIT_TESTING_PATH".environ != ""
+    end
+end
+~~~
+
 ## Generating test suites
 
 Write test suites for big modules can be a repetitive and boring task...
@@ -383,6 +400,10 @@ To solve this issue, `NIT_TESTING_ID` is initialized with a distinct integer ide
 
 Note: `rand` is not a recommended way to get a distinct identifier because its randomness is disabled by default. See `SRAND`.
 
+### `NIT_TESTING_PATH`
+
+Only available for test suites.
+Contains the module test suite path.
 
 # SEE ALSO
 

--- a/src/testing/testing_base.nit
+++ b/src/testing/testing_base.nit
@@ -64,8 +64,8 @@ redef class ToolContext
 			return nitc
 		end
 
-		var nit_dir = nit_dir
-		nitc = nit_dir/"bin/nitc"
+		var nit_dir = nit_dir or else "."
+		nitc = nit_dir / "bin/nitc"
 		if not nitc.file_exists then
 			fatal_error(null, "Error: cannot find nitc. Set envvar NIT_DIR or NITC or use the --nitc option.")
 			abort
@@ -108,7 +108,6 @@ ulimit -t {{{ulimit_usertime}}} 2> /dev/null
 	# If `has_progress_bar` is false, then only the first and last state is shown
 	fun show_unit_status(name: String, tests: SequenceRead[UnitTest])
 	do
-		var esc = 27.code_point.to_s
 		var line = "\r\x1B[K==== {name} ["
 		var done = tests.length
 		var fails = 0

--- a/src/testing/testing_base.nit
+++ b/src/testing/testing_base.nit
@@ -166,6 +166,13 @@ ulimit -t {{{ulimit_usertime}}} 2> /dev/null
 	fun show_unit(test: UnitTest, more_message: nullable String) do
 		print test.to_screen(more_message, not opt_no_color.value)
 	end
+
+	# Set the `NIT_TESTING_PATH` environment variable with `path`.
+	#
+	# If `path == null` then `NIT_TESTING_PATH` is set with the empty string.
+	fun set_testing_path(path: nullable String) do
+		"NIT_TESTING_PATH".setenv(path or else "")
+	end
 end
 
 # A unit test is an elementary test discovered, run and reported by nitunit.

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -129,6 +129,7 @@ class TestSuite
 
 	# Execute the test suite
 	fun run do
+		set_env
 		show_status
 		if not toolcontext.test_dir.file_exists then
 			toolcontext.test_dir.mkdir
@@ -212,6 +213,13 @@ class TestSuite
 		if res != 0 then
 			failure = msg
 		end
+	end
+
+	# Set environment variables for test suite execution
+	fun set_env do
+		var loc = mmodule.location.file
+		if loc == null then return
+		toolcontext.set_testing_path(loc.filename)
 	end
 
 	# Error occured during test-suite compilation.

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -122,8 +122,8 @@ class TestSuite
 	# Test to be executed after the whole test suite.
 	var after_module: nullable TestCase = null
 
-	fun show_status
-	do
+	# Display test suite status in std-out.
+	fun show_status do
 		toolcontext.show_unit_status("Test-suite of module " + mmodule.full_name, test_cases)
 	end
 

--- a/tests/nitunit.args
+++ b/tests/nitunit.args
@@ -7,3 +7,4 @@ test_nitunit3 --no-color -o $WRITE
 test_nitunit_md.md --no-color -o $WRITE
 test_doc3.nit --no-color -o $WRITE
 test_nitunit4 --no-color -o $WRITE
+test_nitunit5.nit --no-color -o $WRITE

--- a/tests/sav/nitunit_args10.res
+++ b/tests/sav/nitunit_args10.res
@@ -1,0 +1,8 @@
+==== Test-suite of module test_nitunit5::test_nitunit5 | tests: 2
+[OK] test_nitunit5$TestNitunit5$test_path_is_set
+[OK] test_nitunit5$TestNitunit5$test_path_is_suite_path
+
+Docunits: Entities: 4; Documented ones: 0; With nitunits: 0
+Test suites: Classes: 1; Test Cases: 2; Failures: 0
+[SUCCESS] All 2 tests passed.
+<testsuites><testsuite package="test_nitunit5::test_nitunit5"></testsuite><testsuite package="test_nitunit5"><testcase classname="nitunit.test_nitunit5.TestNitunit5" name="test_path_is_set" time="0.0"><system-err></system-err></testcase><testcase classname="nitunit.test_nitunit5.TestNitunit5" name="test_path_is_suite_path" time="0.0"><system-err></system-err></testcase></testsuite></testsuites>

--- a/tests/test_nitunit5.nit
+++ b/tests/test_nitunit5.nit
@@ -1,0 +1,29 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module test_nitunit5 is test_suite
+
+import test_suite
+
+class TestNitunit5
+	super TestSuite
+
+	fun test_path_is_set do
+		assert "NIT_TESTING_PATH".environ != ""
+	end
+
+	fun test_path_is_suite_path do
+		assert "NIT_TESTING_PATH".environ.basename == "test_nitunit5.nit"
+	end
+end


### PR DESCRIPTION
When working with test suites, one can now use `NIT_TESTING_PATH` to retrieve the test suite path.

It can be used to access files based on the current test suite location:

~~~nit
class MyTest
	super TestSuite

    fun test_suite_path do
        assert "NIT_TESTING_PATH".environ.basename == "my_test_suite.nit"
    end
end
~~~

Useful for test suites based on model loading like in #2327.