### PR TITLE
Actors upgrade and fixes 

### DIFF
--- a/lib/actors/examples/agent_simulation/agent_simulation.nit
+++ b/lib/actors/examples/agent_simulation/agent_simulation.nit
@@ -1,0 +1,60 @@
+# This file is part of NIT (http://www.nitlanguage.org).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# a "Framework" to make Multi-Agent Simulations in Nit
+module agent_simulation is no_warning("missing-doc")
+
+import actors
+
+# Master of the simulation, it initiates the steps and waits for them to terminate
+class ClockAgent
+	actor
+
+	# Number of steps to do in the simulation
+	var nb_steps: Int
+
+	# List of Agents in the simulation
+	var agents: Array[Agent]
+
+	# Number of agents that finished their step
+	var nb_finished = 0
+
+	fun do_step do
+		for a in agents do a.async.do_step
+		nb_steps -= 1
+	end
+
+	fun finished_step do
+		nb_finished += 1
+		if nb_finished == agents.length then
+			nb_finished = 0
+			if nb_steps != 0 then async.do_step
+		end
+	end
+end
+
+class Agent
+	actor
+
+	# Doing a step in the simulation
+	fun do_step do
+	end
+
+	fun end_step do clock_agent.async.finished_step
+
+end
+
+redef class Sys
+	var clock_agent: ClockAgent is noautoinit,writable
+end

--- a/lib/actors/examples/agent_simulation/simple_simulation.nit
+++ b/lib/actors/examples/agent_simulation/simple_simulation.nit
@@ -1,0 +1,57 @@
+# This file is part of NIT (http://www.nitlanguage.org).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Using `agent_simulation` by refining the Agent class to make
+# a multi-agent simulation where every agent know each other
+# The steps consist of each agent greeting each other, and
+# waiting for every other agent to respond before notifying
+# to the `ClockAgent` that they finished their step.
+module simple_simulation
+
+import agent_simulation
+
+redef class Agent
+	var others = new Array[Agent]
+	var count = 0
+
+	fun greet(message: String, other: Agent) do other.async.greet_back("Hello back !")
+
+	fun greet_back(message: String) do
+		count -= 1
+		if count == 0 then end_step
+	end
+
+	redef fun do_step do
+		for o in others do
+			o.async.greet("Hello !", self)
+			count += 1
+		end
+	end
+end
+
+var nb_steps = 0
+var nb_agents = 0
+if args.is_empty or args.length != 2 then
+	nb_steps = 10
+	nb_agents = 10
+else
+	nb_steps = args[0].to_i
+	nb_agents = args[1].to_i
+end
+
+var agents = new Array[Agent]
+for i in [0..nb_agents[ do agents.add(new Agent)
+for a in agents do for b in agents do if a != b then a.others.add(b)
+clock_agent = new ClockAgent(nb_steps, agents)
+clock_agent.async.do_step

--- a/lib/actors/examples/chameneos-redux/chameneosredux.nit
+++ b/lib/actors/examples/chameneos-redux/chameneosredux.nit
@@ -128,7 +128,7 @@ fun work(n, nb_colors : Int ) do
 
 	for c in creatures do c.async.run
 
-	active_actors.is_empty
+	active_actors.wait
 
 	var total = 0
 	for c in creatures do

--- a/lib/pthreads/concurrent_collections.nit
+++ b/lib/pthreads/concurrent_collections.nit
@@ -508,3 +508,76 @@ class ConcurrentList[E]
 		return value
 	end
 end
+
+# A collection which `is_empty` method blocks until it's empty
+class ReverseBlockingQueue[E]
+	super ConcurrentList[E]
+
+	# Used to block or signal on waiting threads
+	private var cond = new PthreadCond
+
+	# Adding the signal to release eventual waiting thread(s)
+	redef fun push(e) do
+		mutex.lock
+		real_collection.push(e)
+		mutex.unlock
+	end
+
+	# When the Queue is empty, signal any possible waiting thread
+	redef fun remove(e) do
+		mutex.lock
+		real_collection.remove(e)
+		if real_collection.is_empty then cond.signal
+		mutex.unlock
+	end
+
+	# Wait until the Queue is empty
+	redef fun is_empty do
+		mutex.lock
+		while not real_collection.is_empty do self.cond.wait(mutex)
+		mutex.unlock
+		return true
+	end
+end
+
+# A Blocking queue implemented from a `ConcurrentList`
+# `shift` is blocking if there isn't any element in `self`
+# `push` or `unshift` releases every blocking threads
+class BlockingQueue[E]
+	super ConcurrentList[E]
+
+	# Used to block or signal on waiting threads
+	private var cond = new PthreadCond
+
+	# Adding the signal to release eventual waiting thread(s)
+	redef fun push(e) do
+		mutex.lock
+		real_collection.push(e)
+		self.cond.signal
+		real_collection.push(e)
+		mutex.unlock
+	end
+
+	redef fun unshift(e) do
+		mutex.lock
+		real_collection.unshift(e)
+		self.cond.signal
+		mutex.unlock
+	end
+
+	# If empty, blocks until an item is inserted with `push` or `unshift`
+	redef fun shift do
+		mutex.lock
+		while real_collection.is_empty do self.cond.wait(mutex)
+		var r = real_collection.shift
+		mutex.unlock
+		return r
+	end
+
+	redef fun is_empty do
+		mutex.lock
+		var r = real_collection.is_empty
+		mutex.unlock
+		return r
+	end
+end


### PR DESCRIPTION
`BlockingQueue` and `ReverseBlockingQueue` classes have been removed from  `lib/actors`  and are now in `lib/pthreads/concurrent_collections` because it's a better fit for them.
Also, since the implementation of `BlockingQueue` was too coupled with actors, the actor-specific implementation was kept in `lib/actors` and renamed as `Mailbox`.

`ReverseBlockingQueue` is a fun name and could be useful for some specific cases (as it was used in `lib/actors` or for synchronization on a list of dynamic tasks for example), but was too heavy for it's purpose in the `lib/actors` module. It's been replaced with a `SynchronizedCounter`. The `wait` method of this counter is blocking until the counter value equals 0. 

There was multiple synchronization problems with the actor library : 
* The creation of `async`, aka the proxy wasn't synchronized, which means we could create multiple instances of an actor if multiple threads called `async` on an object simultaneously
* Due to the asynchronous start of an actor (a new on a Nit Thread can return before the actual underlying C pthread started running), there was some cases where the mecanism used to wait for every actors to be idle before exiting a program was broken.

This PR adresses theses 2 bugs. The first one is just adding a mutex used for the creation of the `async` object.

The second one was adressed by moving the logic dealing with the idle state of an actor directly into his mailbox.

This PR also makes it possible to redefine an actor class. `lib/actors/agent_simulation` provides an example of this feature:
* `agent_simulation.nit` defines a simple api to which defines a Multi-agent simulation. The `ClockWorker` is in charge of the simulation and executes every steps, waiting for one to be finished before launching the other. the list of `Agent` it manages are all the agents of the simulation, which are actors too. 
* `simple_simulation.nit` redefine the `Agent` class to add specific services for a specific simulation. Here, each agent knows every other one in the simluation and greets them, wait to be greeted back by everyone, then signals the clock that it finished the step.

This feature can be useful, but hasn't been fully tested yet. Furthermore, the Nit actor model still doesn't support subclassing an actor, which could also be really useful.
 
Well, that's pretty much it, enjoy reading :p