### PR TITLE
gamnit: abstract camera scroll and zoom service

### DIFF
--- a/lib/gamnit/camera_control.nit
+++ b/lib/gamnit/camera_control.nit
@@ -1,0 +1,51 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Simple camera control for user, as the method `accept_scroll_and_zoom`
+module camera_control
+
+import gamnit
+import cameras
+
+import camera_control_linux is conditional(linux)
+import camera_control_android is conditional(android)
+
+redef class EulerCamera
+	# Zoom and scroll this camera from user input
+	#
+	# Scrolling is accomplished by moving the camera on the XY plane and
+	# zooming by moving it on the Z axis.
+	#
+	# This method has distinct implementations per platform.
+	# On desktop computers, the mouse wheel changes the zoom level, and
+	# holding down the middle mouse button scrolls the camera.
+	# On Android, a two finger pinch and slide gesture zoom and scroll.
+	#
+	# Returns `true` if the event is used.
+	#
+	# Should be called from `App::accept_event` before accepting pointer events:
+	#
+	# ~~~nitish
+	# redef class App
+	#     redef fun accept_event(event)
+	#     do
+	#         if world_camera.accept_scroll_and_zoom(event) then return true
+	#
+	#         # Handle other events...
+	#         return false
+	#     end
+	# end
+	# ~~~
+	fun accept_scroll_and_zoom(event: InputEvent): Bool do return false
+end

--- a/lib/gamnit/camera_control_android.nit
+++ b/lib/gamnit/camera_control_android.nit
@@ -12,16 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Two fingers camera manipulation, scroll and pinch to zoom
-#
-# Provides the main service `EulerCamera::accept_two_fingers_motion`.
-module android_two_fingers_motion
+# Two fingers camera manipulation, pinch to zoom and slide to scroll
+module camera_control_android
 
-# TODO add an abstraction when another platform supports it
-
-import gamnit
-import cameras
 import android
+import camera_control
 
 redef class EulerCamera
 	# Smoothened history of pointers in the current motion event
@@ -30,23 +25,7 @@ redef class EulerCamera
 	# Start time of the current motion event
 	private var last_motion_start: Int = -1
 
-	# Move and zoom (set `position`) from a two finger pinch and slide option
-	#
-	# Returns `true` if the event is intercepted.
-	#
-	# Should be called from `App::accept_event` before accepting pointer events:
-	#
-	# ~~~nitish
-	# redef class App
-	#     redef fun accept_event(event)
-	#     do
-	#         if world_camera.accept_two_fingers_motion(event) then return true
-	#
-	#         # Handle other events...
-	#     end
-	# end
-	# ~~~
-	fun accept_two_fingers_motion(event: InputEvent): Bool
+	redef fun accept_scroll_and_zoom(event)
 	do
 		if not event isa AndroidMotionEvent then return false
 

--- a/lib/gamnit/camera_control_linux.nit
+++ b/lib/gamnit/camera_control_linux.nit
@@ -1,0 +1,64 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mouse wheel and middle mouse button to control camera
+module camera_control_linux
+
+import linux
+import camera_control
+
+redef class EulerCamera
+
+	# Zoom factor, default at 1.2, higher means more reactive zoom effect
+	var camera_zoom_mod = 1.2 is writable
+
+	# Scoll trigger button mask from SDL2 (1: left, 2: middle, 4: right)
+	#
+	# Set to 0 to deactivate the scrolling feature.
+	var camera_pan_mask = 2 is writable
+
+	redef fun accept_scroll_and_zoom(event)
+	do
+		# Zoom
+		if event isa GamnitMouseWheelEvent then
+			var dy = event.y
+			var mod = camera_zoom_mod
+			if dy > 0.0 then
+				# Zoom in when moving the wheel up
+				mod = 1.0/mod
+			else dy = -dy
+
+			position.z *= dy * mod
+			return true
+		end
+
+		# Scroll
+		var but_mask = camera_pan_mask
+		if but_mask != 0 and event isa GamnitPointerEvent then
+			var native = event.native
+			if native isa SDLMouseMotionEvent and native.state & but_mask == but_mask then
+				var dx = native.xrel.to_f
+				var dy = native.yrel.to_f
+
+				var world_height = field_of_view_y.sin * position.z
+				var mod = app.display.as(not null).height.to_f / world_height
+				position.x -= dx / mod
+				position.y += dy / mod # Y is inverted between the input and output
+				return true
+			end
+		end
+
+		return false
+	end
+end

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -42,8 +42,7 @@ import performance_analysis
 import gamnit
 import gamnit::cameras
 import gamnit::limit_fps
-
-import android_two_fingers_motion is conditional(android)
+import gamnit::camera_control
 
 # Draw a `texture` at `center`
 #

--- a/lib/gamnit/gamnit_linux.nit
+++ b/lib/gamnit/gamnit_linux.nit
@@ -56,6 +56,10 @@ redef class SDLMouseEvent
 	redef fun to_gamnit_event(buffer) do return new GamnitPointerEvent(buffer, self)
 end
 
+redef class SDLMouseWheelEvent
+	redef fun to_gamnit_event(buffer) do return new GamnitMouseWheelEvent(buffer, self)
+end
+
 redef class SDLKeyboardEvent
 	redef fun to_gamnit_event(buffer) do return new GamnitKeyEvent(buffer, self)
 end
@@ -124,6 +128,19 @@ class GamnitPointerEvent
 			return native.state & 1 == 1
 		else abort
 	end
+end
+
+# Event on mouse wheel input
+class GamnitMouseWheelEvent
+	super GamnitInputEvent
+
+	redef type NATIVE: SDLMouseWheelEvent
+
+	# Horizontal scroll amount
+	fun x: Float do return native.x.to_f
+
+	# Vertical scroll amount
+	fun y: Float do return native.y.to_f
 end
 
 # SDL2 event not handled by gamnit

--- a/lib/sdl2/events.nit
+++ b/lib/sdl2/events.nit
@@ -47,6 +47,7 @@ extern class SDLEventBuffer `{SDL_Event *`}
 		if is_mouse_motion then return to_mouse_motion
 		if is_mouse_button_down then return to_mouse_button_down
 		if is_mouse_button_up then return to_mouse_button_up
+		if is_mouse_wheel then return to_mouse_wheel
 		if is_keydown then return to_keydown
 		if is_keyup then return to_keyup
 		return to_event_direct
@@ -86,6 +87,14 @@ extern class SDLEventBuffer `{SDL_Event *`}
 	# Require: `is_mouse_button_up`
 	fun to_mouse_button_up: SDLMouseButtonUpEvent `{ return self; `}
 
+	# Is this a mouse wheel event?
+	fun is_mouse_wheel: Bool `{ return self->type == SDL_MOUSEWHEEL; `}
+
+	# Get a reference to data at `self` as a `SDLMouseWheelEvent`
+	#
+	# Require: `is_mouse_wheel`
+	fun to_mouse_wheel: SDLMouseWheelEvent `{ return self; `}
+
 	# Is this a key presse event?
 	fun is_keydown: Bool `{ return self->type == SDL_KEYDOWN; `}
 
@@ -108,7 +117,6 @@ extern class SDLEventBuffer `{SDL_Event *`}
 	# SDL_WindowEvent window
 	# SDL_TextEditingEvent edit
 	# SDL_TextInputEvent text
-	# SDL_MouseWheelEvent wheel
 	# SDL_JoyAxisEvent jaxis
 	# SDL_JoyBallEvent jball
 	# SDL_JoyHatEvent jhat;
@@ -212,6 +220,17 @@ end
 # Mouse button click event
 extern class SDLMouseButtonDownEvent
 	super SDLMouseButtonEvent
+end
+
+# Mouse wheel event
+extern class SDLMouseWheelEvent
+	super SDLEvent
+
+	# Horizontal scroll amount
+	fun x: Int `{ return self->wheel.x; `}
+
+	# Vertical scroll amount
+	fun y: Int `{ return self->wheel.y; `}
 end
 
 # Keyboard button event


### PR DESCRIPTION
The new service `accept_scroll_and_zoom` lets the user adjust the camera using platform specific controls. On desktop computers, the mouse wheel controls the zoom and the middle mouse button drags the world/camera. On Android, a pinch gesture controls the zoom and 2 fingers slide the scroll.

This reuse the previous `accept_two_fingers_motion` and intro an implementation for desktop computers. It will be used by, at least, Sputnit in which it will replace the current implementation which is broken since the upgrade to SDL2. 