### PR TITLE
lib/core/time: more time related services

### DIFF
--- a/examples/extern_methods.nit
+++ b/examples/extern_methods.nit
@@ -34,7 +34,7 @@ redef enum Int
 	# System call to sleep for `self` seconds
 	#
 	# You can use the FFI to access any system functions, sometimes it's extremely simple.
-	fun sleep `{
+	fun sleep_seconds `{
 		sleep(self);
 	`}
 

--- a/lib/core/time.nit
+++ b/lib/core/time.nit
@@ -19,10 +19,27 @@ import stream
 
 in "C Header" `{
 	#include <time.h>
+	#include <sys/time.h>
 `}
 
-# Unix time: the number of seconds elapsed since January 1, 1970
+# The number of seconds elapsed since January 1, 1970
+#
+# Uses the Unix function `time`.
 fun get_time: Int `{ return time(NULL); `}
+
+# The number of milliseconds elapsed since January 1, 1970
+#
+# Returns `get_microtime / 1000`
+fun get_millitime: Int do return get_microtime / 1000
+
+# The number of microseconds elapsed since January 1, 1970
+#
+# Uses the Unix function `gettimeofday`.
+fun get_microtime: Int `{
+	struct timeval val;
+	gettimeofday(&val, NULL);
+	return val.tv_sec * 1000000 + val.tv_usec;
+`}
 
 redef class Sys
 	# Wait a specific number of second and nanoseconds

--- a/lib/core/time.nit
+++ b/lib/core/time.nit
@@ -51,6 +51,13 @@ redef class Sys
 	`}
 end
 
+redef class Int
+	# Sleep approximately `self` seconds
+	#
+	# Is not interrupted by signals.
+	fun sleep do to_f.sleep
+end
+
 redef class Float
 	# Sleep approximately `self` seconds
 	#


### PR DESCRIPTION
Three things here:
* Introduce `Int::sleep` because of my hatred for `1.0.sleep`
* Introduce `get_microtime` because timestamp are better in microseconds
* Introduce `get_millitime` because sometimes, god forbid, we have to deal with Javascript

Also, I'm using `sys/time`, pretty sure I'm doing something that should not be in the core library.

