### PR TITLE
re_parser: add pre-build target in the Makefile

### DIFF
--- a/contrib/re_parser/Makefile
+++ b/contrib/re_parser/Makefile
@@ -4,6 +4,8 @@ NITUNIT=../../bin/nitunit
 
 all: re_parser re_app
 
+pre-build: grammar
+
 nitcc:
 	cd ../nitcc && make nitcc
 


### PR DESCRIPTION
Some automatic jenkins jobs expect that it this target exists, it can be
used to generate the missing .nit files

Signed-off-by: Jean Privat <jean@pryen.org>