### PR TITLE
nitunit: fix before and after methods

### DIFF
--- a/lib/test_suite.nit
+++ b/lib/test_suite.nit
@@ -38,14 +38,25 @@ class TestSuite
 	fun after_test do end
 end
 
-# Method called before each test-suite.
-#
-# Redefine this method to factorize code that have to be
-# executed before every test suite.
-fun before_module do end
+redef class Sys
+	# Internal empty init.
+	private init nitunit do end
 
-# Method called after each test-suite.
-#
-# Redefine this method to factorize code that have to be
-# executed after every test suite.
-fun after_module do end
+	# No before test for the module
+	private fun before_test do end
+
+	# No after test for the module
+	private fun after_test do end
+
+	# Method called before each test-suite.
+	#
+	# Redefine this method to factorize code that have to be
+	# executed before every test suite.
+	fun before_module do end
+
+	# Method called after each test-suite.
+	#
+	# Redefine this method to factorize code that have to be
+	# executed after every test suite.
+	fun after_module do end
+end

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -138,10 +138,8 @@ class TestSuite
 		compile
 		if failure != null then
 			for case in test_cases do
-				case.is_done = true
-				case.error = "Compilation Error"
+				case.fail "Compilation Error"
 				case.raw_output = failure
-				toolcontext.modelbuilder.failed_tests += 1
 				toolcontext.clear_progress_bar
 				toolcontext.show_unit(case)
 			end
@@ -316,6 +314,15 @@ class TestCase
 			end
 		end
 		is_done = true
+	end
+
+	# Make the test case fail without testing it
+	#
+	# Useful when the compilation or the before_test failed.
+	fun fail(message: String) do
+		is_done = true
+		error = message
+		toolcontext.modelbuilder.failed_tests += 1
 	end
 
 	redef fun xml_classname do

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -344,10 +344,10 @@ redef class MMethodDef
 	private fun is_test: Bool do return name.has_prefix("test_")
 
 	# Is the method a "before_module"?
-	private fun is_before_module: Bool do return mproperty.is_toplevel and name == "before_module"
+	private fun is_before_module: Bool do return name == "before_module"
 
 	# Is the method a "after_module"?
-	private fun is_after_module: Bool do return mproperty.is_toplevel and name == "after_module"
+	private fun is_after_module: Bool do return name == "after_module"
 end
 
 redef class MClassDef
@@ -367,7 +367,7 @@ redef class MModule
 	# "before_module" method for this module.
 	private fun before_test: nullable MMethodDef do
 		for mclassdef in mclassdefs do
-			if not mclassdef.name == "Object" then continue
+			if not mclassdef.name == "Sys" then continue
 			for mpropdef in mclassdef.mpropdefs do
 				if mpropdef isa MMethodDef and mpropdef.is_before_module then return mpropdef
 			end
@@ -378,7 +378,7 @@ redef class MModule
 	# "after_module" method for this module.
 	private fun after_test: nullable MMethodDef do
 		for mclassdef in mclassdefs do
-			if not mclassdef.name == "Object" then continue
+			if not mclassdef.name == "Sys" then continue
 			for mpropdef in mclassdef.mpropdefs do
 				if mpropdef isa MMethodDef and mpropdef.is_after_module then return mpropdef
 			end

--- a/tests/nitunit.args
+++ b/tests/nitunit.args
@@ -8,3 +8,5 @@ test_nitunit_md.md --no-color -o $WRITE
 test_doc3.nit --no-color -o $WRITE
 test_nitunit4 --no-color -o $WRITE
 test_nitunit5.nit --no-color -o $WRITE
+test_nitunit6.nit --no-color -o $WRITE
+test_nitunit7.nit --no-color -o $WRITE

--- a/tests/sav/nitunit_args11.res
+++ b/tests/sav/nitunit_args11.res
@@ -1,0 +1,16 @@
+==== Test-suite of module test_nitunit6::test_nitunit6 | tests: 3
+[KO] test_nitunit6::test_nitunit6$core::Sys$before_module
+     test_nitunit6.nit:27,1--29,3: Runtime Error in file nitunit.out/gen_test_nitunit6.nit
+     Output
+	Runtime error: Assert failed (test_nitunit6.nit:28)
+
+[KO] test_nitunit6$TestNitunit6$test_foo
+     test_nitunit6.nit:22,2--24,4: Nitunit Error: before_module test failed
+[KO] test_nitunit6::test_nitunit6$core::Sys$after_module
+     test_nitunit6.nit:31,1--33,3: Nitunit Error: before_module test failed
+
+Docunits: Entities: 5; Documented ones: 0; With nitunits: 0
+Test suites: Classes: 1; Test Cases: 3; Failures: 3
+[FAILURE] 3/3 tests failed.
+`nitunit.out` is not removed for investigation.
+<testsuites><testsuite package="test_nitunit6::test_nitunit6"></testsuite><testsuite package="test_nitunit6"><testcase classname="nitunit.test_nitunit6.TestNitunit6" name="test_foo" time="0.0"><failure message="Nitunit Error: before_module test failed"></failure></testcase></testsuite></testsuites>

--- a/tests/sav/nitunit_args12.res
+++ b/tests/sav/nitunit_args12.res
@@ -1,0 +1,14 @@
+==== Test-suite of module test_nitunit7::test_nitunit7 | tests: 3
+[OK] test_nitunit7::test_nitunit7$core::Sys$before_module
+[OK] test_nitunit7$TestNitunit7$test_foo
+[KO] test_nitunit7::test_nitunit7$core::Sys$after_module
+     test_nitunit7.nit:31,1--33,3: Runtime Error in file nitunit.out/gen_test_nitunit7.nit
+     Output
+	Runtime error: Assert failed (test_nitunit7.nit:32)
+
+
+Docunits: Entities: 5; Documented ones: 0; With nitunits: 0
+Test suites: Classes: 1; Test Cases: 3; Failures: 1
+[FAILURE] 1/3 tests failed.
+`nitunit.out` is not removed for investigation.
+<testsuites><testsuite package="test_nitunit7::test_nitunit7"></testsuite><testsuite package="test_nitunit7"><testcase classname="nitunit.test_nitunit7.TestNitunit7" name="test_foo" time="0.0"><system-err></system-err></testcase></testsuite></testsuites>

--- a/tests/test_nitunit6.nit
+++ b/tests/test_nitunit6.nit
@@ -1,0 +1,33 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module test_nitunit6 is test_suite
+
+import test_suite
+
+class TestNitunit6
+	super TestSuite
+
+	fun test_foo do
+		assert true
+	end
+end
+
+redef fun before_module do
+	assert false
+end
+
+redef fun after_module do
+	assert false
+end

--- a/tests/test_nitunit7.nit
+++ b/tests/test_nitunit7.nit
@@ -1,0 +1,33 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module test_nitunit7 is test_suite
+
+import test_suite
+
+class TestNitunit7
+	super TestSuite
+
+	fun test_foo do
+		assert true
+	end
+end
+
+redef fun before_module do
+	assert true
+end
+
+redef fun after_module do
+	assert false
+end


### PR DESCRIPTION
Before and after method were not actually called in the test suite process.

This PR enables the compilation and run of these methods.

The new behavior is: if the `before_module` test case fails, all the test cases and the `after_module` are skipped and marked as failed.