### PR TITLE
Rename the extern class `NativeString` to `CString`

### DIFF
--- a/benchmarks/strings/array_to_s_vars/array_to_s_flatstr.nit
+++ b/benchmarks/strings/array_to_s_vars/array_to_s_flatstr.nit
@@ -19,7 +19,7 @@ redef class FlatString
 	redef fun +(o) do
 		var mlen = length
 		var slen = o.length
-		var nns = new NativeString(mlen + slen)
+		var nns = new CString(mlen + slen)
 		items.copy_to(nns, mlen, index_from, 0)
 		if o isa FlatString then
 			o.items.copy_to(nns, slen, o.index_from, mlen)

--- a/benchmarks/strings/array_to_s_vars/array_to_s_manual.nit
+++ b/benchmarks/strings/array_to_s_vars/array_to_s_manual.nit
@@ -33,7 +33,7 @@ redef class Array[E]
 			na[i] = tmp
 			i += 1
 		end
-		var ns = new NativeString(sl + 1)
+		var ns = new CString(sl + 1)
 		ns[sl] = '\0'
 		i = 0
 		var off = 0

--- a/c_src/nitc__abstract_compiler.sep.3.c
+++ b/c_src/nitc__abstract_compiler.sep.3.c
@@ -4181,8 +4181,8 @@ RET_LABEL158:(void)0;
 if (likely(varonce160!=NULL)) {
 var161 = varonce160;
 } else {
-var162 = "NativeString";
-var163 = core__flat___NativeString___to_s_full(var162, 12l, 12l);
+var162 = "CString";
+var163 = core__flat___NativeString___to_s_full(var162, 7l, 7l);
 var161 = var163;
 varonce160 = var161;
 }
@@ -5077,8 +5077,8 @@ RET_LABEL154:(void)0;
 if (likely(varonce156!=NULL)) {
 var157 = varonce156;
 } else {
-var158 = "NativeString";
-var159 = core__flat___NativeString___to_s_full(var158, 12l, 12l);
+var158 = "CString";
+var159 = core__flat___NativeString___to_s_full(var158, 7l, 7l);
 var157 = var159;
 varonce156 = var157;
 }

--- a/c_src/nitc__abstract_compiler.sep.4.c
+++ b/c_src/nitc__abstract_compiler.sep.4.c
@@ -9201,8 +9201,8 @@ goto RET_LABEL;
 if (likely(varonce1468!=NULL)) {
 var1469 = varonce1468;
 } else {
-var1470 = "NativeString";
-var1471 = core__flat___NativeString___to_s_full(var1470, 12l, 12l);
+var1470 = "CString";
+var1471 = core__flat___NativeString___to_s_full(var1470, 7l, 7l);
 var1469 = var1471;
 varonce1468 = var1469;
 }

--- a/c_src/nitc__model.sep.1.c
+++ b/c_src/nitc__model.sep.1.c
@@ -1184,8 +1184,8 @@ fatal_exit(1);
 if (likely(varonce!=NULL)) {
 var3 = varonce;
 } else {
-var4 = "NativeString";
-var5 = core__flat___NativeString___to_s_full(var4, 12l, 12l);
+var4 = "CString";
+var5 = core__flat___NativeString___to_s_full(var4, 7l, 7l);
 var3 = var5;
 varonce = var3;
 }

--- a/c_src/nitc__nitni_base.sep.1.c
+++ b/c_src/nitc__nitni_base.sep.1.c
@@ -1323,8 +1323,8 @@ goto RET_LABEL;
 if (likely(varonce96!=NULL)) {
 var97 = varonce96;
 } else {
-var98 = "NativeString";
-var99 = core__flat___NativeString___to_s_full(var98, 12l, 12l);
+var98 = "CString";
+var99 = core__flat___NativeString___to_s_full(var98, 7l, 7l);
 var97 = var99;
 varonce96 = var97;
 }
@@ -1830,8 +1830,8 @@ goto RET_LABEL;
 if (likely(varonce96!=NULL)) {
 var97 = varonce96;
 } else {
-var98 = "NativeString";
-var99 = core__flat___NativeString___to_s_full(var98, 12l, 12l);
+var98 = "CString";
+var99 = core__flat___NativeString___to_s_full(var98, 7l, 7l);
 var97 = var99;
 varonce96 = var97;
 }
@@ -2124,8 +2124,8 @@ core___core__AbstractArray___core__abstract_collection__Sequence__push(var_17, v
 if (likely(varonce34!=NULL)) {
 var35 = varonce34;
 } else {
-var36 = "NativeString";
-var37 = core__flat___NativeString___to_s_full(var36, 12l, 12l);
+var36 = "CString";
+var37 = core__flat___NativeString___to_s_full(var36, 7l, 7l);
 var35 = var37;
 varonce34 = var35;
 }

--- a/c_src/nitc__separate_compiler.sep.1.c
+++ b/c_src/nitc__separate_compiler.sep.1.c
@@ -3073,8 +3073,8 @@ core___core__AbstractArray___core__abstract_collection__Sequence__push(var_, var
 if (likely(varonce20!=NULL)) {
 var21 = varonce20;
 } else {
-var22 = "NativeString";
-var23 = core__flat___NativeString___to_s_full(var22, 12l, 12l);
+var22 = "CString";
+var23 = core__flat___NativeString___to_s_full(var22, 7l, 7l);
 var21 = var23;
 varonce20 = var21;
 }
@@ -3441,8 +3441,8 @@ RET_LABEL21:(void)0;
 if (likely(varonce23!=NULL)) {
 var24 = varonce23;
 } else {
-var25 = "NativeString";
-var26 = core__flat___NativeString___to_s_full(var25, 12l, 12l);
+var25 = "CString";
+var26 = core__flat___NativeString___to_s_full(var25, 7l, 7l);
 var24 = var26;
 varonce23 = var24;
 }

--- a/c_src/nitc__separate_compiler.sep.2.c
+++ b/c_src/nitc__separate_compiler.sep.2.c
@@ -4232,8 +4232,8 @@ RET_LABEL838:(void)0;
 if (likely(varonce840!=NULL)) {
 var841 = varonce840;
 } else {
-var842 = "NativeString";
-var843 = core__flat___NativeString___to_s_full(var842, 12l, 12l);
+var842 = "CString";
+var843 = core__flat___NativeString___to_s_full(var842, 7l, 7l);
 var841 = var843;
 varonce840 = var841;
 }

--- a/c_src/nitc__separate_compiler.sep.3.c
+++ b/c_src/nitc__separate_compiler.sep.3.c
@@ -1118,8 +1118,8 @@ RET_LABEL229:(void)0;
 if (likely(varonce231!=NULL)) {
 var232 = varonce231;
 } else {
-var233 = "NativeString";
-var234 = core__flat___NativeString___to_s_full(var233, 12l, 12l);
+var233 = "CString";
+var234 = core__flat___NativeString___to_s_full(var233, 7l, 7l);
 var232 = var234;
 varonce231 = var232;
 }
@@ -1768,8 +1768,8 @@ RET_LABEL22:(void)0;
 if (likely(varonce!=NULL)) {
 var24 = varonce;
 } else {
-var25 = "NativeString";
-var26 = core__flat___NativeString___to_s_full(var25, 12l, 12l);
+var25 = "CString";
+var26 = core__flat___NativeString___to_s_full(var25, 7l, 7l);
 var24 = var26;
 varonce = var24;
 }
@@ -2118,8 +2118,8 @@ RET_LABEL22:(void)0;
 if (likely(varonce!=NULL)) {
 var24 = varonce;
 } else {
-var25 = "NativeString";
-var26 = core__flat___NativeString___to_s_full(var25, 12l, 12l);
+var25 = "CString";
+var26 = core__flat___NativeString___to_s_full(var25, 7l, 7l);
 var24 = var26;
 varonce = var24;
 }

--- a/c_src/nitc__separate_compiler.sep.4.c
+++ b/c_src/nitc__separate_compiler.sep.4.c
@@ -6224,8 +6224,8 @@ var71 = nitc___nitc__MType___nitc__model_base__MEntity__name(var64);
 if (likely(varonce72!=NULL)) {
 var73 = varonce72;
 } else {
-var74 = "NativeString";
-var75 = core__flat___NativeString___to_s_full(var74, 12l, 12l);
+var74 = "CString";
+var75 = core__flat___NativeString___to_s_full(var74, 7l, 7l);
 var73 = var75;
 varonce72 = var73;
 }

--- a/c_src/nitc__separate_erasure_compiler.sep.1.c
+++ b/c_src/nitc__separate_erasure_compiler.sep.1.c
@@ -5670,8 +5670,8 @@ RET_LABEL828:(void)0;
 if (likely(varonce830!=NULL)) {
 var831 = varonce830;
 } else {
-var832 = "NativeString";
-var833 = core__flat___NativeString___to_s_full(var832, 12l, 12l);
+var832 = "CString";
+var833 = core__flat___NativeString___to_s_full(var832, 7l, 7l);
 var831 = var833;
 varonce830 = var831;
 }

--- a/c_src/nitc__separate_erasure_compiler.sep.2.c
+++ b/c_src/nitc__separate_erasure_compiler.sep.2.c
@@ -2802,8 +2802,8 @@ RET_LABEL22:(void)0;
 if (likely(varonce!=NULL)) {
 var24 = varonce;
 } else {
-var25 = "NativeString";
-var26 = core__flat___NativeString___to_s_full(var25, 12l, 12l);
+var25 = "CString";
+var26 = core__flat___NativeString___to_s_full(var25, 7l, 7l);
 var24 = var26;
 varonce = var24;
 }
@@ -3176,8 +3176,8 @@ RET_LABEL22:(void)0;
 if (likely(varonce!=NULL)) {
 var24 = varonce;
 } else {
-var25 = "NativeString";
-var26 = core__flat___NativeString___to_s_full(var25, 12l, 12l);
+var25 = "CString";
+var26 = core__flat___NativeString___to_s_full(var25, 7l, 7l);
 var24 = var26;
 varonce = var24;
 }

--- a/contrib/jwrapper/src/model.nit
+++ b/contrib/jwrapper/src/model.nit
@@ -93,7 +93,7 @@ class JavaType
 			end
 		else
 			# Use the prefix and the short class name
-			# e.g. given the prefix Native: java.lang.String -> NativeString
+			# e.g. given the prefix Native: java.lang.String -> CString
 			name = prefix + id
 		end
 

--- a/contrib/pep8analysis/src/pep8analysis_web.nit
+++ b/contrib/pep8analysis/src/pep8analysis_web.nit
@@ -40,7 +40,7 @@ in "C++" `{
 	using namespace emscripten;
 
 	EMSCRIPTEN_BINDINGS(my_module) {
-		function("run_analysis", &NativeString_run_analysis, allow_raw_pointers());
+		function("run_analysis", &CString_run_analysis, allow_raw_pointers());
 	}
 `}
 
@@ -108,11 +108,11 @@ redef class AnalysisManager
 	fun show_graph(content: String) do "show_graph('{content.escape_to_c}');".run_js
 end
 
-redef class NativeString
+redef class CString
 	fun run_analysis do manager.run_web to_s
 end
 
-fun dummy_set_callbacks import NativeString.run_analysis in "C++" `{
+fun dummy_set_callbacks import CString.run_analysis in "C++" `{
 `}
 
 dummy_set_callbacks

--- a/contrib/pep8analysis/www/index.html
+++ b/contrib/pep8analysis/www/index.html
@@ -91,7 +91,7 @@
 				_gaq.push(['_trackEvent', 'Bug', 'No Webworkers', $("#console").text()])
 				Module = Pep8Module
 				try {
-					run_analysis = Module.cwrap('pep8analysis_web___NativeString_run_analysis', null, ['string'])
+					run_analysis = Module.cwrap('pep8analysis_web___CString_run_analysis', null, ['string'])
 					run_analysis(input)
 
 					complete()

--- a/contrib/pep8analysis/www/worker.js
+++ b/contrib/pep8analysis/www/worker.js
@@ -6,7 +6,7 @@ var Module = {
 	'TOTAL_MEMORY': 512000000
 }
 importScripts("pep8analysis.js")
-run_analysis = Module.cwrap('pep8analysis_web___NativeString_run_analysis', null, ['string'])
+run_analysis = Module.cwrap('pep8analysis_web___CString_run_analysis', null, ['string'])
 
 function show_graph(data) {
 	postMessage({'type':"show_graph", 'data': data})

--- a/contrib/sort_downloads/src/sort_downloads.nit
+++ b/contrib/sort_downloads/src/sort_downloads.nit
@@ -64,10 +64,10 @@ redef class String
 
 	# Returns null on success
 	fun file_rename_to(dest: String): nullable String import String.to_cstring,
-	NativeString.to_s, String.as nullable `{
+	CString.to_s, String.as nullable `{
 		int res = rename(String_to_cstring(self), String_to_cstring(dest));
 		if (res == 0) return null_String();
-		return String_as_nullable(NativeString_to_s(strerror(errno)));
+		return String_as_nullable(CString_to_s(strerror(errno)));
 	`}
 
 	# Replace `~` by the path to the home diretory

--- a/lib/android/dalvik.nit
+++ b/lib/android/dalvik.nit
@@ -109,7 +109,7 @@ redef class Sys
 		(*env)->DeleteLocalRef(env, class_class_loader);
 	`}
 
-	private fun load_jclass_intern(instance_class_loader: JavaObject, class_loader_findClass: JMethodID, name: NativeString): JClass import jni_env `{
+	private fun load_jclass_intern(instance_class_loader: JavaObject, class_loader_findClass: JMethodID, name: CString): JClass import jni_env `{
 		JNIEnv *env = Sys_jni_env(self);
 		jobject class_name = (*env)->NewStringUTF(env, name);
 

--- a/lib/android/log.nit
+++ b/lib/android/log.nit
@@ -71,6 +71,6 @@ private fun priority_fatal: Int do return 7
 private fun priority_silent: Int do return 8
 
 # Write `text` to Android log at priority `level` with tag `tag`
-private fun log_write(level: Int, tag, text: NativeString) `{
+private fun log_write(level: Int, tag, text: CString) `{
 	__android_log_write(level, tag, text);
 `}

--- a/lib/android/native_app_glue.nit
+++ b/lib/android/native_app_glue.nit
@@ -260,10 +260,10 @@ extern class NdkNativeActivity `{ ANativeActivity * `}
 	fun java_native_activity: NativeActivity `{ return self->clazz; `}
 
 	# Path to this application's internal data directory.
-	fun internal_data_path: NativeString `{ return (char*)self->internalDataPath; `}
+	fun internal_data_path: CString `{ return (char*)self->internalDataPath; `}
 
 	# Path to this application's external (removable/mountable) data directory.
-	fun external_data_path: NativeString `{ return (char*)self->externalDataPath; `}
+	fun external_data_path: CString `{ return (char*)self->externalDataPath; `}
 
 	# The platform's SDK version code.
 	fun sdk_version: Int `{ return self->sdkVersion; `}
@@ -285,7 +285,7 @@ extern class NdkNativeActivity `{ ANativeActivity * `}
 	# api?
 	#
 	# TODO activate in a future module at API 11
-	#fun obb_path: NativeString `{ return (char*)self->obbPath; `}
+	#fun obb_path: CString `{ return (char*)self->obbPath; `}
 end
 
 # This is the interface for the standard glue code of a threaded

--- a/lib/android/sensors.nit
+++ b/lib/android/sensors.nit
@@ -121,8 +121,8 @@ end
 extern class ASensor `{ASensorRef`}
 
 	new  `{return malloc(sizeof(ASensorRef));`}
-	fun name: NativeString `{return (char*)ASensor_getName(self);`}
-	fun vendor: NativeString `{return (char*)ASensor_getVendor(self);`}
+	fun name: CString `{return (char*)ASensor_getName(self);`}
+	fun vendor: CString `{return (char*)ASensor_getVendor(self);`}
 	fun sensor_type: ASensorType `{return ASensor_getType(self);`}
 	fun resolution: Float `{return ASensor_getResolution(self);`}
 	fun min_delay: Int `{return ASensor_getMinDelay(self);`}

--- a/lib/base64.nit
+++ b/lib/base64.nit
@@ -57,7 +57,7 @@ redef class Byte
 	end
 end
 
-redef class NativeString
+redef class CString
 	# Alphabet used by the base64 algorithm
 	private fun base64_chars : Bytes
 	do

--- a/lib/binary/serialization.nit
+++ b/lib/binary/serialization.nit
@@ -25,7 +25,7 @@
 #        | 0x06 utf8 byte sequence # Char
 #        | 0x07 double(64 bits)    # Float
 #        | 0x08 block              # String
-#        | 0x09 block              # NativeString
+#        | 0x09 block              # CString
 #        | 0x0A flat_array;        # Array[nullable Object]
 #
 # block = int64 int8*;
@@ -129,7 +129,7 @@ class BinaryDeserializer
 	private var unclaimed_attributes = new UnrolledList[HashMap[String, nullable Object]]
 
 	# Buffer for one char
-	private var char_buf: NativeString is lazy do return new NativeString(4)
+	private var char_buf: CString is lazy do return new CString(4)
 
 	# Read and deserialize the next attribute name and value
 	#
@@ -403,7 +403,7 @@ redef class Char
 	end
 end
 
-redef class NativeString
+redef class CString
 	redef fun serialize_to_binary(v)
 	do
 		v.stream.write_byte kind_native_string

--- a/lib/binary/serialization.nit
+++ b/lib/binary/serialization.nit
@@ -53,7 +53,7 @@ private fun kind_bool: Byte do return 0x05u8
 private fun kind_char: Byte do return 0x06u8
 private fun kind_float: Byte do return 0x07u8
 private fun kind_string: Byte do return 0x08u8
-private fun kind_native_string: Byte do return 0x09u8
+private fun kind_c_string: Byte do return 0x09u8
 private fun kind_flat_array: Byte do return 0x0Au8
 
 private fun new_object_end: Byte do return 0x00u8
@@ -233,7 +233,7 @@ class BinaryDeserializer
 			return bf.to_s_with_length(ln)[0]
 		end
 		if kind == kind_string then return stream.read_block
-		if kind == kind_native_string then return stream.read_block.to_cstring
+		if kind == kind_c_string then return stream.read_block.to_cstring
 
 		if kind == kind_flat_array then
 			# An array
@@ -406,7 +406,7 @@ end
 redef class CString
 	redef fun serialize_to_binary(v)
 	do
-		v.stream.write_byte kind_native_string
+		v.stream.write_byte kind_c_string
 		v.stream.write_block to_s
 	end
 end

--- a/lib/c.nit
+++ b/lib/c.nit
@@ -207,9 +207,9 @@ extern class NativeCByteArray `{ unsigned char* `}
 	`}
 end
 
-# Wrapper around an array of `NativeString` in C (`char**`) with length and destroy state.
-class CNativeStringArray
-	super CArray[NativeString]
+# Wrapper around an array of `CString` in C (`char**`) with length and destroy state.
+class CCStringArray
+	super CArray[CString]
 
 	redef type NATIVE: NativeCStringArray
 
@@ -219,10 +219,10 @@ class CNativeStringArray
 		super size
 	end
 
-	# Create from an `SequenceRead[NativeString]`
-	new from(array: SequenceRead[NativeString])
+	# Create from an `SequenceRead[CString]`
+	new from(array: SequenceRead[CString])
 	do
-		var carray = new CNativeStringArray(array.length)
+		var carray = new CCStringArray(array.length)
 		for i in array.length.times do
 			carray[i] = array[i]
 		end
@@ -230,11 +230,11 @@ class CNativeStringArray
 	end
 end
 
-# An array of `NativeString` in C (`char**`)
+# An array of `CString` in C (`char**`)
 extern class NativeCStringArray `{ char** `}
 	super NativeCArray
 
-	redef type E: NativeString
+	redef type E: CString
 
 	# Initialize a new NativeCStringArray of `size` elements.
 	new(size: Int) `{ return calloc(size, sizeof(char*)); `}
@@ -244,7 +244,7 @@ extern class NativeCStringArray `{ char** `}
 	redef fun +(offset) `{ return self + offset; `}
 end
 
-redef class NativeString
+redef class CString
 	super NativeCArray
 	redef type E: Char
 

--- a/lib/cocoa/foundation.nit
+++ b/lib/cocoa/foundation.nit
@@ -35,12 +35,12 @@ extern class NSString in "ObjC" `{ NSString * `}
 	new nil in "ObjC" `{ return nil; `}
 
 	# Get an UTF8 encoded `char*` copy of `self`
-	fun utf8_string: NativeString in "ObjC" `{ return (char *)[self UTF8String]; `}
+	fun utf8_string: CString in "ObjC" `{ return (char *)[self UTF8String]; `}
 
 	redef fun to_s do return utf8_string.to_s_with_copy
 end
 
-redef class NativeString
+redef class CString
 	# Get a `NSString` from `self` with the specified `length`
 	fun to_nsstring(length: Int): NSString in "ObjC" `{
 		return [[NSString alloc] initWithBytes:self
@@ -58,7 +58,7 @@ end
 extern class NSData in "ObjC" `{ NSData * `}
 
 	# Pointer to contained data
-	fun bytes: NativeString in "ObjC" `{ return (char*)self.bytes; `}
+	fun bytes: CString in "ObjC" `{ return (char*)self.bytes; `}
 
 	# Number of bytes containted in `self`
 	fun length: Int in "ObjC" `{ return self.length; `}

--- a/lib/core/bytes.nit
+++ b/lib/core/bytes.nit
@@ -53,7 +53,7 @@ redef class Byte
 	super BytePattern
 
 	# Write self as a string into `ns` at position `pos`
-	private fun add_digest_at(ns: NativeString, pos: Int) do
+	private fun add_digest_at(ns: CString, pos: Int) do
 		var tmp = (0xF0u8 & self) >> 4
 		ns[pos] = if tmp >= 0x0Au8 then tmp + 0x37u8 else tmp + 0x30u8
 		tmp = 0x0Fu8 & self
@@ -146,8 +146,8 @@ class Bytes
 	super AbstractArray[Byte]
 	super BytePattern
 
-	# A NativeString being a char*, it can be used as underlying representation here.
-	var items: NativeString
+	# A CString being a char*, it can be used as underlying representation here.
+	var items: CString
 
 	# Number of bytes in the array
 	redef var length
@@ -163,13 +163,13 @@ class Bytes
 	#     var b = new Bytes.empty
 	#     assert b.to_s == ""
 	init empty do
-		var ns = new NativeString(0)
+		var ns = new CString(0)
 		init(ns, 0, 0)
 	end
 
 	# Init a `Bytes` with capacity `cap`
 	init with_capacity(cap: Int) do
-		var ns = new NativeString(cap)
+		var ns = new CString(cap)
 		init(ns, 0, cap)
 	end
 
@@ -262,7 +262,7 @@ class Bytes
 	# ~~~
 	fun hexdigest: String do
 		var elen = length * 2
-		var ns = new NativeString(elen)
+		var ns = new CString(elen)
 		var i = 0
 		var oi = 0
 		while i < length do
@@ -285,7 +285,7 @@ class Bytes
 	# ~~~
 	fun chexdigest: String do
 		var elen = length * 4
-		var ns = new NativeString(elen)
+		var ns = new CString(elen)
 		var i = 0
 		var oi = 0
 		while i < length do
@@ -308,7 +308,7 @@ class Bytes
 	# ~~~
 	fun binarydigest: String do
 		var elen = length * 8
-		var ns = new NativeString(elen)
+		var ns = new CString(elen)
 		var i = 0
 		var oi = 0
 		while i < length do
@@ -430,13 +430,13 @@ class Bytes
 
 	# Regenerates the buffer, necessary when it was persisted
 	private fun regen do
-		var nns = new NativeString(capacity)
+		var nns = new CString(capacity)
 		items.copy_to(nns, length, 0, 0)
 		persisted = false
 	end
 
 	# Appends the `ln` first bytes of `ns` to self
-	fun append_ns(ns: NativeString, ln: Int) do
+	fun append_ns(ns: CString, ln: Int) do
 		if persisted then regen
 		var nlen = length + ln
 		if nlen > capacity then enlarge(nlen)
@@ -445,7 +445,7 @@ class Bytes
 	end
 
 	# Appends `ln` bytes from `ns` starting at index `from` to self
-	fun append_ns_from(ns: NativeString, ln, from: Int) do
+	fun append_ns_from(ns: CString, ln, from: Int) do
 		if persisted then regen
 		var nlen = length + ln
 		if nlen > capacity then enlarge(nlen)
@@ -466,7 +466,7 @@ class Bytes
 		if capacity >= sz then return
 		persisted = false
 		while capacity < sz do capacity = capacity * 2 + 2
-		var ns = new NativeString(capacity)
+		var ns = new CString(capacity)
 		items.copy_to(ns, length, 0, 0)
 		items = ns
 	end
@@ -637,7 +637,7 @@ end
 private class BytesIterator
 	super IndexedIterator[Byte]
 
-	var tgt: NativeString
+	var tgt: CString
 
 	redef var index
 
@@ -796,7 +796,7 @@ redef class Text
 	#     assert "&lt;STRING&#47;&rt;".hexdigest == "266C743B535452494E47262334373B2672743B"
 	fun hexdigest: String do
 		var ln = byte_length
-		var outns = new NativeString(ln * 2)
+		var outns = new CString(ln * 2)
 		var oi = 0
 		for i in [0 .. ln[ do
 			bytes[i].add_digest_at(outns, oi)
@@ -934,7 +934,7 @@ redef class FlatText
 	end
 end
 
-redef class NativeString
+redef class CString
 	# Creates a new `Bytes` object from `self` with `len` as length
 	#
 	# If `len` is null, strlen will determine the length of the Bytes
@@ -948,7 +948,7 @@ redef class NativeString
 	# If `len` is null, strlen will determine the length of the Bytes
 	fun to_bytes_with_copy(len: nullable Int): Bytes do
 		if len == null then len = cstring_length
-		var nns = new NativeString(len)
+		var nns = new CString(len)
 		copy_to(nns, len, 0, 0)
 		return new Bytes(nns, len, len)
 	end

--- a/lib/core/codecs/codec_base.nit
+++ b/lib/core/codecs/codec_base.nit
@@ -30,12 +30,12 @@ abstract class Codec
 	fun char_max_size: Int is abstract
 
 	# Transforms `c` to its representation in the format of `self`
-	fun encode_char(c: Char): NativeString is abstract
+	fun encode_char(c: Char): CString is abstract
 
 	# Adds a char `c` to bytes `s`
 	#
 	# Returns the number of bytes written to `s`
-	fun add_char_to(c: Char, s: NativeString): Int is abstract
+	fun add_char_to(c: Char, s: CString): Int is abstract
 
 	# Transforms `s` to the format of `self`
 	fun encode_string(s: Text): Bytes is abstract
@@ -57,11 +57,11 @@ abstract class Codec
 	# * 0 if valid
 	# * 1 if incomplete
 	# * 2 if invalid
-	fun is_valid_char(ns: NativeString, position: Int): Int is abstract
+	fun is_valid_char(ns: CString, position: Int): Int is abstract
 
 	# Decodes a char from `b` to a Unicode code-point
-	fun decode_char(b: NativeString): Char is abstract
+	fun decode_char(b: CString): Char is abstract
 
 	# Decodes a string `b` to UTF-8
-	fun decode_string(b: NativeString, len: Int): String is abstract
+	fun decode_string(b: CString, len: Int): String is abstract
 end

--- a/lib/core/codecs/iso8859_1.nit
+++ b/lib/core/codecs/iso8859_1.nit
@@ -28,7 +28,7 @@ private class ISO88591Codec
 	redef fun max_lookahead do return 1
 
 	redef fun encode_char(c) do
-		var ns = new NativeString(c.u8char_len)
+		var ns = new CString(c.u8char_len)
 		add_char_to(c, ns)
 		return ns
 	end

--- a/lib/core/codecs/utf8.nit
+++ b/lib/core/codecs/utf8.nit
@@ -30,7 +30,7 @@ private class UTF8Codec
 	redef fun max_lookahead do return 4
 
 	redef fun encode_char(c) do
-		var ns = new NativeString(c.u8char_len)
+		var ns = new CString(c.u8char_len)
 		add_char_to(c, ns)
 		return ns
 	end
@@ -71,7 +71,7 @@ private class UTF8Codec
 		var ret = ns.to_s_with_length(len)
 		var rit = ret.as(FlatString).items
 		if rit == ns then
-			var nns = new NativeString(len)
+			var nns = new CString(len)
 			rit.copy_to(nns, len, 0, 0)
 			return nns.to_s_full(ret.byte_length, ret.length)
 		end

--- a/lib/core/environ.nit
+++ b/lib/core/environ.nit
@@ -56,9 +56,9 @@ redef class String
 	end
 end
 
-redef class NativeString
-	private fun get_environ: NativeString `{ return getenv(self); `}
-	private fun setenv(value: NativeString) `{
+redef class CString
+	private fun get_environ: CString `{ return getenv(self); `}
+	private fun setenv(value: CString) `{
 #ifdef _WIN32
 		_putenv_s(self, value);
 #else

--- a/lib/core/exec.nit
+++ b/lib/core/exec.nit
@@ -114,7 +114,7 @@ class Process
 	end
 
 	private var data: NativeProcess
-	private fun basic_exec_execute(prog, args: NativeString, argc: Int, pipeflag: Int): NativeProcess `{
+	private fun basic_exec_execute(prog, args: CString, argc: Int, pipeflag: Int): NativeProcess `{
 #ifdef _WIN32
 		// FIXME use a higher level abstraction to support WIN32
 		return -1;
@@ -338,7 +338,7 @@ redef class Sys
 	fun pid: Int `{ return getpid(); `}
 end
 
-redef class NativeString
+redef class CString
 	# Execute self as a shell command.
 	#
 	# See the posix function system(3).

--- a/lib/core/file.nit
+++ b/lib/core/file.nit
@@ -257,7 +257,7 @@ class FileWriter
 	redef var is_writable = false
 
 	# Write `len` bytes from `native`.
-	private fun write_native(native: NativeString, from, len: Int)
+	private fun write_native(native: CString, from, len: Int)
 	do
 		if last_error != null then return
 		if not _is_writable then
@@ -304,20 +304,20 @@ redef class Int
 	# Creates a file stream from a file descriptor `fd` using the file access `mode`.
 	#
 	# NOTE: The `mode` specified must be compatible with the one used in the file descriptor.
-	private fun fd_to_stream(mode: NativeString): NativeFile `{
+	private fun fd_to_stream(mode: CString): NativeFile `{
 		return fdopen((int)self, mode);
 	`}
 end
 
 # Constant for read-only file streams
-private fun read_only: NativeString do return once "r".to_cstring
+private fun read_only: CString do return once "r".to_cstring
 
 # Constant for write-only file streams
 #
 # If a stream is opened on a file with this method,
 # it will wipe the previous file if any.
 # Else, it will create the file.
-private fun wipe_write: NativeString do return once "w".to_cstring
+private fun wipe_write: CString do return once "w".to_cstring
 
 ###############################################################################
 
@@ -1383,7 +1383,7 @@ redef class FlatString
 	end
 end
 
-redef class NativeString
+redef class CString
 	private fun file_exists: Bool `{
 #ifdef _WIN32
 		DWORD attribs = GetFileAttributesA(self);
@@ -1437,7 +1437,7 @@ redef class NativeString
 
 	private fun file_chdir: Bool `{ return !chdir(self); `}
 
-	private fun file_realpath: NativeString `{
+	private fun file_realpath: CString `{
 #ifdef _WIN32
 		DWORD len = GetFullPathName(self, 0, NULL, NULL);
 		char *buf = malloc(len+1); // FIXME don't leak memory
@@ -1503,11 +1503,11 @@ end
 
 # Instance of this class are standard FILE * pointers
 private extern class NativeFile `{ FILE* `}
-	fun io_read(buf: NativeString, len: Int): Int `{
+	fun io_read(buf: CString, len: Int): Int `{
 		return fread(buf, 1, len, self);
 	`}
 
-	fun io_write(buf: NativeString, from, len: Int): Int `{
+	fun io_write(buf: CString, from, len: Int): Int `{
 		return fwrite(buf+from, 1, len, self);
 	`}
 
@@ -1540,9 +1540,9 @@ private extern class NativeFile `{ FILE* `}
 		return setvbuf(self, NULL, (int)mode, buf_length);
 	`}
 
-	new io_open_read(path: NativeString) `{ return fopen(path, "r"); `}
+	new io_open_read(path: CString) `{ return fopen(path, "r"); `}
 
-	new io_open_write(path: NativeString) `{ return fopen(path, "w"); `}
+	new io_open_write(path: CString) `{ return fopen(path, "w"); `}
 
 	new native_stdin `{ return stdin; `}
 
@@ -1555,13 +1555,13 @@ end
 private extern class NativeDir `{ DIR* `}
 
 	# Open a directory
-	new opendir(path: NativeString) `{ return opendir(path); `}
+	new opendir(path: CString) `{ return opendir(path); `}
 
 	# Close a directory
 	fun closedir `{ closedir(self); `}
 
 	# Read the next directory entry
-	fun readdir: NativeString `{
+	fun readdir: CString `{
 		struct dirent *de;
 		de = readdir(self);
 		if (!de) return NULL;
@@ -1706,4 +1706,4 @@ end
 # Return the working (current) directory
 fun getcwd: String do return native_getcwd.to_s
 
-private fun native_getcwd: NativeString `{ return getcwd(NULL, 0); `}
+private fun native_getcwd: CString `{ return getcwd(NULL, 0); `}

--- a/lib/core/fixed_ints.nit
+++ b/lib/core/fixed_ints.nit
@@ -221,13 +221,13 @@ universal Int8
 	#     assert ~0x2Fi8 == 0xD0i8
 	fun ~: Int8 is intern
 
-	# C function to calculate the length of the `NativeString` to receive `self`
+	# C function to calculate the length of the `CString` to receive `self`
 	private fun to_s_len: Int `{
 		return snprintf(NULL, 0, "%"PRIi8, self);
 	`}
 
-	# C function to convert a nit Int to a NativeString (char*)
-	private fun native_to_s(nstr: NativeString, strlen: Int) `{
+	# C function to convert a nit Int to a CString (char*)
+	private fun native_to_s(nstr: CString, strlen: Int) `{
 		snprintf(nstr, strlen, "%"PRIi8, self);
 	`}
 
@@ -237,7 +237,7 @@ universal Int8
 	#     assert (-123i8).to_s  == "-123"
 	redef fun to_s do
 		var nslen = to_s_len
-		var ns = new NativeString(nslen + 1)
+		var ns = new CString(nslen + 1)
 		ns[nslen] = 0u8
 		native_to_s(ns, nslen + 1)
 		return ns.to_s_with_length(nslen)
@@ -367,13 +367,13 @@ universal Int16
 	#     assert ~0x2Fi16 == 0xFFD0i16
 	fun ~: Int16 is intern
 
-	# C function to calculate the length of the `NativeString` to receive `self`
+	# C function to calculate the length of the `CString` to receive `self`
 	private fun to_s_len: Int `{
 		return snprintf(NULL, 0, "%"PRIi16, self);
 	`}
 
-	# C function to convert a nit Int to a NativeString (char*)
-	private fun native_to_s(nstr: NativeString, strlen: Int) `{
+	# C function to convert a nit Int to a CString (char*)
+	private fun native_to_s(nstr: CString, strlen: Int) `{
 		snprintf(nstr, strlen, "%"PRIi16, self);
 	`}
 
@@ -383,7 +383,7 @@ universal Int16
 	#     assert (-123i16).to_s  == "-123"
 	redef fun to_s do
 		var nslen = to_s_len
-		var ns = new NativeString(nslen + 1)
+		var ns = new CString(nslen + 1)
 		ns[nslen] = 0u8
 		native_to_s(ns, nslen + 1)
 		return ns.to_s_with_length(nslen)
@@ -513,13 +513,13 @@ universal UInt16
 	#     assert ~0x2Fu16 == 0xFFD0u16
 	fun ~: UInt16 is intern
 
-	# C function to calculate the length of the `NativeString` to receive `self`
+	# C function to calculate the length of the `CString` to receive `self`
 	private fun to_s_len: Int `{
 		return snprintf(NULL, 0, "%"PRIu16, self);
 	`}
 
-	# C function to convert a nit Int to a NativeString (char*)
-	private fun native_to_s(nstr: NativeString, strlen: Int) `{
+	# C function to convert a nit Int to a CString (char*)
+	private fun native_to_s(nstr: CString, strlen: Int) `{
 		snprintf(nstr, strlen, "%"PRIu16, self);
 	`}
 
@@ -529,7 +529,7 @@ universal UInt16
 	#     assert (-123u16).to_s  == "65413"
 	redef fun to_s do
 		var nslen = to_s_len
-		var ns = new NativeString(nslen + 1)
+		var ns = new CString(nslen + 1)
 		ns[nslen] = 0u8
 		native_to_s(ns, nslen + 1)
 		return ns.to_s_with_length(nslen)
@@ -660,13 +660,13 @@ universal Int32
 	#     assert ~0x2Fi32 == 0xFFFFFFD0i32
 	fun ~: Int32 is intern
 
-	# C function to calculate the length of the `NativeString` to receive `self`
+	# C function to calculate the length of the `CString` to receive `self`
 	private fun to_s_len: Int `{
 		return snprintf(NULL, 0, "%"PRIi32, self);
 	`}
 
-	# C function to convert a nit Int to a NativeString (char*)
-	private fun native_to_s(nstr: NativeString, strlen: Int) `{
+	# C function to convert a nit Int to a CString (char*)
+	private fun native_to_s(nstr: CString, strlen: Int) `{
 		snprintf(nstr, strlen, "%"PRIi32, self);
 	`}
 
@@ -676,7 +676,7 @@ universal Int32
 	#     assert (-123i32).to_s  == "-123"
 	redef fun to_s do
 		var nslen = to_s_len
-		var ns = new NativeString(nslen + 1)
+		var ns = new CString(nslen + 1)
 		ns[nslen] = 0u8
 		native_to_s(ns, nslen + 1)
 		return ns.to_s_with_length(nslen)
@@ -806,13 +806,13 @@ universal UInt32
 	#     assert ~0x2Fu32 == 0xFFFFFFD0u32
 	fun ~: UInt32 is intern
 
-	# C function to calculate the length of the `NativeString` to receive `self`
+	# C function to calculate the length of the `CString` to receive `self`
 	private fun to_s_len: Int `{
 		return snprintf(NULL, 0, "%"PRIu32, self);
 	`}
 
-	# C function to convert a nit Int to a NativeString (char*)
-	private fun native_to_s(nstr: NativeString, strlen: Int) `{
+	# C function to convert a nit Int to a CString (char*)
+	private fun native_to_s(nstr: CString, strlen: Int) `{
 		snprintf(nstr, strlen, "%"PRIu32, self);
 	`}
 
@@ -822,7 +822,7 @@ universal UInt32
 	#     assert (-123u32).to_s  == "4294967173"
 	redef fun to_s do
 		var nslen = to_s_len
-		var ns = new NativeString(nslen + 1)
+		var ns = new CString(nslen + 1)
 		ns[nslen] = 0u8
 		native_to_s(ns, nslen + 1)
 		return ns.to_s_with_length(nslen)

--- a/lib/core/posix.nit
+++ b/lib/core/posix.nit
@@ -61,10 +61,10 @@ extern class Passwd `{struct passwd*`}
 	new from_name(name: String) import String.to_cstring `{ return getpwnam( String_to_cstring(name) ); `}
 
 	# Username
-	fun name: String import NativeString.to_s `{ return NativeString_to_s(self->pw_name); `}
+	fun name: String import CString.to_s `{ return CString_to_s(self->pw_name); `}
 
 	# User password
-	fun passwd: String import NativeString.to_s `{ return NativeString_to_s(self->pw_passwd); `}
+	fun passwd: String import CString.to_s `{ return CString_to_s(self->pw_passwd); `}
 
 	# User ID
 	fun uid: Int `{ return self->pw_uid; `}
@@ -73,10 +73,10 @@ extern class Passwd `{struct passwd*`}
 	fun gid: Int `{ return self->pw_gid; `}
 
 	# Home directory
-	fun dir: String import NativeString.to_s `{ return NativeString_to_s(self->pw_dir); `}
+	fun dir: String import CString.to_s `{ return CString_to_s(self->pw_dir); `}
 
 	# Shell program
-	fun shell: String import NativeString.to_s `{ return NativeString_to_s(self->pw_shell); `}
+	fun shell: String import CString.to_s `{ return CString_to_s(self->pw_shell); `}
 end
 
 # Information on a user group
@@ -88,16 +88,16 @@ extern class Group `{struct group*`}
 	new from_name(name: String) import String.to_cstring `{ return getgrnam( String_to_cstring(name) ); `}
 
 	# Name of this ground
-	fun name: String import NativeString.to_s `{ return NativeString_to_s(self->gr_name); `}
+	fun name: String import CString.to_s `{ return CString_to_s(self->gr_name); `}
 
 	# Encrypted password of this group
-	fun passwd: String import NativeString.to_s `{ return NativeString_to_s(self->gr_passwd); `}
+	fun passwd: String import CString.to_s `{ return CString_to_s(self->gr_passwd); `}
 
 	# Id of this group
 	fun gid: Int `{ return self->gr_gid; `}
 
 	# List of the members of the group
-	fun mem: Array[String] import Array[String], Array[String].add, NativeString.to_s `{
+	fun mem: Array[String] import Array[String], Array[String].add, CString.to_s `{
 		char **mem;
 		int m;
 		Array_of_String ret;
@@ -106,7 +106,7 @@ extern class Group `{struct group*`}
 		ret = new_Array_of_String();
 
 		for (m = 0; mem[m] != NULL; m++)
-			Array_of_String_add(ret, NativeString_to_s(mem[m]));
+			Array_of_String_add(ret, CString_to_s(mem[m]));
 
 		return ret;
 	`}

--- a/lib/core/re.nit
+++ b/lib/core/re.nit
@@ -42,7 +42,7 @@ private extern class NativeRegex `{ regex_t* `}
 	new malloc `{ return malloc(sizeof(regex_t)); `}
 
 	# Compile the regular expression `regex` into a form that is suitable for subsequent `regexec` searches
-	fun regcomp(regex: NativeString, cflags: Int): Int `{
+	fun regcomp(regex: CString, cflags: Int): Int `{
 		return regcomp(self, regex, cflags);
 	`}
 
@@ -50,14 +50,14 @@ private extern class NativeRegex `{ regex_t* `}
 	#
 	# `nmatch` and `pmatch` are used to provide information regarding the location of any matches.
 	# `eflags` may be the bitwise-or of one or both of `flag_notbol` and `flag_noteol`.
-	fun regexec(string: NativeString, nmatch: Int, pmatch: NativeMatchArray, eflags: Int): Int `{
+	fun regexec(string: CString, nmatch: Int, pmatch: NativeMatchArray, eflags: Int): Int `{
 		return regexec(self, string, nmatch, pmatch, eflags);
 	`}
 
 	# Match `string` against the precompiled pattern buffer of `self`, do not locate matches
 	#
 	# `eflags` may be the bitwise-or of one or both of `flag_notbol` and `flag_noteol`.
-	fun regexec_match_only(string: NativeString, eflags: Int): Int `{
+	fun regexec_match_only(string: CString, eflags: Int): Int `{
 		return regexec(self, string, 0, NULL, eflags);
 	`}
 
@@ -67,7 +67,7 @@ private extern class NativeRegex `{ regex_t* `}
 	fun regfree `{ regfree(self); `}
 
 	# Turn the error codes that can be returned by both `regcomp` and `regexec` into error message strings
-	fun regerror(errcode: Int): NativeString `{
+	fun regerror(errcode: Int): CString `{
 		size_t len = regerror(errcode, self, NULL, 0);
 		char *message = malloc(len);
 		regerror(errcode, self, message, len);
@@ -115,8 +115,8 @@ private extern class NativeMatchArray `{ regmatch_t* `}
 	fun [](index: Int): NativeMatchArray `{ return self + index; `}
 end
 
-redef extern class NativeString
-	private fun substring_from(index: Int): NativeString `{ return self + index; `}
+redef extern class CString
+	private fun substring_from(index: Int): CString `{ return self + index; `}
 end
 
 redef class Text

--- a/lib/core/stream.nit
+++ b/lib/core/stream.nit
@@ -81,7 +81,7 @@ abstract class Reader
 	fun read_bytes(i: Int): Bytes
 	do
 		if last_error != null then return new Bytes.empty
-		var s = new NativeString(i)
+		var s = new CString(i)
 		var buf = new Bytes(s, 0, 0)
 		while i > 0 and not eof do
 			var c = read_byte
@@ -521,7 +521,7 @@ abstract class BufferedReader
 			while c < full_len do c = c * 2 + 2
 			_buffer_capacity = c
 		end
-		var nns = new NativeString(_buffer_capacity)
+		var nns = new CString(_buffer_capacity)
 		bf.items.copy_to(nns, bf.length, 0, 0)
 		_buffer.copy_to(nns, remsp, _buffer_pos, bf.length)
 		_buffer = nns
@@ -629,7 +629,7 @@ abstract class BufferedReader
 	end
 
 	# The buffer
-	private var buffer: NativeString = new NativeString(0)
+	private var buffer: CString = new CString(0)
 
 	# The current position in the buffer
 	private var buffer_pos = 0
@@ -649,7 +649,7 @@ abstract class BufferedReader
 	# Allocate a `_buffer` for a given `capacity`.
 	protected fun prepare_buffer(capacity: Int)
 	do
-		_buffer = new NativeString(capacity)
+		_buffer = new CString(capacity)
 		_buffer_pos = 0 # need to read
 		_buffer_length = 0
 		_buffer_capacity = capacity
@@ -727,7 +727,7 @@ class StringReader
 
 	redef fun read_all_bytes do
 		var nslen = source.length - cursor
-		var nns = new NativeString(nslen)
+		var nns = new CString(nslen)
 		source.copy_to_native(nns, nslen, cursor, 0)
 		return new Bytes(nns, nslen, nslen)
 	end

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -1268,9 +1268,9 @@ end
 abstract class FlatText
 	super Text
 
-	# Underlying C-String (`char*`)
+	# Underlying CString (`char*`)
 	#
-	# Warning : Might be void in some subclasses, be sure to check
+	# Warning: Might be void in some subclasses, be sure to check
 	# if set before using it.
 	var items: CString is noinit
 

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -139,7 +139,7 @@ abstract class Text
 	end
 
 	# Return a null terminated char *
-	fun to_cstring: NativeString is abstract
+	fun to_cstring: CString is abstract
 
 	# The index of the last occurrence of an element starting from pos (in reverse order).
 	#
@@ -866,7 +866,7 @@ abstract class Text
 		# If no transformation is needed, return self as a string
 		if not has_percent then return to_s
 
-		var buf = new NativeString(len)
+		var buf = new CString(len)
 		var i = 0
 		var l = 0
 		while i < length do
@@ -1108,15 +1108,15 @@ abstract class Text
 
 	# Copies `n` bytes from `self` at `src_offset` into `dest` starting at `dest_offset`
 	#
-	# Basically a high-level synonym of NativeString::copy_to
+	# Basically a high-level synonym of CString::copy_to
 	#
 	# REQUIRE: `n` must be large enough to contain `len` bytes
 	#
-	#	var ns = new NativeString(8)
+	#	var ns = new CString(8)
 	#	"Text is String".copy_to_native(ns, 8, 2, 0)
 	#	assert ns.to_s_unsafe(8) == "xt is St"
 	#
-	fun copy_to_native(dest: NativeString, n, src_offset, dest_offset: Int) do
+	fun copy_to_native(dest: CString, n, src_offset, dest_offset: Int) do
 		var mypos = src_offset
 		var itspos = dest_offset
 		while n > 0 do
@@ -1272,13 +1272,13 @@ abstract class FlatText
 	#
 	# Warning : Might be void in some subclasses, be sure to check
 	# if set before using it.
-	var items: NativeString is noinit
+	var items: CString is noinit
 
 	# Returns a char* starting at position `first_byte`
 	#
 	# WARNING: If you choose to use this service, be careful of the following.
 	#
-	# Strings and NativeString are *ideally* always allocated through a Garbage Collector.
+	# Strings and CString are *ideally* always allocated through a Garbage Collector.
 	# Since the GC tracks the use of the pointer for the beginning of the char*, it may be
 	# deallocated at any moment, rendering the pointer returned by this function invalid.
 	# Any access to freed memory may very likely cause undefined behaviour or a crash.
@@ -1289,7 +1289,7 @@ abstract class FlatText
 	#
 	# As always, do not modify the content of the String in C code, if this is what you want
 	# copy locally the char* as Nit Strings are immutable.
-	fun fast_cstring: NativeString is abstract
+	fun fast_cstring: CString is abstract
 
 	redef var length = 0
 
@@ -1742,8 +1742,8 @@ redef class Object
 	# User readable representation of `self`.
 	fun to_s: String do return inspect
 
-	# The class name of the object in NativeString format.
-	private fun native_class_name: NativeString is intern
+	# The class name of the object in CString format.
+	private fun native_class_name: CString is intern
 
 	# The class name of the object.
 	#
@@ -1779,13 +1779,13 @@ redef class Bool
 end
 
 redef class Byte
-	# C function to calculate the length of the `NativeString` to receive `self`
+	# C function to calculate the length of the `CString` to receive `self`
 	private fun byte_to_s_len: Int `{
 		return snprintf(NULL, 0, "0x%02x", self);
 	`}
 
-	# C function to convert an nit Int to a NativeString (char*)
-	private fun native_byte_to_s(nstr: NativeString, strlen: Int) `{
+	# C function to convert an nit Int to a CString (char*)
+	private fun native_byte_to_s(nstr: CString, strlen: Int) `{
 		snprintf(nstr, strlen, "0x%02x", self);
 	`}
 
@@ -1795,7 +1795,7 @@ redef class Byte
 	#     assert (-123).to_b.to_s  == "0x85"
 	redef fun to_s do
 		var nslen = byte_to_s_len
-		var ns = new NativeString(nslen + 1)
+		var ns = new CString(nslen + 1)
 		ns[nslen] = 0u8
 		native_byte_to_s(ns, nslen + 1)
 		return ns.to_s_unsafe(nslen)
@@ -1805,7 +1805,7 @@ end
 redef class Int
 
 	# Wrapper of strerror C function
-	private fun strerror_ext: NativeString `{ return strerror((int)self); `}
+	private fun strerror_ext: CString `{ return strerror((int)self); `}
 
 	# Returns a string describing error number
 	fun strerror: String do return strerror_ext.to_s
@@ -1834,13 +1834,13 @@ redef class Int
 		end
 	end
 
-	# C function to calculate the length of the `NativeString` to receive `self`
+	# C function to calculate the length of the `CString` to receive `self`
 	private fun int_to_s_len: Int `{
 		return snprintf(NULL, 0, "%ld", self);
 	`}
 
-	# C function to convert an nit Int to a NativeString (char*)
-	private fun native_int_to_s(nstr: NativeString, strlen: Int) `{
+	# C function to convert an nit Int to a CString (char*)
+	private fun native_int_to_s(nstr: CString, strlen: Int) `{
 		snprintf(nstr, strlen, "%ld", self);
 	`}
 
@@ -1985,7 +1985,7 @@ redef class Char
 	#     assert 'x'.to_s    == "x"
 	redef fun to_s do
 		var ln = u8char_len
-		var ns = new NativeString(ln + 1)
+		var ns = new CString(ln + 1)
 		u8char_tos(ns, ln)
 		return ns.to_s_unsafe(ln)
 	end
@@ -2030,7 +2030,7 @@ redef class Char
 		return buf.to_s
 	end
 
-	private fun u8char_tos(r: NativeString, len: Int) `{
+	private fun u8char_tos(r: CString, len: Int) `{
 		r[len] = '\0';
 		switch(len){
 			case 1:
@@ -2234,7 +2234,7 @@ redef class Sys
 	private fun native_argc: Int is intern
 
 	# Second argument of the main C function.
-	private fun native_argv(i: Int): NativeString is intern
+	private fun native_argv(i: Int): CString is intern
 end
 
 # Comparator that efficienlty use `to_s` to compare things
@@ -2294,7 +2294,7 @@ do
 	return sys.program_args
 end
 
-redef class NativeString
+redef class CString
 	# Get a `String` from the data at `self` copied into Nit memory
 	#
 	# Require: `self` is a null-terminated string.

--- a/lib/core/text/native.nit
+++ b/lib/core/text/native.nit
@@ -83,12 +83,14 @@ redef class Int
 	end
 end
 
-# Native strings are simple C char *
+# C string `char *`
+#
+# Used as underlying implementation for `String` and some other `Text`.
 extern class CString `{ char* `}
-	# Creates a new CString with a capacity of `length`
+	# Create a new `CString` with the capacity for `length` characters
 	new(length: Int) is intern
 
-	# Returns a char* starting at `index`.
+	# Get a char* starting at `index`.
 	#
 	# WARNING: Unsafe for extern code, use only for temporary
 	# pointer manipulation purposes (e.g. write to file or such)

--- a/lib/core/text/native.nit
+++ b/lib/core/text/native.nit
@@ -84,15 +84,15 @@ redef class Int
 end
 
 # Native strings are simple C char *
-extern class NativeString `{ char* `}
-	# Creates a new NativeString with a capacity of `length`
+extern class CString `{ char* `}
+	# Creates a new CString with a capacity of `length`
 	new(length: Int) is intern
 
 	# Returns a char* starting at `index`.
 	#
 	# WARNING: Unsafe for extern code, use only for temporary
 	# pointer manipulation purposes (e.g. write to file or such)
-	fun fast_cstring(index: Int): NativeString is intern
+	fun fast_cstring(index: Int): CString is intern
 
 	# Get char at `index`.
 	fun [](index: Int): Byte is intern
@@ -101,7 +101,7 @@ extern class NativeString `{ char* `}
 	fun []=(index: Int, item: Byte) is intern
 
 	# Copy `self` to `dest`.
-	fun copy_to(dest: NativeString, length: Int, from: Int, to: Int) is intern
+	fun copy_to(dest: CString, length: Int, from: Int, to: Int) is intern
 
 	redef fun ==(o) is intern do return is_same_instance(o)
 

--- a/lib/core/text/ropes.nit
+++ b/lib/core/text/ropes.nit
@@ -90,7 +90,7 @@ private class Concat
 
 	redef fun to_cstring do
 		var len = _byte_length
-		var ns = new NativeString(len + 1)
+		var ns = new CString(len + 1)
 		ns[len] = 0u8
 		var off = 0
 		for i in substrings do
@@ -302,7 +302,7 @@ redef class FlatString
 			var sifrom = s._first_byte
 			var mifrom = _first_byte
 			var sits = s._items
-			var ns = new NativeString(nlen + 1)
+			var ns = new CString(nlen + 1)
 			mits.copy_to(ns, mlen, mifrom, 0)
 			sits.copy_to(ns, slen, sifrom, mlen)
 			return new FlatString.full(ns, nlen, 0, length + s.length)
@@ -333,9 +333,9 @@ end
 private class RopeByteReverseIterator
 	super IndexedIterator[Byte]
 
-	# Current NativeString
-	var ns: NativeString is noautoinit
-	# Current position in NativeString
+	# Current CString
+	var ns: CString is noautoinit
+	# Current position in CString
 	var pns: Int is noautoinit
 	# Position in the Rope (0-indexed)
 	var pos: Int is noautoinit
@@ -377,7 +377,7 @@ private class RopeByteIterator
 	# Position in current `String`
 	var pns: Int is noautoinit
 	# Current `String` being iterated on
-	var ns: NativeString is noautoinit
+	var ns: CString is noautoinit
 	# Substrings of the Rope
 	var subs: IndexedIterator[FlatString] is noautoinit
 	# Maximum position to iterate on (e.g. Rope.byte_length)
@@ -416,9 +416,9 @@ end
 private class RopeCharReverseIterator
 	super IndexedIterator[Char]
 
-	# Current NativeString
+	# Current CString
 	var ns: String is noautoinit
-	# Current position in NativeString
+	# Current position in CString
 	var pns: Int is noautoinit
 	# Position in the Rope (0-indexed)
 	var pos: Int is noautoinit

--- a/lib/core/time.nit
+++ b/lib/core/time.nit
@@ -55,8 +55,8 @@ extern class TimeT `{time_t`}
 	fun update `{ time(&self); `}
 
 	# Convert `self` to a human readable String.
-	fun ctime: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy( ctime(&self) );
+	fun ctime: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy( ctime(&self) );
 	`}
 
 	# Difference in secondes from start (self if the end time)
@@ -132,18 +132,18 @@ extern class Tm `{struct tm *`}
 	fun is_dst: Bool `{ return self->tm_isdst; `}
 
 	# Convert `self` to a human readable String.
-	private fun asctime: NativeString `{ return asctime(self); `}
+	private fun asctime: CString `{ return asctime(self); `}
 
 	# Convert `self` to a human readable String corresponding to `format`.
 	# TODO document allowed format.
-	fun strftime(format: String): String import String.to_cstring, NativeString.to_s_with_copy `{
+	fun strftime(format: String): String import String.to_cstring, CString.to_s_with_copy `{
 		char* buf, *c_format;
 
 		buf = (char*)malloc(100);
 		c_format = String_to_cstring(format);
 
 		strftime(buf, 100, c_format, self);
-		String s = NativeString_to_s_with_copy(buf);
+		String s = CString_to_s_with_copy(buf);
 		free(buf);
 		return s;
 	`}

--- a/lib/cpp.nit
+++ b/lib/cpp.nit
@@ -28,7 +28,7 @@ redef class Text
 	fun to_cpp_string: CppString do return to_cstring.to_cpp_string(length)
 end
 
-redef class NativeString
+redef class CString
 	# Get `self` as a `CppString`
 	fun to_cpp_string(length: Int): CppString in "C++" `{
 		return new std::string(self, length);

--- a/lib/curl/native_curl.nit
+++ b/lib/curl/native_curl.nit
@@ -45,7 +45,7 @@ in "C body" `{
 	}
 `}
 
-redef extern class NativeString
+redef extern class CString
 	private fun native_callback_header(size, count: Int, target: NativeCurlCallbacks): Int
 	do
 		target.header_callback to_s_with_length(size*count)
@@ -115,18 +115,18 @@ extern class NativeCurl `{ CURL * `}
 	# Request Chars internal information from the CURL session
 	fun easy_getinfo_chars(opt: CURLInfoChars): nullable String
 	do
-		 var answ = new Ref[NativeString]("".to_cstring)
+		 var answ = new Ref[CString]("".to_cstring)
 		 if not native_getinfo_chars(opt, answ).is_ok then return null
 		 if answ.item.address_is_null then return null
 		 return answ.item.to_s
 	end
 
 	# Internal method used to get String object information initially knowns as C Chars type
-	private fun native_getinfo_chars(opt: CURLInfoChars, res: Ref[NativeString]): CURLCode
-	import Ref[NativeString].item= `{
+	private fun native_getinfo_chars(opt: CURLInfoChars, res: Ref[CString]): CURLCode
+	import Ref[CString].item= `{
 		char *r;
 		CURLcode c = curl_easy_getinfo( self, opt, &r);
-		if (c == CURLE_OK) Ref_of_NativeString_item__assign(res, r);
+		if (c == CURLE_OK) Ref_of_CString_item__assign(res, r);
 		return c;
 	`}
 
@@ -204,11 +204,11 @@ extern class NativeCurl `{ CURL * `}
 
 	# Register `delegate` to get callbacks about the CURL transfer
 	fun register_callback_header(delegate: NativeCurlCallbacks): CURLCode
-	import NativeString.native_callback_header `{
+	import CString.native_callback_header `{
 		CURLcode e;
 		NativeCurlCallbacks_incr_ref(delegate); // FIXME deallocated these when download completes?
 
-		e = curl_easy_setopt(self, CURLOPT_HEADERFUNCTION, (curl_write_callback)&NativeString_native_callback_header);
+		e = curl_easy_setopt(self, CURLOPT_HEADERFUNCTION, (curl_write_callback)&CString_native_callback_header);
 		if(e != CURLE_OK) return e;
 
 		e = curl_easy_setopt(self, CURLOPT_WRITEHEADER, delegate);
@@ -217,11 +217,11 @@ extern class NativeCurl `{ CURL * `}
 
 	# Register `delegate` to get callbacks about the CURL transfer
 	fun register_callback_body(delegate: NativeCurlCallbacks): CURLCode
-	import NativeString.native_callback_body `{
+	import CString.native_callback_body `{
 		CURLcode e;
 		NativeCurlCallbacks_incr_ref(delegate);
 
-		e = curl_easy_setopt(self, CURLOPT_WRITEFUNCTION, (curl_write_callback)&NativeString_native_callback_body);
+		e = curl_easy_setopt(self, CURLOPT_WRITEFUNCTION, (curl_write_callback)&CString_native_callback_body);
 		if(e != CURLE_OK) return e;
 
 		e = curl_easy_setopt(self, CURLOPT_WRITEDATA, delegate);
@@ -230,11 +230,11 @@ extern class NativeCurl `{ CURL * `}
 
 	# Register `delegate` to get callbacks about the CURL transfer
 	fun register_callback_stream(delegate: NativeCurlCallbacks): CURLCode
-	import NativeString.native_callback_stream `{
+	import CString.native_callback_stream `{
 		CURLcode e;
 		NativeCurlCallbacks_incr_ref(delegate);
 
-		e = curl_easy_setopt(self, CURLOPT_WRITEFUNCTION, (curl_write_callback)&NativeString_native_callback_stream);
+		e = curl_easy_setopt(self, CURLOPT_WRITEFUNCTION, (curl_write_callback)&CString_native_callback_stream);
 		if(e != CURLE_OK) return e;
 
 		e = curl_easy_setopt(self, CURLOPT_WRITEDATA, delegate);
@@ -243,18 +243,18 @@ extern class NativeCurl `{ CURL * `}
 
 	# Register `delegate` to get callbacks about the CURL transfer
 	fun register_callback_read(delegate: NativeCurlCallbacks): CURLCode
-	import NativeString.native_callback_stream `{
+	import CString.native_callback_stream `{
 		NativeCurlCallbacks_incr_ref(delegate);
 
 		return curl_easy_setopt(self, CURLOPT_READFUNCTION, (curl_write_callback)&nit_curl_callback_read_func);
 	`}
 
 	# Convert given string to URL encoded string
-	fun escape(url: String): String import String.to_cstring, NativeString.to_s_with_copy `{
+	fun escape(url: String): String import String.to_cstring, CString.to_s_with_copy `{
 		char *orig_url, *encoded_url = NULL;
 		orig_url = String_to_cstring(url);
 		encoded_url = curl_easy_escape( self, orig_url, strlen(orig_url));
-		String b_url = NativeString_to_s_with_copy(encoded_url);
+		String b_url = CString_to_s_with_copy(encoded_url);
 		curl_free(encoded_url);
 		return b_url;
 	`}
@@ -279,9 +279,9 @@ extern class CURLCode `{ CURLcode `}
 	fun is_valid_protocol: Bool `{ return self == CURLE_UNSUPPORTED_PROTOCOL; `}
 	fun is_valid_init: Bool `{ return self == CURLE_FAILED_INIT; `}
 	fun to_i: Int do return code end
-	redef fun to_s import NativeString.to_s_with_copy `{
+	redef fun to_s import CString.to_s_with_copy `{
 		char *c = (char*)curl_easy_strerror(self);
-		return NativeString_to_s_with_copy(c);
+		return CString_to_s_with_copy(c);
 	`}
 end
 
@@ -313,7 +313,7 @@ extern class CURLSList `{ struct curl_slist * `}
 	private fun native_next_reachable(c: CURLSList): Bool `{ return (c != NULL && c->next != NULL); `}
 
 	# Internal method to get current data
-	private fun native_data(c: CURLSList): String import NativeString.to_s `{ return NativeString_to_s(c->data); `}
+	private fun native_data(c: CURLSList): String import CString.to_s `{ return CString_to_s(c->data); `}
 
 	# Internal method to get next element
 	private fun native_next(c: CURLSList): CURLSList `{ return c->next; `}

--- a/lib/egl.nit
+++ b/lib/egl.nit
@@ -103,7 +103,7 @@ extern class EGLDisplay `{ EGLDisplay `}
 		}
 	`}
 
-	private fun report_egl_error(cmsg: NativeString)
+	private fun report_egl_error(cmsg: CString)
 	do
 		var msg = cmsg.to_s
 		print "libEGL error: {msg}"
@@ -173,8 +173,8 @@ extern class EGLDisplay `{ EGLDisplay `}
 		end
 	end
 
-	private fun query_string(name: Int): String import NativeString.to_s `{
-		return NativeString_to_s((char *)eglQueryString(self, name));
+	private fun query_string(name: Int): String import CString.to_s `{
+		return CString_to_s((char *)eglQueryString(self, name));
 	`}
 
 	fun vendor: String do return query_string(0x3053)

--- a/lib/emscripten/emscripten.nit
+++ b/lib/emscripten/emscripten.nit
@@ -29,7 +29,7 @@ redef class Text
 	# Run `self` as JavaScript code
 	fun run_js do run_js_native(self.escape_to_js.to_cstring)
 
-	private fun run_js_native(script: NativeString) `{ emscripten_run_script(script); `}
+	private fun run_js_native(script: CString) `{ emscripten_run_script(script); `}
 
 	# Escape the content of `self` to pass to JavaScript code
 	fun escape_to_js: Text do return replace('\n', "\\n")

--- a/lib/gettext/gettext.nit
+++ b/lib/gettext/gettext.nit
@@ -29,7 +29,7 @@ redef class Sys
 	end
 end
 
-redef class NativeString
+redef class CString
 	# Sets the locale of the program running
 	#
 	# This can be set at different times in the program,
@@ -54,14 +54,14 @@ redef class String
 
 	# Gettext `gettext`, SEE gettext manual for further info
 	fun gettext: String
-	import String.to_cstring, NativeString.to_s `{
-		return NativeString_to_s(gettext(String_to_cstring(self)));
+	import String.to_cstring, CString.to_s `{
+		return CString_to_s(gettext(String_to_cstring(self)));
 	`}
 
 	# Gettext `dgettext`, SEE gettext manual for further info
 	fun dgettext(domain: String): String
-	import String.to_cstring, NativeString.to_s `{
-		return NativeString_to_s(dgettext(String_to_cstring(domain), String_to_cstring(self)));
+	import String.to_cstring, CString.to_s `{
+		return CString_to_s(dgettext(String_to_cstring(domain), String_to_cstring(self)));
 	`}
 end
 

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -106,12 +106,12 @@ extern class GLProgram `{GLuint`}
 	fun active_attrib_name(index: Int): String
 	do
 		var max_size = active_attribute_max_length
-		var cname = new NativeString(max_size)
+		var cname = new CString(max_size)
 		active_attrib_name_native(index, max_size, cname)
 		return cname.to_s
 	end
 
-	private fun active_attrib_name_native(index, max_size: Int, name: NativeString) `{
+	private fun active_attrib_name_native(index, max_size: Int, name: CString) `{
 		// We get more values than we need, for compatibility. At least the
 		// NVidia driver tries to fill them even if NULL.
 
@@ -142,12 +142,12 @@ extern class GLProgram `{GLuint`}
 	fun active_uniform_name(index: Int): String
 	do
 		var max_size = active_uniform_max_length
-		var cname = new NativeString(max_size)
+		var cname = new CString(max_size)
 		active_uniform_name_native(index, max_size, cname)
 		return cname.to_s
 	end
 
-	private fun active_uniform_name_native(index, max_size: Int, name: NativeString) `{
+	private fun active_uniform_name_native(index, max_size: Int, name: CString) `{
 		int size;
 		GLenum type;
 		glGetActiveUniform(self, index, max_size, NULL, &size, &type, name);
@@ -207,13 +207,13 @@ fun glGetProgramiv(program: GLProgram, pname: GLGetParameterName): Int `{
 fun glGetProgramInfoLog(program: GLProgram): String
 do
 	var size = glGetProgramiv(program, gl_INFO_LOG_LENGTH)
-	var buf = new NativeString(size)
+	var buf = new CString(size)
 	native_glGetProgramInfoLog(program, size, buf)
 	return buf.to_s_with_length(size)
 end
 
 # Return the program information log in `buf`
-private fun native_glGetProgramInfoLog(program: GLProgram, buf_size: Int, buf: NativeString): Int `{
+private fun native_glGetProgramInfoLog(program: GLProgram, buf_size: Int, buf: CString): Int `{
 	int length;
 	glGetProgramInfoLog(program, buf_size, &length, buf);
 	return length;
@@ -233,7 +233,7 @@ extern class GLShader `{GLuint`}
 		return source_native(size).to_s
 	end
 
-	private fun source_native(size: Int): NativeString `{
+	private fun source_native(size: Int): CString `{
 		GLchar *code = malloc(size);
 		glGetShaderSource(self, size, NULL, code);
 		return code;
@@ -277,12 +277,12 @@ fun gl_VALIDATE_STATUS: GLGetParameterName `{ return GL_VALIDATE_STATUS; `}
 fun glGetShaderInfoLog(shader: GLShader): String
 do
 	var size = glGetShaderiv(shader, gl_INFO_LOG_LENGTH)
-	var buf = new NativeString(size)
+	var buf = new CString(size)
 	native_glGetShaderInfoLog(shader, size, buf)
 	return buf.to_s_with_length(size)
 end
 
-private fun native_glGetShaderInfoLog(shader: GLShader, buf_size: Int, buffer: NativeString): Int `{
+private fun native_glGetShaderInfoLog(shader: GLShader, buf_size: Int, buffer: CString): Int `{
 	int length;
 	glGetShaderInfoLog(shader, buf_size, &length, buffer);
 	return length;
@@ -302,7 +302,7 @@ fun glCreateShader(shader_type: GLShaderType): GLShader `{
 `}
 
 # Replace the source code in the `shader` object with `code`
-fun glShaderSource(shader: GLShader, code: NativeString) `{
+fun glShaderSource(shader: GLShader, code: CString) `{
 	glShaderSource(shader, 1, (GLchar const **)&code, NULL);
 `}
 

--- a/lib/gtk/v3_10.nit
+++ b/lib/gtk/v3_10.nit
@@ -90,16 +90,16 @@ extern class GtkHeaderBar `{ GtkHeaderBar* `}
 	new `{ return (GtkHeaderBar*)gtk_header_bar_new(); `}
 
 	fun title=(title: Text) do native_title = title.to_cstring
-	private fun native_title=(title: NativeString) `{ gtk_header_bar_set_title(self, title); `}
+	private fun native_title=(title: CString) `{ gtk_header_bar_set_title(self, title); `}
 
 	fun title: String do return native_title.to_s
-	private fun native_title: NativeString `{ return (gchar *)gtk_header_bar_get_title(self); `}
+	private fun native_title: CString `{ return (gchar *)gtk_header_bar_get_title(self); `}
 
 	fun subtitle=(subtitle: Text) do native_subtitle = subtitle.to_cstring
-	fun native_subtitle=(subtitle: NativeString) `{ gtk_header_bar_set_subtitle(self, subtitle); `}
+	fun native_subtitle=(subtitle: CString) `{ gtk_header_bar_set_subtitle(self, subtitle); `}
 
 	fun subtitle: String do return native_subtitle.to_s
-	fun native_subtitle: NativeString `{ return (gchar *)gtk_header_bar_get_subtitle(self); `}
+	fun native_subtitle: CString `{ return (gchar *)gtk_header_bar_get_subtitle(self); `}
 
 	fun custom_title=(title_widget: GtkWidget) `{ gtk_header_bar_set_custom_title(self, title_widget); `}
 
@@ -121,23 +121,23 @@ extern class GtkStack `{ GtkStack * `}
 	new `{ return (GtkStack*)gtk_stack_new(); `}
 
 	fun stack_add(child: GtkWidget, name: String) do native_stack_add(child, name.to_cstring)
-	private fun native_stack_add(child: GtkWidget, name: NativeString) `{ gtk_stack_add_named(self, child, name); `}
+	private fun native_stack_add(child: GtkWidget, name: CString) `{ gtk_stack_add_named(self, child, name); `}
 
-	fun add_titled(child: GtkWidget, name, title: NativeString) `{ gtk_stack_add_titled(self, child, name, title); `}
-	fun native_add_titled(child: GtkWidget, name, title: NativeString) `{ gtk_stack_add_titled(self, child, name, title); `}
+	fun add_titled(child: GtkWidget, name, title: CString) `{ gtk_stack_add_titled(self, child, name, title); `}
+	fun native_add_titled(child: GtkWidget, name, title: CString) `{ gtk_stack_add_titled(self, child, name, title); `}
 
 	fun visible_child=(child: GtkWidget) `{ gtk_stack_set_visible_child(self, child); `}
 
 	fun visible_child: GtkWidget `{ return gtk_stack_get_visible_child(self); `}
 
 	fun visible_child_name=(name: Text) do native_visible_child_name = name.to_cstring
-	fun native_visible_child_name=(name: NativeString) `{ gtk_stack_set_visible_child_name(self, name); `}
+	fun native_visible_child_name=(name: CString) `{ gtk_stack_set_visible_child_name(self, name); `}
 
 	fun visible_child_name: Text do return native_visible_child_name.to_s
-	fun native_visible_child_name: NativeString `{ return (gchar *)gtk_stack_get_visible_child_name(self); `}
+	fun native_visible_child_name: CString `{ return (gchar *)gtk_stack_get_visible_child_name(self); `}
 
 	fun set_visible_child_full(name: Text, transition: GtkStackTransitionType) do native_set_visible_child_full(name.to_cstring, transition)
-	fun native_set_visible_child_full(name: NativeString, transition: GtkStackTransitionType) `{
+	fun native_set_visible_child_full(name: CString, transition: GtkStackTransitionType) `{
 		gtk_stack_set_visible_child_full(self, name, transition);
 	`}
 

--- a/lib/gtk/v3_4/gtk_assistant.nit
+++ b/lib/gtk/v3_4/gtk_assistant.nit
@@ -72,8 +72,8 @@ extern class GtkAssistant `{GtkAssistant *`}
 		gtk_assistant_set_page_type(self, page, t);
 	`}
 
-	fun get_page_title(page: GtkWidget): String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_assistant_get_page_title(self, page));
+	fun get_page_title(page: GtkWidget): String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_assistant_get_page_title(self, page));
 	`}
 
 	fun set_page_title(page: GtkWidget, title: String) import String.to_cstring `{

--- a/lib/gtk/v3_4/gtk_core.nit
+++ b/lib/gtk/v3_4/gtk_core.nit
@@ -331,8 +331,8 @@ extern class GtkFrame `{GtkFrame *`}
 		return (GtkFrame *)gtk_frame_new(String_to_cstring(lbl));
 	`}
 
-	fun frame_label: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_frame_get_label(self));
+	fun frame_label: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_frame_get_label(self));
 	`}
 
 	fun frame_label=(lbl: String) import String.to_cstring `{
@@ -475,8 +475,8 @@ extern class GtkEntry `{GtkEntry *`}
 		 return (GtkEntry *)gtk_entry_new();
 	`}
 
-	fun text: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_entry_get_text(self));
+	fun text: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_entry_get_text(self));
 	`}
 
 	fun text=(value: String) import String.to_cstring `{
@@ -682,8 +682,8 @@ extern class GtkLabel `{GtkLabel *`}
 	`}
 
 	# Returns the text of the label
-	fun text: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char*)gtk_label_get_text(self));
+	fun text: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char*)gtk_label_get_text(self));
 	`}
 
 	# Sets the angle of rotation for the label.
@@ -704,7 +704,7 @@ extern class GtkLabel `{GtkLabel *`}
 	# lbl.set_markup("<span style=\"italic\">\%s</span>".to_cstring,
 	#                "Italic content")
 	# ~~~
-	fun set_markup(format, content: NativeString) `{
+	fun set_markup(format, content: CString) `{
 		char *formatted = g_markup_printf_escaped(format, content);
 		gtk_label_set_markup(self, formatted);
 		g_free(formatted);
@@ -803,8 +803,8 @@ extern class GtkButton `{GtkButton *`}
 		return (GtkButton *)gtk_button_new_from_stock(String_to_cstring(stock_id));
 	`}
 
-	fun text: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_button_get_label(self));
+	fun text: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_button_get_label(self));
 	`}
 
 	fun text=(value: String) import String.to_cstring `{
@@ -876,8 +876,8 @@ extern class GtkExpander `{GtkExpander *`}
 		gtk_expander_set_spacing(self, pixels);
 	`}
 
-	fun label_text: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_expander_get_label(self));
+	fun label_text: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_expander_get_label(self));
 	`}
 
 	fun label_text=(lbl: String) import String.to_cstring `{
@@ -995,8 +995,8 @@ extern class GtkComboBox `{GtkComboBox *`}
 		gtk_combo_box_set_id_column(self, id_column);
 	`}
 
-	fun active_id: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_combo_box_get_active_id(self));
+	fun active_id: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_combo_box_get_active_id(self));
 	`}
 
 	fun active_id=(id_active: String) import String.to_cstring `{
@@ -1019,8 +1019,8 @@ extern class GtkComboBox `{GtkComboBox *`}
 		gtk_combo_box_popdown(self);
 	`}
 
-	fun title: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_combo_box_get_title(self));
+	fun title: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_combo_box_get_title(self));
 	`}
 
 	fun title=(t: String) import String.to_cstring `{

--- a/lib/gtk/v3_4/gtk_dialogs.nit
+++ b/lib/gtk/v3_4/gtk_dialogs.nit
@@ -52,40 +52,40 @@ extern class GtkAboutDialog `{GtkAboutDialog *`}
 		return (GtkAboutDialog *)gtk_about_dialog_new();
 	`}
 
-	fun program_name: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_about_dialog_get_program_name(self));
+	fun program_name: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_about_dialog_get_program_name(self));
 	`}
 
 	fun program_name=(name: String) import String.to_cstring `{
 		gtk_about_dialog_set_program_name(self, String_to_cstring(name));
 	`}
 
-	fun version: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_about_dialog_get_version(self));
+	fun version: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_about_dialog_get_version(self));
 	`}
 
 	fun version=(v: String) import String.to_cstring `{
 		gtk_about_dialog_set_version(self, String_to_cstring(v));
 	`}
 
-	fun copyright: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_about_dialog_get_copyright(self));
+	fun copyright: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_about_dialog_get_copyright(self));
 	`}
 
 	fun copyright=(c: String) import String.to_cstring `{
 		gtk_about_dialog_set_copyright(self, String_to_cstring(c));
 	`}
 
-	fun comments: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_about_dialog_get_comments(self));
+	fun comments: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_about_dialog_get_comments(self));
 	`}
 
 	fun comments=(com: String) import String.to_cstring `{
 		gtk_about_dialog_set_comments(self, String_to_cstring(com));
 	`}
 
-	fun license: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_about_dialog_get_license(self));
+	fun license: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_about_dialog_get_license(self));
 	`}
 
 	fun license=(li: String) import String.to_cstring `{
@@ -94,16 +94,16 @@ extern class GtkAboutDialog `{GtkAboutDialog *`}
 
 	# license_type
 
-	fun website: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_about_dialog_get_website(self));
+	fun website: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_about_dialog_get_website(self));
 	`}
 
 	fun website=(link: String) import String.to_cstring `{
 		gtk_about_dialog_set_website(self, String_to_cstring(link));
 	`}
 
-	fun website_label: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *) gtk_about_dialog_get_website_label(self));
+	fun website_label: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *) gtk_about_dialog_get_website_label(self));
 	`}
 
 	fun website_label=(link_label: String) import String.to_cstring `{
@@ -111,8 +111,8 @@ extern class GtkAboutDialog `{GtkAboutDialog *`}
 	`}
 
 	# TODO
-	# fun authors: String  import NativeString.to_s_with_copy `{
-	#		return NativeString_to_s_with_copy(gtk_about_dialog_get_authors(self));
+	# fun authors: String  import CString.to_s_with_copy `{
+	#		return CString_to_s_with_copy(gtk_about_dialog_get_authors(self));
 	# `}
 
 	# TODO
@@ -144,8 +144,8 @@ extern class GtkAppChooserDialog `{GtkAppChooserDialog *`}
 
 	fun widget: GtkWidget `{ return gtk_app_chooser_dialog_get_widget(self); `}
 
-	fun heading: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_app_chooser_dialog_get_heading(self));
+	fun heading: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_app_chooser_dialog_get_heading(self));
 	`}
 
 	fun heading=(text: String) import String.to_cstring `{

--- a/lib/gtk/v3_4/gtk_widgets_ext.nit
+++ b/lib/gtk/v3_4/gtk_widgets_ext.nit
@@ -131,8 +131,8 @@ extern class GtkProgressBar `{GtkProgressBar *`}
 		gtk_progress_bar_set_show_text(self, show);
 	`}
 
-	fun text: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy((char *)gtk_progress_bar_get_text(self));
+	fun text: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy((char *)gtk_progress_bar_get_text(self));
 	`}
 
 	fun text=(value: String) import String.to_cstring `{
@@ -275,5 +275,5 @@ extern class GtkCheckButton `{ GtkCheckButton * `}
 
 	new `{ return (GtkCheckButton *)gtk_check_button_new(); `}
 
-	new with_label(lbl: NativeString) `{ return (GtkCheckButton *)gtk_check_button_new_with_label((gchar *)lbl); `}
+	new with_label(lbl: CString) `{ return (GtkCheckButton *)gtk_check_button_new_with_label((gchar *)lbl); `}
 end

--- a/lib/ios/app.nit
+++ b/lib/ios/app.nit
@@ -100,7 +100,7 @@ redef class App
 	#
 	# Nit extracts the first arguments from the `args` sequence,
 	# so we need to add it back. That's why Nit's `args` is smaller than in C.
-	private fun register_args(program_name: NativeString, argc: Int,
+	private fun register_args(program_name: CString, argc: Int,
 	argv: Sequence[String]) import Sequence[String].[], String.to_cstring in "ObjC" `{
 		app_nit_ios_argc = (int)(argc+1);
 

--- a/lib/ios/ios.nit
+++ b/lib/ios/ios.nit
@@ -31,7 +31,7 @@ redef class NSString
 	private fun nslog in "ObjC" `{ NSLog(@"%@", self); `}
 end
 
-redef class NativeString
+redef class CString
 	# FIXME temp workaround for #1945, bypass Unicode checks
 	redef fun char_at(pos) do return self[pos].ascii
 end

--- a/lib/java/ffi_support.nit
+++ b/lib/java/ffi_support.nit
@@ -70,7 +70,7 @@ redef class Sys
 	end
 
 	# Get a Java class by its name from the current `jni_env`
-	fun load_jclass(name: NativeString): JClass import jni_env `{
+	fun load_jclass(name: CString): JClass import jni_env `{
 		JNIEnv *nit_ffi_jni_env = Sys_jni_env(self);
 
 		// retrieve the implementation Java class
@@ -88,12 +88,12 @@ end
 # A standard Java string `java.lang.String`
 #
 # Converted to a Nit string using `to_s`, or to a C string with `to_cstring`.
-# Created using `String::to_java_string` or `NativeString::to_java_string`.
+# Created using `String::to_java_string` or `CString::to_java_string`.
 extern class JavaString in "Java" `{ java.lang.String `}
 	super JavaObject
 
 	# Get the string from Java and copy it to Nit memory
-	fun to_cstring: NativeString import sys, Sys.jni_env `{
+	fun to_cstring: CString import sys, Sys.jni_env `{
 		Sys sys = JavaString_sys(self);
 		JNIEnv *env = Sys_jni_env(sys);
 
@@ -118,7 +118,7 @@ extern class JavaString in "Java" `{ java.lang.String `}
 	end
 end
 
-redef class NativeString
+redef class CString
 	# Get a Java string from this C string
 	#
 	# This instance is only valid until the next execution of Java code.

--- a/lib/json/serialization_read.nit
+++ b/lib/json/serialization_read.nit
@@ -532,7 +532,7 @@ end
 # Metamodel
 
 # Class inheritance graph as a `POSet[String]` serialized to JSON
-private fun class_inheritance_metamodel_json: NativeString is intern
+private fun class_inheritance_metamodel_json: CString is intern
 
 redef class Sys
 	# Class inheritance graph

--- a/lib/json/serialization_write.nit
+++ b/lib/json/serialization_write.nit
@@ -258,7 +258,7 @@ redef class Char
 	end
 end
 
-redef class NativeString
+redef class CString
 	redef fun accept_json_serializer(v) do to_s.accept_json_serializer(v)
 end
 

--- a/lib/jvm.nit
+++ b/lib/jvm.nit
@@ -108,15 +108,15 @@ private extern class JavaVMInitArgs `{ JavaVMInitArgs* `}
 end
 
 private extern class JavaVMOption `{ JavaVMOption* `}
-	fun string: String import NativeString.to_s `{
-		return NativeString_to_s((char*)self->optionString);
+	fun string: String import CString.to_s `{
+		return CString_to_s((char*)self->optionString);
 	`}
 	fun string=(v: String) import String.to_cstring `{
 		self->optionString = String_to_cstring(v);
 	`}
 
-	fun extra_info: String import NativeString.to_s `{
-		return NativeString_to_s((char*)self->extraInfo);
+	fun extra_info: String import CString.to_s `{
+		return CString_to_s((char*)self->extraInfo);
 	`}
 	fun extra_info=(v: String) import String.to_cstring `{
 		self->extraInfo = String_to_cstring(v);
@@ -157,7 +157,7 @@ extern class JavaVM `{JavaVM *`}
 		return jvm;
 	`}
 
-	private fun jni_error(msg: NativeString, v: Int)
+	private fun jni_error(msg: CString, v: Int)
 	do
 		print "JNI Error: {msg} ({v})"
 		abort
@@ -287,8 +287,8 @@ extern class JniEnv `{JNIEnv *`}
 		return res;
 	`}
 
-	# Call a method on `obj` designed by `method_id` with an array `args` of arguments returning a NativeString
-	fun call_string_method(obj: JavaObject, method_id: JMethodID, args: nullable Array[nullable Object]): NativeString import convert_args_to_jni `{
+	# Call a method on `obj` designed by `method_id` with an array `args` of arguments returning a CString
+	fun call_string_method(obj: JavaObject, method_id: JMethodID, args: nullable Array[nullable Object]): CString import convert_args_to_jni `{
 		jvalue * args_tab = JniEnv_convert_args_to_jni(self, args);
 		jobject jobj = (*self)->CallObjectMethod(self, obj, method_id, args_tab);
 		free(args_tab);
@@ -441,16 +441,16 @@ end
 
 # Represents a jni JNINNativeMethod
 extern class JNINativeMethod `{ JNINativeMethod* `}
-	fun name: String import NativeString.to_s `{
-		return NativeString_to_s((void*)self->name);
+	fun name: String import CString.to_s `{
+		return CString_to_s((void*)self->name);
 	`}
 
 	fun name=(name: String) import String.to_cstring `{
 		self->name = String_to_cstring(name);
 	`}
 
-	fun signature: String import NativeString.to_s `{
-		return NativeString_to_s((void*)self->signature);
+	fun signature: String import CString.to_s `{
+		return CString_to_s((void*)self->signature);
 	`}
 
 	fun signature=(signature: String) import String.to_cstring `{
@@ -530,7 +530,7 @@ redef class Bool
 	`}
 end
 
-redef class NativeString
+redef class CString
 	redef fun to_jvalue(env)`{
 		jvalue value;
 		value.l = (*env)->NewStringUTF(env, self);

--- a/lib/libevent.nit
+++ b/lib/libevent.nit
@@ -184,7 +184,7 @@ class Connection
 	do
 		var evbuffer = bev.input_buffer
 		var len = evbuffer.length
-		var buf = new NativeString(len)
+		var buf = new CString(len)
 		evbuffer.remove(buf, len)
 		var str = buf.to_s_with_length(len)
 		read_callback str
@@ -299,7 +299,7 @@ fun evutil_socket_error: Int `{
 `}
 
 # Convert an error code from `evutil_socket_error` to a string
-fun evutil_socket_error_to_string(error_code: Int): NativeString `{
+fun evutil_socket_error_to_string(error_code: Int): CString `{
 	return evutil_socket_error_to_string(error_code);
 `}
 
@@ -344,7 +344,7 @@ extern class NativeBufferEvent `{ struct bufferevent * `}
 
 	# Set callbacks to `read_callback_native`, `write_callback` and `event_callback` of `conn`
 	fun setcb(conn: Connection) import Connection.read_callback_native,
-	Connection.write_callback, Connection.event_callback, NativeString `{
+	Connection.write_callback, Connection.event_callback, CString `{
 		Connection_incr_ref(conn);
 		bufferevent_setcb(self,
 			(bufferevent_data_cb)c_read_cb,
@@ -353,7 +353,7 @@ extern class NativeBufferEvent `{ struct bufferevent * `}
 	`}
 
 	# Write `length` bytes of `line`
-	fun write(line: NativeString, length: Int): Int `{
+	fun write(line: CString, length: Int): Int `{
 		return bufferevent_write(self, line, length);
 	`}
 
@@ -384,7 +384,7 @@ extern class NativeEvBuffer `{ struct evbuffer * `}
 	fun length: Int `{ return evbuffer_get_length(self); `}
 
 	# Read data from an evbuffer and drain the bytes read
-	fun remove(buffer: NativeString, len: Int) `{
+	fun remove(buffer: CString, len: Int) `{
 		evbuffer_remove(self, buffer, len);
 	`}
 end
@@ -410,7 +410,7 @@ end
 # A listener acting on an interface and port, spawns `Connection` on new connections
 extern class ConnectionListener `{ struct evconnlistener * `}
 
-	private new bind_to(base: NativeEventBase, address: NativeString, port: Int, factory: ConnectionFactory)
+	private new bind_to(base: NativeEventBase, address: CString, port: Int, factory: ConnectionFactory)
 	import ConnectionFactory.accept_connection, error_callback `{
 
 		struct sockaddr_in sin;
@@ -465,7 +465,7 @@ class ConnectionFactory
 
 		# Human representation of remote client address
 		var addr_len = 46 # Longest possible IPv6 address + null byte
-		var addr_buf = new NativeString(addr_len)
+		var addr_buf = new CString(addr_len)
 		addr_buf = addrin_to_address(addrin, addr_buf, addr_len)
 		var addr = if addr_buf.address_is_null then
 				"Unknown address"
@@ -493,7 +493,7 @@ class ConnectionFactory
 	end
 
 	# Put string representation of source `address` into `buf`
-	private fun addrin_to_address(address: Pointer, buf: NativeString, buf_len: Int): NativeString `{
+	private fun addrin_to_address(address: Pointer, buf: CString, buf_len: Int): CString `{
 		struct sockaddr *addrin = (struct sockaddr*)address;
 
 		if (addrin->sa_family == AF_INET) {

--- a/lib/md5.nit
+++ b/lib/md5.nit
@@ -500,8 +500,8 @@ redef class Text
 	fun md5: String do return to_cstring.native_md5.to_s
 end
 
-redef class NativeString
-	private fun native_md5: NativeString `{
+redef class CString
+	private fun native_md5: CString `{
 		md5_state_t state;
 		md5_byte_t digest[16]; /* result */
 		char *hex_output = malloc(33*sizeof(char));

--- a/lib/mnit/android/android_assets.nit
+++ b/lib/mnit/android/android_assets.nit
@@ -30,7 +30,7 @@ intrude import android::load_image
 
 extern class AndroidAsset in "C" `{struct AAsset*`}
 
-	fun read(count: Int): nullable String import String.as nullable, NativeString.to_s `{
+	fun read(count: Int): nullable String import String.as nullable, CString.to_s `{
 		char *buffer = malloc(sizeof(char) * (count+1));
 		int read = AAsset_read(self, buffer, count);
 		if (read != count)
@@ -38,7 +38,7 @@ extern class AndroidAsset in "C" `{struct AAsset*`}
 		else
 		{
 			buffer[count] = '\0';
-			return String_as_nullable(NativeString_to_s(buffer));
+			return String_as_nullable(CString_to_s(buffer));
 		}
 	`}
 

--- a/lib/mongodb/mongodb.nit
+++ b/lib/mongodb/mongodb.nit
@@ -91,7 +91,7 @@ private class BSON
 	end
 
 	redef fun to_s do
-		var ns = native.to_native_string
+		var ns = native.to_c_string
 		var res = ns.to_s_with_copy
 		ns.free # manual free of gc allocated CString
 		return res

--- a/lib/mongodb/mongodb.nit
+++ b/lib/mongodb/mongodb.nit
@@ -93,7 +93,7 @@ private class BSON
 	redef fun to_s do
 		var ns = native.to_native_string
 		var res = ns.to_s_with_copy
-		ns.free # manual free of gc allocated NativeString
+		ns.free # manual free of gc allocated CString
 		return res
 	end
 

--- a/lib/mongodb/native_mongodb.nit
+++ b/lib/mongodb/native_mongodb.nit
@@ -48,7 +48,7 @@ extern class NativeBSON `{ bson_t * `}
 	# by parsing the JSON found in `data`.
 	# Only a single JSON object may exist in data or an error will be set and
 	# `NULL` returned.
-	new from_json_string(data: NativeString) import set_mongoc_error `{
+	new from_json_string(data: CString) import set_mongoc_error `{
 		bson_error_t error;
 		bson_t *bson;
 		bson = bson_new_from_json((uint8_t *)data, -1, &error);
@@ -64,7 +64,7 @@ extern class NativeBSON `{ bson_t * `}
 	# The `bson_as_json()` function shall encode bson as a JSON encoded UTF-8 string.
 	# The caller is responsible for freeing the resulting UTF-8 encoded string
 	# by calling `bson_free()` with the result.
-	fun to_native_string: NativeString `{ return bson_as_json(self, NULL); `}
+	fun to_native_string: CString `{ return bson_as_json(self, NULL); `}
 
 	# Wrapper for `bson_destroy()`.
 	#
@@ -100,7 +100,7 @@ extern class BSONError `{ bson_error_t * `}
 	# Wrapper for `error.message`.
 	#
 	# The `error.message` field contains a human printable error message.
-	fun message: NativeString `{ return self->message; `}
+	fun message: CString `{ return self->message; `}
 end
 
 # Wrapper for `bson_oid_t`.
@@ -123,10 +123,10 @@ extern class BSONObjectId `{ bson_oid_t * `}
 	`}
 
 	# Object id.
-	fun id: String import NativeString.to_s_with_copy `{
+	fun id: String import CString.to_s_with_copy `{
 		char str[25];
 		bson_oid_to_string(self, str);
-		return NativeString_to_s_with_copy(str);
+		return CString_to_s_with_copy(str);
 	`}
 
 	# Destroy `self`.
@@ -147,7 +147,7 @@ end
 
 # Wrapper for `char**`.
 #
-# Used to handle array of NativeString returned by MongoDB.
+# Used to handle array of CString returned by MongoDB.
 redef class NativeCStringArray
 	# Frees `self`.
 	#
@@ -167,7 +167,7 @@ extern class NativeMongoClient `{ mongoc_client_t * `}
 	# Wrapper for `mongoc_client_new()`.
 	#
 	# Creates a new `mongoc_client_t` using the `uri` string provided.
-	new(uri: NativeString) `{
+	new(uri: CString) `{
 		mongoc_init();
 		return mongoc_client_new(uri);
 	`}
@@ -229,7 +229,7 @@ extern class NativeMongoDb `{ mongoc_database_t * `}
 	# Database are automatically created on the MongoDB server upon insertion of
 	# the first document into a collection.
 	# There is no need to create a database manually.
-	new(client: NativeMongoClient, db_name: NativeString) `{
+	new(client: NativeMongoClient, db_name: CString) `{
 		return mongoc_client_get_database(client, db_name);
 	`}
 
@@ -252,7 +252,7 @@ extern class NativeMongoDb `{ mongoc_database_t * `}
 	#
 	# Allocates a new `mongoc_collection_t` structure for the collection named
 	# `name` in database.
-	fun collection(name: NativeString): NativeMongoCollection `{
+	fun collection(name: CString): NativeMongoCollection `{
 		return mongoc_database_get_collection(self, name);
 	`}
 
@@ -260,7 +260,7 @@ extern class NativeMongoDb `{ mongoc_database_t * `}
 	#
 	# This function checks to see if a collection exists on the MongoDB server
 	# within database.
-	fun has_collection(name: NativeString): Bool import set_mongoc_error `{
+	fun has_collection(name: CString): Bool import set_mongoc_error `{
 		bson_error_t error;
 		if(!mongoc_database_has_collection(self, name, &error)) {
 			NativeMongoDb_set_mongoc_error(self, &error);
@@ -312,7 +312,7 @@ extern class NativeMongoCollection `{ mongoc_collection_t * `}
 	# Collections are automatically created on the MongoDB server upon insertion
 	# of the first document.
 	# There is no need to create a collection manually.
-	new(client: NativeMongoClient, db, collection: NativeString) `{
+	new(client: NativeMongoClient, db, collection: CString) `{
 		return mongoc_client_get_collection(client, db, collection);
 	`}
 
@@ -494,7 +494,7 @@ extern class NativeMongoCollection `{ mongoc_collection_t * `}
 	# The name of the collection will also be updated internally so it is safe
 	# to continue using this collection after the rename.
 	# Additional operations will occur on renamed collection.
-	fun rename(new_database, new_name: NativeString): Bool `{
+	fun rename(new_database, new_name: CString): Bool `{
 		bson_error_t error;
 		if(!mongoc_collection_rename(self, new_database, new_name, false, &error)){
 			NativeMongoCollection_set_mongoc_error(self, &error);

--- a/lib/mongodb/native_mongodb.nit
+++ b/lib/mongodb/native_mongodb.nit
@@ -64,7 +64,7 @@ extern class NativeBSON `{ bson_t * `}
 	# The `bson_as_json()` function shall encode bson as a JSON encoded UTF-8 string.
 	# The caller is responsible for freeing the resulting UTF-8 encoded string
 	# by calling `bson_free()` with the result.
-	fun to_native_string: CString `{ return bson_as_json(self, NULL); `}
+	fun to_c_string: CString `{ return bson_as_json(self, NULL); `}
 
 	# Wrapper for `bson_destroy()`.
 	#

--- a/lib/mpi/mpi.nit
+++ b/lib/mpi/mpi.nit
@@ -50,11 +50,11 @@ class MPI
 	fun finalize `{ MPI_Finalize(); `}
 
 	# Name of this processor, usually the hostname
-	fun processor_name: String import NativeString.to_s_with_length `{
+	fun processor_name: String import CString.to_s_with_length `{
 		char *name = malloc(MPI_MAX_PROCESSOR_NAME);
 		int size;
 		MPI_Get_processor_name(name, &size);
-		return NativeString_to_s_with_length(name, size);
+		return CString_to_s_with_length(name, size);
 	`}
 
 	# Send the content of a buffer
@@ -338,7 +338,7 @@ extern class SuccessOrError `{ int `}
 	`}
 
 	redef fun to_s do return native_to_s.to_s
-	private fun native_to_s: NativeString `{
+	private fun native_to_s: CString `{
 		char *err = malloc(MPI_MAX_ERROR_STRING);
 		MPI_Error_string(self, err, NULL);
 		return err;
@@ -348,7 +348,7 @@ end
 # An MPI error class
 extern class ErrorClass `{ int `}
 	redef fun to_s do return native_to_s.to_s
-	private fun native_to_s: NativeString `{
+	private fun native_to_s: CString `{
 		char *err = malloc(MPI_MAX_ERROR_STRING);
 		MPI_Error_string(self, err, NULL);
 		return err;

--- a/lib/pnacl/pnacl.nit
+++ b/lib/pnacl/pnacl.nit
@@ -571,10 +571,10 @@ extern class PepperVar `{ struct PP_Var* `}
 	private fun as_bool: Bool `{ return self->value.as_bool; `}
 	private fun as_int: Int `{ return self->value.as_int; `}
 	private fun as_float: Float `{ return self->value.as_double; `}
-	private fun as_string: String import NativeString.to_s_with_length `{
+	private fun as_string: String import CString.to_s_with_length `{
 		uint32_t len;
 		char* str = (char*)g_varInterface->VarToUtf8(*self, &len);
-		return NativeString_to_s_with_length(str, len);
+		return CString_to_s_with_length(str, len);
 	`}
 end
 
@@ -646,7 +646,7 @@ class PnaclStream
 	redef fun is_writable: Bool do return true
 
 	# Checks if there is a message in the queue, and if so the message is handled automatically.
-	fun check_message: NativeString `{
+	fun check_message: CString `{
 		return NitHandleMessage();
 	`}
 
@@ -679,7 +679,7 @@ end
 class PnaclApp
 
 	# Sets everything up to work, need to be called at first.
-	fun initialize import PnaclApp.handle_message, PnaclApp.handle_dictionary, NativeString.to_s_with_length `{
+	fun initialize import PnaclApp.handle_message, PnaclApp.handle_dictionary, CString.to_s_with_length `{
 		app = self;
 	`}
 

--- a/lib/posix_ext.nit
+++ b/lib/posix_ext.nit
@@ -19,5 +19,5 @@ module posix_ext
 
 redef extern class Passwd
 	# User information
-	fun gecos: String import NativeString.to_s `{ return NativeString_to_s(self->pw_gecos); `}
+	fun gecos: String import CString.to_s `{ return CString_to_s(self->pw_gecos); `}
 end

--- a/lib/postgresql/native_postgres.nit
+++ b/lib/postgresql/native_postgres.nit
@@ -35,10 +35,10 @@ extern class ExecStatusType `{int`}
     return !(self == PGRES_BAD_RESPONSE || self == PGRES_NONFATAL_ERROR || self == PGRES_FATAL_ERROR);
   `}
 
-  redef fun to_s import NativeString.to_s `{
+  redef fun to_s import CString.to_s `{
     char * err = PQresStatus(self);
     if(err == NULL) err = "";
-    return NativeString_to_s(err);
+    return CString_to_s(err);
   `}
 end
 
@@ -63,8 +63,8 @@ extern class NativePGResult `{PGresult *`}
   fun status: ExecStatusType `{ return PQresultStatus(self); `}
 
   # Returns the field name of a given column_number
-  fun fname(column_number:Int):String import NativeString.to_s `{
-    return NativeString_to_s( PQfname(self, column_number));
+  fun fname(column_number:Int):String import CString.to_s `{
+    return CString_to_s( PQfname(self, column_number));
   `}
 
   # Returns the column number associated with the column name
@@ -73,8 +73,8 @@ extern class NativePGResult `{PGresult *`}
   `}
 
   # Returns a single field value of one row of the result at row_number, column_number
-  fun value(row_number:Int, column_number:Int):String import NativeString.to_s `{
-    return NativeString_to_s(PQgetvalue(self, row_number, column_number));
+  fun value(row_number:Int, column_number:Int):String import CString.to_s `{
+    return CString_to_s(PQgetvalue(self, row_number, column_number));
   `}
 
   # Tests wether a field is a null value
@@ -123,9 +123,9 @@ extern class NativePostgres `{PGconn *`}
   `}
 
   # Returns the error message of the last operation on the connection
-  fun error: String import NativeString.to_s `{
+  fun error: String import CString.to_s `{
     char * error = PQerrorMessage(self);
-    return NativeString_to_s(error);
+    return CString_to_s(error);
   `}
 
   # Returns the status of this connection

--- a/lib/readline.nit
+++ b/lib/readline.nit
@@ -22,11 +22,11 @@ in "C" `{
 	#include <readline/history.h>
 `}
 
-private fun native_readline(prompt: NativeString): NativeString `{
+private fun native_readline(prompt: CString): CString `{
 	return readline(prompt);
 `}
 
-private fun native_add_history(data: NativeString) `{
+private fun native_add_history(data: CString) `{
 	if (data == NULL) return;
 	add_history(data);
 `}

--- a/lib/sdl.nit
+++ b/lib/sdl.nit
@@ -140,7 +140,7 @@ extern class SDLDisplay `{SDL_Surface *`}
 		return null_SDLInputEvent();
 	`}
 
-	private fun new_key_event(name: NativeString, down: Bool): nullable SDLInputEvent
+	private fun new_key_event(name: CString, down: Bool): nullable SDLInputEvent
 	do return new SDLKeyEvent(name.to_s, down)
 
 	private fun new_mouse_motion_event(x, y, xr, yr: Float, down: Bool): nullable SDLInputEvent
@@ -484,7 +484,7 @@ extern class SDLFont `{TTF_Font *`}
 		if (fn == NULL)
 			return null_String();
 		else
-			return String_as_nullable(NativeString_to_s(fn));
+			return String_as_nullable(CString_to_s(fn));
 	`}
 
 	# Return the style name of the font
@@ -494,11 +494,11 @@ extern class SDLFont `{TTF_Font *`}
 		if (sn == NULL)
 			return null_String();
 		else
-			return String_as_nullable(NativeString_to_s(sn));
+			return String_as_nullable(CString_to_s(sn));
 	`}
 
 	# Return the estimated width of a String if used with the current font
-	fun width_of(text: String): Int import NativeString.to_s `{
+	fun width_of(text: String): Int import CString.to_s `{
 		char *ctext = String_to_cstring(text);
 		int w;
 		if (TTF_SizeText(self, ctext, &w, NULL))

--- a/lib/sdl2/image.nit
+++ b/lib/sdl2/image.nit
@@ -51,12 +51,12 @@ class IMG
 	fun quit `{ IMG_Quit(); `}
 
 	# Get the latest image library error
-	fun error: NativeString `{ return (char*)IMG_GetError(); `}
+	fun error: CString `{ return (char*)IMG_GetError(); `}
 end
 
 redef extern class SDLSurface
 	# Load the image at `path` inferring its type from the file extension
-	new load(path: NativeString) `{ return IMG_Load(path); `}
+	new load(path: CString) `{ return IMG_Load(path); `}
 end
 
 # Flags from `sys.sdl.img.initialize`

--- a/lib/sdl2/sdl2_base.nit
+++ b/lib/sdl2/sdl2_base.nit
@@ -42,7 +42,7 @@ class SDL
 	# Returns the latest SDL error
 	#
 	# After calling this method, you should also call `clear_error`.
-	fun error: NativeString `{ return (char*)SDL_GetError(); `}
+	fun error: CString `{ return (char*)SDL_GetError(); `}
 
 	# Clear the SDL error
 	fun clear_error `{ SDL_ClearError(); `}
@@ -65,7 +65,7 @@ class SDL
 	fun system_ram: Int `{ return SDL_GetSystemRAM(); `}
 
 	# Show a simple message box
-	fun show_simple_message_box(level: SDLMessageBoxFlags, title, content: NativeString) `{
+	fun show_simple_message_box(level: SDLMessageBoxFlags, title, content: CString) `{
 		SDL_ShowSimpleMessageBox(level, title, content, NULL);
 	`}
 
@@ -120,7 +120,7 @@ end
 # A window created by SDL
 extern class SDLWindow `{ SDL_Window * `}
 	# Create a window with the given `title`, `width` and `height`, also apply the `flags`
-	new (title: NativeString, width, height: Int, flags: SDLWindowFlags) `{
+	new (title: CString, width, height: Int, flags: SDLWindowFlags) `{
 		return SDL_CreateWindow(title,
 			SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
 			width, height, flags);
@@ -138,7 +138,7 @@ extern class SDLWindow `{ SDL_Window * `}
 	# Show a simple message box
 	#
 	# Similar to `sys.sdl.show_simple_message_box` but attached to this window
-	fun show_simple_message_box(level: SDLMessageBoxFlags, title, content: NativeString) `{
+	fun show_simple_message_box(level: SDLMessageBoxFlags, title, content: CString) `{
 		SDL_ShowSimpleMessageBox(level, title, content, self);
 	`}
 
@@ -379,12 +379,12 @@ end
 extern class SDLSurface `{ SDL_Surface * `}
 
 	# Load the BMP file at `path`
-	new load_bmp(path: NativeString) `{ return SDL_LoadBMP(path); `}
+	new load_bmp(path: CString) `{ return SDL_LoadBMP(path); `}
 
 	redef fun free `{ SDL_FreeSurface(self); `}
 
 	# Save this texture to a BMP file
-	fun save_bmp(path: NativeString) `{ SDL_SaveBMP(self, path); `}
+	fun save_bmp(path: CString) `{ SDL_SaveBMP(self, path); `}
 end
 
 # A loaded bitmap texture
@@ -526,7 +526,7 @@ extern class SDLRendererInfo `{ SDL_RendererInfo * `}
 	new malloc `{ return malloc(sizeof(SDL_RendererInfo)); `}
 
 	# Name of the renderer's driver
-	fun name: NativeString `{ return (char*)self->name; `}
+	fun name: CString `{ return (char*)self->name; `}
 
 	# Maximum texture width supported by the renderer
 	fun max_texture_width: Int `{ return self->max_texture_width; `}

--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -239,7 +239,7 @@ redef class Bool super DirectSerializable end
 redef class Char super DirectSerializable end
 redef class Int super DirectSerializable end
 redef class Float super DirectSerializable end
-redef class NativeString super DirectSerializable end
+redef class CString super DirectSerializable end
 redef class Text super DirectSerializable end
 redef class SimpleCollection[E] super Serializable end
 redef class Map[K, V] super Serializable end

--- a/lib/sha1.nit
+++ b/lib/sha1.nit
@@ -217,8 +217,8 @@ in "C Header" `{
 	}
 `}
 
-redef class NativeString
-	private fun sha1_intern(len: Int): NativeString `{
+redef class CString
+	private fun sha1_intern(len: Int): CString `{
 		sha1nfo s;
 
 		sha1_init(&s);
@@ -239,7 +239,7 @@ redef class String
 
 	# Computes the SHA1 of the receiver
 	#
-	# Returns a digest of 20 bytes as a NativeString,
+	# Returns a digest of 20 bytes as a CString,
 	# note that all the characters are not necessarily ASCII.
 	# If you want the hex string version of the digest, use
 	# sha1_hexdigest.

--- a/lib/socket/socket.nit
+++ b/lib/socket/socket.nit
@@ -71,7 +71,7 @@ class TCPStream
 	# Creates a socket connection to host `host` on port `port`
 	init connect(host: String, port: Int)
 	do
-		_buffer = new NativeString(1024)
+		_buffer = new CString(1024)
 		_buffer_pos = 0
 		native = new NativeSocket.socket(new NativeSocketAddressFamilies.af_inet,
 			new NativeSocketTypes.sock_stream, new NativeSocketProtocolFamilies.pf_null)
@@ -216,7 +216,7 @@ class TCPStream
 		if _buffer_capacity >= len then return
 		_buffer_capacity = len
 
-		var ns = new NativeString(_buffer_capacity)
+		var ns = new CString(_buffer_capacity)
 		_buffer.copy_to(ns, _buffer_length - _buffer_pos, _buffer_pos, 0)
 		_buffer = ns
 	end
@@ -401,7 +401,7 @@ class UDPSocket
 	# On error, returns an empty string and sets `error` appropriately.
 	fun recv(length: Int): String
 	do
-		var buf = new NativeString(length)
+		var buf = new CString(length)
 		var len = native.recvfrom(buf, length, 0, new NativeSocketAddrIn.nul)
 		if len == -1 then
 			error = new IOError.from_errno
@@ -416,7 +416,7 @@ class UDPSocket
 	fun recv_from(length: Int, sender: Ref[nullable SocketAddress]): String
 	do
 		var src = new NativeSocketAddrIn
-		var buf = new NativeString(length)
+		var buf = new CString(length)
 
 		var len = native.recvfrom(buf, length, 0, src)
 		if len == -1 then

--- a/lib/socket/socket_c.nit
+++ b/lib/socket/socket_c.nit
@@ -126,7 +126,7 @@ extern class NativeSocket `{ int* `}
 	`}
 
 	# Write `length` bytes from `buffer`
-	fun write(buffer: NativeString, length: Int): Int `{
+	fun write(buffer: CString, length: Int): Int `{
 		return write(*self, buffer, length);
 	`}
 
@@ -137,7 +137,7 @@ extern class NativeSocket `{ int* `}
 	`}
 
 	# Read `length` bytes into `buffer`, returns the number of bytes read
-	fun read(buffer: NativeString, length: Int): Int `{
+	fun read(buffer: CString, length: Int): Int `{
 		return read(*self, buffer, length);
 	`}
 
@@ -227,17 +227,17 @@ extern class NativeSocket `{ int* `}
 	`}
 
 	# Send `len` bytes from `buf` to `dest_addr`
-	fun sendto(buf: NativeString, len: Int, flags: Int, dest_addr: NativeSocketAddrIn): Int `{
+	fun sendto(buf: CString, len: Int, flags: Int, dest_addr: NativeSocketAddrIn): Int `{
 		return sendto(*self, buf, len, flags, (struct sockaddr*)dest_addr, sizeof(struct sockaddr_in));
 	`}
 
 	# Receive a message into `buf` of maximum `len` bytes
-	fun recv(buf: NativeString, len: Int, flags: Int): Int `{
+	fun recv(buf: CString, len: Int, flags: Int): Int `{
 		return recv(*self, buf, len, flags);
 	`}
 
 	# Receive a message into `buf` of maximum `len` bytes and store sender info into `src_addr`
-	fun recvfrom(buf: NativeString, len: Int, flags: Int, src_addr: NativeSocketAddrIn): Int `{
+	fun recvfrom(buf: CString, len: Int, flags: Int, src_addr: NativeSocketAddrIn): Int `{
 		socklen_t srclen = sizeof(struct sockaddr_in);
 		return recvfrom(*self, buf, len, flags, (struct sockaddr*)src_addr, &srclen);
 	`}
@@ -275,7 +275,7 @@ extern class NativeSocketAddrIn `{ struct sockaddr_in* `}
 	`}
 
 	# Internet address as then IPV4 numbers-and-dots notation
-	fun address: NativeString `{ return (char*)inet_ntoa(self->sin_addr); `}
+	fun address: CString `{ return (char*)inet_ntoa(self->sin_addr); `}
 
 	# Set `address` to `INADDR_ANY`
 	fun address_any `{ self->sin_addr.s_addr = INADDR_ANY; `}
@@ -298,7 +298,7 @@ end
 
 # Host entry information, a pointer to a `struct hostent`
 extern class NativeSocketHostent `{ struct hostent* `}
-	private fun native_h_aliases(i: Int): NativeString `{
+	private fun native_h_aliases(i: Int): CString `{
 		return self->h_aliases[i];
 	`}
 
@@ -314,7 +314,7 @@ extern class NativeSocketHostent `{ struct hostent* `}
 		return res
 	end
 
-	fun h_addr: NativeString `{
+	fun h_addr: CString `{
 		return (char*)inet_ntoa(*(struct in_addr*)self->h_addr);
 	`}
 
@@ -322,7 +322,7 @@ extern class NativeSocketHostent `{ struct hostent* `}
 
 	fun h_length: Int `{ return self->h_length; `}
 
-	fun h_name: NativeString `{ return self->h_name; `}
+	fun h_name: CString `{ return self->h_name; `}
 end
 
 extern class NativeTimeval `{ struct timeval* `}
@@ -518,7 +518,7 @@ end
 
 redef class Sys
 	# Get network host entry
-	fun gethostbyname(name: NativeString): NativeSocketHostent `{
+	fun gethostbyname(name: CString): NativeSocketHostent `{
 		return gethostbyname(name);
 	`}
 

--- a/lib/sqlite3/native_sqlite3.nit
+++ b/lib/sqlite3/native_sqlite3.nit
@@ -78,7 +78,7 @@ extern class Sqlite3Code `{int`}
 		return err.to_s
 	end
 
-	private fun native_to_s: NativeString `{
+	private fun native_to_s: CString `{
 #if SQLITE_VERSION_NUMBER >= 3007015
 		return (char *)sqlite3_errstr(self);
 #else
@@ -95,7 +95,7 @@ extern class NativeStatement `{sqlite3_stmt*`}
 		return sqlite3_step(self);
 	`}
 
-	fun column_name(i: Int): NativeString `{
+	fun column_name(i: Int): CString `{
 		return (char *)sqlite3_column_name(self, i);
 	`}
 
@@ -112,7 +112,7 @@ extern class NativeStatement `{sqlite3_stmt*`}
 		return sqlite3_column_int(self, i);
 	`}
 
-	fun column_text(i: Int): NativeString `{
+	fun column_text(i: Int): CString `{
 		return (char *)sqlite3_column_text(self, i);
 	`}
 
@@ -138,7 +138,7 @@ end
 extern class NativeSqlite3 `{sqlite3 *`}
 
 	# Open a connection to a database in UTF-8
-	new open(filename: NativeString) `{
+	new open(filename: CString) `{
 		sqlite3 *self = NULL;
 		int err = sqlite3_open(filename, &self);
 		nit_sqlite_open_error = err;
@@ -163,12 +163,12 @@ extern class NativeSqlite3 `{sqlite3 *`}
 	`}
 
 	# Execute a SQL statement
-	fun exec(sql: NativeString): Sqlite3Code `{
+	fun exec(sql: CString): Sqlite3Code `{
 		return sqlite3_exec(self, sql, NULL, NULL, NULL);
 	`}
 
 	# Prepare a SQL statement
-	fun prepare(sql: NativeString): NativeStatement `{
+	fun prepare(sql: CString): NativeStatement `{
 		sqlite3_stmt *stmt;
 		int res = sqlite3_prepare_v2(self, sql, -1, &stmt, 0);
 		if (res == SQLITE_OK)

--- a/lib/sqlite3/sqlite3.nit
+++ b/lib/sqlite3/sqlite3.nit
@@ -250,9 +250,9 @@ class StatementEntry
 	do
 		assert statement_closed: statement.is_open
 
-		var native_string = statement.native_statement.column_text(index)
-		if native_string.address_is_null then return ""
-		return native_string.to_s_with_copy
+		var c_string = statement.native_statement.column_text(index)
+		if c_string.address_is_null then return ""
+		return c_string.to_s_with_copy
 	end
 
 	# Get this entry as `Blob`

--- a/lib/websocket/websocket.nit
+++ b/lib/websocket/websocket.nit
@@ -66,7 +66,7 @@ class WebsocketConnection
 	super TCPStream
 
 	init do
-		_buffer = new NativeString(1024)
+		_buffer = new CString(1024)
 		_buffer_pos = 0
 		_buffer_capacity = 1024
 		_buffer_length = 0
@@ -236,9 +236,9 @@ class WebsocketConnection
 	end
 
 	# Unmasks a message sent by a client
-	private fun unmask_message(key: NativeString, message: NativeString, len: Int): NativeString
+	private fun unmask_message(key: CString, message: CString, len: Int): CString
 	do
-		var return_message = new NativeString(len)
+		var return_message = new CString(len)
 
 		for i in [0 .. len[ do
 			return_message[i] = message[i] ^ key[i % 4]

--- a/lib/xdg_basedir/xdg_basedir.nit
+++ b/lib/xdg_basedir/xdg_basedir.nit
@@ -49,18 +49,18 @@ extern class XdgBasedir `{ xdgHandle* `}
 	fun update: Bool `{ return xdgUpdateData(self); `}
 
 	# Base directory for user specific data files.
-	fun data_home: String import NativeString.to_s `{
-		return NativeString_to_s((char*)xdgDataHome(self));
+	fun data_home: String import CString.to_s `{
+		return CString_to_s((char*)xdgDataHome(self));
 	`}
 
 	# Base directory for user specific configuration files.
-	fun config_home: String import NativeString.to_s `{
-		return NativeString_to_s((char*)xdgConfigHome(self));
+	fun config_home: String import CString.to_s `{
+		return CString_to_s((char*)xdgConfigHome(self));
 	`}
 
 	# Base directory for user specific non-essential data files.
-	fun cache_home: String import NativeString.to_s `{
-		return NativeString_to_s((char*)xdgCacheHome(self));
+	fun cache_home: String import CString.to_s `{
+		return CString_to_s((char*)xdgCacheHome(self));
 	`}
 
 	# Preference-ordered set of base directories to search for data files
@@ -111,13 +111,13 @@ end
 private extern class ConstPointer `{ const void * `}
 	# Convert a C `char **` to a Nit `Array[String]`
 	fun to_string_array: Array[String]
-	import Array[String], Array[String].add, NativeString.to_s `{
+	import Array[String], Array[String].add, CString.to_s `{
 		char **strings = (char**)self;
 
 		Array_of_String aos = new_Array_of_String();
 		int p = 0;
 		while (strings[p] != NULL) {
-			Array_of_String_add(aos, NativeString_to_s((char*)strings[p]));
+			Array_of_String_add(aos, CString_to_s((char*)strings[p]));
 			p ++;
 		}
 

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -1491,7 +1491,7 @@ abstract class AbstractCompilerVisitor
 	end
 
 	# Return a "const char*" variable associated to the classname of the dynamic type of an object
-	# NOTE: we do not return a `RuntimeVariable` "NativeString" as the class may not exist in the module/program
+	# NOTE: we do not return a `RuntimeVariable` "CString" as the class may not exist in the module/program
 	fun class_name_string(value: RuntimeVariable): String is abstract
 
 	# Variables handling
@@ -1684,8 +1684,8 @@ abstract class AbstractCompilerVisitor
 		return res
 	end
 
-	# Generates a NativeString instance fully escaped in C-style \xHH fashion
-	fun native_string_instance(ns: NativeString, len: Int): RuntimeVariable do
+	# Generates a CString instance fully escaped in C-style \xHH fashion
+	fun native_string_instance(ns: CString, len: Int): RuntimeVariable do
 		var mtype = mmodule.native_string_type
 		var nat = new_var(mtype)
 		var byte_esc = new Buffer.with_cap(len * 4)
@@ -2073,7 +2073,7 @@ redef class MClassType
 			return "int32_t"
 		else if mclass.name == "UInt32" then
 			return "uint32_t"
-		else if mclass.name == "NativeString" then
+		else if mclass.name == "CString" then
 			return "char*"
 		else if mclass.name == "NativeArray" then
 			return "val*"
@@ -2115,7 +2115,7 @@ redef class MClassType
 			return "i32"
 		else if mclass.name == "UInt32" then
 			return "u32"
-		else if mclass.name == "NativeString" then
+		else if mclass.name == "CString" then
 			return "str"
 		else if mclass.name == "NativeArray" then
 			#return "{self.arguments.first.ctype}*"
@@ -2584,7 +2584,7 @@ redef class AMethPropdef
 				v.ret(v.new_expr("(uint32_t){arguments[0]}", ret.as(not null)))
 				return true
 			end
-		else if cname == "NativeString" then
+		else if cname == "CString" then
 			if pname == "[]" then
 				v.ret(v.new_expr("(unsigned char)((int){arguments[0]}[{arguments[1]}])", ret.as(not null)))
 				return true
@@ -2608,7 +2608,7 @@ redef class AMethPropdef
 				v.ret(v.new_expr("!{res}", ret.as(not null)))
 				return true
 			else if pname == "new" then
-				var alloc = v.nit_alloc(arguments[1].to_s, "NativeString")
+				var alloc = v.nit_alloc(arguments[1].to_s, "CString")
 				v.ret(v.new_expr("(char*){alloc}", ret.as(not null)))
 				return true
 			else if pname == "fetch_4_chars" then

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -1685,8 +1685,8 @@ abstract class AbstractCompilerVisitor
 	end
 
 	# Generates a CString instance fully escaped in C-style \xHH fashion
-	fun native_string_instance(ns: CString, len: Int): RuntimeVariable do
-		var mtype = mmodule.native_string_type
+	fun c_string_instance(ns: CString, len: Int): RuntimeVariable do
+		var mtype = mmodule.c_string_type
 		var nat = new_var(mtype)
 		var byte_esc = new Buffer.with_cap(len * 4)
 		for i in [0 .. len[ do
@@ -1706,7 +1706,7 @@ abstract class AbstractCompilerVisitor
 		self.add("if (likely({name}!=NULL)) \{")
 		self.add("{res} = {name};")
 		self.add("\} else \{")
-		var native_mtype = mmodule.native_string_type
+		var native_mtype = mmodule.c_string_type
 		var nat = self.new_var(native_mtype)
 		self.add("{nat} = \"{string.escape_to_c}\";")
 		var byte_length = self.int_instance(string.byte_length)
@@ -3726,7 +3726,7 @@ redef class AStringExpr
 		var s = v.string_instance(value)
 		if is_string then return s
 		if is_bytestring then
-			var ns = v.native_string_instance(bytes.items, bytes.length)
+			var ns = v.c_string_instance(bytes.items, bytes.length)
 			var ln = v.int_instance(bytes.length)
 			var cs = to_bytes_with_copy
 			assert cs != null
@@ -3800,7 +3800,7 @@ redef class ASuperstringExpr
 			v.native_array_set(a, i, e)
 		end
 
-		# Fast join the native string to get the result
+		# Fast join the C string to get the result
 		var res = v.send(v.get_property("native_to_s", a.mtype), [a])
 		assert res != null
 

--- a/src/compiler/global_compiler.nit
+++ b/src/compiler/global_compiler.nit
@@ -330,7 +330,7 @@ class GlobalCompilerVisitor
 	redef fun unbox_extern(value, mtype)
 	do
 		if mtype isa MClassType and mtype.mclass.kind == extern_kind and
-		   mtype.mclass.name != "NativeString" then
+		   mtype.mclass.name != "CString" then
 			var res = self.new_var_extern(mtype)
 			self.add "{res} = ((struct {mtype.c_name}*){value})->value; /* unboxing {value.mtype} */"
 			return res
@@ -342,7 +342,7 @@ class GlobalCompilerVisitor
 	redef fun box_extern(value, mtype)
 	do
 		if not mtype isa MClassType or mtype.mclass.kind != extern_kind or
-			mtype.mclass.name == "NativeString" then return value
+			mtype.mclass.name == "CString" then return value
 
 		var valtype = value.mtype.as(MClassType)
 		var res = self.new_var(mtype)

--- a/src/compiler/java_compiler.nit
+++ b/src/compiler/java_compiler.nit
@@ -1318,7 +1318,7 @@ redef class MClassType
 			return "double"
 		else if mclass.name == "Byte" then
 			return "byte"
-		else if mclass.name == "NativeString" then
+		else if mclass.name == "CString" then
 			return "String"
 		else if mclass.name == "NativeArray" then
 			return "Array"

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -252,7 +252,7 @@ class SeparateCompiler
 	do
 		# Collect all bas box class
 		# FIXME: this is not completely fine with a separate compilation scheme
-		for classname in ["Int", "Bool", "Byte", "Char", "Float", "NativeString",
+		for classname in ["Int", "Bool", "Byte", "Char", "Float", "CString",
 		                 "Pointer", "Int8", "Int16", "UInt16", "Int32", "UInt32"] do
 			var classes = self.mainmodule.model.get_mclasses_by_name(classname)
 			if classes == null then continue
@@ -269,7 +269,7 @@ class SeparateCompiler
 		#if mclass.mclass_type.ctype == "val*" or mclass.mclass_type.is_subtype(self.mainmodule, mclass.mclass_type pointer_type) then
 		if mclass.mclass_type.ctype_extern == "val*" then
 			return 0
-		else if mclass.kind == extern_kind and mclass.name != "NativeString" then
+		else if mclass.kind == extern_kind and mclass.name != "CString" then
 			return self.box_kinds[self.mainmodule.pointer_type.mclass]
 		else
 			return self.box_kinds[mclass]
@@ -938,9 +938,9 @@ class SeparateCompiler
 			v.add("return (val*){res};")
 			v.add("\}")
 			return
-		else if mtype.mclass.kind == extern_kind and mtype.mclass.name != "NativeString" then
-			# Is an extern class (other than Pointer and NativeString)
-			# Pointer is caught in a previous `if`, and NativeString is internal
+		else if mtype.mclass.kind == extern_kind and mtype.mclass.name != "CString" then
+			# Is an extern class (other than Pointer and CString)
+			# Pointer is caught in a previous `if`, and CString is internal
 
 			var pointer_type = mainmodule.pointer_type
 
@@ -1242,7 +1242,7 @@ class SeparateCompilerVisitor
 				return res
 			end
 			var valtype = value.mtype.as(MClassType)
-			if mtype isa MClassType and mtype.mclass.kind == extern_kind and mtype.mclass.name != "NativeString" then
+			if mtype isa MClassType and mtype.mclass.kind == extern_kind and mtype.mclass.name != "CString" then
 				valtype = compiler.mainmodule.pointer_type
 			end
 			var res = self.new_var(mtype)
@@ -1267,7 +1267,7 @@ class SeparateCompilerVisitor
 	redef fun unbox_extern(value, mtype)
 	do
 		if mtype isa MClassType and mtype.mclass.kind == extern_kind and
-		   mtype.mclass.name != "NativeString" then
+		   mtype.mclass.name != "CString" then
 			var pointer_type = compiler.mainmodule.pointer_type
 			var res = self.new_var_extern(mtype)
 			self.add "{res} = ((struct instance_{pointer_type.c_name}*){value})->value; /* unboxing {value.mtype} */"
@@ -1280,7 +1280,7 @@ class SeparateCompilerVisitor
 	redef fun box_extern(value, mtype)
 	do
 		if mtype isa MClassType and mtype.mclass.kind == extern_kind and
-		   mtype.mclass.name != "NativeString" then
+		   mtype.mclass.name != "CString" then
 			var valtype = compiler.mainmodule.pointer_type
 			var res = self.new_var(mtype)
 			compiler.undead_types.add(mtype)
@@ -1888,7 +1888,7 @@ class SeparateCompilerVisitor
 		if not value.mtype.is_c_primitive then
 			self.add "{res} = {value} == NULL ? \"null\" : {type_info(value)}->name;"
 		else if value.mtype isa MClassType and value.mtype.as(MClassType).mclass.kind == extern_kind and
-			value.mtype.as(MClassType).name != "NativeString" then
+			value.mtype.as(MClassType).name != "CString" then
 			self.add "{res} = \"{value.mtype.as(MClassType).mclass}\";"
 		else
 			self.require_declaration("type_{value.mtype.c_name}")

--- a/src/compiler/separate_erasure_compiler.nit
+++ b/src/compiler/separate_erasure_compiler.nit
@@ -322,7 +322,7 @@ class SeparateErasureCompiler
 			v.add("return (val*){res};")
 			v.add("\}")
 			return
-		else if mtype.mclass.kind == extern_kind and mtype.mclass.name != "NativeString" then
+		else if mtype.mclass.kind == extern_kind and mtype.mclass.name != "CString" then
 			var pointer_type = mainmodule.pointer_type
 
 			self.provide_declaration("NEW_{c_name}", "{mtype.ctype} NEW_{c_name}();")
@@ -603,7 +603,7 @@ class SeparateErasureCompilerVisitor
 	redef fun unbox_extern(value, mtype)
 	do
 		if mtype isa MClassType and mtype.mclass.kind == extern_kind and
-		   mtype.mclass.name != "NativeString" then
+		   mtype.mclass.name != "CString" then
 			var pointer_type = compiler.mainmodule.pointer_type
 			var res = self.new_var_extern(mtype)
 			self.add "{res} = ((struct instance_{pointer_type.c_name}*){value})->value; /* unboxing {value.mtype} */"
@@ -616,7 +616,7 @@ class SeparateErasureCompilerVisitor
 	redef fun box_extern(value, mtype)
 	do
 		if mtype isa MClassType and mtype.mclass.kind == extern_kind and
-		   mtype.mclass.name != "NativeString" then
+		   mtype.mclass.name != "CString" then
 			var valtype = compiler.mainmodule.pointer_type
 			var res = self.new_var(mtype)
 			if compiler.runtime_type_analysis != null and not compiler.runtime_type_analysis.live_types.has(value.mtype.as(MClassType)) then

--- a/src/interpreter/dynamic_loading_ffi/dynamic_loading_ffi.nit
+++ b/src/interpreter/dynamic_loading_ffi/dynamic_loading_ffi.nit
@@ -130,8 +130,8 @@ private extern class CallArg `{ nit_call_arg* `}
 	# The `Instance` held by this cell
 	fun instance=(value: Instance) is light_ffi `{ self->value_Pointer = value; `}
 
-	# The `NativeString` held by this cell
-	fun native_string: NativeString `{ return (char*)self->value_Pointer; `}
+	# The `CString` held by this cell
+	fun native_string: CString `{ return (char*)self->value_Pointer; `}
 
 	# Set the content of this cell according to `static_type`
 	#
@@ -168,8 +168,8 @@ private extern class CallArg `{ nit_call_arg* `}
 		else if static_type.name == "Float" then
 			assert value isa PrimitiveInstance[Float]
 			self.float = value.val
-		else if static_type.name == "NativeString" then
-			assert value isa PrimitiveInstance[NativeString]
+		else if static_type.name == "CString" then
+			assert value isa PrimitiveInstance[CString]
 			self.pointer = value.val
 		else if static_type isa MClassType and static_type.mclass.kind == extern_kind then
 			assert value isa PrimitiveInstance[Pointer] else print value.class_name
@@ -207,8 +207,8 @@ private extern class CallArg `{ nit_call_arg* `}
 			return v.uint32_instance(self.uint32)
 		else if name == "Float" then
 			return v.float_instance(self.float)
-		else if name == "NativeString" then
-			var instance = new PrimitiveInstance[NativeString](static_type, self.native_string)
+		else if name == "CString" then
+			var instance = new PrimitiveInstance[CString](static_type, self.native_string)
 			v.init_instance_primitive instance
 			return instance
 		else if static_type isa MClassType and static_type.mclass.kind == extern_kind then
@@ -225,17 +225,17 @@ end
 # Handle to foreign code library
 private extern class ForeignCodeLib
 	# Open and load the library at `path`
-	new dlopen(path: NativeString) `{
+	new dlopen(path: CString) `{
 		return dlopen(path, RTLD_LOCAL | RTLD_NOW);
 	`}
 
 	# Find the `ForeignCodeEntry` at `symbol_name`
-	fun dlsym(symbol_name: NativeString): ForeignCodeEntry `{
+	fun dlsym(symbol_name: CString): ForeignCodeEntry `{
 		return dlsym(self, symbol_name);
 	`}
 end
 
-private fun dlerror: NativeString `{ return dlerror(); `}
+private fun dlerror: CString `{ return dlerror(); `}
 
 # Handle to an implementation function in a `ForeignCodeLib`
 private extern class ForeignCodeEntry`{ nit_foreign_lib_entry `}

--- a/src/interpreter/dynamic_loading_ffi/dynamic_loading_ffi.nit
+++ b/src/interpreter/dynamic_loading_ffi/dynamic_loading_ffi.nit
@@ -131,7 +131,7 @@ private extern class CallArg `{ nit_call_arg* `}
 	fun instance=(value: Instance) is light_ffi `{ self->value_Pointer = value; `}
 
 	# The `CString` held by this cell
-	fun native_string: CString `{ return (char*)self->value_Pointer; `}
+	fun c_string: CString `{ return (char*)self->value_Pointer; `}
 
 	# Set the content of this cell according to `static_type`
 	#
@@ -208,7 +208,7 @@ private extern class CallArg `{ nit_call_arg* `}
 		else if name == "Float" then
 			return v.float_instance(self.float)
 		else if name == "CString" then
-			var instance = new PrimitiveInstance[CString](static_type, self.native_string)
+			var instance = new PrimitiveInstance[CString](static_type, self.c_string)
 			v.init_instance_primitive instance
 			return instance
 		else if static_type isa MClassType and static_type.mclass.kind == extern_kind then

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -329,7 +329,7 @@ class NaiveInterpreter
 	end
 
 	# Return a new native string initialized with `txt`
-	fun native_string_instance_from_ns(txt: NativeString, len: Int): Instance
+	fun native_string_instance_from_ns(txt: CString, len: Int): Instance
 	do
 		var instance = native_string_instance_len(len)
 		var val = instance.val
@@ -339,12 +339,12 @@ class NaiveInterpreter
 	end
 
 	# Return a new native string initialized of `length`
-	fun native_string_instance_len(length: Int): PrimitiveInstance[NativeString]
+	fun native_string_instance_len(length: Int): PrimitiveInstance[CString]
 	do
-		var val = new NativeString(length)
+		var val = new CString(length)
 
 		var t = mainmodule.native_string_type
-		var instance = new PrimitiveInstance[NativeString](t, val)
+		var instance = new PrimitiveInstance[CString](t, val)
 		init_instance_primitive(instance)
 		return instance
 	end
@@ -1148,11 +1148,11 @@ redef class AMethPropdef
 			else if pname == "round" then
 				return v.float_instance(args[0].to_f.round)
 			end
-		else if cname == "NativeString" then
+		else if cname == "CString" then
 			if pname == "new" then
 				return v.native_string_instance_len(args[1].to_i)
 			end
-			var recvval = args.first.val.as(NativeString)
+			var recvval = args.first.val.as(CString)
 			if pname == "[]" then
 				var arg1 = args[1].to_i
 				return v.byte_instance(recvval[arg1])
@@ -1161,8 +1161,8 @@ redef class AMethPropdef
 				recvval[arg1] = args[2].val.as(Byte)
 				return null
 			else if pname == "copy_to" then
-				# sig= copy_to(dest: NativeString, length: Int, from: Int, to: Int)
-				var destval = args[1].val.as(NativeString)
+				# sig= copy_to(dest: CString, length: Int, from: Int, to: Int)
+				var destval = args[1].val.as(CString)
 				var lenval = args[2].to_i
 				var fromval = args[3].to_i
 				var toval = args[4].to_i
@@ -1174,11 +1174,11 @@ redef class AMethPropdef
 				var ns = recvval.fast_cstring(args[1].to_i)
 				return v.native_string_instance(ns.to_s)
 			else if pname == "fetch_4_chars" then
-				return v.int_instance(args[0].val.as(NativeString).fetch_4_chars(args[1].to_i))
+				return v.int_instance(args[0].val.as(CString).fetch_4_chars(args[1].to_i))
 			else if pname == "fetch_4_hchars" then
-				return v.int_instance(args[0].val.as(NativeString).fetch_4_hchars(args[1].to_i))
+				return v.int_instance(args[0].val.as(CString).fetch_4_hchars(args[1].to_i))
 			else if pname == "utf8_length" then
-				return v.int_instance(args[0].val.as(NativeString).utf8_length(args[1].to_i, args[2].to_i))
+				return v.int_instance(args[0].val.as(CString).utf8_length(args[1].to_i, args[2].to_i))
 			end
 		else if cname == "NativeArray" then
 			if pname == "new" then

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -317,10 +317,10 @@ class NaiveInterpreter
 		end
 	end
 
-	# Return a new native string initialized with `txt`
-	fun native_string_instance(txt: String): Instance
+	# Return a new C string initialized with `txt`
+	fun c_string_instance(txt: String): Instance
 	do
-		var instance = native_string_instance_len(txt.byte_length+1)
+		var instance = c_string_instance_len(txt.byte_length+1)
 		var val = instance.val
 		val[txt.byte_length] = 0u8
 		txt.to_cstring.copy_to(val, txt.byte_length, 0, 0)
@@ -328,22 +328,22 @@ class NaiveInterpreter
 		return instance
 	end
 
-	# Return a new native string initialized with `txt`
-	fun native_string_instance_from_ns(txt: CString, len: Int): Instance
+	# Return a new C string initialized with `txt`
+	fun c_string_instance_from_ns(txt: CString, len: Int): Instance
 	do
-		var instance = native_string_instance_len(len)
+		var instance = c_string_instance_len(len)
 		var val = instance.val
 		txt.copy_to(val, len, 0, 0)
 
 		return instance
 	end
 
-	# Return a new native string initialized of `length`
-	fun native_string_instance_len(length: Int): PrimitiveInstance[CString]
+	# Return a new C string initialized of `length`
+	fun c_string_instance_len(length: Int): PrimitiveInstance[CString]
 	do
 		var val = new CString(length)
 
-		var t = mainmodule.native_string_type
+		var t = mainmodule.c_string_type
 		var instance = new PrimitiveInstance[CString](t, val)
 		init_instance_primitive(instance)
 		return instance
@@ -352,7 +352,7 @@ class NaiveInterpreter
 	# Return a new String instance for `txt`
 	fun string_instance(txt: String): Instance
 	do
-		var nat = native_string_instance(txt)
+		var nat = c_string_instance(txt)
 		var res = self.send(self.force_get_primitive_method("to_s_full", nat.mtype), [nat, self.int_instance(txt.byte_length), self.int_instance(txt.length)])
 		assert res != null
 		return res
@@ -941,7 +941,7 @@ redef class AMethPropdef
 		else if pname == "native_class_name" then
 			var recv = args.first
 			var txt = recv.mtype.to_s
-			return v.native_string_instance(txt)
+			return v.c_string_instance(txt)
 		else if pname == "==" then
 			# == is correctly redefined for instances
 			return v.bool_instance(args[0] == args[1])
@@ -952,7 +952,7 @@ redef class AMethPropdef
 		else if pname == "is_same_instance" then
 			return v.bool_instance(args[0].eq_is(args[1]))
 		else if pname == "class_inheritance_metamodel_json" then
-			return v.native_string_instance(v.mainmodule.flatten_mclass_hierarchy.to_thin_json)
+			return v.c_string_instance(v.mainmodule.flatten_mclass_hierarchy.to_thin_json)
 		else if pname == "exit" then
 			exit(args[1].to_i)
 			abort
@@ -1150,7 +1150,7 @@ redef class AMethPropdef
 			end
 		else if cname == "CString" then
 			if pname == "new" then
-				return v.native_string_instance_len(args[1].to_i)
+				return v.c_string_instance_len(args[1].to_i)
 			end
 			var recvval = args.first.val.as(CString)
 			if pname == "[]" then
@@ -1172,7 +1172,7 @@ redef class AMethPropdef
 				return v.int_instance(recvval.atoi)
 			else if pname == "fast_cstring" then
 				var ns = recvval.fast_cstring(args[1].to_i)
-				return v.native_string_instance(ns.to_s)
+				return v.c_string_instance(ns.to_s)
 			else if pname == "fetch_4_chars" then
 				return v.int_instance(args[0].val.as(CString).fetch_4_chars(args[1].to_i))
 			else if pname == "fetch_4_hchars" then
@@ -1468,7 +1468,7 @@ redef class AMethPropdef
 			return v.int_instance(v.arguments.length)
 		else if pname == "native_argv" then
 			var txt = v.arguments[args[1].to_i]
-			return v.native_string_instance(txt)
+			return v.c_string_instance(txt)
 		else if pname == "lexer_goto" then
 			return v.int_instance(lexer_goto(args[1].to_i, args[2].to_i))
 		else if pname == "lexer_accept" then
@@ -2019,7 +2019,7 @@ redef class AStringExpr
 		var s = v.string_instance(value)
 		if is_string then return s
 		if is_bytestring then
-			var ns = v.native_string_instance_from_ns(bytes.items, bytes.length)
+			var ns = v.c_string_instance_from_ns(bytes.items, bytes.length)
 			var ln = v.int_instance(bytes.length)
 			var prop = to_bytes_with_copy
 			assert prop != null

--- a/src/interpreter/primitive_types.nit
+++ b/src/interpreter/primitive_types.nit
@@ -47,14 +47,14 @@ class PrimitiveNativeFile
 		return false
 	end
 
-	fun io_read(buf: NativeString, len: Int): Int do
+	fun io_read(buf: CString, len: Int): Int do
 		if file isa FileStream then return file.as(FileStream)._file.io_read(buf, len)
 		var str = file.as(Reader).read(len)
 		str.to_cstring.copy_to(buf, str.length, 0, 0)
 		return str.length
 	end
 
-	fun io_write(buf: NativeString, from, len: Int): Int do
+	fun io_write(buf: CString, from, len: Int): Int do
 		if file isa FileStream then return file.as(FileStream)._file.io_write(buf, from, len)
 		file.as(Writer).write(buf.to_s_with_length(len).substring_from(from))
 		return len

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -252,8 +252,8 @@ redef class MModule
 	# The primitive type `String`
 	var string_type: MClassType = self.get_primitive_class("String").mclass_type is lazy
 
-	# The primitive type `NativeString`
-	var native_string_type: MClassType = self.get_primitive_class("NativeString").mclass_type is lazy
+	# The primitive type `CString`
+	var native_string_type: MClassType = self.get_primitive_class("CString").mclass_type is lazy
 
 	# A primitive type of `Array`
 	fun array_type(elt_type: MType): MClassType do return array_class.get_mtype([elt_type])

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -253,7 +253,7 @@ redef class MModule
 	var string_type: MClassType = self.get_primitive_class("String").mclass_type is lazy
 
 	# The primitive type `CString`
-	var native_string_type: MClassType = self.get_primitive_class("CString").mclass_type is lazy
+	var c_string_type: MClassType = self.get_primitive_class("CString").mclass_type is lazy
 
 	# A primitive type of `Array`
 	fun array_type(elt_type: MType): MClassType do return array_class.get_mtype([elt_type])

--- a/src/nitni/nitni_base.nit
+++ b/src/nitni/nitni_base.nit
@@ -102,7 +102,7 @@ redef class MClassType
 		if name == "UInt16" then return "uint16_t"
 		if name == "Int32" then return "int32_t"
 		if name == "UInt32" then return "uint32_t"
-		if name == "NativeString" then return "char*"
+		if name == "CString" then return "char*"
 		if mclass.kind == extern_kind then
 			var ctype = mclass.ctype
 			assert ctype != null
@@ -123,7 +123,7 @@ redef class MClassType
 		if name == "UInt16" then return "uint16_t"
 		if name == "Int32" then return "int32_t"
 		if name == "UInt32" then return "uint32_t"
-		if name == "NativeString" then return "char*"
+		if name == "CString" then return "char*"
 		if mclass.kind == extern_kind then return "void*"
 		return super
 	end
@@ -131,7 +131,7 @@ redef class MClassType
 	redef fun mangled_cname do return mclass.name
 
 	redef fun is_cprimitive do return mclass.kind == extern_kind or
-			(once ["Bool", "Char", "Float", "Int", "NativeString",
+			(once ["Bool", "Char", "Float", "Int", "CString",
 			       "Byte", "Int8", "Int16", "UInt16", "Int32", "UInt32"]).has(mclass.name)
 end
 

--- a/src/rapid_type_analysis.nit
+++ b/src/rapid_type_analysis.nit
@@ -587,7 +587,7 @@ end
 redef class AStringFormExpr
 	redef fun accept_rapid_type_visitor(v)
 	do
-		var native = v.analysis.mainmodule.native_string_type
+		var native = v.analysis.mainmodule.c_string_type
 		v.add_type(native)
 		var prop = v.get_method(native, "to_s_full")
 		v.add_monomorphic_send(native, prop)

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -1487,7 +1487,7 @@ redef class AugmentedStringFormExpr
 		var mclass = v.get_mclass(self, "String")
 		if mclass == null then return # Forward error
 		if is_bytestring then
-			to_bytes_with_copy = v.get_method(self, v.mmodule.native_string_type, "to_bytes_with_copy", false)
+			to_bytes_with_copy = v.get_method(self, v.mmodule.c_string_type, "to_bytes_with_copy", false)
 			mclass = v.get_mclass(self, "Bytes")
 		else if is_re then
 			to_re = v.get_method(self, mclass.mclass_type, "to_re", false)

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -1480,7 +1480,7 @@ redef class AugmentedStringFormExpr
 	var newline: nullable CallSite = null
 	# Regex::extended, used for suffix `b` on `re`
 	var extended: nullable CallSite = null
-	# NativeString::to_bytes_with_copy, used for prefix `b`
+	# CString::to_bytes_with_copy, used for prefix `b`
 	var to_bytes_with_copy: nullable CallSite = null
 
 	redef fun accept_typing(v) do

--- a/tests/base_test_obj_id.nit
+++ b/tests/base_test_obj_id.nit
@@ -26,5 +26,5 @@ assert 'd'.object_id.to_s.is_numeric
 # Check Float.object_id
 assert 1.0.object_id.to_s.is_numeric
 
-# Check NativeString.object_id
+# Check CString.object_id
 assert "Test".as(FlatString).items.object_id.to_s.is_numeric

--- a/tests/error_needed_method.nit
+++ b/tests/error_needed_method.nit
@@ -32,7 +32,7 @@ end
 class String
 end
 
-enum NativeString
+enum CString
 end
 
 class Array[E]

--- a/tests/sav/error_needed_method_alt3.res
+++ b/tests/sav/error_needed_method_alt3.res
@@ -1,1 +1,1 @@
-alt/error_needed_method_alt3.nit:48,9--13: Fatal Error: `NativeString` must have a property named `to_s_full`.
+alt/error_needed_method_alt3.nit:48,9--13: Fatal Error: `CString` must have a property named `to_s_full`.

--- a/tests/sav/nitce/test_new_native.res
+++ b/tests/sav/nitce/test_new_native.res
@@ -1,4 +1,4 @@
-NativeString
+CString
 0x4e
 Nit
 NativeArray

--- a/tests/sav/nitce/test_new_native_alt1.res
+++ b/tests/sav/nitce/test_new_native_alt1.res
@@ -1,4 +1,4 @@
-NativeString
+CString
 0x4e
 Nit
 NativeArray

--- a/tests/sav/niti/error_needed_method_alt4.res
+++ b/tests/sav/niti/error_needed_method_alt4.res
@@ -1,1 +1,1 @@
-alt/error_needed_method_alt4.nit:49,10--14: Fatal Error: `NativeString` must have a property named `to_s_full`.
+alt/error_needed_method_alt4.nit:49,10--14: Fatal Error: `CString` must have a property named `to_s_full`.

--- a/tests/sav/nitj/test_new_native.res
+++ b/tests/sav/nitj/test_new_native.res
@@ -1,4 +1,4 @@
-NativeString
+CString
 N
 Nit
 NativeArray

--- a/tests/sav/nitj/test_new_native_alt1.res
+++ b/tests/sav/nitj/test_new_native_alt1.res
@@ -1,4 +1,4 @@
-NativeString
+CString
 N
 Nit
 NativeArray

--- a/tests/sav/nitpretty_args21.res
+++ b/tests/sav/nitpretty_args21.res
@@ -70,8 +70,8 @@ extern class TimeT `{time_t`}
 	new from_i(i: Int) `{ return i; `}
 	fun update `{ time(&self); `}
 
-	fun ctime: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy( ctime(&self) );
+	fun ctime: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy( ctime(&self) );
 	`}
 
 	# Difference in secondes from start (self if the end time)

--- a/tests/sav/nitpretty_args52.res
+++ b/tests/sav/nitpretty_args52.res
@@ -71,8 +71,8 @@ extern class TimeT `{time_t`}
 
 	fun update `{ time(&self); `}
 
-	fun ctime: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy( ctime(&self) );
+	fun ctime: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy( ctime(&self) );
 	`}
 
 	# Difference in secondes from start (self if the end time)

--- a/tests/sav/string_ffi_ref_test.res
+++ b/tests/sav/string_ffi_ref_test.res
@@ -1,3 +1,3 @@
 This is a test string
 This is a test string
-Do the strings have the same NativeString reference ? False
+Do the strings have the same CString reference ? False

--- a/tests/sav/test_new_native.res
+++ b/tests/sav/test_new_native.res
@@ -1,4 +1,4 @@
-NativeString
+CString
 0x4e
 Nit
 NativeArray[Int]

--- a/tests/sav/test_new_native_alt1.res
+++ b/tests/sav/test_new_native_alt1.res
@@ -1,4 +1,4 @@
 Runtime error: Cast failed. Expected `E`, got `Bool` (../lib/core/collection/array.nit:991)
-NativeString
+CString
 0x4e
 Nit

--- a/tests/shootout_nsieve_bytes_alt.nit
+++ b/tests/shootout_nsieve_bytes_alt.nit
@@ -39,7 +39,7 @@ fun nsieve(n: Int): Int
 do
 	var count = 0
 	var b_arrsz = ((n - 1).to_f / 8.0).ceil.to_i
-	var bitarr = new Bitarray(new Bytes(new NativeString(b_arrsz), b_arrsz, b_arrsz))
+	var bitarr = new Bitarray(new Bytes(new CString(b_arrsz), b_arrsz, b_arrsz))
 	for i in [2 .. n[ do
 		# If self is already false, then no need to check for multiples
 		if not bitarr[i] then continue

--- a/tests/string_ffi_ref_test.nit
+++ b/tests/string_ffi_ref_test.nit
@@ -25,18 +25,18 @@ class StringTest
 
 	var referenced_str: nullable String = null
 
-	fun get_c_string import FlatString.items, NativeString.to_s, NativeString.to_s_with_copy, StringTest.ref_test, StringTest.copy_test `{
+	fun get_c_string import FlatString.items, CString.to_s, CString.to_s_with_copy, StringTest.ref_test, StringTest.copy_test `{
 		char* string = "This is a test string";
 
-		FlatString ref_string = NativeString_to_s(string);
+		FlatString ref_string = CString_to_s(string);
 		StringTest_ref_test(self, ref_string);
 
-		FlatString copy_string = NativeString_to_s_with_copy(string);
+		FlatString copy_string = CString_to_s_with_copy(string);
 		StringTest_copy_test(self, copy_string);
 
 		int same_refs = FlatString_items(copy_string) == FlatString_items(ref_string);
 
-		printf("Do the strings have the same NativeString reference ? ");
+		printf("Do the strings have the same CString reference ? ");
 
 		if(same_refs){
 			printf("True\n");

--- a/tests/test_copy_to_native.nit
+++ b/tests/test_copy_to_native.nit
@@ -16,7 +16,7 @@ import core
 #alt1 intrude import core::text::ropes
 #alt2 intrude import core::text::ropes
 
-var ons = new NativeString(9)
+var ons = new CString(9)
 var base_str = "%Dégâštr"
 
 var str: String = base_str

--- a/tests/test_ffi_c_accessor.nit
+++ b/tests/test_ffi_c_accessor.nit
@@ -24,16 +24,16 @@ class A
 			String_to_cstring( A_r( self ) ),
 			String_to_cstring( A_rw( self ) ) );
 	`}
-	fun modify import NativeString.to_s, w=, rw= `{
-		A_w__assign( self, NativeString_to_s( "w set from native" ) );
-		A_rw__assign( self, NativeString_to_s( "rw set from native" ) );
+	fun modify import CString.to_s, w=, rw= `{
+		A_w__assign( self, CString_to_s( "w set from native" ) );
+		A_rw__assign( self, CString_to_s( "rw set from native" ) );
 	`}
 end
 
 class B
-	fun print_and_modify( a : A ) import A.rw, A.rw=, String.to_cstring, NativeString.to_s `{
+	fun print_and_modify( a : A ) import A.rw, A.rw=, String.to_cstring, CString.to_s `{
 		printf( "%s\n", String_to_cstring( A_rw( a ) ) );
-		A_rw__assign( a, NativeString_to_s( "set from native" ) );
+		A_rw__assign( a, CString_to_s( "set from native" ) );
 		printf( "%s\n", String_to_cstring( A_rw( a ) ) );
 	`}
 end

--- a/tests/test_ffi_c_callback_extern_receiver.nit
+++ b/tests/test_ffi_c_callback_extern_receiver.nit
@@ -29,11 +29,11 @@ extern class Test
         return foobar;
     `}
 
-    fun test_me is extern import Test.foo, NativeString.to_s `{
+    fun test_me is extern import Test.foo, CString.to_s `{
         int i;
         for(i = 0; i < 2000; ++i) {
             printf("%d\n", i);
-            Test_foo(self, NativeString_to_s("asdf"));
+            Test_foo(self, CString_to_s("asdf"));
         }
     `}
 

--- a/tests/test_ffi_c_more.nit
+++ b/tests/test_ffi_c_more.nit
@@ -38,8 +38,8 @@ extern class A
 
 	fun m : Int is extern `{ return 10; `}
 
-	fun n : String is extern import NativeString.to_s `{
-		return NativeString_to_s( "allo" );
+	fun n : String is extern import CString.to_s `{
+		return CString_to_s( "allo" );
 	`}
 
 	fun o ( str : String ) is extern import String.to_cstring `{

--- a/tests/test_ffi_c_new_extern.nit
+++ b/tests/test_ffi_c_new_extern.nit
@@ -23,11 +23,11 @@ extern class IntPtr `{ int* `}
 		return r;
 	`}
 
-	redef fun to_s import NativeString, NativeString.to_s `{
+	redef fun to_s import CString, CString.to_s `{
 		int len = snprintf(NULL, 0, "%d", *self) + 1;
-		char *c = new_NativeString(len);
+		char *c = new_CString(len);
 		sprintf(c, "%d", *self);
-		return NativeString_to_s(c);
+		return CString_to_s(c);
 	`}
 end
 

--- a/tests/test_ffi_c_primitives.nit
+++ b/tests/test_ffi_c_primitives.nit
@@ -32,7 +32,7 @@ fun plus_0x10(v: Byte): Byte `{
 	return v + 0x10;
 `}
 
-fun print_ns(s: NativeString) `{
+fun print_ns(s: CString) `{
 	printf("%s\n", s);
 `}
 

--- a/tests/test_ffi_c_strings.nit
+++ b/tests/test_ffi_c_strings.nit
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-fun print_cstring(cstr: NativeString) `{
+fun print_cstring(cstr: CString) `{
 	printf("cstr-> %s\n", cstr);
 `}
 
-fun get_cstring: NativeString `{
+fun get_cstring: CString `{
 	return "char* from C";
 `}
 
@@ -26,8 +26,8 @@ fun print_string(str: String) import String.to_cstring `{
 	printf("str-> %s\n", String_to_cstring(str) );
 `}
 
-fun get_string: String import NativeString.to_s, String.output `{
-	String str = NativeString_to_s("Nit string from C");
+fun get_string: String import CString.to_s, String.output `{
+	String str = CString_to_s("Nit string from C");
 	String_output(str);
 	printf("\n");
 	return str;

--- a/tests/test_ffi_c_super.nit
+++ b/tests/test_ffi_c_super.nit
@@ -21,7 +21,7 @@ end
 class B
 	super A
 
-	redef fun id : String import super, NativeString.to_s, String.to_cstring `{
+	redef fun id : String import super, CString.to_s, String.to_cstring `{
 		char *new_name;
 		char *prefix = "B special ";
 		char *super_name = String_to_cstring( B_id___super( self ) );
@@ -31,7 +31,7 @@ class B
 		strcpy( new_name+strlen( prefix ), super_name );
 		new_name[ strlen( prefix )+strlen( super_name ) ] = '\0';
 
-		return NativeString_to_s( new_name );
+		return CString_to_s( new_name );
 	`}
 end
 

--- a/tests/test_hash_text.nit
+++ b/tests/test_hash_text.nit
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-var x = "string__NativeString__to_s_with_length"
+var x = "string__CString__to_s_with_length"
 
-var y = "string" + "__" + "NativeString" + "__" + "to_s_with_length"
+var y = "string" + "__" + "CString" + "__" + "to_s_with_length"
 
 var z = new FlatBuffer.from("string")
 z.append("__")
-z.append("NativeString")
+z.append("CString")
 z.append("__")
 z.append("to_s_with_length")
 
-var a = ["string", "NativeString", "to_s_with_length"].join("__")
+var a = ["string", "CString", "to_s_with_length"].join("__")
 
 print x.hash == y.hash
 print y.hash == z.hash

--- a/tests/test_nativestring_fill_from.nit
+++ b/tests/test_nativestring_fill_from.nit
@@ -21,7 +21,7 @@ var cpstr: Text = src_s
 #alt2 cpstr = new FlatBuffer.from(src_s)
 #alt3 cpstr = cpstr.substring(1, 5)
 
-var ns = new NativeString(cpstr.byte_length)
+var ns = new CString(cpstr.byte_length)
 ns.fill_from(cpstr)
 
 print ns.to_s_with_length(cpstr.byte_length)

--- a/tests/test_new_native.nit
+++ b/tests/test_new_native.nit
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-var s = new NativeString(4)
+var s = new CString(4)
 s[0] = 0x4Eu8
 s[2] = 0x74u8
 s[1] = 0x69u8

--- a/tests/test_pretty/test_extern1.nit
+++ b/tests/test_pretty/test_extern1.nit
@@ -70,8 +70,8 @@ extern class TimeT `{time_t`}
 
 	fun update `{ time(&self); `}
 
-	fun ctime: String import NativeString.to_s_with_copy `{
-		return NativeString_to_s_with_copy( ctime(&self) );
+	fun ctime: String import CString.to_s_with_copy `{
+		return CString_to_s_with_copy( ctime(&self) );
 	`}
 
 	# Difference in secondes from start (self if the end time)


### PR DESCRIPTION
`NativeString` used to be mainly implemented by the engines, but in the last few years it became gradually a normal extern class. As such, its instances are now C strings (`char *`). Most of its methods are extern and implemented in the library instead of the engines. It is also widely used by extern methods implemented in C as `char *`, the type appears 300+ times in the general lib and 67 times in `lib/core/text`.

This PR renames `NativeString` to `CString`. This change makes it clear to beginner programmers that its instances are pointers to C strings and how they are passed to C code. Plus, it fits better next to `CppString`, `JavaString` and `NSString`.

The only remaining engine not using it as a C string is the Java compiler, which implements it as a Java string. This still works and as long as it behaves like a C string there is no problem.

This PR also updates the related doc and attempts to update all indirect references to the new `CString`.

As discussed with @privat and @R4PaSs.