### PR TITLE
Docker, portability and crosscompiling tweaks

### DIFF
--- a/lib/core/kernel.nit
+++ b/lib/core/kernel.nit
@@ -1063,7 +1063,7 @@ extern class Pointer
 	fun free `{ free(self); `}
 
 	# Use the address value
-	redef fun hash `{ return (long)self; `}
+	redef fun hash `{ return (long)(intptr_t)self; `}
 
 	# Is equal to any instance pointing to the same address
 	redef fun ==(o) do return o isa Pointer and native_equals(o)

--- a/misc/docker/full/Dockerfile
+++ b/misc/docker/full/Dockerfile
@@ -20,6 +20,7 @@ RUN dpkg --add-architecture i386 \
 		libsdl-ttf2.0-dev \
 		libsdl1.2-dev \
 		libsdl2-dev \
+		libsdl2-image-dev \
 		libsqlite3-dev \
 		libx11-dev \
 		libxdg-basedir-dev \

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -350,9 +350,9 @@ class MakefileToolchain
 		var debug = toolcontext.opt_debug.value
 
 		makefile.write """
-CC = ccache cc
-CXX = ccache c++
-CFLAGS = -g {{{if not debug then "-O2" else ""}}} -Wno-unused-value -Wno-switch -Wno-attributes -Wno-trigraphs
+CC ?= ccache cc
+CXX ?= ccache c++
+CFLAGS ?= -g {{{if not debug then "-O2" else ""}}} -Wno-unused-value -Wno-switch -Wno-attributes -Wno-trigraphs
 CINCL =
 LDFLAGS ?=
 LDLIBS  ?= -lm {{{linker_options.join(" ")}}}
@@ -361,9 +361,9 @@ LDLIBS  ?= -lm {{{linker_options.join(" ")}}}
 		makefile.write "\n# SPECIAL CONFIGURATION FLAGS\n"
 		if platform.supports_libunwind then
 			if toolcontext.opt_no_stacktrace.value then
-				makefile.write "NO_STACKTRACE=True"
+				makefile.write "NO_STACKTRACE ?= True"
 			else
-				makefile.write "NO_STACKTRACE= # Set to `True` to enable"
+				makefile.write "NO_STACKTRACE ?= # Set to `True` to enable"
 			end
 		end
 

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -349,7 +349,14 @@ class MakefileToolchain
 		end
 		var debug = toolcontext.opt_debug.value
 
-		makefile.write("CC = ccache cc\nCXX = ccache c++\nCFLAGS = -g{ if not debug then " -O2 " else " "}-Wno-unused-value -Wno-switch -Wno-attributes -Wno-trigraphs\nCINCL =\nLDFLAGS ?= \nLDLIBS  ?= -lm {linker_options.join(" ")}\n\n")
+		makefile.write """
+CC = ccache cc
+CXX = ccache c++
+CFLAGS = -g {{{if not debug then "-O2" else ""}}} -Wno-unused-value -Wno-switch -Wno-attributes -Wno-trigraphs
+CINCL =
+LDFLAGS ?=
+LDLIBS  ?= -lm {{{linker_options.join(" ")}}}
+\n"""
 
 		makefile.write "\n# SPECIAL CONFIGURATION FLAGS\n"
 		if platform.supports_libunwind then


### PR DESCRIPTION
* Add the missing SDL2 package (since #2376) to the full DockerFile.
* Fix a warning raised by the C compiler when called by niti on 32 bits platforms.
* Clean up Makefile generation and enable using environment variables to override the default C compiler, C++ compiler, CFLAGS and whether or not to use libunwind. Making it possible to change the compiler for cross compilation and to skip linking with libunwind to create binaries compatible with more GNU/Linux systems.