### PR TITLE
lib/popcorn: introduce tasks

### DIFF
--- a/examples/extern_methods.nit
+++ b/examples/extern_methods.nit
@@ -34,7 +34,7 @@ redef enum Int
 	# System call to sleep for `self` seconds
 	#
 	# You can use the FFI to access any system functions, sometimes it's extremely simple.
-	fun sleep `{
+	fun sleep_seconds `{
 		sleep(self);
 	`}
 

--- a/lib/core/time.nit
+++ b/lib/core/time.nit
@@ -19,10 +19,27 @@ import stream
 
 in "C Header" `{
 	#include <time.h>
+	#include <sys/time.h>
 `}
 
-# Unix time: the number of seconds elapsed since January 1, 1970
+# The number of seconds elapsed since January 1, 1970
+#
+# Uses the Unix function `time`.
 fun get_time: Int `{ return time(NULL); `}
+
+# The number of milliseconds elapsed since January 1, 1970
+#
+# Returns `get_microtime / 1000`
+fun get_millitime: Int do return get_microtime / 1000
+
+# The number of microseconds elapsed since January 1, 1970
+#
+# Uses the Unix function `gettimeofday`.
+fun get_microtime: Int `{
+	struct timeval val;
+	gettimeofday(&val, NULL);
+	return val.tv_sec * 1000000 + val.tv_usec;
+`}
 
 redef class Sys
 	# Wait a specific number of second and nanoseconds

--- a/lib/core/time.nit
+++ b/lib/core/time.nit
@@ -51,6 +51,13 @@ redef class Sys
 	`}
 end
 
+redef class Int
+	# Sleep approximately `self` seconds
+	#
+	# Is not interrupted by signals.
+	fun sleep do to_f.sleep
+end
+
 redef class Float
 	# Sleep approximately `self` seconds
 	#

--- a/lib/popcorn/pop_tasks.nit
+++ b/lib/popcorn/pop_tasks.nit
@@ -1,0 +1,78 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Copyright 2016 Alexandre Terrasa <alexandre@moz-code.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Popcorn threaded tasks
+#
+# Tasks allow you to execute code in another thread than the app listening loop.
+# Useful when you want to run some tasks periodically.
+#
+# Let's say you want to purge the `downloads/` directory of your app every hour:
+#
+# ~~~nitish
+# class PurgeTask
+#	super PopTask
+#
+#	var dir: String
+#
+#	redef fun main do
+#		loop
+#			dir.rmdir
+#			3600.sleep
+#		end
+#	end
+# end
+#
+# var app = new App
+#
+# # Register a new task
+# app.register_task(new PurgeTask("downloads/"))
+#
+# # Add your handlers
+# # app.use('/', new MyHandler)
+#
+# # Run the tasks
+# app.run_tasks
+#
+# # Start the app
+# app.listen("0.0.0.0", 3000)
+# ~~~
+module pop_tasks
+
+import pop_handlers
+import pthreads
+
+# An abstract Popcorn task
+#
+# Redefine the `main` method to do something
+#
+# TODO provide a CRON-like syntax like SpringBoot?
+abstract class PopTask
+	super Thread
+
+	redef fun main do return null
+end
+
+redef class App
+
+	# Tasks to run
+	var tasks = new Array[PopTask]
+
+	# Register a new task in `self`
+	fun register_task(task: PopTask) do tasks.add task
+
+	# Run all registered tasks
+	fun run_tasks do for task in tasks do task.start
+end

--- a/lib/popcorn/popcorn.nit
+++ b/lib/popcorn/popcorn.nit
@@ -18,6 +18,7 @@
 module popcorn
 
 import nitcorn
+import pop_tasks
 import pop_sessions
 import pop_logging
 intrude import pop_handlers


### PR DESCRIPTION

This PR is based on #2436 

## Popcorn threaded tasks

 Tasks allow you to execute code in another thread than the app listening loop.
 Useful when you want to run some tasks periodically.

 Let's say you want to purge the `downloads/` directory of your app every hour:

~~~nit
 class PurgeTask
	super PopTask

	var dir: String

	redef fun main do
		loop
			dir.rmdir
			3600.sleep
		end
	end
 end

 var app = new App

 # Register a new task
 app.register_task(new PurgeTask("downloads/"))

 # Add your handlers
 # app.use('/', new MyHandler)

 # Run the tasks
 app.run_tasks

 # Start the app
 app.listen("0.0.0.0", 3000)
~~~