### PR TITLE
gamnit: fix nitunit compatibility

### DIFF
--- a/lib/android/platform.nit
+++ b/lib/android/platform.nit
@@ -19,6 +19,9 @@ module platform is platform "android"
 
 import java
 import app
+intrude import app::app_base # For test_bound_platform
 import aware
 
 redef fun bound_platform do return "Android"
+
+redef fun test_bound_platform do end

--- a/lib/android/platform.nit
+++ b/lib/android/platform.nit
@@ -20,3 +20,5 @@ module platform is platform "android"
 import java
 import app
 import aware
+
+redef fun bound_platform do return "Android"

--- a/lib/app/app_base.nit
+++ b/lib/app/app_base.nit
@@ -115,5 +115,12 @@ end
 # The running `App`
 fun app: App do return once new App
 
+# Platform bound at compilation (by importation or -m)
+#
+# This value should not be used to decide the behavior of the software.
+# Class refinement provide a safer and a static solution to apply variations.
+# However, this value can be used in log files and communications with servers.
+fun bound_platform: String do return "none"
+
 app.setup
 app.run

--- a/lib/app/app_base.nit
+++ b/lib/app/app_base.nit
@@ -122,5 +122,16 @@ fun app: App do return once new App
 # However, this value can be used in log files and communications with servers.
 fun bound_platform: String do return "none"
 
+# Test if the application was bound to a platform, if not crash
+private fun test_bound_platform
+do
+	print_error "Apps must be bound to a platform at compilation using `-m linux` or `-m android`"
+	exit 1
+end
+
+if "NIT_TESTING".environ == "true" then exit 0
+
+test_bound_platform
+
 app.setup
 app.run

--- a/lib/app/assets.nit
+++ b/lib/app/assets.nit
@@ -37,7 +37,7 @@ class TextAsset
 	redef var to_s = load is lazy
 
 	# Load this asset
-	fun load: String is abstract
+	fun load: String do return ""
 
 	# Error on the last call to `load`, if any
 	var error: nullable Error = null

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -1077,7 +1077,7 @@ end
 #
 # array.add "E"
 # assert array.to_s == "[A,B,c,D,E]"
-# assert array.capacity == 5
+# assert array.capacity == 6
 # assert array.length == 5
 #
 # array.remove "A"

--- a/lib/gamnit/gamnit.nit
+++ b/lib/gamnit/gamnit.nit
@@ -78,11 +78,3 @@ redef class App
 	# right after this method returns. They should not be preserved.
 	fun accept_event(event: InputEvent): Bool do return false
 end
-
-redef class Sys
-	redef fun run
-	do
-		if "NIT_TESTING".environ == "true" then exit 0
-		super
-	end
-end

--- a/lib/linux/linux.nit
+++ b/lib/linux/linux.nit
@@ -18,6 +18,7 @@
 module linux
 
 import app
+intrude import app::app_base # For test_bound_platform
 
 redef class App
 	# Path to the expected location of the asset folder of this program
@@ -62,3 +63,5 @@ redef class TextAsset
 end
 
 redef fun bound_platform do return "GNU/Linux"
+
+redef fun test_bound_platform do end

--- a/lib/linux/linux.nit
+++ b/lib/linux/linux.nit
@@ -60,3 +60,5 @@ redef class TextAsset
 		return content
 	end
 end
+
+redef fun bound_platform do return "GNU/Linux"


### PR DESCRIPTION
Unit tests in the gamnit module were not executed because Sys::setup exited right away when detecting NIT_TESTING. It affected all gamnit games. This PR check is a platform is bound at the beginning of `Sys::main`, allowing unit tests to run (whether they redef `main` or not).

The check is made possible by the new `bound_platform` which tells what platform is currently bound. This value can be useful in some other cases.

This is an alternative to #2394.