### PR TITLE
coloring: Only generate strictly positive IDs

### DIFF
--- a/src/compiler/coloring.nit
+++ b/src/compiler/coloring.nit
@@ -160,9 +160,16 @@ end
 #
 # Possible colors:
 #
-# * A:0, B:1, C: 2, D: 1, E: 3, F:3, G:2, H:4
+# * A: 0
+# * B: 1
+# * C: 2
+# * D: 1
+# * E: 3
+# * F: 3
+# * G: 2
+# * H: 4
 #
-# see: Ducournau, R. (2011).
+# SEE: Ducournau, R. (2011).
 # Coloring, a versatile technique for implementing object-oriented languages.
 # Software: Practice and Experience, 41(6), 627–659.
 class POSetColorer[E: Object]

--- a/src/compiler/coloring.nit
+++ b/src/compiler/coloring.nit
@@ -178,6 +178,9 @@ class POSetColorer[E: Object]
 	var is_colored = false
 
 	# Resulting ids
+	#
+	# All ids are strictly positive (`>= 1`).
+	#
 	# REQUIRE: is_colored
 	fun ids: Map[E, Int] do
 		assert is_colored
@@ -223,7 +226,7 @@ class POSetColorer[E: Object]
 		ids_cache.clear
 		var elements = new HashSet[E].from(poset_cache.to_a)
 		for e in poset_cache.linearize(elements) do
-			ids_cache[e] = ids_cache.length
+			ids_cache[e] = ids_cache.length + 1
 		end
 	end
 

--- a/src/compiler/test_coloring.nit
+++ b/src/compiler/test_coloring.nit
@@ -1,0 +1,32 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module test_coloring is test_suite
+
+import test_suite
+import coloring
+
+class TestPOSetColorer
+	super TestSuite
+
+	fun test_ids_strictly_positive do
+		var poset = new POSet[String]
+		poset.add_node "A"
+
+		var colorer = new POSetColorer[String]
+		colorer.colorize(poset)
+
+		assert colorer.ids["A"] > 0
+	end
+end


### PR DESCRIPTION
This will allow to reserve negative IDs (including 0) for special purposes.

Signed-off-by: Jean-Christophe Beaupré <jcbrinfo@users.noreply.github.com>