### PR TITLE
macOS: update realtime lib for Sierra

### DIFF
--- a/lib/realtime.nit
+++ b/lib/realtime.nit
@@ -23,7 +23,7 @@ in "C header" `{
 
 in "C" `{
 
-#ifdef __MACH__
+#if defined(__MACH__) && !defined(CLOCK_REALTIME)
 /* OS X does not have clock_gettime, mascarade it and use clock_get_time
  * cf http://stackoverflow.com/questions/11680461/monotonic-clock-on-osx
 */
@@ -148,7 +148,7 @@ class Clock
 	# Smallest time frame reported by clock
 	fun resolution: Timespec `{
 		struct timespec* tv = malloc( sizeof(struct timespec) );
-#ifdef __MACH__
+#if defined(__MACH__) && !defined(CLOCK_REALTIME)
 		clock_serv_t cclock;
 		int nsecs;
 		mach_msg_type_number_t count;


### PR DESCRIPTION
The latest version of macOS, Sierra, defines the functions `clock_gettime` and `clock_getres` which were previously missing. This PR adds support for Sierra while preserving compatibility with El Capitan using a simple heuristic to either use the system provided functions or define them locally.

Reported-by: Marie-Pier Lessard @mplessard