### PR TITLE
gamnit: cache each camera matrix and avoid boxing floats in matrix operations

### DIFF
--- a/lib/gamnit/cameras.nit
+++ b/lib/gamnit/cameras.nit
@@ -264,7 +264,7 @@ class UICamera
 	# Bottom right corner of the screen, at z = 0
 	fun bottom_right: Point3d[Float] do return new Point3d[Float](position.x + width, position.y - height, 0.0)
 
-	# TODO cache the anchors and the matrix
+	# TODO cache the anchors
 
 	redef fun mvp_matrix
 	do

--- a/lib/gamnit/cameras_cache.nit
+++ b/lib/gamnit/cameras_cache.nit
@@ -1,0 +1,124 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cache the `Matrix` produced by `Camera::mvp_matrix`
+module cameras_cache
+
+import cameras
+
+redef class Camera
+	private var mvp_matrix_cache: nullable Matrix = null
+
+	private var position_cache = new Point3d[Float](0.0, 0.0, 0.0)
+
+	# Has `position` changed from `position_cache`? Update the cache at the same time
+	private fun check_position_changed: Bool
+	do
+		if position.x != position_cache.x or
+		   position.y != position_cache.y or
+		   position.z != position_cache.z then
+			position_cache.x = position.x
+			position_cache.y = position.y
+			position_cache.z = position.z
+			return true
+		end
+		return false
+	end
+end
+
+redef class EulerCamera
+	# The returned matrix must not be modified as it is cached.
+	redef fun mvp_matrix
+	do
+		var m = mvp_matrix_cache
+		if m == null or check_position_changed then
+			m = super
+			mvp_matrix_cache = m
+		end
+		return m
+	end
+
+	redef fun pitch=(value)
+	do
+		super
+		mvp_matrix_cache = null
+	end
+
+	redef fun yaw=(value)
+	do
+		super
+		mvp_matrix_cache = null
+	end
+
+	redef fun roll=(value)
+	do
+		super
+		mvp_matrix_cache = null
+	end
+
+	redef fun field_of_view_y=(value)
+	do
+		super
+		mvp_matrix_cache = null
+	end
+
+	redef fun near=(value)
+	do
+		super
+		mvp_matrix_cache = null
+	end
+
+	redef fun far=(value)
+	do
+		super
+		mvp_matrix_cache = null
+	end
+end
+
+redef class UICamera
+	# The returned matrix must not be modified as it is cached.
+	redef fun mvp_matrix
+	do
+		var m = mvp_matrix_cache
+		if m == null or check_position_changed then
+			m = super
+			mvp_matrix_cache = m
+		end
+		return m
+	end
+
+	redef fun near=(value)
+	do
+		super
+		mvp_matrix_cache = null
+	end
+
+	redef fun far=(value)
+	do
+		super
+		mvp_matrix_cache = null
+	end
+
+	redef fun width=(value)
+	do
+		super
+		mvp_matrix_cache = null
+	end
+
+	redef fun height=(value)
+	do
+		super
+		mvp_matrix_cache = null
+	end
+end

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -35,6 +35,7 @@ module flat
 
 import glesv2
 intrude import geometry::points_and_lines # For _x, _y and _z
+intrude import matrix
 import matrix::projection
 import more_collections
 import performance_analysis
@@ -859,7 +860,7 @@ private class SpriteContext
 			else
 				rot = new Matrix.rotation(sprite.rotation, 0.0, 0.0, 1.0)
 			end
-			data.fill_from(rot.items, o+15)
+			data.fill_from_matrix(rot, o+15)
 
 			o += float_per_vertex
 		end
@@ -1256,4 +1257,22 @@ private class GroupedArray[E]
 		end
 		return ss.join
 	end
+end
+
+redef class GLfloatArray
+	private fun fill_from_matrix(matrix: Matrix, dst_offset: nullable Int)
+	do
+		dst_offset = dst_offset or else 0
+		var mat_len = matrix.width*matrix.height
+		assert length >= mat_len + dst_offset
+		native_array.fill_from_matrix_native(matrix.items, dst_offset, mat_len)
+	end
+end
+
+redef class NativeGLfloatArray
+	private fun fill_from_matrix_native(matrix: matrix::NativeDoubleArray, dst_offset, len: Int) `{
+		int i;
+		for (i = 0; i < len; i ++)
+			self[i+dst_offset] = (GLfloat)matrix[i];
+	`}
 end

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -40,7 +40,7 @@ import more_collections
 import performance_analysis
 
 import gamnit
-import gamnit::cameras
+import gamnit::cameras_cache
 import gamnit::dynamic_resolution
 import gamnit::limit_fps
 import gamnit::camera_control


### PR DESCRIPTION
Optimize the gamnit framework to avoid excessive garbage collection and a general speedup.

Replace the use of a generic `Array[E]` to implement matrices of floats, as it caused the boxing of each floats at each access. The new custom extern class does not suffer from the boxing and allow for some optimization in C code. This structure is allocated in the Nit GC (hackishly), and doesn't need an explicit liberation. A limitation of the current solution is about the size of the floating points in C, `matrix` uses doubles and `glesv2` floats, the data is copied and cast in C code, this could be optimized further as needed.

Caching each camera matrix avoids recreating them at each frame, which was quite costly, especially for the UI camera that rarely moves. The caching logic is implemented as a distinct class allowing easy debugging.