### PR TITLE
nitcorn: fix HttpRequest::int_arg

### DIFF
--- a/lib/nitcorn/http_request.nit
+++ b/lib/nitcorn/http_request.nit
@@ -76,13 +76,13 @@ class HttpRequest
 		return s
 	end
 
-	# Returns argument `arg_name` as an Int or `null` if not found or not a number.
+	# Returns argument `arg_name` as an Int or `null` if not found or not an integer.
 	#
 	# NOTE: Prioritizes POST before GET
 	fun int_arg(arg_name: String): nullable Int do
 		if not all_args.has_key(arg_name) then return null
 		var i = all_args[arg_name]
-		if not i.is_numeric then return null
+		if not i.is_int then return null
 		return i.to_i
 	end
 


### PR DESCRIPTION
Before this commit, sending `?n=9.5` to a nitcorn application using `int_arg`
caused the app to crash (see the following to_i).

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>