### PR TITLE
proposal: lib/config

### DIFF
--- a/contrib/nitrpg/README.md
+++ b/contrib/nitrpg/README.md
@@ -42,7 +42,9 @@ It should alwaysd be up if you want your game to be kept up-to-date.
 
 To run the listener:
 
+~~~raw
 	./listener <host> <port>
+~~~
 
 The arguments `host` and `port` must correspond to what you entered in your
 GitHub hook settings.
@@ -53,7 +55,9 @@ The `web` program act as a [nitcorn](http://nitlanguage.org/doc/stdlib/module_ni
 
 To run the webserver:
 
+~~~raw
 	./web <host> <port> <root>
+~~~
 
 The arguments `host` and `port` must correspond to what you entered in your
 GitHub hook settings.
@@ -62,11 +66,15 @@ NitRPG root.
 
 For example, if NitRPG is installed in `yourdomain.com/nitrpg`:
 
+~~~raw
 	./web localhost 3000 "/nitrpg"
+~~~
 
 Leave it empty if NitRPG is installed at the root of the domain:
 
+~~~raw
 	./web localhost 3000 ""
+~~~
 
 The webserver can then be accessed at `http://yourdomain.com:3000/nitrpg/`.
 

--- a/lib/config.ini
+++ b/lib/config.ini
@@ -1,0 +1,11 @@
+[package]
+name=config
+tags=config,options,ini,lib
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/lib/config.nit
+git=https://github.com/nitlang/nit.git
+git.directory=lib/config.nit
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/lib/config.nit
+++ b/lib/config.nit
@@ -1,0 +1,279 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration options for nit tools and apps
+#
+# This module provides basic services for options handling in your Nit programs.
+#
+# ## Basic configuration holder
+#
+# The `Config` class can be used as a simple option holder and processor:
+#
+# ~~~
+# import config
+#
+# # Create a new config option
+# var opt_my = new OptionString("My option", "--my")
+#
+# # Create the config and add the option
+# var config = new Config
+# config.add_option(opt_my)
+#
+# # Parse the program arguments, usually `args`
+# config.parse_options(["--my", "myOption", "arg1", "arg2"])
+#
+# # Access the options and args
+# assert opt_my.value == "myOption"
+# assert config.args == ["arg1", "arg2"]
+# ~~~
+#
+# ## Custom configuration class
+#
+# Instead of using basic `Config` instances, it is better to define new sublcasses
+# to store options and define custom services.
+#
+# ~~~
+# import config
+#
+# class MyConfig
+#	super Config
+#
+#	var opt_my = new OptionString("My option", "--my")
+#
+#	init do
+#		super
+#		tool_description = "Usage: MyExample [OPTION]... [ARGS]..."
+#		add_option(opt_my)
+#	end
+#
+#	fun my: String do return opt_my.value or else "Default value"
+# end
+#
+# var config = new MyConfig
+# config.parse_options(["--my", "myOption", "arg1", "arg2"])
+#
+# assert config.my == "myOption"
+# assert config.args == ["arg1", "arg2"]
+# ~~~
+#
+# We define the `my` method to provide an elegant shortcut to `opt_my.value`
+# and define the default value if the option was not set by the user.
+#
+# The `tool_description` attribute is used to set the `usage` header printed when
+# the user request the `help` message.
+#
+# ~~~
+# config.parse_options(["-h"])
+# if config.help then
+#	config.usage
+#	exit 0
+# end
+# ~~~
+#
+# This will display the tool usage like this:
+#
+# ~~~raw
+# Usage: MyExample [OPTION]... [ARGS]...
+#  -h, --help   Show this help message
+#  --my         My option
+# ~~~
+#
+# ## Configuration with `ini` file
+#
+# The `IniConfig` class extends `Config` to add an easy way to link your
+# configuration to an ini file.
+
+# ~~~
+# class MyIniConfig
+#	super IniConfig
+#
+#	var opt_my = new OptionString("My option", "--my")
+#
+#	init do
+#		super
+#		tool_description = "Usage: MyExample [OPTION]... [ARGS]..."
+#		opts.add_option(opt_my)
+#	end
+#
+#	fun my: String do return opt_my.value or else ini["my"] or else "Default"
+# end
+# ~~~
+#
+# This time, we define the `my` method to return the option value or the ini
+# if no option was passed. Finally, if no ini value can be found, we return the
+# default value.
+#
+# By default, `IniConfig` looks at a `config.ini` file in the execution directory.
+# This can be overrided in multiple ways.
+#
+# First by the app user by setting the `--config` option:
+#
+# ~~~
+# var config = new MyIniConfig
+# config.parse_options(["--config", "my_config.ini"])
+#
+# assert config.config_file == "my_config.ini"
+# ~~~
+#
+# Default config file can also be changed by the library client through the
+# `default_config_file` attribute:
+#
+# ~~~
+# config = new MyIniConfig
+# config.default_config_file = "my_config.ini"
+# config.parse_options(["arg"])
+#
+# assert config.config_file == "my_config.ini"
+# ~~~
+#
+# Or by the library developper in the custom config class:
+#
+# ~~~
+# class MyCustomIniConfig
+#	super IniConfig
+#
+#	redef var default_config_file = "my_config.ini"
+# end
+#
+# var config = new MyCustomIniConfig
+# config.parse_options(["arg"])
+#
+# assert config.config_file == "my_config.ini"
+# ~~~
+module config
+
+import ini
+import opts
+
+# Basic configuration class
+#
+# ~~~
+# import config
+#
+# class MyConfig
+#	super Config
+#
+#	var opt_my = new OptionString("My option", "--my")
+#
+#	init do
+#		super
+#		tool_description = "Usage: MyExample [OPTION]... [ARGS]..."
+#		opts.add_option(opt_my)
+#	end
+#
+#	fun my: String do return opt_my.value or else "Default value"
+# end
+#
+# var config = new MyConfig
+# config.parse_options(["--my", "hello", "arg1", "arg2"])
+# assert config.my == "hello"
+# assert config.args == ["arg1", "arg2"]
+# ~~~
+class Config
+
+	# Context used to store and parse options
+	var opts = new OptionContext
+
+	# Help option
+	var opt_help = new OptionBool("Show this help message", "-h", "--help")
+
+	# Redefine this init to add your options
+	init do
+		add_option(opt_help)
+	end
+
+	# Add an option to `self`
+	#
+	# Shortcut to `opts.add_option`.
+	fun add_option(opt: Option...) do opts.add_option(opt...)
+
+	# Initialize `self` options from `args`
+	fun parse_options(args: Collection[String]) do
+		opts.parse(args)
+	end
+
+	# Return the remaining args once options are parsed by `from_args`
+	fun args: Array[String] do return opts.rest
+
+	# Name, usage and synopsis of the tool.
+	# It is mainly used in `usage`.
+	# Should be correctly set by the client before calling `usage`
+	# A multi-line string is recommended.
+	#
+	# eg. `"Usage: tool [OPTION]... [FILE]...\nDo some things."`
+	var tool_description: String = "Usage: [OPTION]... [ARG]..." is writable
+
+	# Was the `--help` option requested?
+	fun help: Bool do return opt_help.value
+
+	# Display `tool_description` and options usage in console
+	fun usage do
+		print tool_description
+		opts.usage
+	end
+end
+
+# Configuration class based on a INI file.
+#
+# ~~~
+# class MyIniConfig
+#	super IniConfig
+#
+#	var opt_my = new OptionString("My option", "--my")
+#
+#	init do
+#		super
+#		tool_description = "Usage: MyExample [OPTION]... [ARGS]..."
+#		opts.add_option(opt_my)
+#	end
+#
+#	fun my: String do return opt_my.value or else ini["my"] or else "Default"
+# end
+#
+# var config = new MyIniConfig
+# config.default_config_file = "my_config.ini"
+# config.parse_options(args)
+#
+# if config.help then
+#	config.usage
+#	exit 0
+# end
+#
+# assert config.my == "Default"
+# ~~~
+class IniConfig
+	super Config
+
+	# Config tree used to store config options
+	var ini: ConfigTree is noinit
+
+	# Path to app config file
+	var opt_config = new OptionString("Path to config file", "--config")
+
+	init do
+		super
+		opts.add_option(opt_config)
+	end
+
+	redef fun parse_options(args) do
+		super
+		ini = new ConfigTree(config_file)
+	end
+
+	# Default config file path
+	var default_config_file = "config.ini" is writable
+
+	# Return the config file path from options or the default
+	fun config_file: String do return opt_config.value or else default_config_file
+end

--- a/lib/github/api.nit
+++ b/lib/github/api.nit
@@ -757,6 +757,9 @@ class PullRequest
 
 	# Changed files count.
 	var changed_files: Int is writable
+
+	# URL to patch file
+	var patch_url: nullable String is writable
 end
 
 # A pull request reference (used for head and base).

--- a/lib/opts.nit
+++ b/lib/opts.nit
@@ -292,9 +292,7 @@ class OptionContext
 	private var optmap = new HashMap[String, Option]
 
 	# Add one or more options to the context
-	fun add_option(opts: Option...) do
-			options.add_all(opts)
-	end
+	fun add_option(opts: Option...) do options.add_all(opts)
 
 	# Display all the options available
 	fun usage

--- a/lib/popcorn/pop_repos.nit
+++ b/lib/popcorn/pop_repos.nit
@@ -131,39 +131,28 @@ redef class AppConfig
 	# Default database hostname
 	var default_db_name = "popcorn"
 
-	# MongoDB server used for data persistence
-	var db_host: String is lazy do return value_or_default("db.host", default_db_host)
-
-	# MongoDB DB used for data persistence
-	var db_name: String is lazy do return value_or_default("db.name", default_db_name)
-
-	# Mongo db client
-	var client = new MongoClient(db_host) is lazy
-
-	# Mongo db instance
-	var db: MongoDb = client.database(db_name) is lazy
-
-	redef init from_options(opts) do
-		super
-		var db_host = opts.opt_db_host.value
-		if db_host != null then self["db.host"] = db_host
-		var db_name = opts.opt_db_name.value
-		if db_name != null then self["db.name"] = db_name
-	end
-end
-
-redef class AppOptions
-
 	# MongoDb host name
 	var opt_db_host = new OptionString("MongoDb host", "--db-host")
 
 	# MongoDb database name
 	var opt_db_name = new OptionString("MongoDb database name", "--db-name")
 
+	# MongoDB server used for data persistence
+	fun db_host: String do return opt_db_host.value or else ini["db.host"] or else default_db_host
+
+	# MongoDB DB used for data persistence
+	fun db_name: String do return opt_db_name.value or else ini["db.name"] or else default_db_name
+
 	init do
 		super
 		add_option(opt_db_host, opt_db_name)
 	end
+
+	# Mongo db client
+	var client = new MongoClient(db_host) is lazy
+
+	# Mongo db instance
+	var db: MongoDb = client.database(db_name) is lazy
 end
 
 # A Repository is an object that can store serialized instances.

--- a/src/nitweb.nit
+++ b/src/nitweb.nit
@@ -15,7 +15,6 @@
 # Runs a webserver based on nitcorn that render things from model.
 module nitweb
 
-import popcorn::pop_config
 import popcorn::pop_auth
 import frontend
 import web
@@ -27,15 +26,13 @@ redef class NitwebConfig
 	#
 	# * key: `github.client_id`
 	# * default: ``
-	var github_client_id: String is lazy do return value_or_default("github.client.id", "")
+	fun github_client_id: String do return ini["github.client.id"] or else ""
 
 	# Github client secret used for Github OAuth login.
 	#
 	# * key: `github.client_secret`
 	# * default: ``
-	var github_client_secret: String is lazy do
-		return value_or_default("github.client.secret", "")
-	end
+	fun github_client_secret: String do return ini["github.client.secret"] or else ""
 end
 
 redef class ToolContext
@@ -64,17 +61,17 @@ private class NitwebPhase
 
 	# Build the nitweb config from `toolcontext` options.
 	fun build_config(toolcontext: ToolContext, mainmodule: MModule): NitwebConfig do
-		var config_file = toolcontext.opt_config.value
-		if config_file == null then config_file = "nitweb.ini"
 		var config = new NitwebConfig(
-			config_file,
 			toolcontext.modelbuilder.model,
 			mainmodule,
 			toolcontext.modelbuilder)
+		var config_file = toolcontext.opt_config.value
+		if config_file == null then config.default_config_file = "nitweb.ini"
+		config.parse_options(args)
 		var opt_host = toolcontext.opt_host.value
-		if opt_host != null then config["app.host"] = opt_host
+		if opt_host != null then config.ini["app.host"] = opt_host
 		var opt_port = toolcontext.opt_port.value
-		if opt_port >= 0 then config["app.port"] = opt_port.to_s
+		if opt_port >= 0 then config.ini["app.port"] = opt_port.to_s
 		return config
 	end
 


### PR DESCRIPTION
We often need basic option handling in our app.

Here a minimalist proposal that covers the basics:
* options holder
* default values
* loading options from ini file

Extract from doc:

# Configuration options for nit tools and apps

This module provides basic services for options handling in your nit programs.

## Basic configuration holder

The `Config` class can be used as a simple option holder and processor:

~~~nit
import config

# Create a new config option
var opt_my = new OptionString("My option", "--my")

# Create the config and add the option
var config = new Config
config.add_option(opt_my)

# Parse the program arguments, usually `args`
config.parse_options(["--my", "myOption", "arg1", "arg2"])

# Access the options and args
assert opt_my.value == "myOption"
assert config.args == ["arg1", "arg2"]
~~~

## Custom configuration class

Instead of using basic `Config` instances, it is better to define new sublcasses
to store options and define custom services.

~~~nit
import config

class MyConfig
	super Config

	var opt_my = new OptionString("My option", "--my")

	init do
		super
		tool_description = "Usage: MyExample [OPTION]... [ARGS]..."
		add_option(opt_my)
	end

	fun my: String do return opt_my.value or else "Default value"
end

var config = new MyConfig
config.parse_options(["--my", "myOption", "arg1", "arg2"])

assert config.my == "myOption"
assert config.args == ["arg1", "arg2"]
~~~

We define the `my` method to provide an elegant shortcut to `opt_my.value`
and define the default value if the option was not set by the user.

The `tool_description` attribute is used to set the `usage` header printed when
the user request the `help` message.

~~~nit
config.parse_options(["-h"])
if config.help then
	config.usage
	exit 0
end
~~~

This will display the tool usage like this:

~~~raw
Usage: MyExample [OPTION]... [ARGS]...
 -h, --help   Show this help message
 --my         My option
~~~

## Configuration with `ini` file

The `IniConfig` class provides an easy way to link your configuration to an ini
file.

~~~nit
class MyIniConfig
	super IniConfig

	var opt_my = new OptionString("My option", "--my")

	init do
		super
		tool_description = "Usage: MyExample [OPTION]... [ARGS]..."
		opts.add_option(opt_my)
	end

	fun my: String do return opt_my.value or else ini["my"] or else "Default"
end
~~~

This time, we define the `my` method to return the option value or the ini
if no option was passed. Finally, if no ini value can be found, we return the
default value.

By default, `IniConfig` looks at a `config.ini` file in the execution directory.
This can be overrided in multiple ways.

First by the app user by setting the `--config` option:

~~~nit
var config = new MyIniConfig
config.parse_options(["--config", "my_config.ini"])

assert config.config_file == "my_config.ini"
~~~

Default config file can also be changed by the library client through the
`default_config_file` attribute:

~~~nit
config = new MyIniConfig
config.default_config_file = "my_config.ini"
config.parse_options(["arg"])

assert config.config_file == "my_config.ini"
~~~

Or by the library developper in the custom config class:

~~~nit
class MyCustomIniConfig
	super IniConfig

	redef var default_config_file = "my_config.ini"
end

var config = new MyCustomIniConfig
config.parse_options(["arg"])

assert config.config_file == "my_config.ini"
~~~

