### PR TITLE
geometry: implement 3D `dist` and improve API

### DIFF
--- a/lib/geometry/boxes.nit
+++ b/lib/geometry/boxes.nit
@@ -83,6 +83,8 @@ interface Boxed[N: Numeric]
 	# assert b.left == 2 and b.right == 8 and b.top == 13 and b.bottom == 7
 	# ~~~
 	fun padded(dist: N): Box[N] do return new Box[N].lrtb(left - dist, right + dist, top + dist, bottom - dist)
+
+	redef fun to_s do return "<{class_name} left: {left}, right: {right}, top: {top}, bottom: {bottom}>"
 end
 
 # A 2d bounded object and an implementation of `Boxed`
@@ -146,8 +148,6 @@ class Box[N: Numeric]
 	do
 		init(left, left+width, top, top - height)
 	end
-
-	redef fun to_s do return "<left: {left}, right: {right}, top: {top}, bottom: {bottom}>"
 end
 
 # An 3d abstract bounded object
@@ -195,6 +195,8 @@ interface Boxed3d[N: Numeric]
 	end
 
 	redef fun padded(dist): Box3d[N] do return new Box3d[N].lrtbfb(left - dist, right + dist, top + dist, bottom - dist, front + dist, back - dist)
+
+	redef fun to_s do return "<{class_name} left: {left}, right: {right}, top: {top}, bottom: {bottom}, front: {front}, back: {back}>"
 end
 
 # A 3d bounded object and an implementation of Boxed
@@ -278,8 +280,6 @@ class Box3d[N: Numeric]
 		self.front = front
 		self.back = front - depth
 	end
-
-	redef fun to_s do return "<left: {left}, right: {right}, top: {top}, bottom: {bottom}, front: {front}, back: {back}"
 end
 
 redef class IPoint[N]
@@ -330,7 +330,7 @@ class BoxedArray[E: Boxed[Numeric]]
 	private var data: Array[E] = new Array[E]
 
 	redef fun add(item) do data.add(item)
-	redef fun items_overlapping(item): SimpleCollection[E]
+	redef fun items_overlapping(item)
 	do
 		var arr = new Array[E]
 		for i in data do

--- a/lib/geometry/boxes.nit
+++ b/lib/geometry/boxes.nit
@@ -322,22 +322,19 @@ interface BoxedCollection[E: Boxed[Numeric]]
 	fun items_overlapping(region :Boxed[Numeric]): SimpleCollection[E] is abstract
 end
 
-# A BoxedCollection implemented with an array, linear performances for searching but really
-# fast for creation and filling
+# `BoxedCollection` implemented by an array
+#
+# Linear performances for searching, but really fast creation and filling.
 class BoxedArray[E: Boxed[Numeric]]
 	super BoxedCollection[E]
+	super Array[E]
 
-	private var data: Array[E] = new Array[E]
-
-	redef fun add(item) do data.add(item)
 	redef fun items_overlapping(item)
 	do
 		var arr = new Array[E]
-		for i in data do
+		for i in self do
 			if i.intersects(item) then arr.add(i)
 		end
 		return arr
 	end
-
-	redef fun iterator do return data.iterator
 end

--- a/lib/geometry/points_and_lines.nit
+++ b/lib/geometry/points_and_lines.nit
@@ -38,7 +38,16 @@ interface IPoint[N: Numeric]
 	# assert p0.dist(p1).is_approx(3.6, 0.01)
 	# ~~~
 	#
-	# TODO 3D implementation.
+	# If `self` or `other` are in 3D, the distance takes into account the 3 axes.
+	# For a 2D point, the Z coordinate is considered to be 0.
+	#
+	# ~~~
+	# var p2 = new Point3d[Float](0.0, 0.0, 0.0)
+	# var p3 = new Point3d[Float](2.0, 3.0, 4.0)
+	# var p4 = new Point[Float](2.0, 3.0)
+	# assert p2.dist(p3).is_approx(5.385, 0.01)
+	# assert p2.dist(p4).is_approx(3.606, 0.01)
+	# ~~~
 	fun dist(other: Point[Numeric]): N
 	do
 		return x.value_of(dist2(other).to_f.sqrt)
@@ -54,8 +63,28 @@ interface IPoint[N: Numeric]
 	# assert p0.dist2(p1) == 13.0
 	# ~~~
 	#
-	# TODO 3D implementation.
+	# If `self` or `other` are in 3D, the distance takes into account the 3 axes.
+	# For a 2D point, the Z coordinate is considered to be 0.
+	#
+	# ~~~
+	# var p2 = new Point3d[Float](0.0, 0.0, 0.0)
+	# var p3 = new Point3d[Float](2.0, 3.0, 4.0)
+	# var p4 = new Point[Float](2.0, 3.0)
+	# assert p2.dist2(p3).is_approx(29.0, 0.01)
+	# assert p2.dist2(p4).is_approx(13.0, 0.01)
+	# assert p4.dist2(p2).is_approx(13.0, 0.01)
+	# ~~~
 	fun dist2(other: Point[Numeric]): N
+	do return x.value_of(other.dist2_with_2d(self))
+
+	private fun dist2_with_2d(other: IPoint[Numeric]): Numeric
+	do return dist2_xy(other)
+
+	private fun dist2_with_3d(other: IPoint3d[Numeric]): Numeric
+	do return dist2_xy(other).add(other.z.mul(other.z))
+
+	# Square of the distance with `other` on the X and Y axes
+	private fun dist2_xy(other: IPoint[N]): N
 	do
 		var dx = other.x.sub(x)
 		var dy = other.y.sub(y)
@@ -100,6 +129,19 @@ interface IPoint3d[N: Numeric]
 	fun z: N is abstract
 
 	redef fun to_s do return "({x}, {y}, {z})"
+
+	redef fun dist2(other)
+	do return x.value_of(other.dist2_with_3d(self))
+
+	redef fun dist2_with_2d(other)
+	do return dist2_xy(other).add(z.mul(z))
+
+	redef fun dist2_with_3d(other)
+	do
+		var dz = other.z.sub(z)
+		var s = dist2_xy(other).add(dz.mul(dz))
+		return x.value_of(s)
+	end
 end
 
 # 3D point with `x`, `y` and `z`

--- a/lib/geometry/points_and_lines.nit
+++ b/lib/geometry/points_and_lines.nit
@@ -88,8 +88,8 @@ end
 class Point[N: Numeric]
 	super IPoint[N]
 
-	redef var x: N is writable
-	redef var y: N is writable
+	redef var x: N = 0.0 is writable, optional
+	redef var y: N = 0.0 is writable, optional
 end
 
 # Abstract 3d point, strongly linked to its implementation `Point3d`
@@ -107,7 +107,7 @@ class Point3d[N: Numeric]
 	super IPoint3d[N]
 	super Point[N]
 
-	redef var z: N is writable
+	redef var z: N = 0.0 is writable, optional
 end
 
 # Abstract 2D line segment between two ordered points


### PR DESCRIPTION
The main change in this PR is the reimplementation of `Point::dist` and `dist2` to support 3D points, including comparing 2D and 3D points. The double dispatch logic is a bit complex but it works with any receiver.

This PR also tweaks existing services to improve the API and doc:
* Make all attributes of `Point` optional for gradual creation/space allocation. In practice, points are often created with a default value, as a kind of buffer, or with the Z axis at 0.
* Rework `BoxedArray` as a subclass of `Array` to inherit its services (incl. `remove`) while using less code.
* Move the custom `to_s` from the concrete boxes to the interfaces as it is very useful when debugging.