### PR TITLE
nitweb: auto link entitites found in `span code`

### DIFF
--- a/src/web/api_docdown.nit
+++ b/src/web/api_docdown.nit
@@ -84,19 +84,13 @@ class NitwebInlineDecorator
 	end
 end
 
-redef interface DocCommand
-
-	# Emit the HTML related to the execution of this doc command
-	fun render(v: MarkdownEmitter, token: TokenWikiLink, model: ModelView) do
-		write_error(v, "Not yet implemented command `{token.link or else "null"}`")
-	end
-
+redef class MarkdownEmitter
 	# Find the MEntity that matches `name`.
 	#
 	# Write an error if the entity is not found
-	fun find_mentity(v: MarkdownEmitter, model: ModelView, name: nullable String): nullable MEntity do
+	fun find_mentity(model: ModelView, name: nullable String): nullable MEntity do
 		if name == null then
-			write_error(v, "No MEntity found")
+			write_error("No MEntity found")
 			return null
 		end
 		# Lookup by full name
@@ -118,7 +112,7 @@ redef interface DocCommand
 				end
 				msg.append ")"
 			end
-			write_error(v, msg.write_to_string)
+			write_error(msg.write_to_string)
 			return null
 		else if mentities.length > 1 then
 			var msg = new Buffer
@@ -131,29 +125,53 @@ redef interface DocCommand
 				i += 1
 			end
 			msg.append ")"
-			write_warning(v, msg.write_to_string)
+			write_warning(msg.write_to_string)
 		end
 		return mentities.first
 	end
 
 	# Write a warning in the output
-	fun write_warning(v: MarkdownEmitter, text: String) do
-		v.emit_text "<p class='text-warning'>Warning: {text}</p>"
+	fun write_warning(text: String) do
+		emit_text "<p class='text-warning'>Warning: {text}</p>"
 	end
 
 	# Write an error in the output
-	fun write_error(v: MarkdownEmitter, text: String) do
-		v.emit_text "<p class='text-danger'>Error: {text}</p>"
+	fun write_error(text: String) do
+		emit_text "<p class='text-danger'>Error: {text}</p>"
 	end
 
 	# Write a link to a mentity in the output
-	fun write_mentity_link(v: MarkdownEmitter, mentity: MEntity) do
+	fun write_mentity_link(mentity: MEntity) do
 		var link = mentity.web_url
 		var name = mentity.name
 		var mdoc = mentity.mdoc_or_fallback
 		var comment = null
 		if mdoc != null then comment = mdoc.synopsis
-		v.decorator.add_link(v, link, name, comment)
+		decorator.add_link(self, link, name, comment)
+	end
+
+	# Write a mentity list in the output
+	fun write_mentity_list(mentities: Collection[MEntity]) do
+		add "<ul>"
+		for mentity in mentities do
+			var mdoc = mentity.mdoc_or_fallback
+			add "<li>"
+			write_mentity_link(mentity)
+			if mdoc != null then
+				add " - "
+				emit_text mdoc.synopsis
+			end
+			add "</li>"
+		end
+		add "</ul>"
+	end
+end
+
+redef interface DocCommand
+
+	# Emit the HTML related to the execution of this doc command
+	fun render(v: MarkdownEmitter, token: TokenWikiLink, model: ModelView) do
+		v.write_error("Not yet implemented command `{token.link or else "null"}`")
 	end
 end
 
@@ -161,32 +179,32 @@ redef class UnknownCommand
 	redef fun render(v, token, model) do
 		var link = token.link
 		if link == null then
-			write_error(v, "Empty command")
+			v.write_error("Empty command")
 			return
 		end
 		var full_name = link.write_to_string
-		var mentity = find_mentity(v, model, full_name)
+		var mentity = v.find_mentity(model, full_name)
 		if mentity == null then return
-		write_mentity_link(v, mentity)
+		v.write_mentity_link(mentity)
 	end
 end
 
 redef class ArticleCommand
 	redef fun render(v, token, model) do
 		if args.is_empty then
-			write_error(v, "Expected one arg: the MEntity name")
+			v.write_error("Expected one arg: the MEntity name")
 			return
 		end
 		var name = args.first
-		var mentity = find_mentity(v, model, name)
+		var mentity = v.find_mentity(model, name)
 		if mentity == null then return
 		var mdoc = mentity.mdoc_or_fallback
 		if mdoc == null then
-			write_warning(v, "No MDoc for mentity `{name}`")
+			v.write_warning("No MDoc for mentity `{name}`")
 			return
 		end
 		v.add "<h3>"
-		write_mentity_link(v, mentity)
+		v.write_mentity_link(mentity)
 		v.add " - "
 		v.emit_text mdoc.synopsis
 		v.add "</h3>"
@@ -197,15 +215,15 @@ end
 redef class CommentCommand
 	redef fun render(v, token, model) do
 		if args.is_empty then
-			write_error(v, "Expected one arg: the MEntity name")
+			v.write_error("Expected one arg: the MEntity name")
 			return
 		end
 		var name = args.first
-		var mentity = find_mentity(v, model, name)
+		var mentity = v.find_mentity(model, name)
 		if mentity == null then return
 		var mdoc = mentity.mdoc_or_fallback
 		if mdoc == null then
-			write_warning(v, "No MDoc for mentity `{name}`")
+			v.write_warning("No MDoc for mentity `{name}`")
 			return
 		end
 		v.add v.processor.process(mdoc.comment).write_to_string
@@ -215,63 +233,47 @@ end
 redef class ListCommand
 	redef fun render(v, token, model) do
 		if args.is_empty then
-			write_error(v, "Expected one arg: the MEntity name")
+			v.write_error("Expected one arg: the MEntity name")
 			return
 		end
 		var name = args.first
-		var mentity = find_mentity(v, model, name)
+		var mentity = v.find_mentity(model, name)
 		if mentity == null then return
 		if mentity isa MPackage then
-			write_list(v, mentity.mgroups)
+			v.write_mentity_list(mentity.mgroups)
 		else if mentity isa MGroup then
 			var res = new Array[MEntity]
 			res.add_all mentity.in_nesting.smallers
 			res.add_all mentity.mmodules
-			write_list(v, res)
+			v.write_mentity_list(res)
 		else if mentity isa MModule then
-			write_list(v, mentity.mclassdefs)
+			v.write_mentity_list(mentity.mclassdefs)
 		else if mentity isa MClass then
-			write_list(v, mentity.collect_intro_mproperties(model))
+			v.write_mentity_list(mentity.collect_intro_mproperties(model))
 		else if mentity isa MClassDef then
-			write_list(v, mentity.mpropdefs)
+			v.write_mentity_list(mentity.mpropdefs)
 		else if mentity isa MProperty then
-			write_list(v, mentity.mpropdefs)
+			v.write_mentity_list(mentity.mpropdefs)
 		else
-			write_error(v, "No list found for name `{name}`")
+			v.write_error("No list found for name `{name}`")
 		end
-	end
-
-	# Write a mentity list in the output
-	fun write_list(v: MarkdownEmitter, mentities: Collection[MEntity]) do
-		v.add "<ul>"
-		for mentity in mentities do
-			var mdoc = mentity.mdoc_or_fallback
-			v.add "<li>"
-			write_mentity_link(v, mentity)
-			if mdoc != null then
-				v.add " - "
-				v.emit_text mdoc.synopsis
-			end
-			v.add "</li>"
-		end
-		v.add "</ul>"
 	end
 end
 
 redef class CodeCommand
 	redef fun render(v, token, model) do
 		if args.is_empty then
-			write_error(v, "Expected one arg: the MEntity name")
+			v.write_error("Expected one arg: the MEntity name")
 			return
 		end
 		var name = args.first
-		var mentity = find_mentity(v, model, name)
+		var mentity = v.find_mentity(model, name)
 		if mentity == null then return
 		if mentity isa MClass then mentity = mentity.intro
 		if mentity isa MProperty then mentity = mentity.intro
 		var source = render_source(mentity, v.decorator.as(NitwebDecorator).modelbuilder)
 		if source == null then
-			write_error(v, "No source for MEntity `{name}`")
+			v.write_error("No source for MEntity `{name}`")
 			return
 		end
 		v.add "<pre>"
@@ -292,11 +294,11 @@ end
 redef class GraphCommand
 	redef fun render(v, token, model) do
 		if args.is_empty then
-			write_error(v, "Expected one arg: the MEntity name")
+			v.write_error("Expected one arg: the MEntity name")
 			return
 		end
 		var name = args.first
-		var mentity = find_mentity(v, model, name)
+		var mentity = v.find_mentity(model, name)
 		if mentity == null then return
 		var g = new InheritanceGraph(mentity, model)
 		v.add g.draw(3, 3).to_svg


### PR DESCRIPTION
This PR introduces a stub feature for nitweb: autolinking entities from `span` code.

Each time nitweb renders a Markdown comment it evaluates the content of each inline `code` tag and tries to match it with the model index. If the content of the `code` tag matches a package, module, class or property, the `code` content is wrapped in a link to that entity.

Examples:

* `Object`: will be rendered as `<a href='/doc/core::Object'>Object</a>`
* `nullable Object`: will be rendered as `<a href='/doc/core::Object'>nullable Object</a>`
* `is_same_instance`: will be rendered as `<a href='/doc/core::Object::is_same_instance'>is_same_instance</a>`.

The name matching algorithm is the same as the one used to resolve short links like `[Object]` or complex directives like `[graph: core]`.

Demo: http://nitweb.moz-code.org

The documentation from the `core` package benefits from the new feature: http://nitweb.moz-code.org/doc/core
