### PR TITLE
inkscape_tools: support Inkscape versions before and after 0.92

### DIFF
--- a/contrib/inkscape_tools/src/svg_to_png_and_nit.nit
+++ b/contrib/inkscape_tools/src/svg_to_png_and_nit.nit
@@ -255,7 +255,7 @@ end
 
 var opt_out_src = new OptionString("Path to output source file (folder or file)", "--src", "-s")
 var opt_assets = new OptionString("Path to assert dir where to put PNG files", "--assets", "-a")
-var opt_scale = new OptionFloat("Apply scaling to exported images (default at 1.0 of 96dpi)", 1.0, "--scale", "-x")
+var opt_scale = new OptionFloat("Apply scaling to exported images (default at 1.0)", 1.0, "--scale", "-x")
 var opt_gamnit = new OptionBool("Target the Gamnit framework (by default it targets Mnit)", "--gamnit", "-g")
 var opt_pow2 = new OptionBool("Round the image size to the next power of 2", "--pow2")
 var opt_help = new OptionBool("Print this help message", "--help", "-h")
@@ -280,6 +280,23 @@ if not "inkscape".program_is_in_path then
 	exit 1
 end
 
+# Get the inkscape version
+var p = new ProcessReader("inkscape", "--version")
+var version_string = p.read_all
+p.wait
+p.close
+var version_re = "([0-9]+\).([0-9]+\).[0-9]+".to_re
+var match = version_string.search(version_re)
+assert match != null
+var major = match[1]
+var minor = match[2]
+assert major != null and minor != null
+
+# Set the default API using the version as heuristic
+var default_dpi = 96.0
+if major.to_s.to_i == 0 and minor.to_s.to_i < 92 then default_dpi = 90.0
+
+# Collect source files
 var drawings = rest
 for drawing in drawings do
 	if not drawing.file_exists then
@@ -414,7 +431,7 @@ for drawing in drawings do
 	# Output png file to assets
 	var png_path = "{assets_path}/images/{drawing_name}.png"
 	var proc2 = new Process.from_a(prog, [drawing, "--without-gui",
-		"--export-dpi={(96.0*scale).to_i}",
+		"--export-dpi={(default_dpi*scale).to_i}",
 		"--export-png={png_path}",
 		"--export-area={min_x}:{y0}:{max_x}:{y1}",
 		"--export-background=#000000", "--export-background-opacity=0.0"])


### PR DESCRIPTION
Inkscape changed the default DPI at version 0.92. This PR improves `svg_to_png_and_nit` to set the default DPI according to the detected Inkscape version, 90 DPI up until version 0.92 and 96 DPI for version 0.92 and later. 

Reference: http://wiki.inkscape.org/wiki/index.php/Release_notes/0.92#Important_changes

This is a more portable solution than #2374.