### PR TITLE
nitweb: add READMEs summaries

### DIFF
--- a/share/nitweb/directives/ui-summary.html
+++ b/share/nitweb/directives/ui-summary.html
@@ -1,0 +1,23 @@
+<div>
+	<h4>Summary</h4>
+	<div ng-repeat='entry in headings' class='summary'>
+		<h1 ng-if='entry.level == 1'>
+			<a ng-click='goTo(entry)'>{{entry.text}}</a>
+		</h1>
+		<h2 ng-if='entry.level == 2'>
+			<a ng-click='goTo(entry)'>{{entry.text}}</a>
+		</h2>
+		<h3 ng-if='entry.level == 3'>
+			<a ng-click='goTo(entry)'>{{entry.text}}</a>
+		</h3>
+		<h4 ng-if='entry.level == 4'>
+			<a ng-click='goTo(entry)'>{{entry.text}}</a>
+		</h4>
+		<h5 ng-if='entry.level == 5'>
+			<a ng-click='goTo(entry)'>{{entry.text}}</a>
+		</h5>
+		<h6 ng-if='entry.level == 6'>
+			<a ng-click='goTo(entry)'>{{entry.text}}</a>
+		</h6>
+	</div>
+</div>

--- a/share/nitweb/javascripts/nitweb.js
+++ b/share/nitweb/javascripts/nitweb.js
@@ -51,7 +51,8 @@
 			.when('/doc/:id', {
 				templateUrl: 'views/doc.html',
 				controller: 'EntityCtrl',
-				controllerAs: 'entityCtrl'
+				controllerAs: 'entityCtrl',
+				reloadOnSearch: false
 			})
 			.otherwise({
 				templateUrl: 'views/error.html'

--- a/share/nitweb/javascripts/ui.js
+++ b/share/nitweb/javascripts/ui.js
@@ -129,6 +129,61 @@
 			};
 		})
 
+		.directive('uiSummary', function($rootScope, $location, $anchorScroll) {
+			return {
+				restrict: 'E',
+				scope: {
+					target: '@'
+				},
+				replace: true,
+				templateUrl: '/directives/ui-summary.html',
+				link: function ($scope, element, attrs) {
+					$scope.goTo = function(entity) {
+						$location.hash(entity.id);
+					}
+
+					$scope.textToId = function(text) {
+						return text.replace(/ /g, '-').replace(/[^A-Za-z_-]/g, '');
+					}
+
+					$rootScope.reloadSummary = function() {
+						var h = angular.element(document.querySelectorAll(
+							$scope.target + ' h1, ' +
+							$scope.target + ' h2, ' +
+							$scope.target + ' h3, ' +
+							$scope.target + ' h4, ' +
+							$scope.target + ' h5, ' +
+							$scope.target + ' h6 '));
+
+						$scope.headings = [];
+						angular.forEach(h, function(heading) {
+							var head = angular.element(heading);
+							if(!head.is(':visible')) { return ; }
+							var text = head.text().trim();
+							var id = $scope.textToId(text);
+							if(!head.attr('id')) {
+								head.attr('id', id);
+							} else {
+								id = head.attr('id');
+							}
+							$scope.headings.push({
+								id: id,
+								text: text,
+								level: parseInt(head[0].nodeName[1])
+							});
+						});
+						$anchorScroll();
+					}
+
+					$scope.$watch('target', function() {
+						setTimeout(function() {
+							$rootScope.reloadSummary();
+						}, 100);
+					});
+				}
+			};
+		})
+
 		.directive('uiFilterForm', function() {
 			return {
 				restrict: 'E',

--- a/share/nitweb/stylesheets/nitweb.css
+++ b/share/nitweb/stylesheets/nitweb.css
@@ -94,7 +94,7 @@ entity-list:hover .btn-filter {
 /* doc */
 
 .nitdoc .synopsys {
-	font-size: 2em;
+	margin-top: 0;
 }
 
 .signature {
@@ -223,6 +223,23 @@ entity-list:hover .btn-filter {
 	margin-top: 8px;
 	margin-bottom: 0px;
 }
+
+/* Summary */
+
+.summary h1, .summary h2, .summary h3, .summary h4, .summary h5, .summary h6 {
+	margin: 5px 0;
+}
+
+.summary h1 a, .summary h2 a, .summary h3 a, .summary h4 a, .summary h5 a, .summary h6 a {
+	color: #555;
+}
+
+.summary h1 { font-size: 14px; margin-left: 0px; font-weight: bold; }
+.summary h2 { font-size: 13px; margin-left: 5px; font-weight: bold; }
+.summary h3 { font-size: 12px; margin-left: 10px; }
+.summary h4 { font-size: 11px; margin-left: 15px; }
+.summary h5 { font-size: 10px; margin-left: 20px; }
+.summary h6 { font-size: 9px; margin-left: 25px; }
 
 /*
  * Ratings

--- a/share/nitweb/views/class.html
+++ b/share/nitweb/views/class.html
@@ -28,23 +28,28 @@
 
 <div class='tab-content'>
 	<div role='tabpanel' class='tab-pane fade in active' id='doc'>
-		<entity-card mentity='mentity' default-tab='doc' no-synopsis='true' />
+		<div class='col-xs-3'>
+			<ui-summary target='#summary-content' />
+		</div>
+		<div id='summary-content' class='col-xs-9'>
+			<entity-card mentity='mentity' default-tab='doc' no-synopsis='true' />
 
-		<entity-list list-title='Parents'
-			list-entities='mentity.parents'
-			list-object-filter='{}' />
+			<entity-list list-title='Parents'
+				list-entities='mentity.parents'
+				list-object-filter='{}' />
 
-		<entity-list list-title='Constructors'
-			list-entities='mentity.all_mproperties'
-			list-object-filter='{is_init: true}' />
+			<entity-list list-title='Constructors'
+				list-entities='mentity.all_mproperties'
+				list-object-filter='{is_init: true}' />
 
-		<entity-list list-title='Introduced properties'
-			list-entities='mentity.intro_mproperties'
-			list-object-filter='{is_init: "!true"}' />
+			<entity-list list-title='Introduced properties'
+				list-entities='mentity.intro_mproperties'
+				list-object-filter='{is_init: "!true"}' />
 
-		<entity-list list-title='Redefined properties'
-			list-entities='mentity.redef_mproperties'
-			list-object-filter='{is_init: "!true"}' />
+			<entity-list list-title='Redefined properties'
+				list-entities='mentity.redef_mproperties'
+				list-object-filter='{is_init: "!true"}' />
+		</div>
 	</div>
 	<div role='tabpanel' class='tab-pane fade' id='all_props'>
 		<entity-list list-title='All properties' list-entities='mentity.all_mproperties'

--- a/share/nitweb/views/group.html
+++ b/share/nitweb/views/group.html
@@ -18,16 +18,21 @@
 
 <div class='tab-content'>
 	<div role='tabpanel' class='tab-pane fade in active' id='doc'>
-		<entity-card mentity='mentity' default-tab='doc' no-synopsis='true' />
+		<div class='col-xs-3'>
+			<ui-summary target='#summary-content' />
+		</div>
+		<div class='col-xs-9' id='summary-content'>
+			<entity-card mentity='mentity' default-tab='doc' no-synopsis='true' />
 
-		<entity-list list-title='Parent group' list-entities='[mentity.parent]'
-			list-object-filter='{}' ng-if='mentity.parent' />
+			<entity-list list-title='Parent group' list-entities='[mentity.parent]'
+				list-object-filter='{}' ng-if='mentity.parent' />
 
-		<entity-list list-title='Subgroups' list-entities='mentity.mgroups'
-			list-object-filter='{}' />
+			<entity-list list-title='Subgroups' list-entities='mentity.mgroups'
+				list-object-filter='{}' />
 
-		<entity-list list-title='Modules' list-entities='mentity.mmodules'
-			list-object-filter='{}' />
+			<entity-list list-title='Modules' list-entities='mentity.mmodules'
+				list-object-filter='{}' />
+		</div>
 	</div>
 	<div role='tabpanel' class='tab-pane fade' id='graph'>
 		<div class='card'>

--- a/share/nitweb/views/module.html
+++ b/share/nitweb/views/module.html
@@ -28,17 +28,21 @@
 
 <div class='tab-content'>
 	<div role='tabpanel' class='tab-pane fade in active' id='doc'>
-		<entity-card mentity='mentity' default-tab='doc' no-synopsis='true' />
+		<div class='col-xs-3'>
+			<ui-summary target='#summary-content' />
+		</div>
+		<div class='col-xs-9' id='summary-content'>
+			<entity-card mentity='mentity' default-tab='doc' no-synopsis='true' />
 
-		<entity-list list-title='Imported modules' list-entities='mentity.imports'
-			list-object-filter='{}' />
+			<entity-list list-title='Imported modules' list-entities='mentity.imports'
+				list-object-filter='{}' />
 
-		<entity-list list-title='Introduced classes' list-entities='mentity.intro_mclasses'
-			list-object-filter='{}' />
+			<entity-list list-title='Introduced classes' list-entities='mentity.intro_mclasses'
+				list-object-filter='{}' />
 
-		<entity-list list-title='Class redefinitions' list-entities='mentity.redef_mclassdefs'
-			list-object-filter='{}' />
-
+			<entity-list list-title='Class redefinitions' list-entities='mentity.redef_mclassdefs'
+				list-object-filter='{}' />
+		</div>
 	</div>
 	<div role='tabpanel' class='tab-pane fade' id='code'>
 		<div class='card'>

--- a/share/nitweb/views/package.html
+++ b/share/nitweb/views/package.html
@@ -18,10 +18,15 @@
 
 <div class='tab-content'>
 	<div role='tabpanel' class='tab-pane fade in active' id='doc'>
-		<entity-card mentity='mentity' default-tab='doc' no-synopsis='true' />
+		<div class='col-xs-3'>
+			<ui-summary target='#summary-content' />
+		</div>
+		<div class='col-xs-9' id='summary-content'>
+			<entity-card mentity='mentity' default-tab='doc' no-synopsis='true' />
 
-		<entity-list list-title='Groups' list-entities='mentity.mgroups'
-			list-object-filter='{}' />
+			<entity-list list-title='Groups' list-entities='mentity.mgroups'
+				list-object-filter='{}' />
+		</div>
 	</div>
 	<div role='tabpanel' class='tab-pane fade' id='graph'>
 		<div class='card'>

--- a/share/nitweb/views/property.html
+++ b/share/nitweb/views/property.html
@@ -13,7 +13,12 @@
 
 <div class='tab-content'>
 	<div role='tabpanel' class='tab-pane fade in active' id='doc'>
-		<entity-card mentity='mentity' default-tab='doc' no-synopsis='true' />
+		<div class='col-xs-3'>
+			<ui-summary target='#summary-content' />
+		</div>
+		<div class='col-xs-9' id='summary-content'>
+			<entity-card mentity='mentity' default-tab='doc' no-synopsis='true' />
+		</div>
 	</div>
 	<div role='tabpanel' class='tab-pane fade' id='linearization'>
 		<entity-linearization

--- a/src/doc/doc_down.nit
+++ b/src/doc/doc_down.nit
@@ -73,7 +73,7 @@ redef class MDoc
 			   not lines.first.has_prefix("\t") then
 				# parse synopsys
 				var syn = inline_proc.process(lines.shift)
-				res.add "<p class=\"synopsys\">{syn}</p>"
+				res.add "<h1 class=\"synopsys\">{syn}</h1>"
 			end
 		end
 		# check for annotations

--- a/src/nitcatalog.nit
+++ b/src/nitcatalog.nit
@@ -232,12 +232,19 @@ redef class Catalog
 		var name = mpackage.name.html_escape
 		res.more_head.add """<title>{{{name}}}</title>"""
 
-		res.add """
-<div class="content">
-<h1 class="package-name">{{{name}}}</h1>
-"""
+		res.add """<div class="content">"""
+
 		var mdoc = mpackage.mdoc_or_fallback
-		if mdoc != null then res.add mdoc.html_documentation
+		if mdoc == null then
+			res.add """<h1 class="package-name">{{{name}}}</h1>"""
+		else
+			res.add """
+<div style="float: left">
+	<h1 class="package-name">{{{name}}}&nbsp;-&nbsp;</h1>
+</div>
+"""
+			res.add mdoc.html_documentation
+		end
 
 		res.add "<h2>Content</h2>"
 		var ot = new OrderedTree[MConcern]

--- a/tests/sav/nitcatalog_args1.res
+++ b/tests/sav/nitcatalog_args1.res
@@ -27,9 +27,10 @@
    </div>
   </nav>
  </div>
-<div class="content">
-<h1 class="package-name">test_prog</h1>
-<div class="nitdoc"><p class="synopsys">Test program for model tools.</p><p>This program creates a fake model that can be used to test tools like:</p>
+<div class="content"><div style="float: left">
+	<h1 class="package-name">test_prog&nbsp;-&nbsp;</h1>
+</div>
+<div class="nitdoc"><h1 class="synopsys">Test program for model tools.</h1><p>This program creates a fake model that can be used to test tools like:</p>
 <ul>
 <li><code class="nitcode"><span class="nitcode"><span class="line"><span class="nc_i">nitdoc</span></span></span></code></li>
 <li><code class="nitcode"><span class="nitcode"><span class="line"><span class="nc_i">nitmetrics</span></span></span></code></li>


### PR DESCRIPTION
Automatically add a summary extracted from the README / doc contents

![image](https://cloud.githubusercontent.com/assets/583144/20892633/fef2fd4a-badc-11e6-89f5-5de007981914.png)

Also add anchors to the content of the README, so you can make links like:

http://nitweb.moz-code.org/doc/core#Methods-Implicitly-Defined-in-Sys