### PR TITLE
lib/json: fix array serialization

### DIFF
--- a/lib/json/serialization_write.nit
+++ b/lib/json/serialization_write.nit
@@ -325,11 +325,11 @@ redef class SimpleCollection[E]
 			v.stream.write """","""
 			v.new_line_and_indent
 			v.stream.write """"__items": """
-
+			serialize_to_pure_json v
 			core_serialize_to v
+		else
+			serialize_to_pure_json v
 		end
-
-		serialize_to_pure_json v
 
 		if not v.plain_json then
 			v.indent_level -= 1


### PR DESCRIPTION
Fixes serialization error for array subclasses.

Be the following Nit code:

~~~nit
class Foo
    super Array[String]
    serialize

    var foo: String
end

print (new Foo("foo")).serialize_to_json
~~~

Output before:

~~~json
{"__kind":"obj","__id":0,"__class":"Foo", "__items":, "foo":"foo"[]}
~~~

Output after:

~~~json
{"__kind":"obj","__id":0,"__class":"Foo", "foo":"foo", "__items":[]}
~~~

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>