### PR TITLE
JSON: optimize writing strings

### DIFF
--- a/lib/json/serialization_write.nit
+++ b/lib/json/serialization_write.nit
@@ -144,26 +144,49 @@ redef class Text
 	redef fun accept_json_serializer(v)
 	do
 		v.stream.write "\""
+
+		var start_i = 0
+		var escaped = null
 		for i in [0 .. self.length[ do
 			var char = self[i]
 			if char == '\\' then
-				v.stream.write "\\\\"
+				escaped = "\\\\"
 			else if char == '\"' then
-				v.stream.write "\\\""
+				escaped = "\\\""
 			else if char < ' ' then
 				if char == '\n' then
-					v.stream.write "\\n"
+					escaped = "\\n"
 				else if char == '\r' then
-					v.stream.write "\\r"
+					escaped = "\\r"
 				else if char == '\t' then
-					v.stream.write "\\t"
+					escaped = "\\t"
 				else
-					v.stream.write char.escape_to_utf16
+					escaped = char.escape_to_utf16
 				end
-			else
-				v.stream.write char.to_s
+			end
+
+			if escaped != null then
+				# Write open non-escaped string
+				if start_i <= i then
+					v.stream.write substring(start_i, i-start_i)
+				end
+
+				# Write escaped character
+				v.stream.write escaped
+				escaped = null
+				start_i = i+1
 			end
 		end
+
+		# Write remaining non-escaped string
+		if start_i < length then
+			if start_i == 0 then
+				v.stream.write self
+			else
+				v.stream.write substring(start_i, length-start_i)
+			end
+		end
+
 		v.stream.write "\""
 	end
 end


### PR DESCRIPTION
Changes how strings are serialized to JSON by grouping non-escaped characters in a single call to write. So if a string has no escape characters, it is written as is. This replaces the old behavior where there was a call to write for each character.

This PR addresses the same issue as #2367 and #2371 but it targets JSON string writing only. The best results are obtained when this PR is merged with #2371. On my machine, parsing and writing `magic.json`  takes the following wall clock time depending on the branch:

* master: 14s
* #2367 (char cache): 6.2s
* #2371 (buffer): 4.0s
* this PR: 4.8s
* this PR + #2371: 3.6s