### PR TITLE
lib/graph: Fix `to_dot`

### DIFF
--- a/lib/graphs/digraph.nit
+++ b/lib/graphs/digraph.nit
@@ -369,15 +369,17 @@ interface Digraph[V: Object]
 	fun to_dot: String
 	do
 		var s = "digraph \{\n"
+		var id_set = new HashMap[V, Int]
 		# Writing the vertices
-		for u in vertices_iterator do
-			s += "   \"{u.to_s.escape_to_dot}\" "
+		for u in vertices_iterator, i in [0 .. vertices.length[ do
+			id_set[u] = i
+			s += "   \"{i}\" "
 			s += "[label=\"{u.to_s.escape_to_dot}\"];\n"
 		end
 		# Writing the arcs
 		for arc in arcs do
-			s += "   {arc[0].to_s.escape_to_dot} "
-			s += "-> {arc[1].to_s.escape_to_dot};"
+			s += "   {id_set[arc[0]]} "
+			s += "-> {id_set[arc[1]]};"
 		end
 		s += "\}"
 		return s


### PR DESCRIPTION
The `Graph::to_dot` function seldom produced bad dot when used on objects with special formatting in their `to_s` method.

This PR changes that by overriding the ID of a node by an Int.
There is still the concern that the new implementation might explode when used on a very large graph, there might be a better way to generate it or to escape the node's ids, but I can't find another one at the moment.

Poke @ablondin, this might interest you