### PR TITLE
Windows: path, PATH, and exec improvements

### DIFF
--- a/lib/core/environ.nit
+++ b/lib/core/environ.nit
@@ -46,10 +46,12 @@ redef class String
 	# Search for the program `self` in all directories from `PATH`
 	fun program_is_in_path: Bool
 	do
+		var sep = if is_windows then ";" else ":"
 		var full_path = "PATH".environ
-		var paths = full_path.split(":")
+		var paths = full_path.split(sep)
 		for path in paths do if path.file_exists then
 			if path.join_path(self).file_exists then return true
+			if is_windows and (path / self + ".exe").file_exists then return true
 		end
 
 		return false

--- a/lib/core/exec.nit
+++ b/lib/core/exec.nit
@@ -164,7 +164,7 @@ class Process
 				return NULL;
 			}
 			start_info.hStdInput = in_fd[0];
-			result->in_fd = _open_osfhandle((intptr_t)in_fd[1], _O_APPEND);
+			result->in_fd = _open_osfhandle((intptr_t)in_fd[1], _O_WRONLY);
 			if ( !SetHandleInformation(in_fd[1], HANDLE_FLAG_INHERIT, 0) )
 				return NULL;
 		} else {
@@ -213,6 +213,10 @@ class Process
 			NULL,       // use parent's current directory
 			&start_info,
 			&proc_info);
+
+		if (pipeflag & 1) CloseHandle(in_fd[0]);
+		if (pipeflag & 2) CloseHandle(out_fd[1]);
+		if (pipeflag & 3) CloseHandle(err_fd[1]);
 
 		// Error?
 		if (!created) {

--- a/tests/MINGW64_NT.skip
+++ b/tests/MINGW64_NT.skip
@@ -1,0 +1,16 @@
+cocoa_extern_types
+cocoa_message_box
+hello_cocoa
+hello_ios
+test_platform_ios
+mnit
+shoot_linux
+dino_linux
+ballz_linux
+mpi
+emscripten
+neo_doxygen
+neo4j
+mongo
+pernicious_numbers
+frankuchredux

--- a/tests/sav/test_exec.res
+++ b/tests/sav/test_exec.res
@@ -1,7 +1,8 @@
 A hello world!
 0
 
-B hello world!0
+B hello world!true
+0
 
 C hello world!
 0

--- a/tests/test_exec.nit
+++ b/tests/test_exec.nit
@@ -24,6 +24,7 @@ print ""
 
 var ip = new ProcessReader("echo", "B hello world!")
 ip.read_line.output
+ip.eof.output
 ip.wait
 print ip.status
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -154,6 +154,8 @@ else
 	HOSTNAME="hostname -s"
 fi
 
+UNAME=`uname | sed s/-.*//`
+
 # $1 is the pattern of the test
 # $2 is the file to compare to
 # the result is:
@@ -373,7 +375,7 @@ need_skip()
 	fi
 
 	# Skip by OS
-	local os_skip_file=`uname`.skip
+	local os_skip_file=$UNAME.skip
 	if test -e $os_skip_file && echo "$1" | grep -f "$os_skip_file" >/dev/null 2>&1; then
 		echo "=> $2: [skip os]"
 		echo >>$xml "<testcase classname='`xmlesc "$3"`' name='`xmlesc "$2"`' `timestamp`><skipped/></testcase>"
@@ -530,7 +532,7 @@ case $engine in
 		;;
 esac
 
-savdirs="sav/`$HOSTNAME` sav/`uname` sav/$engine $savdirs sav/"
+savdirs="sav/`$HOSTNAME` sav/$UNAME sav/$engine $savdirs sav/"
 
 # The default nitc compiler
 [ -z "$NITC" ] && find_nitc


### PR DESCRIPTION
This PR further improves Windows support in the Nit standard library and testing tools:

* Improve Windows path manipulation and standardize the solution. On Windows, services working on path strings first replace all `\` by `/`. This allows sharing the main code with other OS, data copy should be limited since only the first operation on a string should update it.
  All `file` services depending on the path separator should have been updated, except for `relpath`. Note that there is still no special treatment for FS root like `C:/`, so further work is needed.
* Support for Windows' PATH where the separator is `;`.
* Fix pipes left open on the parent side after `CreateProcess`.
* Intro a basic skip list for MINGW64 Windows system with projects that are either incompatible (cocoa & ios) or not available with msys2 and that I don't plan to configure manually on the test server in the near future.

There are still issues (including an int overflow in `Float::to_s`), but this PR allows a few larger projects to work on Windows. With #2390 gamnit projects can be compiled entirely from a Windows machine (or cross-compiled).

---

The unit tests are marked `~~~nitish` because they are only valid when `is_windows == true`. Maybe we could have a `~~~nitwindows` or something like that for such tests in the future. Note that you can set `-D is_windows=true` to try them (but not on nitunit sadly).

The Jenkins Windows test server is currently broken. I'll see if I can fix it, otherwise, I'll share the results form my test server later.