### PR TITLE
contrib/re_parser

### DIFF
--- a/contrib/nitcc/src/autom.nit
+++ b/contrib/nitcc/src/autom.nit
@@ -537,7 +537,7 @@ class Automaton
 
 		var dfa = new Automaton.empty
 		var n2d = new ArrayMap[Set[State], State]
-		var seen = new ArraySet[Set[State]] 
+		var seen = new ArraySet[Set[State]]
 		var alphabet = new HashSet[Int]
 		var st = eclosure([start])
 		var todo = [st]
@@ -628,7 +628,7 @@ class Automaton
 			for t in s.outs do
 				if t.symbol != null then continue
 				var to = t.to
-				if res.has(to) then continue 
+				if res.has(to) then continue
 				res.add(to)
 				todo.add(to)
 			end
@@ -649,7 +649,7 @@ class Automaton
 				var l = sym.last
 				if l != null and l < symbol then continue
 				var to = t.to
-				if res.has(to) then continue 
+				if res.has(to) then continue
 				res.add(to)
 			end
 		end

--- a/contrib/nitcc/src/autom.nit
+++ b/contrib/nitcc/src/autom.nit
@@ -252,8 +252,8 @@ class Automaton
 				if t.symbol == null then continue
 
 				# Check overlaps
-				var tf = t.symbol.first
-				var tl = t.symbol.last
+				var tf = t.symbol.as(not null).first
+				var tl = t.symbol.as(not null).last
 				if l != null and tf > l then continue
 				if tl != null and f > tl then continue
 
@@ -607,7 +607,7 @@ class Automaton
 					seen.add(nfa_dest)
 				end
 				if lastst != null and lastst.to == dfa_dest then
-					lastst.symbol.last = sym.last
+					lastst.symbol.as(not null).last = sym.last
 				else
 					lastst = dfa_state.add_trans(dfa_dest, sym)
 				end

--- a/contrib/nitcc/src/autom.nit
+++ b/contrib/nitcc/src/autom.nit
@@ -466,8 +466,8 @@ class Automaton
 		end
 	end
 
-	# Produce a graphvis file for the automaton
-	fun to_dot(filepath: String)
+	# Produce a graphviz string from the automatom
+	fun to_dot: String
 	do
 		var names = new HashMap[State, String]
 		var ni = 0
@@ -476,25 +476,25 @@ class Automaton
 			ni += 1
 		end
 
-		var f = new FileWriter.open(filepath)
-                f.write("digraph g \{\n")
+		var f = new Buffer
+                f.append("digraph g \{\n")
 
 		for s in states do
-			f.write("s{names[s]}[shape=oval")
+			f.append("s{names[s]}[shape=oval")
 			#f.write("label=\"\",")
 			if accept.has(s) then
-				f.write(",color=blue")
+				f.append(",color=blue")
 			end
 			if tags.has_key(s) then
-				f.write(",label=\"")
+				f.append(",label=\"")
 				for token in tags[s] do
-					f.write("{token.name.escape_to_c}\\n")
+					f.append("{token.name.escape_to_c}\\n")
 				end
-				f.write("\"")
+				f.append("\"")
 			else
-				f.write(",label=\"\"")
+				f.append(",label=\"\"")
 			end
-			f.write("];\n")
+			f.append("];\n")
 			var outs = new HashMap[State, Array[nullable TSymbol]]
 			for t in s.outs do
 				var a
@@ -518,13 +518,12 @@ class Automaton
 						labe += c.to_s
 					end
 				end
-				f.write("s{names[s]}->s{names[s2]} [label=\"{labe.escape_to_c}\"];\n")
+				f.append("s{names[s]}->s{names[s2]} [label=\"{labe.escape_to_c}\"];\n")
 			end
 		end
-		f.write("empty->s{names[start]}; empty[label=\"\",shape=none];\n")
-
-                f.write("\}\n")
-		f.close
+		f.append("empty->s{names[start]}; empty[label=\"\",shape=none];\n")
+		f.append("\}\n")
+		return f.write_to_string
 	end
 
 	# Transform a NFA to a DFA.

--- a/contrib/nitcc/src/nitcc.nit
+++ b/contrib/nitcc/src/nitcc.nit
@@ -111,14 +111,14 @@ f.close
 
 var nfa = v2.nfa
 print "NFA automaton: {nfa.states.length} states (see {name}.nfa.dot)"
-nfa.to_dot("{name}.nfa.dot")
+nfa.to_dot.write_to_file("{name}.nfa.dot")
 
 var dfa = nfa.to_dfa.to_minimal_dfa
 
 dfa.solve_token_inclusion
 
 print "DFA automaton: {dfa.states.length} states (see {name}.dfa.dot)"
-dfa.to_dot("{name}.dfa.dot")
+dfa.to_dot.write_to_file("{name}.dfa.dot")
 
 if dfa.tags.has_key(dfa.start) then
 	print "Error: Empty tokens {dfa.tags[dfa.start].join(" ")}"

--- a/contrib/nitcc/src/nitcc.nit
+++ b/contrib/nitcc/src/nitcc.nit
@@ -46,7 +46,7 @@ var node = p.parse
 
 if not node isa NProd then
 	assert node isa NError
-	print "{node.position.to_s} Syntax Error: {node.message}"
+	print "{node.position.as(not null)} Syntax Error: {node.message}"
 	exit 1
 	abort
 end

--- a/contrib/nitcc/src/nitcc_semantic.nit
+++ b/contrib/nitcc/src/nitcc_semantic.nit
@@ -221,7 +221,7 @@ redef class Nexpr
 		end
 		is_building = false
 		var nre = self.children[2]
-		res = nre.make_rfa
+		res = nre.make_nfa
 		nfa = res
 		return res
 	end
@@ -230,7 +230,7 @@ end
 redef class Nre_id
 	# The named expression
 	var nexpr: nullable Nexpr
-	
+
 	redef fun accept_check_name_visitor(v) do
 		var id = children.first.as(Nid)
 		var name = id.text
@@ -251,7 +251,7 @@ redef class Nre_id
 		v.nexpr.precs.add(node)
 	end
 
-	redef fun make_rfa
+	redef fun make_nfa
 	do
 		return nexpr.nfa.dup
 	end

--- a/contrib/nitcc/src/re2nfa.nit
+++ b/contrib/nitcc/src/re2nfa.nit
@@ -34,7 +34,7 @@ end
 
 redef class Nstr
 	redef fun value do return text.substring(1, text.length-2).unescape_nit
-	redef fun make_rfa: Automaton
+	redef fun make_rfa
 	do
 		var a = new Automaton.epsilon
 		for c in self.value.chars do
@@ -47,7 +47,7 @@ end
 
 redef class Nch_dec
 	redef fun value do return text.substring_from(1).to_i.code_point.to_s
-	redef fun make_rfa: Automaton
+	redef fun make_rfa
 	do
 		var a = new Automaton.atom(self.value.chars.first.code_point)
 		return a
@@ -56,7 +56,7 @@ end
 
 redef class Nch_hex
 	redef fun value do return text.substring_from(2).to_hex.code_point.to_s
-	redef fun make_rfa: Automaton
+	redef fun make_rfa
 	do
 		var a = new Automaton.atom(self.value.chars.first.code_point)
 		return a
@@ -64,7 +64,7 @@ redef class Nch_hex
 end
 
 redef class NProd
-	redef fun make_rfa: Automaton
+	redef fun make_rfa
 	do
 		assert children.length == 1 else print "no make_rfa for {self}"
 		return children.first.make_rfa
@@ -228,7 +228,7 @@ redef class Nre_par
 end
 
 redef class Nre_class
-	redef fun make_rfa: Automaton
+	redef fun make_rfa
 	do
 		var c1 = children[0].children[0].value
 		var c2 = children[3].children[0].value
@@ -243,7 +243,7 @@ redef class Nre_class
 end
 
 redef class Nre_openclass
-	redef fun make_rfa: Automaton
+	redef fun make_rfa
 	do
 		var c1 = children[0].children[0].value
 		if c1.length != 1 then
@@ -257,7 +257,7 @@ redef class Nre_openclass
 end
 
 redef class Nre_any
-	redef fun make_rfa: Automaton
+	redef fun make_rfa
 	do
 		var a = new Automaton.cla(0, null)
 		return a

--- a/contrib/nitcc/src/re2nfa.nit
+++ b/contrib/nitcc/src/re2nfa.nit
@@ -33,7 +33,7 @@ redef class Node
 end
 
 redef class Nstr
-	redef fun value: String do return text.substring(1, text.length-2).unescape_nit
+	redef fun value do return text.substring(1, text.length-2).unescape_nit
 	redef fun make_rfa: Automaton
 	do
 		var a = new Automaton.epsilon
@@ -46,7 +46,7 @@ redef class Nstr
 end
 
 redef class Nch_dec
-	redef fun value: String do return text.substring_from(1).to_i.code_point.to_s
+	redef fun value do return text.substring_from(1).to_i.code_point.to_s
 	redef fun make_rfa: Automaton
 	do
 		var a = new Automaton.atom(self.value.chars.first.code_point)
@@ -55,7 +55,7 @@ redef class Nch_dec
 end
 
 redef class Nch_hex
-	redef fun value: String do return text.substring_from(2).to_hex.code_point.to_s
+	redef fun value do return text.substring_from(2).to_hex.code_point.to_s
 	redef fun make_rfa: Automaton
 	do
 		var a = new Automaton.atom(self.value.chars.first.code_point)

--- a/contrib/nitcc/src/re2nfa.nit
+++ b/contrib/nitcc/src/re2nfa.nit
@@ -20,7 +20,7 @@ import autom
 
 redef class Node
 	# Build the NFA of the regular expression
-	fun make_rfa: Automaton do
+	fun make_nfa: Automaton do
 		print inspect
 		abort
 	end
@@ -34,7 +34,7 @@ end
 
 redef class Nstr
 	redef fun value do return text.substring(1, text.length-2).unescape_nit
-	redef fun make_rfa
+	redef fun make_nfa
 	do
 		var a = new Automaton.epsilon
 		for c in self.value.chars do
@@ -47,7 +47,7 @@ end
 
 redef class Nch_dec
 	redef fun value do return text.substring_from(1).to_i.code_point.to_s
-	redef fun make_rfa
+	redef fun make_nfa
 	do
 		var a = new Automaton.atom(self.value.chars.first.code_point)
 		return a
@@ -56,7 +56,7 @@ end
 
 redef class Nch_hex
 	redef fun value do return text.substring_from(2).to_hex.code_point.to_s
-	redef fun make_rfa
+	redef fun make_nfa
 	do
 		var a = new Automaton.atom(self.value.chars.first.code_point)
 		return a
@@ -64,28 +64,28 @@ redef class Nch_hex
 end
 
 redef class NProd
-	redef fun make_rfa
+	redef fun make_nfa
 	do
-		assert children.length == 1 else print "no make_rfa for {self}"
-		return children.first.make_rfa
+		assert children.length == 1 else print "no make_nfa for {self}"
+		return children.first.make_nfa
 	end
 end
 
 redef class Nre_alter
-	redef fun make_rfa
+	redef fun make_nfa
 	do
-		var a = children[0].make_rfa
-		var b = children[2].make_rfa
+		var a = children[0].make_nfa
+		var b = children[2].make_nfa
 		a.alternate(b)
 		return a
 	end
 end
 
 redef class Nre_minus
-	redef fun make_rfa
+	redef fun make_nfa
 	do
-		var a = children[0].make_rfa
-		var b = children[2].make_rfa.to_dfa
+		var a = children[0].make_nfa
+		var b = children[2].make_nfa.to_dfa
 		for t in b.start.outs do
 			if not t.to.outs.is_empty then
 				# `b` is not a single char, so just use except
@@ -107,7 +107,7 @@ redef class Nre_minus
 end
 
 redef class Nre_end
-	redef fun make_rfa
+	redef fun make_nfa
 	do
 		print "{children.first.position.to_s}: NOT YET IMPLEMENTED: token `End`; replaced with an empty string"
 		return new Automaton.epsilon
@@ -115,12 +115,12 @@ redef class Nre_end
 end
 
 redef class Nre_and
-	redef fun make_rfa
+	redef fun make_nfa
 	do
-		var a = children[0].make_rfa
+		var a = children[0].make_nfa
 		var ta = new Token("1")
 		a.tag_accept(ta)
-		var b = children[2].make_rfa
+		var b = children[2].make_nfa
 		var tb = new Token("2")
 		b.tag_accept(tb)
 
@@ -141,18 +141,18 @@ redef class Nre_and
 end
 
 redef class Nre_except
-	redef fun make_rfa
+	redef fun make_nfa
 	do
-		var a = children[0].make_rfa
-		var b = children[2].make_rfa
+		var a = children[0].make_nfa
+		var b = children[2].make_nfa
 		return a.except(b)
 	end
 end
 
 redef class Nre_shortest
-	redef fun make_rfa
+	redef fun make_nfa
 	do
-		var a = children[2].make_rfa
+		var a = children[2].make_nfa
 		a = a.to_dfa
 		for s in a.accept do
 			for t in s.outs.to_a do t.delete
@@ -162,9 +162,9 @@ redef class Nre_shortest
 end
 
 redef class Nre_longest
-	redef fun make_rfa
+	redef fun make_nfa
 	do
-		var a = children[2].make_rfa
+		var a = children[2].make_nfa
 		a = a.to_dfa
 		for s in a.accept.to_a do
 			if not s.outs.is_empty then a.accept.remove(s)
@@ -174,9 +174,9 @@ redef class Nre_longest
 end
 
 redef class Nre_prefixes
-	redef fun make_rfa
+	redef fun make_nfa
 	do
-		var a = children[2].make_rfa
+		var a = children[2].make_nfa
 		a.trim
 		a.accept.add_all a.states
 		return a
@@ -184,51 +184,51 @@ redef class Nre_prefixes
 end
 
 redef class Nre_conc
-	redef fun make_rfa
+	redef fun make_nfa
 	do
-		var a = children[0].make_rfa
-		var b = children[1].make_rfa
+		var a = children[0].make_nfa
+		var b = children[1].make_nfa
 		a.concat(b)
 		return a
 	end
 end
 
 redef class Nre_star
-	redef fun make_rfa
+	redef fun make_nfa
 	do
-		var a = children[0].make_rfa
+		var a = children[0].make_nfa
 		a.close
 		return a
 	end
 end
 
 redef class Nre_ques
-	redef fun make_rfa
+	redef fun make_nfa
 	do
-		var a = children[0].make_rfa
+		var a = children[0].make_nfa
 		a.optionnal
 		return a
 	end
 end
 
 redef class Nre_plus
-	redef fun make_rfa
+	redef fun make_nfa
 	do
-		var a = children[0].make_rfa
+		var a = children[0].make_nfa
 		a.plus
 		return a
 	end
 end
 
 redef class Nre_par
-	redef fun make_rfa
+	redef fun make_nfa
 	do
-		return children[1].make_rfa
+		return children[1].make_nfa
 	end
 end
 
 redef class Nre_class
-	redef fun make_rfa
+	redef fun make_nfa
 	do
 		var c1 = children[0].children[0].value
 		var c2 = children[3].children[0].value
@@ -243,7 +243,7 @@ redef class Nre_class
 end
 
 redef class Nre_openclass
-	redef fun make_rfa
+	redef fun make_nfa
 	do
 		var c1 = children[0].children[0].value
 		if c1.length != 1 then
@@ -257,7 +257,7 @@ redef class Nre_openclass
 end
 
 redef class Nre_any
-	redef fun make_rfa
+	redef fun make_nfa
 	do
 		var a = new Automaton.cla(0, null)
 		return a

--- a/contrib/re_parser/.gitignore
+++ b/contrib/re_parser/.gitignore
@@ -1,0 +1,8 @@
+*.dot
+*parser_parser.nit
+*parser_lexer.nit
+*_test_parser*
+*.out
+
+re_parser
+re_app

--- a/contrib/re_parser/Makefile
+++ b/contrib/re_parser/Makefile
@@ -1,0 +1,27 @@
+NITC=../../bin/nitc
+NITCC=../../nitcc/src/nitcc
+NITUNIT=../../bin/nitunit
+
+all: re_parser re_app
+
+nitcc:
+	cd ../nitcc && make nitcc
+
+grammar: nitcc
+	cd src/ && ${NITCC} re_parser.sablecc
+
+re_parser: grammar
+	${NITC} src/re_parser.nit
+
+re_app: grammar
+	${NITC} src/re_app.nit
+
+check:
+	${NITUNIT} .
+
+clean:
+	rm re_parser re_app 2>/dev/null || true
+	cd src/ && rm -r \
+		*.dot *.out \
+		re_parser_lexer.nit re_parser_parser.nit re_parser_test_parser.nit re_parser_parser_gen \
+		2>/dev/null || true

--- a/contrib/re_parser/README.md
+++ b/contrib/re_parser/README.md
@@ -1,0 +1,75 @@
+# RE Parser
+
+RE parser provides a simple API to regular expression parsing.
+It is also able to convert a regular expression into a NFA or a DFA and produce dot files from it.
+
+## Building RE parser
+
+From the `re_parser` directory:
+
+~~~raw
+make all
+~~~
+
+## RE parser in command line
+
+RE parser can be used as a command line tool to generate NFA and DFA dot files from a regular expression:
+
+~~~raw
+./re_parser "a(b|c)+d*"
+~~~
+
+Will produce the two files `nfa.dot` and `dfa.dot`.
+
+These can be directly viwed with `xdot`:
+
+~~~raw
+xdot nfa.dot
+xdot dfa.dot
+~~~
+
+Or translated to png images with `dot`:
+
+~~~raw
+dot -Tpng -onfa.png nfa.dot
+dot -Tpng -odfa.png dfa.dot
+~~~
+
+See `man dot` for available formats.
+
+## RE parser as a web app
+
+RE parser comes with a web app that allow users to submit regular expression and see the resulting NFA and DFA.
+
+To run the web app server:
+
+~~~raw
+./re_app --host localhost --port 3000
+~~~
+
+The server will be available at <a href='http://localhost:3000'>http://localhost:3000</a>.
+
+## RE parser as a library
+
+You can also use RE parser as a library by importing `re_parser`.
+
+	import re_parser
+
+	var re = "a(b|c)+d*"
+
+	# Parse re
+	var re_parser = new REParser
+	var node = re_parser.parse_re(re)
+
+	if node == null then
+		print re_parser.last_error.as(not null)
+		exit 1
+		abort
+	end
+
+	# Build NFA and DFA
+	var nfa = re_parser.make_nfa(node)
+	print nfa.to_dot(false)
+	print nfa.to_dfa.to_dot(false)
+
+Use `to_dot(true)` to merge transitions on characters.

--- a/contrib/re_parser/package.ini
+++ b/contrib/re_parser/package.ini
@@ -1,0 +1,11 @@
+[package]
+name=re_parser
+tags=re
+maintainer=Alexandre Terrasa <alexandre@moz-code.org>
+license=Apache-2.0
+[upstream]
+browse=https://github.com/nitlang/nit/tree/master/contrib/re_parser/
+git=https://github.com/nitlang/nit.git
+git.directory=contrib/re_parser/
+homepage=http://nitlanguage.org
+issues=https://github.com/nitlang/nit/issues

--- a/contrib/re_parser/src/re_app.nit
+++ b/contrib/re_parser/src/re_app.nit
@@ -1,0 +1,135 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module re_app
+
+import re_parser
+import popcorn
+import popcorn::pop_config
+
+class REHandler
+	super Handler
+
+	redef fun get(req, res) do
+		res.html new RETemplate
+	end
+
+	redef fun post(req, res) do
+		# TODO Retrieve re from post body
+		var re = req.string_arg("re")
+
+		var tpl = new RETemplate
+
+		if re == null or re.is_empty then
+			tpl.error = "Error: empty regexp"
+			res.html tpl
+			return
+		end
+
+		tpl.re = re
+
+		# Parse re
+		var re_parser = new REParser
+		var node = re_parser.parse_re(re)
+
+		if node == null then
+			tpl.error = re_parser.last_error.as(not null)
+			res.html tpl
+			return
+		end
+
+		# Build nfa and dfa
+		var nfa = re_parser.make_nfa(node)
+		tpl.nfa = automaton_to_svg(nfa)
+		tpl.dfa = automaton_to_svg(nfa.to_dfa)
+
+		res.html tpl
+	end
+
+	private fun automaton_to_svg(automaton: Automaton): String do
+		automaton.to_dot(false).write_to_file "dot.tmp"
+		sys.system "dot -Tsvg -osvg.tmp dot.tmp"
+		var svg = "svg.tmp".to_path.read_all
+		sys.system "rm -f dot.tmp svg.tmp"
+		return svg
+	end
+end
+
+class RETemplate
+	super Template
+
+	var re = "a*(b|cd?)+"
+	var nfa: nullable String = null
+	var dfa: nullable String = null
+	var error: nullable String = null
+
+	redef fun rendering do
+		add """
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>REParser</title>
+		<link rel="stylesheet"
+			href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" />
+	</head>
+	<body>
+		<div class="container">
+			<h1>Regular Expressions to NFA and DFA</h1>
+			<br><br>
+			<label for="re">Enter a regular expression:</label>
+			<form action="/" method="POST" class="input-group">
+				<input id="re" name="re" type="text" class="form-control" value="{{{re}}}">
+				<span class="input-group-btn">
+					<input type="submit" class="btn btn-default" value="Convert" />
+				</span>
+			</form>
+			<br><br>"""
+
+			var error = self.error
+			if error != null then
+				add """<p class="text-danger">{{{error}}}</p>"""
+			end
+
+			var nfa = self.nfa
+			if nfa != null then
+				add """
+				<h2>NFA</h2>
+				<div>{{{nfa}}}</div><br><br>"""
+			end
+
+			var dfa = self.dfa
+			if dfa != null then
+				add """
+				<h2>DFA</h2>
+				<div>{{{dfa}}}</div><br><br>"""
+			end
+
+		add """</div>
+		<div class="text-center text-muted">
+			<p>Powered by <a href="http://nitlanguage.org">nit</a>!</p>
+		</div>
+	</body>
+</html>"""
+	end
+end
+
+var config = new AppConfig
+config.parse_options(args)
+
+var app = new App
+app.use("/", new REHandler)
+app.listen(config.app_host, config.app_port)

--- a/contrib/re_parser/src/re_parser.nit
+++ b/contrib/re_parser/src/re_parser.nit
@@ -1,0 +1,216 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module re_parser
+
+import nitcc::autom
+import re_parser_lexer
+import re_parser_parser
+
+# Parse regular expression into NFA
+#
+# ~~~
+# # Parse the regular expression
+# var re = "(a|b)*"
+# var re_parser = new REParser
+# var node = re_parser.parse_re(re)
+#
+# # Check syntax errors
+# assert node != null else
+#	print re_parser.last_error.as(not null)
+# end
+#
+# # Build nfa and dfa
+# var nfa = re_parser.make_nfa(node)
+# print nfa.to_dot
+# print nfa.to_dfa.to_dot
+# ~~~
+class REParser
+
+	# Parse the regular expression `re` and return the root production node.
+	#
+	# Returns `null` in case of syntax error. See `last_error`.
+	#
+	# ~~~
+	# var re_parser = new REParser
+	#
+	# # Valid regular expression
+	# assert re_parser.parse_re("(a|b)*") != null
+	# assert re_parser.last_error == null
+	#
+	# # Invalid regular expression
+	# assert re_parser.parse_re("a|b)*") == null
+	# assert re_parser.last_error != null
+	# ~~~
+	fun parse_re(re: String): nullable NProd do
+		var l = new Lexer_re_parser(re)
+		var ts = l.lex
+
+		var p = new Parser_re_parser
+		p.tokens.add_all ts
+
+		var node = p.parse
+
+		if not node isa NProd then
+			if node isa NError then
+				last_error = "{node.position.as(not null).to_s} Syntax Error: {node.message}"
+			else
+				last_error = "Parsing Error: expected `NProd` got `{node.class_name}`"
+			end
+			return null
+		end
+		last_error = null
+		return node
+	end
+
+	# Contains the error from the last call to `parse_re` or null if no error
+	#
+	# ~~~
+	# var re_parser = new REParser
+	#
+	# # Invalid regular expression
+	# assert re_parser.parse_re("a|b)*") == null
+	# assert re_parser.last_error != null
+	# ~~~
+	var last_error: nullable String
+
+	# Build the NFA for `node`
+	#
+	# Use `parse_re` to transform a re string into a NProd.
+	fun make_nfa(node: NProd): Automaton do
+		var v = new REVisitor
+		v.start(node)
+		return v.nfa
+	end
+end
+
+class REVisitor
+	super Visitor
+
+	var nfa = new Automaton
+
+	fun start(n: Node) do
+		enter_visit(n)
+	end
+
+	redef fun visit(n) do n.accept_revisitor(self)
+end
+
+redef class Node
+	fun accept_revisitor(v: REVisitor) do visit_children(v)
+
+	# Build the NFA of the regular expression
+	fun make_nfa: Automaton do
+		print inspect
+		abort
+	end
+end
+
+redef class Nre
+	redef fun accept_revisitor(v) do
+		v.nfa = make_nfa
+	end
+
+	redef fun make_nfa do
+		var a = new Automaton
+		for child in children do
+			if child == null then continue
+			a.concat(child.make_nfa)
+		end
+		return a
+	end
+end
+
+redef class Nre_char
+	redef fun make_nfa do
+		return new Automaton.atom(n_char.text.chars.first.code_point)
+	end
+end
+
+redef class Nre_alter
+	redef fun make_nfa
+	do
+		var a = n_re.make_nfa
+		var b = n_re2.make_nfa
+		a.alternate(b)
+		return a
+	end
+end
+
+redef class Nre_conc
+	redef fun make_nfa
+	do
+		var a = n_re.make_nfa
+		var b = n_re2.make_nfa
+		a.concat(b)
+		return a
+	end
+end
+
+redef class Nre_star
+	redef fun make_nfa
+	do
+		var a = n_re.make_nfa
+		a.close
+		return a
+	end
+end
+
+redef class Nre_ques
+	redef fun make_nfa
+	do
+		var a = n_re.make_nfa
+		a.optionnal
+		return a
+	end
+end
+
+redef class Nre_plus
+	redef fun make_nfa
+	do
+		var a = n_re.make_nfa
+		a.plus
+		return a
+	end
+end
+
+redef class Nre_par
+	redef fun make_nfa
+	do
+		return n_re.make_nfa
+	end
+end
+
+# Parse arguments
+if args.is_empty then
+	print "usage: re_parser <re>"
+	exit 1
+end
+var re = args.first
+
+# Parse re
+var re_parser = new REParser
+var node = re_parser.parse_re(re)
+
+if node == null then
+	print re_parser.last_error.as(not null)
+	exit 1
+	abort
+end
+
+# Build nfa and dfa
+var nfa = re_parser.make_nfa(node)
+nfa.to_dot(false).write_to_file("nfa.dot")
+nfa.to_dfa.to_dot(false).write_to_file("dfa.dot")
+print "Produced files `nfa.dot` and `dfa.dot`"

--- a/contrib/re_parser/src/re_parser.sablecc
+++ b/contrib/re_parser/src/re_parser.sablecc
@@ -1,0 +1,25 @@
+Grammar re_parser;
+
+Lexer
+
+// A printable character (inside strings)
+char = ' ' ...;
+
+// Igndored stufs
+blank = ' ';
+
+Parser
+
+Ignored blank;
+
+re =
+	{char:} char	|
+	{par:} '(' re ')'
+Unary
+	{ques:} re '?' |
+	{star:} re '*' |
+	{plus:} re '+'
+Left
+	{conc:} re re
+Left
+	{alter:} re '|' re;


### PR DESCRIPTION
# RE Parser

RE parser provides a simple API to regular expression parsing.
It is also able to convert a regular expression into a NFA or a DFA and produce dot files from it.

## Building RE parser

From the `re_parser` directory:

~~~bash
make all
~~~

## RE parser in command line

RE parser can be used as a command line tool to generate NFA and DFA dot files from a regular expression:

~~~bash
./re_parser "a(b|c)+d*"
~~~

Will produce the two files `nfa.dot` and `dfa.dot`.

These can be directly viwed with `xdot`:

~~~bash
xdot nfa.dot
xdot dfa.dot
~~~

Or translated to png images with `dot`:

~~~bash
dot -Tpng -onfa.png nfa.dot
dot -Tpng -odfa.png dfa.dot
~~~

See `man dot` for available formats.

## RE parser as a web app

RE parser comes with a web app that allow users to submit regular expression and see the resulting NFA and DFA.

To run the web app server:

~~~bash
./re_app --host localhost --port 3000
~~~

The server will be available at <a href='http://localhost:3000'>http://localhost:3000</a>.

## RE parser as a library

You can also use RE parser as a library by importing `re_parser`.

~~~nit
	import re_parser

	var re = "a(b|c)+d*"

	# Parse the expression
	var l = new Lexer_re_parser(re)
	var p = new Parser_re_parser
	p.tokens.add_all l.lex
	var node = p.parse

	# Check errors
	if not node isa NProd then
		print "Error parsing the regular expression"
		abort
	end

	# Get NFA and DFA
	var v = new REVisitor
	v.start(node)
	print v.nfa.to_dot
	print v.nfa.to_dfa.to_dot
~~~

Web app demo: http://re.moz-code.org/