### PR TITLE
Use `UInt32` to manipulate Unicode chars and support 32 bits platforms

### DIFF
--- a/lib/core/fixed_ints.nit
+++ b/lib/core/fixed_ints.nit
@@ -34,7 +34,7 @@
 # * UInt32 => u32
 module fixed_ints
 
-import text
+import kernel
 
 in "C" `{
 #include <inttypes.h>
@@ -220,28 +220,6 @@ universal Int8
 	#
 	#     assert ~0x2Fi8 == 0xD0i8
 	fun ~: Int8 is intern
-
-	# C function to calculate the length of the `CString` to receive `self`
-	private fun to_s_len: Int `{
-		return snprintf(NULL, 0, "%"PRIi8, self);
-	`}
-
-	# C function to convert a nit Int to a CString (char*)
-	private fun native_to_s(nstr: CString, strlen: Int) `{
-		snprintf(nstr, strlen, "%"PRIi8, self);
-	`}
-
-	# Displayable Int8
-	#
-	#     assert 1i8.to_s       == "1"
-	#     assert (-123i8).to_s  == "-123"
-	redef fun to_s do
-		var nslen = to_s_len
-		var ns = new CString(nslen + 1)
-		ns[nslen] = 0u8
-		native_to_s(ns, nslen + 1)
-		return ns.to_s_unsafe(nslen, copy=false)
-	end
 end
 
 # Native 16-bit signed integer.
@@ -366,28 +344,6 @@ universal Int16
 	#
 	#     assert ~0x2Fi16 == 0xFFD0i16
 	fun ~: Int16 is intern
-
-	# C function to calculate the length of the `CString` to receive `self`
-	private fun to_s_len: Int `{
-		return snprintf(NULL, 0, "%"PRIi16, self);
-	`}
-
-	# C function to convert a nit Int to a CString (char*)
-	private fun native_to_s(nstr: CString, strlen: Int) `{
-		snprintf(nstr, strlen, "%"PRIi16, self);
-	`}
-
-	# Displayable Int16
-	#
-	#     assert 1i16.to_s       == "1"
-	#     assert (-123i16).to_s  == "-123"
-	redef fun to_s do
-		var nslen = to_s_len
-		var ns = new CString(nslen + 1)
-		ns[nslen] = 0u8
-		native_to_s(ns, nslen + 1)
-		return ns.to_s_unsafe(nslen, copy=false)
-	end
 end
 
 # Native 16-bit unsigned integer.
@@ -512,30 +468,7 @@ universal UInt16
 	#
 	#     assert ~0x2Fu16 == 0xFFD0u16
 	fun ~: UInt16 is intern
-
-	# C function to calculate the length of the `CString` to receive `self`
-	private fun to_s_len: Int `{
-		return snprintf(NULL, 0, "%"PRIu16, self);
-	`}
-
-	# C function to convert a nit Int to a CString (char*)
-	private fun native_to_s(nstr: CString, strlen: Int) `{
-		snprintf(nstr, strlen, "%"PRIu16, self);
-	`}
-
-	# Displayable UInt16
-	#
-	#     assert 1u16.to_s       == "1"
-	#     assert (-123u16).to_s  == "65413"
-	redef fun to_s do
-		var nslen = to_s_len
-		var ns = new CString(nslen + 1)
-		ns[nslen] = 0u8
-		native_to_s(ns, nslen + 1)
-		return ns.to_s_unsafe(nslen, copy=false)
-	end
 end
-
 
 # Native 32-bit signed integer.
 # Same as a C `int32_t`
@@ -659,28 +592,6 @@ universal Int32
 	#
 	#     assert ~0x2Fi32 == 0xFFFFFFD0i32
 	fun ~: Int32 is intern
-
-	# C function to calculate the length of the `CString` to receive `self`
-	private fun to_s_len: Int `{
-		return snprintf(NULL, 0, "%"PRIi32, self);
-	`}
-
-	# C function to convert a nit Int to a CString (char*)
-	private fun native_to_s(nstr: CString, strlen: Int) `{
-		snprintf(nstr, strlen, "%"PRIi32, self);
-	`}
-
-	# Displayable Int32
-	#
-	#     assert 1i32.to_s       == "1"
-	#     assert (-123i32).to_s  == "-123"
-	redef fun to_s do
-		var nslen = to_s_len
-		var ns = new CString(nslen + 1)
-		ns[nslen] = 0u8
-		native_to_s(ns, nslen + 1)
-		return ns.to_s_unsafe(nslen, copy=false)
-	end
 end
 
 # Native 32-bit unsigned integer.
@@ -805,195 +716,4 @@ universal UInt32
 	#
 	#     assert ~0x2Fu32 == 0xFFFFFFD0u32
 	fun ~: UInt32 is intern
-
-	# C function to calculate the length of the `CString` to receive `self`
-	private fun to_s_len: Int `{
-		return snprintf(NULL, 0, "%"PRIu32, self);
-	`}
-
-	# C function to convert a nit Int to a CString (char*)
-	private fun native_to_s(nstr: CString, strlen: Int) `{
-		snprintf(nstr, strlen, "%"PRIu32, self);
-	`}
-
-	# Displayable UInt32
-	#
-	#     assert 1u32.to_s       == "1"
-	#     assert (-123u32).to_s  == "4294967173"
-	redef fun to_s do
-		var nslen = to_s_len
-		var ns = new CString(nslen + 1)
-		ns[nslen] = 0u8
-		native_to_s(ns, nslen + 1)
-		return ns.to_s_unsafe(nslen, copy=false)
-	end
-end
-
-redef class Text
-
-	# Removes the numeric head of `self` if present
-	#
-	#     intrude import core::fixed_ints
-	#     assert "0xFFEF".strip_numhead  == "FFEF"
-	#     assert "0o7364".strip_numhead  == "7364"
-	#     assert "0b01001".strip_numhead == "01001"
-	#     assert "98".strip_numhead      == "98"
-	private fun strip_numhead: Text do
-		if get_numhead != "" then return substring_from(2)
-		return self
-	end
-
-	# Gets the numeric head of `self` if present
-	# Returns "" otherwise
-	#
-	#     intrude import core::fixed_ints
-	#     assert "0xFEFF".get_numhead  == "0x"
-	#     assert "0b01001".get_numhead == "0b"
-	#     assert "0o872".get_numhead   == "0o"
-	#     assert "98".get_numhead      == ""
-	private fun get_numhead: Text do
-		if self.length < 2 then return ""
-		var c = self[0]
-		if c != '0' then return ""
-		c = self[1]
-		if c == 'x' or c == 'b' or c == 'o' or
-		   c == 'X' or c == 'B' or c == 'O' then return substring(0, 2)
-		return ""
-	end
-
-	# Removes the numeric extension if present
-	#
-	#     intrude import core::fixed_ints
-	#     assert "0xFEFFu8".strip_numext  == "0xFEFF"
-	#     assert "0b01001u8".strip_numext == "0b01001"
-	#     assert "0o872u8".strip_numext   == "0o872"
-	#     assert "98".strip_numext        == "98"
-	private fun strip_numext: Text do
-		var ext = get_numext
-		if ext != "" then return substring(0, length - ext.length)
-		return self
-	end
-
-	# Gets the numeric extension (i/u 8/16/32) in `self` is present
-	# Returns "" otherwise
-	#
-	#     intrude import core::fixed_ints
-	#     assert "0xFEFFu8".get_numext  == "u8"
-	#     assert "0b01001u8".get_numext == "u8"
-	#     assert "0o872u8".get_numext   == "u8"
-	#     assert "98".get_numext        == ""
-	private fun get_numext: Text do
-		var len = self.length
-		var max = if self.length < 3 then self.length else 3
-		for i in [1 .. max] do
-			var c = self[len - i]
-			if c == 'i' or c == 'u' then return substring_from(len - i)
-		end
-		return ""
-	end
-
-	# Is `self` a well-formed Integer (i.e. parsable via `to_i`)
-	#
-	#     assert "123".is_int
-	#     assert "0b1011".is_int
-	#     assert not "0x_".is_int
-	#     assert not "0xGE".is_int
-	#     assert not "".is_int
-	#     assert not "Not an Int".is_int
-	#     assert not "-".is_int
-	fun is_int: Bool do
-		if byte_length == 0 then return false
-		var s = remove_all('_')
-		var pos = 0
-		var len = s.length
-		while pos < len and s[pos] == '-' do
-			pos += 1
-		end
-		s = s.substring_from(pos)
-		var rets = s.strip_numhead
-		if rets == "" then return false
-		var hd = get_numhead
-		if hd == "0x" or hd == "0X" then return rets.is_hex
-		if hd == "0b" or hd == "0B" then return rets.is_bin
-		if hd == "0o" or hd == "0O" then return rets.is_oct
-		return rets.is_dec
-	end
-
-	redef fun to_i
-	do
-		assert self.is_int
-		var s = remove_all('_')
-		var val = 0
-		var neg = false
-		var pos = 0
-		while s[pos] == '-' do
-			neg = not neg
-			pos += 1
-		end
-		s = s.substring_from(pos)
-		if s.length >= 2 then
-			var s1 = s[1]
-			if s1 == 'x' or s1 == 'X' then
-				val = s.substring_from(2).to_hex
-			else if s1 == 'o' or s1 == 'O' then
-				val = s.substring_from(2).to_oct
-			else if s1 == 'b' or s1 == 'B' then
-				val = s.substring_from(2).to_bin
-			else if s1.is_numeric then
-				val = s.to_dec
-			end
-		else
-			val = s.to_dec
-		end
-		return if neg then -val else val
-	end
-
-	# Is `self` a valid integer ?
-	#
-	#     assert "0xFE46u8".is_num
-	#     assert "0b0100".is_num
-	#     assert "0o645".is_num
-	#     assert "897u8".is_num
-	fun is_num: Bool do
-		var prefix = get_numhead
-		var s = strip_numhead.strip_numext.remove_all('_')
-		if prefix != "" then
-			var c = prefix[1]
-			if c == 'x' or c == 'X' then return s.is_hex
-			if c == 'o' or c == 'O' then return s.is_oct
-			if c == 'b' or c == 'B' then return s.is_bin
-		end
-		return s.is_dec
-	end
-
-	# If `self` is a properly formatted integer, returns the corresponding value
-	# Returns `null` otherwise
-	#
-	#     assert "0xFEu8".to_num  == 254u8
-	#     assert "0b10_10".to_num != 10u8
-	fun to_num: nullable Numeric do
-		if not is_num then return null
-		var s = remove_all('_')
-		var ext = s.get_numext
-		var trunk = s.strip_numext
-		if trunk.strip_numhead == "" then return null
-		var trval = trunk.to_i
-		if ext == "u8" then
-			return trval.to_b
-		else if ext == "i8" then
-			return trval.to_i8
-		else if ext == "i16" then
-			return trval.to_i16
-		else if ext == "u16" then
-			return trval.to_u16
-		else if ext == "i32" then
-			return trval.to_i32
-		else if ext == "u32" then
-			return trval.to_u32
-		else if ext == "" then
-			return trval
-		else
-			return null
-		end
-	end
 end

--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -789,17 +789,17 @@ abstract class Text
 		if pos == null then pos = 0
 		if ln == null then ln = length - pos
 		if ln < 6 then return 0xFFFD.code_point
-		var cp = from_utf16_digit(pos + 2)
-		if cp < 0xD800 then return cp.code_point
-		if cp > 0xDFFF then return cp.code_point
-		if cp > 0xDBFF then return 0xFFFD.code_point
+		var cp = from_utf16_digit(pos + 2).to_u32
+		if cp < 0xD800u32 then return cp.code_point
+		if cp > 0xDFFFu32 then return cp.code_point
+		if cp > 0xDBFFu32 then return 0xFFFD.code_point
 		if ln == 6 then return 0xFFFD.code_point
 		if ln < 12 then return 0xFFFD.code_point
 		cp <<= 16
-		cp += from_utf16_digit(pos + 8)
-		var cplo = cp & 0xFFFF
-		if cplo < 0xDC00 then return 0xFFFD.code_point
-		if cplo > 0xDFFF then return 0xFFFD.code_point
+		cp += from_utf16_digit(pos + 8).to_u32
+		var cplo = cp & 0xFFFFu32
+		if cplo < 0xDC00u32 then return 0xFFFD.code_point
+		if cplo > 0xDFFFu32 then return 0xFFFD.code_point
 		return cp.from_utf16_surr.code_point
 	end
 

--- a/lib/core/text/fixed_ints_text.nit
+++ b/lib/core/text/fixed_ints_text.nit
@@ -1,0 +1,311 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Text services to complement `fixed_ints`
+module fixed_ints_text
+
+import abstract_text
+import string_search
+
+in "C" `{
+	#include <inttypes.h>
+`}
+
+redef class Int8
+	# C function to calculate the length of the `CString` to receive `self`
+	private fun to_s_len: Int `{
+		return snprintf(NULL, 0, "%"PRIi8, self);
+	`}
+
+	# C function to convert a nit Int to a CString (char*)
+	private fun native_to_s(nstr: CString, strlen: Int) `{
+		snprintf(nstr, strlen, "%"PRIi8, self);
+	`}
+
+	# Displayable Int8
+	#
+	#     assert 1i8.to_s       == "1"
+	#     assert (-123i8).to_s  == "-123"
+	redef fun to_s do
+		var nslen = to_s_len
+		var ns = new CString(nslen + 1)
+		ns[nslen] = 0u8
+		native_to_s(ns, nslen + 1)
+		return ns.to_s_unsafe(nslen, copy=false)
+	end
+end
+
+redef class Int16
+	private fun to_s_len: Int `{
+		return snprintf(NULL, 0, "%"PRIi16, self);
+	`}
+
+	# C function to convert a nit Int to a CString (char*)
+	private fun native_to_s(nstr: CString, strlen: Int) `{
+		snprintf(nstr, strlen, "%"PRIi16, self);
+	`}
+
+	# Displayable Int16
+	#
+	#     assert 1i16.to_s       == "1"
+	#     assert (-123i16).to_s  == "-123"
+	redef fun to_s do
+		var nslen = to_s_len
+		var ns = new CString(nslen + 1)
+		ns[nslen] = 0u8
+		native_to_s(ns, nslen + 1)
+		return ns.to_s_unsafe(nslen, copy=false)
+	end
+end
+
+redef class UInt16
+	# C function to calculate the length of the `CString` to receive `self`
+	private fun to_s_len: Int `{
+		return snprintf(NULL, 0, "%"PRIu16, self);
+	`}
+
+	# C function to convert a nit Int to a CString (char*)
+	private fun native_to_s(nstr: CString, strlen: Int) `{
+		snprintf(nstr, strlen, "%"PRIu16, self);
+	`}
+
+	# Displayable UInt16
+	#
+	#     assert 1u16.to_s       == "1"
+	#     assert (-123u16).to_s  == "65413"
+	redef fun to_s do
+		var nslen = to_s_len
+		var ns = new CString(nslen + 1)
+		ns[nslen] = 0u8
+		native_to_s(ns, nslen + 1)
+		return ns.to_s_unsafe(nslen, copy=false)
+	end
+end
+
+redef class Int32
+	# C function to calculate the length of the `CString` to receive `self`
+	private fun to_s_len: Int `{
+		return snprintf(NULL, 0, "%"PRIi32, self);
+	`}
+
+	# C function to convert a nit Int to a CString (char*)
+	private fun native_to_s(nstr: CString, strlen: Int) `{
+		snprintf(nstr, strlen, "%"PRIi32, self);
+	`}
+
+	# Displayable Int32
+	#
+	#     assert 1i32.to_s       == "1"
+	#     assert (-123i32).to_s  == "-123"
+	redef fun to_s do
+		var nslen = to_s_len
+		var ns = new CString(nslen + 1)
+		ns[nslen] = 0u8
+		native_to_s(ns, nslen + 1)
+		return ns.to_s_unsafe(nslen, copy=false)
+	end
+end
+
+redef class UInt32
+	# C function to calculate the length of the `CString` to receive `self`
+	private fun to_s_len: Int `{
+		return snprintf(NULL, 0, "%"PRIu32, self);
+	`}
+
+	# C function to convert a nit Int to a CString (char*)
+	private fun native_to_s(nstr: CString, strlen: Int) `{
+		snprintf(nstr, strlen, "%"PRIu32, self);
+	`}
+
+	# Displayable UInt32
+	#
+	#     assert 1u32.to_s       == "1"
+	#     assert (-123u32).to_s  == "4294967173"
+	redef fun to_s do
+		var nslen = to_s_len
+		var ns = new CString(nslen + 1)
+		ns[nslen] = 0u8
+		native_to_s(ns, nslen + 1)
+		return ns.to_s_unsafe(nslen, copy=false)
+	end
+end
+
+redef class Text
+
+	# Removes the numeric head of `self` if present
+	#
+	#     intrude import core::fixed_ints_text
+	#     assert "0xFFEF".strip_numhead  == "FFEF"
+	#     assert "0o7364".strip_numhead  == "7364"
+	#     assert "0b01001".strip_numhead == "01001"
+	#     assert "98".strip_numhead      == "98"
+	private fun strip_numhead: Text do
+		if get_numhead != "" then return substring_from(2)
+		return self
+	end
+
+	# Gets the numeric head of `self` if present
+	# Returns "" otherwise
+	#
+	#     intrude import core::fixed_ints_text
+	#     assert "0xFEFF".get_numhead  == "0x"
+	#     assert "0b01001".get_numhead == "0b"
+	#     assert "0o872".get_numhead   == "0o"
+	#     assert "98".get_numhead      == ""
+	private fun get_numhead: Text do
+		if self.length < 2 then return ""
+		var c = self[0]
+		if c != '0' then return ""
+		c = self[1]
+		if c == 'x' or c == 'b' or c == 'o' or
+		   c == 'X' or c == 'B' or c == 'O' then return substring(0, 2)
+		return ""
+	end
+
+	# Removes the numeric extension if present
+	#
+	#     intrude import core::fixed_ints_text
+	#     assert "0xFEFFu8".strip_numext  == "0xFEFF"
+	#     assert "0b01001u8".strip_numext == "0b01001"
+	#     assert "0o872u8".strip_numext   == "0o872"
+	#     assert "98".strip_numext        == "98"
+	private fun strip_numext: Text do
+		var ext = get_numext
+		if ext != "" then return substring(0, length - ext.length)
+		return self
+	end
+
+	# Gets the numeric extension (i/u 8/16/32) in `self` is present
+	# Returns "" otherwise
+	#
+	#     intrude import core::fixed_ints_text
+	#     assert "0xFEFFu8".get_numext  == "u8"
+	#     assert "0b01001u8".get_numext == "u8"
+	#     assert "0o872u8".get_numext   == "u8"
+	#     assert "98".get_numext        == ""
+	private fun get_numext: Text do
+		var len = self.length
+		var max = if self.length < 3 then self.length else 3
+		for i in [1 .. max] do
+			var c = self[len - i]
+			if c == 'i' or c == 'u' then return substring_from(len - i)
+		end
+		return ""
+	end
+
+	# Is `self` a well-formed Integer (i.e. parsable via `to_i`)
+	#
+	#     assert "123".is_int
+	#     assert "0b1011".is_int
+	#     assert not "0x_".is_int
+	#     assert not "0xGE".is_int
+	#     assert not "".is_int
+	#     assert not "Not an Int".is_int
+	#     assert not "-".is_int
+	fun is_int: Bool do
+		if byte_length == 0 then return false
+		var s = remove_all('_')
+		var pos = 0
+		var len = s.length
+		while pos < len and s[pos] == '-' do
+			pos += 1
+		end
+		s = s.substring_from(pos)
+		var rets = s.strip_numhead
+		if rets == "" then return false
+		var hd = get_numhead
+		if hd == "0x" or hd == "0X" then return rets.is_hex
+		if hd == "0b" or hd == "0B" then return rets.is_bin
+		if hd == "0o" or hd == "0O" then return rets.is_oct
+		return rets.is_dec
+	end
+
+	redef fun to_i
+	do
+		assert self.is_int
+		var s = remove_all('_')
+		var val = 0
+		var neg = false
+		var pos = 0
+		while s[pos] == '-' do
+			neg = not neg
+			pos += 1
+		end
+		s = s.substring_from(pos)
+		if s.length >= 2 then
+			var s1 = s[1]
+			if s1 == 'x' or s1 == 'X' then
+				val = s.substring_from(2).to_hex
+			else if s1 == 'o' or s1 == 'O' then
+				val = s.substring_from(2).to_oct
+			else if s1 == 'b' or s1 == 'B' then
+				val = s.substring_from(2).to_bin
+			else if s1.is_numeric then
+				val = s.to_dec
+			end
+		else
+			val = s.to_dec
+		end
+		return if neg then -val else val
+	end
+
+	# Is `self` a valid integer ?
+	#
+	#     assert "0xFE46u8".is_num
+	#     assert "0b0100".is_num
+	#     assert "0o645".is_num
+	#     assert "897u8".is_num
+	fun is_num: Bool do
+		var prefix = get_numhead
+		var s = strip_numhead.strip_numext.remove_all('_')
+		if prefix != "" then
+			var c = prefix[1]
+			if c == 'x' or c == 'X' then return s.is_hex
+			if c == 'o' or c == 'O' then return s.is_oct
+			if c == 'b' or c == 'B' then return s.is_bin
+		end
+		return s.is_dec
+	end
+
+	# If `self` is a properly formatted integer, returns the corresponding value
+	# Returns `null` otherwise
+	#
+	#     assert "0xFEu8".to_num  == 254u8
+	#     assert "0b10_10".to_num != 10u8
+	fun to_num: nullable Numeric do
+		if not is_num then return null
+		var s = remove_all('_')
+		var ext = s.get_numext
+		var trunk = s.strip_numext
+		if trunk.strip_numhead == "" then return null
+		var trval = trunk.to_i
+		if ext == "u8" then
+			return trval.to_b
+		else if ext == "i8" then
+			return trval.to_i8
+		else if ext == "i16" then
+			return trval.to_i16
+		else if ext == "u16" then
+			return trval.to_u16
+		else if ext == "i32" then
+			return trval.to_i32
+		else if ext == "u32" then
+			return trval.to_u32
+		else if ext == "" then
+			return trval
+		else
+			return null
+		end
+	end
+end

--- a/lib/core/text/flat.nit
+++ b/lib/core/text/flat.nit
@@ -1359,7 +1359,7 @@ redef class CString
 		while rem > 0 do
 			while rem >= 4 do
 				var i = fetch_4_chars(pos)
-				if i & 0x80808080 != 0 then break
+				if i & 0x80808080u32 != 0u32 then break
 				pos += 4
 				chr_ln += 4
 				rem -= 4

--- a/lib/core/text/native.nit
+++ b/lib/core/text/native.nit
@@ -13,6 +13,7 @@ module native
 
 import kernel
 import math
+import fixed_ints
 
 in "C" `{
 #ifdef __linux__
@@ -68,19 +69,26 @@ redef class Byte
 	end
 end
 
-redef class Int
+redef class UInt32
 	# Returns the code_point from a utf16 surrogate pair
 	#
-	#     assert 0xD83DDE02.from_utf16_surr == 0x1F602
-	fun from_utf16_surr: Int do
-		var hi = (self & 0xFFFF0000) >> 16
-		var lo = self & 0xFFFF
-		var cp = 0
-		cp += (hi - 0xD800) << 10
-		cp += lo - 0xDC00
-		cp += 0x10000
+	#     assert 0xD83DDE02u32.from_utf16_surr == 0x1F602u32
+	fun from_utf16_surr: UInt32 do
+		var hi = (self & 0xFFFF0000u32) >> 16
+		var lo = self & 0xFFFFu32
+		var cp = 0u32
+		cp += (hi - 0xD800u32) << 10
+		cp += lo - 0xDC00u32
+		cp += 0x10000u32
 		return cp
 	end
+
+	# The character which code point (unicode-wise) is `self`
+	#
+	#     assert 65u32.code_point == 'A'
+	#     assert 10u32.code_point == '\n'
+	#     assert 0x220Bu32.code_point == '∋'
+	fun code_point: Char `{ return self; `}
 end
 
 # C string `char *`
@@ -141,26 +149,26 @@ extern class CString `{ char* `}
 		var c = self[pos]
 		if c & 0x80u8 == 0u8 then return c.ascii
 		var b = fetch_4_hchars(pos)
-		var ret = 0
-		if b & 0xC00000 != 0x800000 then return 0xFFFD.code_point
-		if b & 0xE0000000 == 0xC0000000 then
-			ret |= (b & 0x1F000000) >> 18
-			ret |= (b & 0x3F0000) >> 16
+		var ret = 0u32
+		if b & 0xC00000u32 != 0x800000u32 then return 0xFFFD.code_point
+		if b & 0xE0000000u32 == 0xC0000000u32 then
+			ret |= (b & 0x1F000000u32) >> 18
+			ret |= (b & 0x3F0000u32) >> 16
 			return ret.code_point
 		end
-		if not b & 0xC000 == 0x8000 then return 0xFFFD.code_point
-		if b & 0xF0000000 == 0xE0000000 then
-			ret |= (b & 0xF000000) >> 12
-			ret |= (b & 0x3F0000) >> 10
-			ret |= (b & 0x3F00) >> 8
+		if not b & 0xC000u32 == 0x8000u32 then return 0xFFFD.code_point
+		if b & 0xF0000000u32 == 0xE0000000u32 then
+			ret |= (b & 0xF000000u32) >> 12
+			ret |= (b & 0x3F0000u32) >> 10
+			ret |= (b & 0x3F00u32) >> 8
 			return ret.code_point
 		end
-		if not b & 0xC0 == 0x80 then return 0xFFFD.code_point
-		if b & 0xF8000000 == 0xF0000000 then
-			ret |= (b.to_i & 0x7000000) >> 6
-			ret |= (b.to_i & 0x3F0000) >> 4
-			ret |= (b.to_i & 0x3F00) >> 2
-			ret |= b.to_i & 0x3F
+		if not b & 0xC0u32 == 0x80u32 then return 0xFFFD.code_point
+		if b & 0xF8000000u32 == 0xF0000000u32 then
+			ret |= (b & 0x7000000u32) >> 6
+			ret |= (b & 0x3F0000u32) >> 4
+			ret |= (b & 0x3F00u32) >> 2
+			ret |= b & 0x3Fu32
 			return ret.code_point
 		end
 		return 0xFFFD.code_point
@@ -200,7 +208,7 @@ extern class CString `{ char* `}
 		while dist > 0 do
 			while dist >= 4 do
 				var i = fetch_4_chars(ns_i)
-				if i & 0x80808080 != 0 then break
+				if i & 0x80808080u32 != 0u32 then break
 				ns_i += 4
 				my_i += 4
 				dist -= 4
@@ -214,7 +222,7 @@ extern class CString `{ char* `}
 		while dist < 0 do
 			while dist <= -4 do
 				var i = fetch_4_chars(ns_i - 4)
-				if i & 0x80808080 != 0 then break
+				if i & 0x80808080u32 != 0u32 then break
 				ns_i -= 4
 				my_i -= 4
 				dist += 4
@@ -256,8 +264,8 @@ extern class CString `{ char* `}
 	# If the char is invalid UTF-8, `pos` is returned as-is
 	#
 	# ~~~raw
-	# 	assert "abc".items.find_beginning_of_char_at(2) == 2
-	# 	assert "か".items.find_beginning_of_char_at(1) == 0
+	#	assert "abc".items.find_beginning_of_char_at(2) == 2
+	#	assert "か".items.find_beginning_of_char_at(1) == 0
 	#	assert [0x41u8, 233u8].to_s.items.find_beginning_of_char_at(1) == 1
 	# ~~~
 	fun find_beginning_of_char_at(pos: Int): Int do
@@ -280,7 +288,7 @@ extern class CString `{ char* `}
 		while byte_length > 0 do
 			while byte_length >= 4 do
 				var i = fetch_4_chars(st)
-				if i & 0x80808080 != 0 then break
+				if i & 0x80808080u32 != 0u32 then break
 				byte_length -= 4
 				st += 4
 				ln += 4
@@ -295,11 +303,10 @@ extern class CString `{ char* `}
 	end
 
 	# Fetch 4 chars in `self` at `pos`
-	fun fetch_4_chars(pos: Int): Int is intern `{ return (long)*((uint32_t*)(self+pos)); `}
+	fun fetch_4_chars(pos: Int): UInt32 is intern `{ return *((uint32_t*)(self+pos)); `}
 
 	# Fetch 4 chars in `self` at `pos`
-	fun fetch_4_hchars(pos: Int): Int is intern `{ return (long)be32toh(*((uint32_t*)(self+pos))); `}
-
+	fun fetch_4_hchars(pos: Int): UInt32 is intern `{ return (uint32_t)be32toh(*((uint32_t*)(self+pos))); `}
 
 	# Right shifts `len` bytes of `self` from `sh` bytes starting at position `pos`
 	fun rshift(sh, len, pos: Int) do

--- a/lib/core/text/text.nit
+++ b/lib/core/text/text.nit
@@ -13,3 +13,4 @@ module text
 
 import ropes
 import string_search
+import fixed_ints_text

--- a/lib/ios/ios.nit
+++ b/lib/ios/ios.nit
@@ -30,8 +30,3 @@ end
 redef class NSString
 	private fun nslog in "ObjC" `{ NSLog(@"%@", self); `}
 end
-
-redef class CString
-	# FIXME temp workaround for #1945, bypass Unicode checks
-	redef fun char_at(pos) do return self[pos].ascii
-end

--- a/lib/json/static.nit
+++ b/lib/json/static.nit
@@ -81,7 +81,7 @@ redef class Text
 						if self[i + 5] == '\\' and self[i + 6] == 'u' then
 							u16_esc <<= 16
 							u16_esc += from_utf16_digit(i + 7)
-							char = u16_esc.from_utf16_surr.code_point
+							char = u16_esc.to_u32.from_utf16_surr.code_point
 							i += 6
 						else
 							char = 0xFFFD.code_point

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -2612,10 +2612,10 @@ redef class AMethPropdef
 				v.ret(v.new_expr("(char*){alloc}", ret.as(not null)))
 				return true
 			else if pname == "fetch_4_chars" then
-				v.ret(v.new_expr("(long)*((uint32_t*)({arguments[0]} + {arguments[1]}))", ret.as(not null)))
+				v.ret(v.new_expr("*((uint32_t*)({arguments[0]} + {arguments[1]}))", ret.as(not null)))
 				return true
 			else if pname == "fetch_4_hchars" then
-				v.ret(v.new_expr("(long)be32toh(*((uint32_t*)({arguments[0]} + {arguments[1]})))", ret.as(not null)))
+				v.ret(v.new_expr("(uint32_t)be32toh(*((uint32_t*)({arguments[0]} + {arguments[1]})))", ret.as(not null)))
 				return true
 			end
 		else if cname == "NativeArray" then

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -3057,7 +3057,7 @@ redef class AMethPropdef
 			end
 		end
 		if pname == "exit" then
-			v.add("exit({arguments[1]});")
+			v.add("exit((int){arguments[1]});")
 			return true
 		else if pname == "sys" then
 			v.ret(v.new_expr("glob_sys", ret.as(not null)))

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -1610,7 +1610,7 @@ abstract class AbstractCompilerVisitor
 	fun int8_instance(value: Int8): RuntimeVariable
 	do
 		var t = mmodule.int8_type
-		var res = new RuntimeVariable("((int8_t){value.to_s})", t, t)
+		var res = new RuntimeVariable("INT8_C({value.to_s})", t, t)
 		return res
 	end
 
@@ -1618,7 +1618,7 @@ abstract class AbstractCompilerVisitor
 	fun int16_instance(value: Int16): RuntimeVariable
 	do
 		var t = mmodule.int16_type
-		var res = new RuntimeVariable("((int16_t){value.to_s})", t, t)
+		var res = new RuntimeVariable("INT16_C({value.to_s})", t, t)
 		return res
 	end
 
@@ -1626,7 +1626,7 @@ abstract class AbstractCompilerVisitor
 	fun uint16_instance(value: UInt16): RuntimeVariable
 	do
 		var t = mmodule.uint16_type
-		var res = new RuntimeVariable("((uint16_t){value.to_s})", t, t)
+		var res = new RuntimeVariable("UINT16_C({value.to_s})", t, t)
 		return res
 	end
 
@@ -1634,7 +1634,7 @@ abstract class AbstractCompilerVisitor
 	fun int32_instance(value: Int32): RuntimeVariable
 	do
 		var t = mmodule.int32_type
-		var res = new RuntimeVariable("((int32_t){value.to_s})", t, t)
+		var res = new RuntimeVariable("INT32_C({value.to_s})", t, t)
 		return res
 	end
 
@@ -1642,7 +1642,7 @@ abstract class AbstractCompilerVisitor
 	fun uint32_instance(value: UInt32): RuntimeVariable
 	do
 		var t = mmodule.uint32_type
-		var res = new RuntimeVariable("((uint32_t){value.to_s})", t, t)
+		var res = new RuntimeVariable("UINT32_C({value.to_s})", t, t)
 		return res
 	end
 

--- a/src/compiler/global_compiler.nit
+++ b/src/compiler/global_compiler.nit
@@ -405,12 +405,12 @@ class GlobalCompilerVisitor
 		return false
 	end
 
-	redef fun native_array_instance(elttype: MType, length: RuntimeVariable): RuntimeVariable
+	redef fun native_array_instance(elttype, length)
 	do
 		var ret_type = mmodule.native_array_type(elttype)
 		ret_type = anchor(ret_type).as(MClassType)
 		length = autobox(length, compiler.mainmodule.int_type)
-		return self.new_expr("NEW_{ret_type.c_name}({length})", ret_type)
+		return self.new_expr("NEW_{ret_type.c_name}((int){length})", ret_type)
 	end
 
 	redef fun native_array_get(nat, i)

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -2085,7 +2085,7 @@ class SeparateCompilerVisitor
 		return res
 	end
 
-	redef fun native_array_instance(elttype: MType, length: RuntimeVariable): RuntimeVariable
+	redef fun native_array_instance(elttype, length)
 	do
 		var mtype = mmodule.native_array_type(elttype)
 		self.require_declaration("NEW_{mtype.mclass.c_name}")
@@ -2098,11 +2098,11 @@ class SeparateCompilerVisitor
 			var recv = self.frame.arguments.first
 			var recv_type_info = self.type_info(recv)
 			self.require_declaration(mtype.const_color)
-			return self.new_expr("NEW_{mtype.mclass.c_name}({length}, {recv_type_info}->resolution_table->types[{mtype.const_color}])", mtype)
+			return self.new_expr("NEW_{mtype.mclass.c_name}((int){length}, {recv_type_info}->resolution_table->types[{mtype.const_color}])", mtype)
 		end
 		compiler.undead_types.add(mtype)
 		self.require_declaration("type_{mtype.c_name}")
-		return self.new_expr("NEW_{mtype.mclass.c_name}({length}, &type_{mtype.c_name})", mtype)
+		return self.new_expr("NEW_{mtype.mclass.c_name}((int){length}, &type_{mtype.c_name})", mtype)
 	end
 
 	redef fun native_array_def(pname, ret_type, arguments)

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -1174,9 +1174,9 @@ redef class AMethPropdef
 				var ns = recvval.fast_cstring(args[1].to_i)
 				return v.c_string_instance(ns.to_s)
 			else if pname == "fetch_4_chars" then
-				return v.int_instance(args[0].val.as(CString).fetch_4_chars(args[1].to_i))
+				return v.uint32_instance(args[0].val.as(CString).fetch_4_chars(args[1].to_i))
 			else if pname == "fetch_4_hchars" then
-				return v.int_instance(args[0].val.as(CString).fetch_4_hchars(args[1].to_i))
+				return v.uint32_instance(args[0].val.as(CString).fetch_4_hchars(args[1].to_i))
 			else if pname == "utf8_length" then
 				return v.int_instance(args[0].val.as(CString).utf8_length(args[1].to_i, args[2].to_i))
 			end


### PR DESCRIPTION
Unicode support was broken on 32 bits platforms and anywhere a C `long` was on 32 bits (such as 64 bits Windows). This caused issues when compiling Nit tools.

This PR modifies the critical code in order to use `UInt32` instead of `Int` to fit all the 32 bits of Unicode chars. To do so, the first commit inverts the dependency order of the modules `fixed_int` and `text` so that `text` becomes a client of `fixed_int`. Also, update how constants are declared and fix a few implicit cast warnings.

Fix Debian 32 bits support #2355 after a c_src regen.

Fix #1945 Unicode support on iOS.

Allows to bootstrap under Windows with other minor changes (for another PR).

Reported-by: Alexandre Blondin Massé <alexandre.blondin.masse@gmail.com>