### PR TITLE
lib/text: do not replace undecoded `%` by `?`

### DIFF
--- a/lib/core/bytes.nit
+++ b/lib/core/bytes.nit
@@ -581,6 +581,7 @@ class Bytes
 	#     assert "incomplete %".to_bytes.from_percent_encoding == "incomplete %".to_bytes
 	#     assert "invalid % usage".to_bytes.from_percent_encoding == "invalid % usage".to_bytes
 	#     assert "%c3%a9%e3%81%82%e3%81%84%e3%81%86".to_bytes.from_percent_encoding == "éあいう".to_bytes
+	#     assert "%1 %A %C3%A9A9".to_bytes.from_percent_encoding == "%1 %A éA9".to_bytes
 	fun from_percent_encoding: Bytes do
 		var tmp = new Bytes.with_capacity(length)
 		var pos = 0

--- a/lib/core/bytes.nit
+++ b/lib/core/bytes.nit
@@ -572,14 +572,14 @@ class Bytes
 
 	# Decode `self` from percent (or URL) encoding to a clear string
 	#
-	# Replace invalid use of '%' with '?'.
+	# Invalid '%' are not decoded.
 	#
 	#     assert "aBc09-._~".to_bytes.from_percent_encoding == "aBc09-._~".to_bytes
 	#     assert "%25%28%29%3c%20%3e".to_bytes.from_percent_encoding == "%()< >".to_bytes
 	#     assert ".com%2fpost%3fe%3dasdf%26f%3d123".to_bytes.from_percent_encoding == ".com/post?e=asdf&f=123".to_bytes
 	#     assert "%25%28%29%3C%20%3E".to_bytes.from_percent_encoding == "%()< >".to_bytes
-	#     assert "incomplete %".to_bytes.from_percent_encoding == "incomplete ?".to_bytes
-	#     assert "invalid % usage".to_bytes.from_percent_encoding == "invalid ? usage".to_bytes
+	#     assert "incomplete %".to_bytes.from_percent_encoding == "incomplete %".to_bytes
+	#     assert "invalid % usage".to_bytes.from_percent_encoding == "invalid % usage".to_bytes
 	#     assert "%c3%a9%e3%81%82%e3%81%84%e3%81%86".to_bytes.from_percent_encoding == "éあいう".to_bytes
 	fun from_percent_encoding: Bytes do
 		var tmp = new Bytes.with_capacity(length)
@@ -592,14 +592,14 @@ class Bytes
 				continue
 			end
 			if length - pos < 2 then
-				tmp.add '?'.ascii
+				tmp.add '%'.ascii
 				pos += 1
 				continue
 			end
 			var bn = self[pos + 1]
 			var bnn = self[pos + 2]
 			if not bn.is_valid_hexdigit or not bnn.is_valid_hexdigit then
-				tmp.add '?'.ascii
+				tmp.add '%'.ascii
 				pos += 1
 				continue
 			end

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -843,14 +843,14 @@ abstract class Text
 
 	# Decode `self` from percent (or URL) encoding to a clear string
 	#
-	# Replace invalid use of '%' with '?'.
+	# Invalid '%' are not decoded.
 	#
 	#     assert "aBc09-._~".from_percent_encoding == "aBc09-._~"
 	#     assert "%25%28%29%3c%20%3e".from_percent_encoding == "%()< >"
 	#     assert ".com%2fpost%3fe%3dasdf%26f%3d123".from_percent_encoding == ".com/post?e=asdf&f=123"
 	#     assert "%25%28%29%3C%20%3E".from_percent_encoding == "%()< >"
-	#     assert "incomplete %".from_percent_encoding == "incomplete ?"
-	#     assert "invalid % usage".from_percent_encoding == "invalid ? usage"
+	#     assert "incomplete %".from_percent_encoding == "incomplete %"
+	#     assert "invalid % usage".from_percent_encoding == "invalid % usage"
 	#     assert "%c3%a9%e3%81%82%e3%81%84%e3%81%86".from_percent_encoding == "éあいう"
 	fun from_percent_encoding: String
 	do
@@ -874,7 +874,7 @@ abstract class Text
 			if c == '%' then
 				if i + 2 >= length then
 					# What follows % has been cut off
-					buf[l] = '?'.ascii
+					buf[l] = '%'.ascii
 				else
 					i += 1
 					var hex_s = substring(i, 2)
@@ -884,7 +884,7 @@ abstract class Text
 						i += 1
 					else
 						# What follows a % is not Hex
-						buf[l] = '?'.ascii
+						buf[l] = '%'.ascii
 						i -= 1
 					end
 				end

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -852,6 +852,7 @@ abstract class Text
 	#     assert "incomplete %".from_percent_encoding == "incomplete %"
 	#     assert "invalid % usage".from_percent_encoding == "invalid % usage"
 	#     assert "%c3%a9%e3%81%82%e3%81%84%e3%81%86".from_percent_encoding == "éあいう"
+	#     assert "%1 %A %C3%A9A9".from_percent_encoding == "%1 %A éA9"
 	fun from_percent_encoding: String
 	do
 		var len = byte_length


### PR DESCRIPTION
Change the specification of `from_percent_encoding` so undecoded `%` are not replaced by `?`.

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>