### PR TITLE
Nitin catches the runtime errors

### DIFF
--- a/contrib/nitin/README.md
+++ b/contrib/nitin/README.md
@@ -11,11 +11,11 @@ This tool is outside src/ because:
 * use GNU readline to read lines
 * use importation/refinement to handle incremental execution (so basically everything works out of the box)
 * maintain an interpreter and live objects (the model grows but the interpreter and runtime data are reused)
+* runtime errors/aborts return to the interactive loop
 
 Main missing features
 
 * top-level variables are local
-* runtime error/aborts just abort the interactive loop
 * FFI is strange
 * No model/object inspection
 

--- a/contrib/nitin/nitin.nit
+++ b/contrib/nitin/nitin.nit
@@ -184,6 +184,21 @@ loop
 
 	# Run the main if the AST contains a main
 	if amodule.n_classdefs.not_empty and amodule.n_classdefs.last isa AMainClassdef then
-		interpreter.send(mainprop, [mainobj])
+		do
+			interpreter.catch_count += 1
+			interpreter.send(mainprop, [mainobj])
+		catch
+			var e = interpreter.last_error
+			if e != null then
+				var en = e.node
+				if en != null then
+					print "{en.location}: Runtime error: {e.message}\n{en.location.colored_line("0;31")}"
+				else
+					print "Runtime error: {e.message}"
+				end
+			end
+			print interpreter.stack_trace
+			interpreter.frames.clear
+		end
 	end
 end

--- a/tests/nitin.inputs
+++ b/tests/nitin.inputs
@@ -45,3 +45,21 @@ import json
 print([0..10[.to_a.to_json)
 
 %$^&
+
+fun foo_abstract is abstract
+fun foo_intern is intern
+class B
+var a: B is noautoinit
+fun foo do print "B"
+end
+fun nil: nullable B do return null
+
+abort
+nil.foo
+foo_abstract
+assert false
+(new A).as(B).foo
+print((new B).a)
+foo_intern
+
+print "Finished"

--- a/tests/sav/nitin.res
+++ b/tests/sav/nitin.res
@@ -23,4 +23,49 @@
 -->-->-->-->[0,1,2,3,4,5,6,7,8,9]
 -->-->	[0;31m%[0m$^&
 	^: Syntax Error: unexpected operator '%'.
+-->-->-->-->.........-->-->-->1,1--5: Runtime error: Aborted
+	[0;31mabort[0m
+	^
+,---- Stack trace -- - -  -
+| input-22$Sys$main (1,1--5)
+`------------------- - -  -
+-->1,1--7: Runtime error: Receiver is null
+	[0;31mnil.foo[0m
+	^
+,---- Stack trace -- - -  -
+| input-23$Sys$main (1,1--7)
+`------------------- - -  -
+-->1,1--28: Runtime error: Abstract method `foo_abstract` called on `Sys`
+	[0;31mfun foo_abstract is abstract[0m
+	^
+,---- Stack trace -- - -  -
+| input-18$Sys$foo_abstract (1,1--28)
+| input-24$Sys$main (1,1--12)
+`------------------- - -  -
+-->1,1--12: Runtime error: Assert failed
+	[0;31massert false[0m
+	^
+,---- Stack trace -- - -  -
+| input-25$Sys$main (1,1--12)
+`------------------- - -  -
+-->1,1--13: Runtime error: Cast failed. Expected `B`, got `A`
+	[0;31m(new A).as(B)[0m.foo
+	^
+,---- Stack trace -- - -  -
+| input-26$Sys$main (1,1--13)
+`------------------- - -  -
+-->1,7--15: Runtime error: Uninitialized attribute _a
+	print([0;31m(new B).a[0m)
+	      ^
+,---- Stack trace -- - -  -
+| input-27$Sys$main (1,7--15)
+`------------------- - -  -
+-->1,1--24: Runtime error: NOT YET IMPLEMENTED intern input-19$Sys$foo_intern
+	[0;31mfun foo_intern is intern[0m
+	^
+,---- Stack trace -- - -  -
+| input-19$Sys$foo_intern (1,1--24)
+| input-28$Sys$main (1,1--10)
+`------------------- - -  -
+-->-->Finished
 -->


### PR DESCRIPTION
~~~
-->abort
1,1--5: Runtime error: Aborted
	abort
	^
,---- Stack trace -- - -  -
| input-1$Sys$main (1,1--5)
`------------------- - -  -
-->fun toto is abstract
-->toto
1,1--20: Runtime error: Abstract method `toto` called on `Sys`
	fun toto is abstract
	^
,---- Stack trace -- - -  -
| input-2$Sys$toto (1,1--20)
| input-3$Sys$main (1,1--4)
`------------------- - -  -
-->class A
...var a: String is noautoinit
...fun foo do print a
...end
-->(new A).foo
3,18: Runtime error: Uninitialized attribute _a
	fun foo do print a
	                 ^
,---- Stack trace -- - -  -
| input-4$A$foo (3,18)
| input-5$Sys$main (1,1--11)
`------------------- - -  -
-->
~~~