### PR TITLE
core: fix dynamic error on the input type in `Text::replace`

### DIFF
--- a/lib/core/text/string_search.nit
+++ b/lib/core/text/string_search.nit
@@ -470,11 +470,14 @@ redef class Text
 		return res
 	end
 
-	# Replace all occurences of `pattern` with `string`
+	# Replace all occurrences of `pattern` with `string`
 	#
-	#     assert "hlelo".replace("le", "el")	     ==  "hello"
-	#     assert "hello".replace('l', "")	     ==  "heo"
-	fun replace(pattern: Pattern, string: SELFTYPE): String
+	#     assert "hlelo".replace("le", "el") == "hello"
+	#     assert "hello".replace('l', "")    == "heo"
+	#
+	#     var t: Text = "hello"
+	#     assert t.replace("hello", new FlatBuffer) == ""
+	fun replace(pattern: Pattern, string: Text): String
 	do
 		return self.split_with(pattern).join(string)
 	end


### PR DESCRIPTION
The previous use of the virtual `SELFTYPE` on a parameter of `replace` was too restrictive and caused a dynamic crash when replacing something in a  `String` by a `FlatBuffer` (for example). This PR uses the more general `Text` as the parameter type, which is already supported by the existing implementation.

The minimal case is not the most useful as doc but I've added it as a unit test anyway:
~~~
var t: Text = "hello"
assert t.replace("hello", new FlatBuffer) == ""
~~~