### PR TITLE
Windows: last changes for a working bootstrap

### DIFF
--- a/lib/core/file.nit
+++ b/lib/core/file.nit
@@ -1057,7 +1057,8 @@ redef class String
 	# ~~~
 	fun simplify_path: String
 	do
-		var a = self.split_with("/")
+		var path_sep = if is_windows then "\\" else "/"
+		var a = self.split_with(path_sep)
 		var a2 = new Array[String]
 		for x in a do
 			if x == "." and not a2.is_empty then continue # skip `././`

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -403,6 +403,15 @@ ifeq ($(uname_S),Darwin)
 	LDLIBS := $(filter-out -lrt,$(LDLIBS))
 endif
 
+# Special configuration for Windows under mingw64
+ifeq ($(uname_S),MINGW64_NT-10.0)
+	# Use the pcreposix regex library
+	LDLIBS += -lpcreposix
+
+	# Remove POSIX flag -lrt
+	LDLIBS := $(filter-out -lrt,$(LDLIBS))
+endif
+
 """
 
 		makefile.write("all: {outpath}\n")

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -410,6 +410,9 @@ ifeq ($(uname_S),MINGW64_NT-10.0)
 
 	# Remove POSIX flag -lrt
 	LDLIBS := $(filter-out -lrt,$(LDLIBS))
+
+	# Silence warnings when storing Int, Char and Bool as pointer address
+	CFLAGS += -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
 endif
 
 """

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -510,8 +510,10 @@ endif
 		self.toolcontext.info(command, 2)
 
 		var res
-		if self.toolcontext.verbose_level >= 3 or is_windows then
+		if self.toolcontext.verbose_level >= 3 then
 			res = sys.system("{command} 2>&1")
+		else if is_windows then
+			res = sys.system("{command} 2>&1 >nul")
 		else
 			res = sys.system("{command} 2>&1 >/dev/null")
 		end

--- a/src/toolcontext.nit
+++ b/src/toolcontext.nit
@@ -566,7 +566,7 @@ The Nit language documentation and the source code of its tools and libraries ma
 	#
 	# It uses, in order:
 	#
-	# * the option `opt_no_color`
+	# * the option `opt_nit_dir`
 	# * the environment variable `NIT_DIR`
 	# * the runpath of the program from argv[0]
 	# * the runpath of the process from /proc
@@ -610,7 +610,8 @@ The Nit language documentation and the source code of its tools and libraries ma
 		end
 
 		# search in the PATH
-		var ps = "PATH".environ.split(":")
+		var path_sep = if is_windows then ";" else ":"
+		var ps = "PATH".environ.split(path_sep)
 		for p in ps do
 			res = p/".."
 			if check_nit_dir(res) then return res.simplify_path


### PR DESCRIPTION
This PR tweaks the generated Makefile so it works under Windows and silences the excessive warnings when casting ints to pointers, which is used to optimize `Int`, `Char` and `Bool`. And, to fix the heuristic that finds the Nit dir, this PR modifies two methods to support Windows path separator `\` and the PATH env var separator `;`.

These should be the last changes to get a working bootstrap on Windows using msys2/mingw64 tools. Once we regen c_src, you can clone and make Nit from Windows by following the first guide at: http://nitlanguage.org/windows.html Using msys2/mingw64 allows to compile native Windows apps using GNU tools, so the resulting program is an exe file that can use any Windows .dll file and show standard Windows windows.

These changes are far from fixing all issues for running Nit on Windows. However, a working bootstrap will simplify future incremental improvements and will allow detecting regressions with automated testing.