### PR TITLE
highlight: give more control to clients and fix regressions

### DIFF
--- a/src/highlight.nit
+++ b/src/highlight.nit
@@ -551,8 +551,8 @@ redef class MVirtualType
 		var res = new HInfoBox(v, to_s)
 		res.href = v.hrefto(mproperty)
 		var p = mproperty
+		res.new_field("virtual type").add p.intro.linkto(v)
 		add_doc_to_infobox(res)
-		if mdoc != null then mdoc.fill_infobox(res)
 		return res
 	end
 	redef fun linkto(v)

--- a/src/highlight.nit
+++ b/src/highlight.nit
@@ -25,7 +25,8 @@ class HighlightVisitor
 	# The root of the HTML hierarchy
 	var html = new HTMLTag("span")
 
-	# Is the HTML include a nested `<span class"{type_of_node}">` element for each `ANode` of the AST?
+	# Should the HTML include a nested `<span class"{type_of_node}">` element for each `ANode` of the AST?
+	#
 	# Used to have a really huge and verbose HTML (mainly for debug)
 	var with_ast = false is writable
 
@@ -62,7 +63,7 @@ class HighlightVisitor
 	#
 	# By default, `null` is returned.
 	# Clients are therefore encouraged to redefine the method in a subclass to control where entities should link to.
-	fun hrefto(entitiy: MEntity): nullable String do return null
+	fun hrefto(entity: MEntity): nullable String do return null
 
 	init
 	do

--- a/src/highlight.nit
+++ b/src/highlight.nit
@@ -363,12 +363,14 @@ class HInfoBox
 	end
 
 	# Append a new dropdown in the popuped content
-	fun new_dropdown(title, text: String): HTMLTag
+	fun new_dropdown(title, text: String, text_is_html: nullable Bool): HTMLTag
 	do
 		content.add_raw_html """<div class="dropdown"> <a data-toggle="dropdown" href="#"><b>"""
 		content.append(title)
 		content.add_raw_html "</b> "
-		content.append(text)
+		if text_is_html == true then
+			content.add_raw_html(text)
+		else content.append(text)
 		content.add_raw_html """<span class="caret"></span></a>"""
 		var res = content.open("ul").add_class("dropdown-menu").attr("role", "menu").attr("aria-labelledby", "dLabel")
 		content.add_raw_html "</div>"

--- a/src/model/mdoc.nit
+++ b/src/model/mdoc.nit
@@ -45,6 +45,7 @@ redef class MEntity
 	#   their introducing definition.
 	# * `MClassType`s fall back to their wrapped `MClass`.
 	# * `MVirtualType`s fall back to their wrapped `MProperty`.
+	# * `CallSite` fall back on the wrapped `MProperty`.
 	# * Other entities do not fall back.
 	#
 	# One may use `MDoc::original_mentity` to retrieve the original

--- a/src/model/mdoc.nit
+++ b/src/model/mdoc.nit
@@ -35,7 +35,7 @@ end
 
 redef class MEntity
 	# The documentation associated to the entity
-	var mdoc: nullable MDoc is writable
+	var mdoc: nullable MDoc = null is writable
 
 	# The documentation associated to the entity or their main nested entity.
 	#

--- a/src/nitlight.nit
+++ b/src/nitlight.nit
@@ -32,7 +32,7 @@ class NitlightVisitor
 	# Entities outside these modules will not be linked.
 	var mmodules: Collection[MModule]
 
-	redef fun hrefto(entitiy) do return entitiy.href(self)
+	redef fun hrefto(entity) do return entity.href(self)
 end
 
 redef class MEntity

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -740,7 +740,7 @@ end
 class CallSite
 	super MEntity
 
-	redef var location: Location
+	redef var location
 
 	# The static type of the receiver (possibly unresolved)
 	var recv: MType
@@ -791,7 +791,7 @@ end
 
 redef class Variable
 	# The declared type of the variable
-	var declared_type: nullable MType is writable
+	var declared_type: nullable MType = null is writable
 
 	# Was the variable type-adapted?
 	# This is used to speedup type retrieval while it remains `false`

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -785,6 +785,8 @@ class CallSite
 	fun dump_info(v: ASTDump): String do
 		return "{recv}.{mpropdef}{msignature}"
 	end
+
+	redef fun mdoc_or_fallback do return mproperty.intro.mdoc
 end
 
 redef class Variable


### PR DESCRIPTION
Allow clients to send HTML to `new_dropdown`. Fix two regression bugs introduced by #2231: support for `CallSite` and `MVirtualType`. And as usual, also fix a few local warnings and typos.

This is used by my landing page generator script.