### PR TITLE
testing: define the env var NIT_TESTING_TOOL

### DIFF
--- a/lib/gamnit/README.md
+++ b/lib/gamnit/README.md
@@ -8,13 +8,13 @@ It is based on the portability framework _app.nit_ and the OpenGL ES 2.0 standar
 To compile the _gamnit_ apps packaged with the Nit repositoy on GNU/Linux you need to install the dev version of a few libraries and some tools.
 Under Debian 8.2, this command should install everything needed:
 
-~~~
+~~~raw
 apt-get install libgles2-mesa-dev libsdl2-dev libsdl2-image-dev inkscape mpg123
 ~~~
 
 Under Windows 64 bits, using msys2, you can install the required packages with:
 
-~~~
+~~~raw
 pacman -S mingw-w64-x86_64-angleproject-git mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_image
 ~~~
 

--- a/lib/gamnit/gamnit.nit
+++ b/lib/gamnit/gamnit.nit
@@ -82,7 +82,7 @@ end
 redef class Sys
 	redef fun run
 	do
-		if "NIT_TESTING".environ == "true" then exit 0
+		if "NIT_TESTING_TOOL".environ == "tests.sh" then exit 0
 		super
 	end
 end

--- a/src/nitunit.nit
+++ b/src/nitunit.nit
@@ -67,6 +67,7 @@ if "NIT_TESTING".environ != "" then
 end
 
 "NIT_TESTING".setenv("true")
+"NIT_TESTING_TOOL".setenv("nitunit")
 "NIT_TESTING_ID".setenv(pid.to_s)
 "SRAND".setenv("0")
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -322,6 +322,9 @@ $ cat out/zzz_test_post_proc.res
 The environment variable `NIT_TESTING` is set to `true` during the execution of program tests.
 Some libraries of programs can use it to produce specific reproducible results ; or just to exit their executions.
 
+The environment variable `NIT_TESTING_TOOL` is set to `tests.sh` during excution by the script of the same name.
+It can be used to differentiate between testing by `tests.sh` and by `nitunit`.
+
 ~~~
 $ cat zzz_tests/zzz_test_envvar.nit
 $ ./tests.sh zzz_tests/zzz_test_envvar.nit

--- a/tests/sav/zzz_test_envvar.res
+++ b/tests/sav/zzz_test_envvar.res
@@ -1,1 +1,2 @@
 true
+tests.sh

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -21,6 +21,7 @@
 export LANG=C
 export LC_ALL=C
 export NIT_TESTING=true
+export NIT_TESTING_TOOL=tests.sh
 # Use the pid as a collision prevention
 export NIT_TESTING_ID=$$
 export NIT_SRAND=0

--- a/tests/zzz_tests/zzz_test_envvar.nit
+++ b/tests/zzz_tests/zzz_test_envvar.nit
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 print "NIT_TESTING".environ
+print "NIT_TESTING_TOOL".environ


### PR DESCRIPTION
Unit tests in the `gamnit` module were not executed because `Sys::setup` exited right away when detecting `NIT_TESTING`.

This PR fix the issue by adding a new environment variable `NIT_TESTING_TOOL`, allowing programs to distinguish between the two testing tools: `tests.sh` and `nitunit`.