### PR TITLE
core & gamnit: basic support for the characters nbsp, pld and plu

### DIFF
--- a/lib/core/kernel.nit
+++ b/lib/core/kernel.nit
@@ -1045,12 +1045,13 @@ universal Char
 	#
 	#     assert 'A'.is_whitespace  == false
 	#     assert ','.is_whitespace  == false
-	#     assert ' '.is_whitespace  == true
+	#     assert ' '.is_whitespace  == true # space
+	#     assert ' '.is_whitespace  == true # non-breaking space
 	#     assert '\t'.is_whitespace == true
 	fun is_whitespace: Bool
 	do
 		var i = code_point
-		return i <= 0x20 or i == 0x7F
+		return i <= 0x20 or i == 0x7F or i == 0xA0
 	end
 end
 

--- a/lib/gamnit/tileset.nit
+++ b/lib/gamnit/tileset.nit
@@ -83,6 +83,12 @@ class TileSetFont
 	# A negative value may display overlapped tiles.
 	var vspace: Numeric = 0.0 is writable
 
+	# Line spacing modifier for `pld` and `plu`
+	#
+	# This value acts as multiplier to `height + vspace`.
+	# Defaults to 0.4, so a `pld` moves chars down by about half a line.
+	var partial_line_mod: Numeric = 0.4 is writable
+
 	# The glyph/tile/texture associated to `char`
 	#
 	# Returns null if `char` is not in `chars`.
@@ -164,6 +170,12 @@ class TextSprites
 				dy -= font.height.to_f + font.vspace.to_f
 				dx = font.advance/2.0
 				continue
+			else if c == pld then
+				dy -= (font.height.to_f + font.vspace.to_f) * font.partial_line_mod.to_f
+				continue
+			else if c == plu then
+				dy += (font.height.to_f + font.vspace.to_f) * font.partial_line_mod.to_f
+				continue
 			else if c.is_whitespace then
 				dx += font.advance
 				continue
@@ -184,3 +196,9 @@ class TextSprites
 		target_sprite_set.add_all sprites
 	end
 end
+
+# Partial line forward (U+008B)
+fun pld: Char do return ''
+
+# Partial line backward (U+008C)
+fun plu: Char do return ''

--- a/tests/sav/error_class_glob.res
+++ b/tests/sav/error_class_glob.res
@@ -8,6 +8,6 @@
 ../lib/core/kernel.nit:517,1--599,3: Error: `kernel$Float` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
 ../lib/core/kernel.nit:601,1--705,3: Error: `kernel$Byte` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
 ../lib/core/kernel.nit:707,1--885,3: Error: `kernel$Int` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
-../lib/core/kernel.nit:887,1--1055,3: Error: `kernel$Char` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
-../lib/core/kernel.nit:1057,1--1074,3: Error: `kernel$Pointer` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
-../lib/core/kernel.nit:1076,1--1085,3: Error: `kernel$Task` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
+../lib/core/kernel.nit:887,1--1056,3: Error: `kernel$Char` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
+../lib/core/kernel.nit:1058,1--1075,3: Error: `kernel$Pointer` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?
+../lib/core/kernel.nit:1077,1--1086,3: Error: `kernel$Task` does not specialize `module_0$Object`. Possible duplication of the root class `Object`?


### PR DESCRIPTION
Detect non-breaking spaces in `is_whitespace`, and extend `TextSprites` to accept partial line skips, for sub/superscripts or simple half line skip.