### PR TITLE
gamnit: use SDL2 windows and events

### DIFF
--- a/contrib/model_viewer/src/model_viewer.nit
+++ b/contrib/model_viewer/src/model_viewer.nit
@@ -128,7 +128,7 @@ redef class App
 			else if event.is_arrow_left then
 				cycle_model -1
 			end
-		else if event isa PointerEvent and event.depressed then
+		else if event isa PointerEvent and not event.is_move and event.depressed then
 			if event.x.to_i > display.width / 2 then
 				cycle_model 1
 			else cycle_model -1

--- a/lib/app/audio.nit
+++ b/lib/app/audio.nit
@@ -41,16 +41,16 @@ abstract class PlayableAudio
 	protected var is_loaded = false is writable
 
 	# Load this playable audio
-	fun load is abstract
+	fun load do end
 
 	# Play the sound
-	fun play is abstract
+	fun play do end
 
 	# Pause the sound
-	fun pause is abstract
+	fun pause do end
 
 	# Resume the sound
-	fun resume is abstract
+	fun resume do end
 end
 
 # Short sound

--- a/lib/core/kernel.nit
+++ b/lib/core/kernel.nit
@@ -1061,6 +1061,13 @@ extern class Pointer
 
 	# Free the memory pointed by this pointer
 	fun free `{ free(self); `}
+
+	# Use the address value
+	redef fun hash `{ return (long)self; `}
+
+	# Is equal to any instance pointing to the same address
+	redef fun ==(o) do return o isa Pointer and native_equals(o)
+	private fun native_equals(o: Pointer): Bool `{ return self == o; `}
 end
 
 # Task with a `main` method to be implemented by subclasses

--- a/lib/egl.nit
+++ b/lib/egl.nit
@@ -42,12 +42,7 @@ extern class EGLDisplay `{ EGLDisplay `}
 	fun is_valid: Bool `{ return self != EGL_NO_DISPLAY; `}
 
 	fun initialize: Bool `{
-		EGLBoolean r = eglInitialize(self, NULL, NULL);
-		if (r == EGL_FALSE) {
-			fprintf(stderr, "Unable to eglInitialize");
-			return 0;
-		}
-		return 1;
+		return eglInitialize(self, NULL, NULL);
 	`}
 
 	fun major_version: Int `{
@@ -88,7 +83,7 @@ extern class EGLDisplay `{ EGLDisplay `}
 		}
 
 		configs = (EGLConfig*)malloc(sizeof(EGLConfig)*n_configs);
- 
+
 		r = eglChooseConfig(self, c_attribs, configs, n_configs, &n_configs);
 
 		if (r == EGL_FALSE) {
@@ -136,11 +131,7 @@ extern class EGLDisplay `{ EGLDisplay `}
 	`}
 
 	fun make_current(draw, read: EGLSurface, context: EGLContext): Bool `{
-		if (eglMakeCurrent(self, draw, read, context) == EGL_FALSE) {
-			fprintf(stderr, "Unable to eglMakeCurrent");
-			return 0;
-		}
-		return 1;
+		return eglMakeCurrent(self, draw, read, context);
 	`}
 
 	# Can be used directly, but it is preferable to use a `EGLSurfaceAttribs`
@@ -181,7 +172,7 @@ extern class EGLDisplay `{ EGLDisplay `}
 
 	fun version: String do return query_string(0x3054)
 
-	fun extensions: Array[String] do return query_string(0x3055).split_with(" ")
+	fun extensions: Array[String] do return query_string(0x3055).trim.split_with(" ")
 
 	fun client_apis: Array[String] do return query_string(0x308D).split_with(" ")
 

--- a/lib/gamnit/README.md
+++ b/lib/gamnit/README.md
@@ -9,7 +9,13 @@ To compile the _gamnit_ apps packaged with the Nit repositoy on GNU/Linux you ne
 Under Debian 8.2, this command should install everything needed:
 
 ~~~
-apt-get install libgles2-mesa-dev libsdl1.2-dev libsdl-image1.2-dev libsdl-ttf2.0-dev inkscape mpg123
+apt-get install libgles2-mesa-dev libsdl2-dev libsdl2-image-dev inkscape mpg123
+~~~
+
+Under Windows 64 bits, using msys2, you can install the required packages with:
+
+~~~
+pacman -S mingw-w64-x86_64-angleproject-git mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_image
 ~~~
 
 # Services by submodules

--- a/lib/gamnit/depth/particles.nit
+++ b/lib/gamnit/depth/particles.nit
@@ -252,12 +252,12 @@ class ParticleProgram
 		uniform bool use_texture;
 
 		// Texture to apply on this particle
-		uniform sampler2D texture;
+		uniform sampler2D texture0;
 
 		void main()
 		{
 			if (use_texture) {
-				gl_FragColor = texture2D(texture, gl_PointCoord) * v_color;
+				gl_FragColor = texture2D(texture0, gl_PointCoord) * v_color;
 				if (gl_FragColor.a <= 0.01) discard;
 			} else {
 				gl_FragColor = v_color;
@@ -272,7 +272,7 @@ class ParticleProgram
 	var use_texture = uniforms["use_texture"].as(UniformBool) is lazy
 
 	# Visible texture unit
-	var texture = uniforms["texture"].as(UniformSampler2D) is lazy
+	var texture = uniforms["texture0"].as(UniformSampler2D) is lazy
 
 	# Color tint per vertex
 	var color = attributes["color"].as(AttributeVec4) is lazy

--- a/lib/gamnit/display_linux.nit
+++ b/lib/gamnit/display_linux.nit
@@ -15,8 +15,7 @@
 # Gamnit display implementation for GNU/Linux using `egl`, `sdl` and `x11`
 module display_linux
 
-import sdl
-import x11
+import sdl2::image
 
 import egl # local to gamnit
 intrude import display
@@ -32,24 +31,22 @@ redef class GamnitDisplay
 	fun height=(value: Int) do requested_height = value
 	private var requested_height = 1080
 
-	redef fun show_cursor do return sdl_display.show_cursor
+	redef fun show_cursor do return sdl.show_cursor
 
-	redef fun show_cursor=(val) do sdl_display.show_cursor = val
+	redef fun show_cursor=(val) do sdl.show_cursor = val
 
-	# Setup SDL, X11, EGL in order
+	# Setup SDL, wm, EGL in order
 	redef fun setup
 	do
 		if debug_gamnit then print "Setting up SDL"
-		self.sdl_display = setup_sdl(requested_width, requested_height)
+		self.sdl_window = setup_sdl(requested_width, requested_height)
 
-		if debug_gamnit then print "Setting up X11"
-		var x11_display = setup_x11
-		var window_handle = window_handle
-		setup_egl_display x11_display
+		if debug_gamnit then print "Setting up window manager"
+		setup_egl_display sdl_window.wm_info.display_handle
 
 		if debug_gamnit then print "Setting up EGL context"
 		select_egl_config(red_bits, green_bits, blue_bits, 8, 8, 0, 0)
-		setup_egl_context window_handle
+		setup_egl_context sdl_window.wm_info.window_handle
 	end
 
 	# Close EGL and SDL in reverse order of `setup` (nothing to do for X11)
@@ -63,55 +60,52 @@ redef class GamnitDisplay
 	# SDL
 
 	# The SDL display managing the window and events
-	var sdl_display: SDLDisplay is noautoinit
+	var sdl_window: SDLWindow is noautoinit
+
+	# Title of the window, must be set before creating the window (or redef)
+	var window_title = "gamnit game" is lazy, writable
 
 	# Setup the SDL display and lib
-	fun setup_sdl(window_width, window_height: Int): SDLDisplay
+	fun setup_sdl(window_width, window_height: Int): SDLWindow
 	do
-		var sdl_display = new SDLDisplay(window_width, window_height)
-		assert not sdl_display.address_is_null else print "Opening SDL display failed"
-		return sdl_display
+		assert sdl.initialize((new SDLInitFlags).video) else
+			print_error "Failed to initialize SDL2: {sdl.error}"
+		end
+
+		var img_flags = (new SDLImgInitFlags).png.jpg
+		assert sdl.img.initialize(img_flags) == img_flags else
+			print_error "Failed to initialize SDL2 IMG: {sdl.error}"
+		end
+
+		var sdl_window = new SDLWindow(window_title.to_cstring, window_width, window_height, (new SDLWindowFlags).opengl)
+		assert not sdl_window.address_is_null else
+			print_error "Failed to create SDL2 window: {sdl.error}"
+		end
+
+		return sdl_window
 	end
 
 	# Close the SDL display
-	fun close_sdl do sdl_display.destroy
-
-	# Get a native handle to the current SDL window
-	fun window_handle: Pointer
-	do
-		var sdl_wm_info = new SDLSystemWindowManagerInfo
-		return sdl_wm_info.x11_window_handle
-	end
-
-	# ---
-	# X11
-
-	# Get a native handle to the current X11 display
-	fun setup_x11: Pointer
-	do
-		var x11_display = x_open_default_display
-		assert not x11_display.address_is_null else print "Opening X11 display failed"
-		return x11_display
-	end
+	fun close_sdl do sdl_window.destroy
 end
 
 redef class TextureAsset
 
 	redef fun load_from_platform
 	do
-		var path = "assets" / path # TODO use app.assets_dir
-		var sdl_tex = new SDLImage.from_file(path)
+		var path = "assets" / path
 
-		if sdl_tex.address_is_null then
+		var surface = new SDLSurface.load(path.to_cstring)
+		if surface.address_is_null then
 			error = new Error("Failed to load texture at '{path}'")
 			return
 		end
 
-		self.width = sdl_tex.width.to_f
-		self.height = sdl_tex.height.to_f
-		var format = if sdl_tex.amask > 0 then gl_RGBA else gl_RGB
-		var pixels = sdl_tex.pixels
+		self.width = surface.w.to_f
+		self.height = surface.h.to_f
+		var format = if surface.format.amask > 0u32 then gl_RGBA else gl_RGB
+		var pixels = surface.pixels
 
-		load_from_pixels(pixels, sdl_tex.width, sdl_tex.height, format)
+		load_from_pixels(pixels, surface.w, surface.h, format)
 	end
 end

--- a/lib/gamnit/egl.nit
+++ b/lib/gamnit/egl.nit
@@ -33,10 +33,10 @@ redef class GamnitDisplay
 	# The selected EGL configuration
 	var egl_config: EGLConfig is noautoinit
 
-	# Setup the EGL display for the given `x11_display`
-	protected fun setup_egl_display(x11_display: Pointer)
+	# Setup the EGL display for the given `native_display`
+	protected fun setup_egl_display(native_display: Pointer)
 	do
-		var egl_display = new EGLDisplay(x11_display)
+		var egl_display = new EGLDisplay(native_display)
 		assert egl_display.is_valid else print "new EGL display is not valid"
 
 		egl_display.initialize
@@ -79,10 +79,10 @@ redef class GamnitDisplay
 		self.egl_config = configs.first
 	end
 
-	# Setup the EGL context for the given `window_handle`
-	protected fun setup_egl_context(window_handle: Pointer)
+	# Setup the EGL context for the given `native_window`
+	protected fun setup_egl_context(native_window: Pointer)
 	do
-		var window_surface = egl_display.create_window_surface(egl_config, window_handle, [0])
+		var window_surface = egl_display.create_window_surface(egl_config, native_window, [0])
 		assert window_surface.is_ok else print "Creating EGL window surface failed: {egl_display.error}"
 		self.window_surface = window_surface
 

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -361,7 +361,7 @@ class Simple2dProgram
 		uniform bool use_texture;
 
 		// Texture to apply on this object
-		uniform sampler2D texture;
+		uniform sampler2D texture0;
 
 		// Input from the vertex shader
 		varying vec4 v_color;
@@ -370,7 +370,7 @@ class Simple2dProgram
 		void main()
 		{
 			if(use_texture) {
-				gl_FragColor = v_color * texture2D(texture, v_coord);
+				gl_FragColor = v_color * texture2D(texture0, v_coord);
 				if (gl_FragColor.a == 0.0) discard;
 			} else {
 				gl_FragColor = v_color;
@@ -385,7 +385,7 @@ class Simple2dProgram
 	var use_texture = uniforms["use_texture"].as(UniformBool) is lazy
 
 	# Visible texture unit
-	var texture = uniforms["texture"].as(UniformSampler2D) is lazy
+	var texture = uniforms["texture0"].as(UniformSampler2D) is lazy
 
 	# Coordinates on the textures, per vertex
 	var tex_coord = attributes["tex_coord"].as(AttributeVec2) is lazy

--- a/lib/gamnit/gamnit.nit
+++ b/lib/gamnit/gamnit.nit
@@ -68,13 +68,14 @@ redef class App
 	# The implementation varies per platform.
 	private fun feed_events do end
 
-	# Main method to receive `InputEvent` produced by the system
+	# Hook to receive and respond to `event` triggered by the user or system
 	#
 	# Returns whether or not the event is used or intercepted.
 	# If `true`, the event will not be processed further by the system.
 	# Returns `false` to intercepts events like the back key on mobile devices.
 	#
-	# This method should be refined by client modules to react to user inputs.
+	# The instances passed as `event` may be freed (or overwritten),
+	# right after this method returns. They should not be preserved.
 	fun accept_event(event: InputEvent): Bool do return false
 end
 

--- a/lib/gamnit/gamnit_linux.nit
+++ b/lib/gamnit/gamnit_linux.nit
@@ -15,31 +15,118 @@
 # Support services for Gamnit on GNU/Linux
 module gamnit_linux
 
+import sdl2::events
+
 intrude import gamnit
-import display_linux
 
 redef class App
+	private var sdl_event_buffer = new SDLEventBuffer.malloc
+
 	redef fun feed_events
 	do
 		var display = display
 		if display == null then return
 
-		var events = display.sdl_display.events
-		display.check_lock_cursor
-		for event in events do accept_event(event)
+		loop
+			var avail = sdl_event_buffer.poll_event
+			if not avail then break
+
+			# Convert to an SDL event with data
+			var sdl_event = sdl_event_buffer.to_event
+			# Convert to `mnit::inputs` conforming objects
+			var gamnit_event = sdl_event.to_gamnit_event(sdl_event_buffer)
+			accept_event gamnit_event
+		end
 	end
 end
 
-redef class GamnitDisplay
+# ---
+# Redef services from `sdl2::events`
 
-	# HACK to keep the cursor in the center of the screen without producing move events
-	private fun check_lock_cursor
+redef class SDLEvent
+	private fun to_gamnit_event(buffer: SDLEventBuffer): GamnitInputEvent
+	do return new GamnitOtherEvent(buffer, self)
+end
+
+redef class SDLQuitEvent
+	redef fun to_gamnit_event(buffer) do return new GamnitQuitEvent(buffer, self)
+end
+
+redef class SDLMouseEvent
+	redef fun to_gamnit_event(buffer) do return new GamnitPointerEvent(buffer, self)
+end
+
+redef class SDLKeyboardEvent
+	redef fun to_gamnit_event(buffer) do return new GamnitKeyEvent(buffer, self)
+end
+
+# ---
+# Implement `mnit::inputs` interfaces
+
+# SDL2 event wrapper implementing the `mnit::input` API
+#
+# There is two views to the underlying native object: `buffer` and `native`.
+class GamnitInputEvent
+	super InputEvent
+
+	# Native SDL 2 event buffer with the pseudo class hierarchy metadata
+	var buffer: SDLEventBuffer
+
+	# Native SDL 2 event
+	var native: NATIVE
+
+	# Type of the `native` underlying SDL 2 event
+	type NATIVE: SDLEvent
+end
+
+# Event on user requested quit
+class GamnitQuitEvent
+	super GamnitInputEvent
+	super QuitEvent
+
+	redef type NATIVE: SDLQuitEvent
+end
+
+# Event on keyboard input
+class GamnitKeyEvent
+	super GamnitInputEvent
+	super KeyEvent
+
+	redef type NATIVE: SDLKeyboardEvent
+
+	redef fun is_down do return buffer.is_keydown
+	redef fun is_up do return buffer.is_keyup
+	redef fun is_arrow_up do return native.keysym.is_up
+	redef fun is_arrow_left do return native.keysym.is_left
+	redef fun is_arrow_down do return native.keysym.is_down
+	redef fun is_arrow_right do return native.keysym.is_right
+	redef fun to_c do return native.to_s.chars.first
+	redef fun name do return native.to_s.to_lower
+end
+
+# Event on pointer, mouse and finger input
+class GamnitPointerEvent
+	super GamnitInputEvent
+	super PointerEvent
+
+	redef type NATIVE: SDLMouseEvent
+
+	redef fun x do return native.x.to_f
+	redef fun y do return native.y.to_f
+	redef fun is_move do return buffer.is_mouse_motion
+
+	redef fun pressed
 	do
-		var sdl_display = sdl_display
-		if lock_cursor and sdl_display.input_focus then
-			sdl_display.ignore_mouse_motion_events = true
-			sdl_display.warp_mouse(width/2, height/2)
-			sdl_display.ignore_mouse_motion_events = false
-		end
+		var native = native
+		if native isa SDLMouseButtonEvent then
+			return native.pressed and native.button == 1
+		else if native isa SDLMouseMotionEvent then
+			return native.state & 1 == 1
+		else abort
 	end
+end
+
+# SDL2 event not handled by gamnit
+class GamnitOtherEvent
+	super GamnitInputEvent
 end

--- a/lib/glesv2/examples/opengles2_hello_triangle.nit
+++ b/lib/glesv2/examples/opengles2_hello_triangle.nit
@@ -14,16 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Basic example of OpenGL ES 2.0 usage from the book OpenGL ES 2.0 Programming Guide.
+# Basic example of OpenGL ES 2.0 usage using SDL 2
 #
-# Code reference:
+# From the book OpenGL ES 2.0 Programming Guide, see code reference:
 # https://code.google.com/p/opengles-book-samples/source/browse/trunk/LinuxX11/Chapter_2/Hello_Triangle/Hello_Triangle.c
 module opengles2_hello_triangle
 
 import glesv2
 import egl
-import sdl
-import x11
+import sdl2
 
 import realtime
 
@@ -33,22 +32,24 @@ var window_width = 800
 var window_height = 600
 
 #
-## SDL
+## SDL2
 #
-var sdl_display = new SDLDisplay(window_width, window_height)
-var sdl_wm_info = new SDLSystemWindowManagerInfo
-var x11_window_handle = sdl_wm_info.x11_window_handle
+assert sdl.initialize((new SDLInitFlags).video) else
+	print sdl.error
+end
 
-#
-## X11
-#
-var x_display = x_open_default_display
-assert x_display != 0 else print "x11 fail"
+var sdl_window = new SDLWindow("Title".to_cstring, window_width, window_height, (new SDLWindowFlags).opengl)
+assert not sdl_window.address_is_null else print sdl.error
+
+var sdl_wm_info = sdl_window.wm_info
+var native_window = sdl_wm_info.window_handle
+var native_display = sdl_wm_info.display_handle
+assert not native_display.address_is_null else print "Failed to get handle to native display"
 
 #
 ## EGL
 #
-var egl_display = new EGLDisplay(x_display)
+var egl_display = new EGLDisplay(native_display)
 assert egl_display.is_valid else print "EGL display is not valid"
 
 egl_display.initialize
@@ -85,7 +86,7 @@ end
 
 var config = configs.first
 
-var surface = egl_display.create_window_surface(config, x11_window_handle, [0])
+var surface = egl_display.create_window_surface(config, native_window, [0])
 assert surface.is_ok else print egl_display.error
 
 var context = egl_display.create_context(config)
@@ -194,7 +195,7 @@ egl_display.destroy_context context
 egl_display.destroy_surface surface
 
 #
-## SDL
+## SDL2
 #
 # close
-sdl_display.destroy
+sdl.quit

--- a/lib/linux/audio.nit
+++ b/lib/linux/audio.nit
@@ -20,22 +20,7 @@ module audio
 import app::audio
 import linux
 
-redef class Sound
-
-	redef fun play do
-		if path.has_suffix(".wav") then
-			sys.system "aplay -q {app.assets_dir}{path} &"
-		else if path.has_suffix(".mp3") then
-			sys.system "mpg123 -q {app.assets_dir}{path} &"
-		end
-	end
-
-	redef fun load do end
-	redef fun pause do end
-	redef fun resume do end
-end
-
-redef class Music
+redef class PlayableAudio
 
 	redef fun play do
 		if path.has_suffix(".wav") then

--- a/lib/sdl2/events.nit
+++ b/lib/sdl2/events.nit
@@ -23,7 +23,7 @@ in "C Header" `{
 	#include <SDL2/SDL_events.h>
 `}
 
-# A temporary buffer for a SDL 2 event
+# Temporary buffer for an SDL 2 event exposing the pseudo-class hierarchy metadata
 #
 # An instance of this class should be used to call `poll_event` and `to_event`.
 extern class SDLEventBuffer `{SDL_Event *`}
@@ -41,46 +41,71 @@ extern class SDLEventBuffer `{SDL_Event *`}
 	#
 	# Note: The returned `SDLEvent` is just a different Nit instance pointing to the same data.
 	# A call to `poll_event` will invalidate any instances returned previously by `to_event`.
-	#
-	# TODO remove `nullable` from the return type once all cases are correctly handled.
-	fun to_event: nullable SDLEvent
+	fun to_event: SDLEvent
 	do
 		if is_quit then return to_quit
 		if is_mouse_motion then return to_mouse_motion
 		if is_mouse_button_down then return to_mouse_button_down
 		if is_mouse_button_up then return to_mouse_button_up
-		return null
+		if is_keydown then return to_keydown
+		if is_keyup then return to_keyup
+		return to_event_direct
 	end
+
+	private fun to_event_direct: SDLEvent `{ return self; `}
 
 	# Is this a quit event?
 	fun is_quit: Bool `{ return self->type == SDL_QUIT; `}
 
 	# Get a reference to data at `self` as a `SDLQuitEvent`
+	#
+	# Require: `is_quit`
 	fun to_quit: SDLQuitEvent `{ return self; `}
 
 	# Is this a mouse motion event?
 	fun is_mouse_motion: Bool `{ return self->type == SDL_MOUSEMOTION; `}
 
 	# Get a reference to data at `self` as a `SDLMouseMotionEvent`
+	#
+	# Require: `is_mouse_motion`
 	fun to_mouse_motion: SDLMouseMotionEvent `{ return self; `}
 
 	# Is this a mouse button down event?
 	fun is_mouse_button_down: Bool `{ return self->type == SDL_MOUSEBUTTONDOWN; `}
 
 	# Get a reference to data at `self` as a `SDLMouseButtonDownEvent`
+	#
+	# Require: `is_mouse_button_down`
 	fun to_mouse_button_down: SDLMouseButtonDownEvent `{ return self; `}
 
 	# Is this a mouse button up event?
 	fun is_mouse_button_up: Bool `{ return self->type == SDL_MOUSEBUTTONUP; `}
 
 	# Get a reference to data at `self` as a `SDLMouseButtonUpEvent`
+	#
+	# Require: `is_mouse_button_up`
 	fun to_mouse_button_up: SDLMouseButtonUpEvent `{ return self; `}
+
+	# Is this a key presse event?
+	fun is_keydown: Bool `{ return self->type == SDL_KEYDOWN; `}
+
+	# Get a reference to data at `self` as a `SDLKeyboardDownEvent`
+	#
+	# Require: `is_keydown`
+	fun to_keydown: SDLKeyboardDownEvent `{ return self; `}
+
+	#  Is this a key release event?
+	fun is_keyup: Bool `{ return self->type == SDL_KEYUP; `}
+
+	# Get a reference to data at `self` as a `SDLKeyboardUpEvent`
+	#
+	# Require: `is_keyup`
+	fun to_keyup: SDLKeyboardUpEvent `{ return self; `}
 
 	# TODO other SDL events:
 	#
 	# SDL_CommonEvent common
 	# SDL_WindowEvent window
-	# SDL_KeyboardEvent key
 	# SDL_TextEditingEvent edit
 	# SDL_TextInputEvent text
 	# SDL_MouseWheelEvent wheel
@@ -92,7 +117,6 @@ extern class SDLEventBuffer `{SDL_Event *`}
 	# SDL_ControllerAxisEvent caxis
 	# SDL_ControllerButtonEvent cbutton
 	# SDL_ControllerDeviceEvent cdevice
-	# SDL_QuitEvent quit
 	# SDL_UserEvent user
 	# SDL_SysWMEvent syswm
 	# SDL_TouchFingerEvent tfinger
@@ -101,16 +125,16 @@ extern class SDLEventBuffer `{SDL_Event *`}
 	# SDL_DropEvent drop
 end
 
-# An event from SDL 2
+# SDL 2 event, only the data and no metadata
 extern class SDLEvent `{SDL_Event *`}
 end
 
-# A quit event, usually from the close window button
+# Quit event, usually from the close window button
 extern class SDLQuitEvent
 	super SDLEvent
 end
 
-# A mouse event
+# Mouse event
 extern class SDLMouseEvent
 	super SDLEvent
 
@@ -121,17 +145,30 @@ extern class SDLMouseEvent
 
 	# Which mouse, pointer or finger raised this event
 	fun which: Int `{ return self->motion.which; `}
+
+	# X coordinate on screen of this event
+	fun x: Int is abstract
+
+	# Y coordinate on screen of this event
+	fun y: Int is abstract
 end
 
-# A mouse motion event
+# Mouse motion event
 extern class SDLMouseMotionEvent
 	super SDLMouseEvent
 
-	# X coordinate on screen of this event
-	fun x: Int `{ return self->motion.x; `}
+	redef fun x `{ return self->motion.x; `}
 
-	# Y coordinate on screen of this event
-	fun y: Int `{ return self->motion.y; `}
+	redef fun y `{ return self->motion.y; `}
+
+	# State of the buttons
+	#
+	# ~~~raw
+	# state & 1 == 1 -> left button down
+	# state & 2 == 2 -> middle button down
+	# state & 4 == 4 -> right button down
+	# ~~~
+	fun state: Int `{ return self->motion.state; `}
 
 	# Difference on the X axis between this event and the previous one
 	fun xrel: Int `{ return self->motion.xrel; `}
@@ -140,26 +177,84 @@ extern class SDLMouseMotionEvent
 	fun yrel: Int `{ return self->motion.yrel; `}
 end
 
-# A mouse button event
+# Mouse button event
 #
 # This could as well be an abstract class. All instances of `SDLMouseButtonEvent`
 # is either a `SDLMouseButtonUpEvent` or a `SDLMouseButtonDownEvent`.
 extern class SDLMouseButtonEvent
 	super SDLMouseEvent
 
-	# X coordinate on screen of this event
-	fun x: Int `{ return self->button.x; `}
+	# Index of the button
+	#
+	# ~~~raw
+	# 1 -> left button
+	# 2 -> center button
+	# 3 -> right button
+	# ~~~
+	fun button: Int `{ return self->button.button; `}
 
-	# Y coordinate on screen of this event
-	fun y: Int `{ return self->button.y; `}
+	# Is the button currently pressed down?
+	fun pressed: Bool `{ return self->button.state == SDL_PRESSED; `}
+
+	# Number of clicks (1 or 2)
+	fun clicks: Int `{ return self->button.clicks; `}
+
+	redef fun x `{ return self->button.x; `}
+
+	redef fun y `{ return self->button.y; `}
 end
 
-# A mouse button release event
+# Mouse button release event
 extern class SDLMouseButtonUpEvent
 	super SDLMouseButtonEvent
 end
 
-# A mouse button click event
+# Mouse button click event
 extern class SDLMouseButtonDownEvent
 	super SDLMouseButtonEvent
+end
+
+# Keyboard button event
+extern class SDLKeyboardEvent
+	super SDLEvent
+
+	# Is this is a key repeat?
+	fun repeat: Bool `{ return self->key.repeat; `}
+
+	# The key that was pressed or released
+	fun keysym: SDLKeysym `{ return &self->key.keysym; `}
+
+	redef fun to_s do return native_to_s.to_s
+	private fun native_to_s: CString `{
+		return (char*)SDL_GetKeyName(self->key.keysym.sym);
+	`}
+end
+
+# Keyboard button release event
+extern class SDLKeyboardUpEvent
+	super SDLKeyboardEvent
+end
+
+# Keyboard button click event
+extern class SDLKeyboardDownEvent
+	super SDLKeyboardEvent
+end
+
+# Key information
+extern class SDLKeysym `{ SDL_Keysym * `}
+	# Is this the arrow right key?
+	fun is_right: Bool `{ return self->sym == SDLK_RIGHT; `}
+
+	# Is this the arrow left key?
+	fun is_left: Bool `{ return self->sym == SDLK_LEFT; `}
+
+	# Is this the arrow down key?
+	fun is_down: Bool `{ return self->sym == SDLK_DOWN; `}
+
+	# Is this the arrow up key?
+	fun is_up: Bool `{ return self->sym == SDLK_UP; `}
+
+	# Modification keys
+	fun mod: Int `{ return self->mod; `}
+	# TODO related masks
 end

--- a/lib/sdl2/image.nit
+++ b/lib/sdl2/image.nit
@@ -60,7 +60,7 @@ redef extern class SDLSurface
 end
 
 # Flags from `sys.sdl.img.initialize`
-extern class SDLImgInitFlags `{ int `}
+extern class SDLImgInitFlags `{ IMG_InitFlags `}
 	# Get the default empty flag set
 	new `{ return 0; `}
 

--- a/lib/sdl2/sdl2_base.nit
+++ b/lib/sdl2/sdl2_base.nit
@@ -76,6 +76,25 @@ class SDL
 	# This method should not normally be used, refer to the SDL source code
 	# before use.
 	fun set_main_ready `{ SDL_SetMainReady(); `}
+
+	# Show or hide the cursor
+	fun show_cursor=(val: Bool) `{ SDL_ShowCursor(val? SDL_ENABLE: SDL_DISABLE); `}
+
+	# Is the cursor visible?
+	fun show_cursor: Bool `{ return SDL_ShowCursor(SDL_QUERY); `}
+
+	# Collect only relative mouse events and hide cursor
+	#
+	# Check `relative_mouse_mode` to see if the mode could be applied,
+	# if not, see `error`.
+	fun relative_mouse_mode=(value: Bool) `{
+		SDL_SetRelativeMouseMode(value);
+	`}
+
+	# Hide cursor and collect only relative mouse events?
+	fun relative_mouse_mode: Bool `{
+		return SDL_GetRelativeMouseMode();
+	`}
 end
 
 # Flags for `sys.sdl.initialize` and related methods
@@ -385,6 +404,42 @@ extern class SDLSurface `{ SDL_Surface * `}
 
 	# Save this texture to a BMP file
 	fun save_bmp(path: CString) `{ SDL_SaveBMP(self, path); `}
+
+	# Format of the pixels
+	fun format: SDL_PixelFormat `{ return self->format; `}
+
+	# Width in pixels
+	fun w: Int `{ return self->w; `}
+
+	# Height in pixels
+	fun h: Int `{ return self->h; `}
+
+	# Bytes in a row of pixels
+	fun pitch: Int `{ return self->pitch; `}
+
+	# Pointer to pixel data
+	fun pixels: Pointer `{ return self->pixels; `}
+end
+
+# Pixel format information
+extern class SDL_PixelFormat `{ SDL_PixelFormat * `}
+	# Number of significant bits in a pixel
+	fun bits_per_pixel: Int `{ return self->BitsPerPixel; `}
+
+	# Number of bytes required to hold a pixel
+	fun bytes_per_pixel: Int `{ return self->BytesPerPixel; `}
+
+	# Mask of the location of the red component
+	fun rmask: UInt32 `{ return self->Rmask; `}
+
+	# Mask of the location of the green component
+	fun gmask: UInt32 `{ return self->Gmask; `}
+
+	# Mask of the location of the blue component
+	fun bmask: UInt32 `{ return self->Bmask; `}
+
+	# Mask of the location of the alpha component
+	fun amask: UInt32 `{ return self->Amask; `}
 end
 
 # A loaded bitmap texture

--- a/lib/sdl2/sdl2_base.nit
+++ b/lib/sdl2/sdl2_base.nit
@@ -36,8 +36,8 @@ class SDL
 	# TODO make this private and only called through `sys.sdl`
 	init internal do end
 
-	# Initialize the given SDL `subsystems`
-	fun initialize(subsystems: SDLInitFlags): Bool `{ return SDL_Init(subsystems); `}
+	# Initialize the given SDL `subsystems`, returns `false` on error
+	fun initialize(subsystems: SDLInitFlags): Bool `{ return SDL_Init(subsystems) == 0; `}
 
 	# Returns the latest SDL error
 	#

--- a/lib/sdl2/syswm.nit
+++ b/lib/sdl2/syswm.nit
@@ -99,10 +99,21 @@ extern class SDLSysWMInfo `{ SDL_SysWMinfo * `}
 		#endif
 	`}
 
-	# Returns the handle of this window on a X11 window system
-	#
-	# Require: `is_x11`
-	fun x11_window_handle: Pointer `{
-		return (void*)self->info.x11.window;
+	# Handle to the window
+	fun window_handle: Pointer `{
+		#ifdef _WIN32
+			return (void*)self->info.win.window;
+		#else
+			return (void*)self->info.x11.window;
+		#endif
+	`}
+
+	# Handle to the display or device context
+	fun display_handle: Pointer `{
+		#ifdef _WIN32
+			return (void*)self->info.win.hdc;
+		#else
+			return (void*)self->info.x11.display;
+		#endif
 	`}
 end

--- a/tests/sav/error_class_glob.res
+++ b/tests/sav/error_class_glob.res
@@ -9,5 +9,5 @@
 ../lib/core/kernel.nit:601,1--705,3: Error: `kernel$Byte` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
 ../lib/core/kernel.nit:707,1--885,3: Error: `kernel$Int` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
 ../lib/core/kernel.nit:887,1--1055,3: Error: `kernel$Char` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
-../lib/core/kernel.nit:1057,1--1064,3: Error: `kernel$Pointer` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
-../lib/core/kernel.nit:1066,1--1075,3: Error: `kernel$Task` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
+../lib/core/kernel.nit:1057,1--1071,3: Error: `kernel$Pointer` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
+../lib/core/kernel.nit:1073,1--1082,3: Error: `kernel$Task` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?

--- a/tests/sav/nituml_args3.res
+++ b/tests/sav/nituml_args3.res
@@ -68,7 +68,7 @@ Char [
 Discrete -> Char [dir=back arrowtail=open style=dashed];
 
 Pointer [
- label = "{Pointer||+ address_is_null(): Bool\l+ free()\l}"
+ label = "{Pointer||+ address_is_null(): Bool\l+ free()\l- native_equals(o: Pointer): Bool\l}"
 ]
 Object -> Pointer [dir=back arrowtail=open style=dashed];
 


### PR DESCRIPTION
_gamnit_ update to use SDL2 instead of SDL1.2. This change brings better code portability and fixes a few known SDL1.2 limitations. This PR does not significantly change the API, asides from removing the workarounds for old limitations.

As support, this PR also:
* Adds more SDL2 events and surface services.
* Updates the `opengles1_hello_triangle` example to use SDL2 and make it compatible with ANGLE and Windows.
* Drops the _gamnit_ workarounds for the previously slow mouse move events and mouse wrap for FPS like controls.
* Fixes shader compatibility with some graphics card and driver.
* General cleanup for the `egl` module.