### PR TITLE
nitweb: load catalog at startup instead of first page display

### DIFF
--- a/src/nitweb.nit
+++ b/src/nitweb.nit
@@ -63,6 +63,7 @@ private class NitwebPhase
 	do
 		var config = build_config(toolcontext, mainmodule)
 		config.model.nitdoc_md_processor = config.md_processor
+		config.build_catalog
 
 		var app = new App
 

--- a/src/web/api_catalog.nit
+++ b/src/web/api_catalog.nit
@@ -20,7 +20,12 @@ import catalog
 redef class NitwebConfig
 
 	# Catalog to pass to handlers.
-	var catalog: Catalog is lazy do
+	var catalog: Catalog is noinit
+
+	# Build the catalog
+	#
+	# This method should be called at nitweb startup.
+	fun build_catalog do
 		var catalog = new Catalog(modelbuilder)
 		for mpackage in model.mpackages do
 			catalog.deps.add_node(mpackage)
@@ -36,7 +41,7 @@ redef class NitwebConfig
 			catalog.git_info(mpackage)
 			catalog.package_page(mpackage)
 		end
-		return catalog
+		self.catalog = catalog
 	end
 end
 


### PR DESCRIPTION
So the first user to access Nitweb does not have to wait 5 minutes for the catalog to be compiled.

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>