### PR TITLE
gamnit & sdl2: implement app::audio using SDL2 mixer

### DIFF
--- a/lib/android/audio.nit
+++ b/lib/android/audio.nit
@@ -498,7 +498,10 @@ redef class PlayableAudio
 	# Used when the app pause all sounds or resume all sounds
 	var paused: Bool = false
 
-	redef init do sounds.add self
+	# Is `self` already loaded?
+	protected var is_loaded = false is writable
+
+	redef var error = null
 end
 
 redef class Sound
@@ -642,7 +645,6 @@ end
 
 redef class App
 
-
 	# Returns the default MediaPlayer of the application.
 	# When you load a music, it goes in this MediaPlayer.
 	# Use it for advanced sound management
@@ -666,16 +668,12 @@ redef class App
 
 	# Same as `load_sound` but load the sound from the `res/raw` folder
 	fun load_sound_from_res(sound_name: String): Sound do
-		var sound = default_soundpool.load_name(resource_manager,self.native_activity, sound_name)
-		sys.sounds.add sound
-		return sound
+		return default_soundpool.load_name(resource_manager, native_activity, sound_name)
 	end
 
 	# Same as `load_music` but load the sound from the `res/raw` folder
 	fun load_music_from_res(music: String): Music do
-		var sound = default_mediaplayer.load_sound(resource_manager.raw_id(music), self.native_activity)
-		sys.sounds.add sound
-		return sound
+		return default_mediaplayer.load_sound(resource_manager.raw_id(music), native_activity)
 	end
 
 	redef fun on_pause do
@@ -707,11 +705,4 @@ redef class App
 			if not s.paused then s.resume
 		end
 	end
-end
-
-redef class Sys
-
-	# Sounds handled by the application, when you load a sound, it's added to this list.
-	# This array is used in `pause` and `resume`
-	private var sounds = new Array[PlayableAudio]
 end

--- a/lib/app/audio.nit
+++ b/lib/app/audio.nit
@@ -31,14 +31,13 @@ import android::audio is conditional(android)
 # Abstraction of a playable Audio
 abstract class PlayableAudio
 
+	init do sounds.add self
+
 	# Path to the audio file in the assets folder
 	var path: String
 
 	# Last error on this sound, if any
-	var error: nullable Error = null is writable
-
-	# Is `self` already loaded?
-	protected var is_loaded = false is writable
+	fun error: nullable Error do return null
 
 	# Load this playable audio
 	fun load do end
@@ -61,4 +60,10 @@ end
 # Long sound that can bee looped
 class Music
 	super PlayableAudio
+end
+
+redef class Sys
+
+	# All instantiated sounds
+	var sounds = new Array[PlayableAudio]
 end

--- a/lib/gamnit/README.md
+++ b/lib/gamnit/README.md
@@ -9,13 +9,13 @@ To compile the _gamnit_ apps packaged with the Nit repositoy on GNU/Linux you ne
 Under Debian 8.2, this command should install everything needed:
 
 ~~~
-apt-get install libgles2-mesa-dev libsdl2-dev libsdl2-image-dev inkscape mpg123
+apt-get install libgles2-mesa-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev inkscape mpg123
 ~~~
 
 Under Windows 64 bits, using msys2, you can install the required packages with:
 
 ~~~
-pacman -S mingw-w64-x86_64-angleproject-git mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_image
+pacman -S mingw-w64-x86_64-angleproject-git mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_mixer
 ~~~
 
 # Services by submodules

--- a/lib/linux/audio.nit
+++ b/lib/linux/audio.nit
@@ -14,23 +14,112 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Linux audio implementation
+# `app::audio` implementation for GNU/Linux using SDL2 mixer
 module audio
 
 import app::audio
+import sdl2::mixer
 import linux
 
 redef class PlayableAudio
+	redef var error = null
 
-	redef fun play do
-		if path.has_suffix(".wav") then
-			sys.system "aplay -q {app.assets_dir}{path} &"
-		else if path.has_suffix(".mp3") then
-			sys.system "mpg123 -q {app.assets_dir}{path} &"
+	# Real file system path to this asset
+	private fun fs_path: String do return app.assets_dir / path
+
+	# Does `fs_path` exist?
+	private fun fs_path_exists: Bool
+	do
+		if not fs_path.file_exists then
+			error = new Error("Failed to load audio '{path}': file not found")
+			return false
 		end
+		return true
+	end
+end
+
+redef class Sound
+
+	private var native: nullable MixChunk = null
+
+	redef fun load
+	do
+		if not fs_path_exists then return
+
+		# SDL2 mixer load
+		var native = mix.load_wav(fs_path.to_cstring)
+		if native.address_is_null then
+			error = new Error("Failed to load sound '{path}': {mix.error}")
+			return
+		end
+
+		self.native = native
 	end
 
-	redef fun load do end
-	redef fun pause do end
-	redef fun resume do end
+	redef fun play
+	do
+		var native = native
+
+		if native == null and error == null then
+			# Lazy load
+			load
+
+			# Auto print errors on lazy loading only
+			var error = error
+			if error != null then print_error error
+		end
+
+		# If there's an error, silently skip
+		if error != null then return
+		native = self.native
+		assert native != null
+
+		# Play on any available channel
+		mix.play_channel(-1, native, 0)
+	end
+end
+
+redef class Music
+
+	private var native: nullable MixMusic = null
+
+	redef fun load
+	do
+		if not fs_path_exists then return
+
+		# SDL2 mixer load
+		var native = mix.load_mus(fs_path.to_cstring)
+		if native.address_is_null then
+			error = new Error("Failed to load music '{path}': {mix.error}")
+			return
+		end
+
+		self.native = native
+	end
+
+	redef fun play
+	do
+		var native = native
+
+		if native == null and error == null then
+			# Lazy load
+			load
+
+			# Auto print errors on lazy loading only
+			var error = error
+			if error != null then print_error error
+		end
+
+		# If there's an error, silently skip
+		if error != null then return
+		native = self.native
+		assert native != null
+
+		# Play looping
+		mix.play_music(native, -1)
+	end
+
+	redef fun pause do mix.pause_music
+
+	redef fun resume do mix.resume_music
 end

--- a/lib/sdl2/mixer.nit
+++ b/lib/sdl2/mixer.nit
@@ -1,0 +1,167 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SDL2 mixer with sample/sounds and music
+#
+# C API documentation: https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer.html
+module mixer is pkgconfig "SDL2_mixer"
+
+import sdl2_base
+
+`{
+	#include "SDL2/SDL_mixer.h"
+`}
+
+redef class Sys
+	# SDL2 mixer services
+	var mix = new Mix is lazy
+end
+
+# SDL2 mixer services
+class Mix
+	# Initialize supports for loading formats in `flags`
+	#
+	# Returns the initialized supports.
+	fun initialize(flags: MixInitFlags): MixInitFlags `{
+		return Mix_Init(flags);
+	`}
+
+	# FLAC format support, for `initialize`
+	fun flac: MixInitFlags `{ return MIX_INIT_FLAC; `}
+
+	# MOD format support, for `initialize`
+	fun mod: MixInitFlags `{ return MIX_INIT_MOD; `}
+
+	# MP3 format support, for `initialize`
+	fun mp3: MixInitFlags `{ return MIX_INIT_MP3; `}
+
+	# OGG format support, for `initialize`
+	fun ogg: MixInitFlags `{ return MIX_INIT_OGG; `}
+
+	# Clean up all dynamically loaded library handles
+	#
+	# May be called after loading all the sounds.
+	fun quit `{ Mix_Quit(); `}
+
+	# Initialize and configure the mixer API
+	#
+	# Playback is configured with:
+	# * The output sample `frequency`, in samples per second (Hz).
+	# * The output sample `format`, may be `mix_default_format`.
+	# * The number of sound `channels`, 1 for mono or 2 for stereo.
+	# * The number of bytes used by output sample size as `chunk_size`.
+	fun open_audio(frequency: Int, format: MixFormat, channels, chunk_size: Int): Bool `{
+		return Mix_OpenAudio(frequency, format, channels, chunk_size) == 0;
+	`}
+
+	# Default frequency for `open_audio` (22050)
+	fun default_frequency: Int `{ return MIX_DEFAULT_FREQUENCY; `}
+
+	# Default format for `open_audio`
+	fun default_format: MixFormat `{ return MIX_DEFAULT_FORMAT; `}
+	# TODO other formats: AUDIO_U8, AUDIO_S8, etc.
+
+	# Shutdown and cleanup the mixer API
+	fun close_audio `{ Mix_CloseAudio(); `}
+
+	# Last error produced by the mixer API
+	fun error: CString `{ return (char*)Mix_GetError(); `}
+
+	# ---
+	# Chunks/sounds
+
+	# Load `file` for use as a sample
+	#
+	# Returns a null pointer on error.
+	#
+	# Can load WAVE, AIFF, RIFF, OGG and VOC files.
+	fun load_wav(file: CString): MixChunk `{ return Mix_LoadWAV(file); `}
+
+	# Play `chunk` on `channel`
+	#
+	# If `channel == -1` the first unreserved channel is used.
+	# The sound is repeated `loops` times, `loops == 0` plays it once and
+	# `loops == -1` loops infinitely.
+	fun play_channel(channel: Int, chunk: MixChunk, loops: Int): Bool `{
+		return Mix_PlayChannel(channel, chunk, loops) == 0;
+	`}
+
+	# Set the chunk volume out of `mix.max_volume` and return the previous value
+	#
+	# Use `volume = -1` to only read the previous value.
+	fun volume_chunk(chunk: MixChunk, volume: Int) `{
+		Mix_VolumeChunk(chunk, volume);
+	`}
+
+	# ---
+	# Music
+
+	# Load music from `file`
+	#
+	# Returns a null pointer on error.
+	#
+	# WAVE, MOD, MIDI, OGG, MP3, FLAC VOC files
+	fun load_mus(file: CString): MixMusic `{ return Mix_LoadMUS(file); `}
+
+	# Play `music` `loops` times
+	#
+	# The music is plays once if `loops == 1` and repeats infinitely if `loops == -1`.
+	fun play_music(music: MixMusic, loops: Int): Bool `{
+		return Mix_PlayMusic(music, loops) == 0;
+	`}
+
+	# Pause music playback
+	fun pause_music `{ Mix_PauseMusic(); `}
+
+	# Resume music playback
+	fun resume_music `{ Mix_ResumeMusic(); `}
+
+	# Set the music volume out of `mix.max_volume` and return the previous value
+	#
+	# Use `volume = -1` to only read the previous value.
+	fun volume_music(volume: Int): Int `{
+		return Mix_VolumeMusic(volume);
+	`}
+
+	# Maximum volume value for `volume_music` and `volume_chunk`
+	fun max_volume: Int `{ return MIX_MAX_VOLUME; `}
+end
+
+# Chunk/sound handle, loaded by `mix.load_wav`
+extern class MixChunk
+	redef fun free `{ Mix_FreeChunk(self); `}
+end
+
+# Music handle, loaded by `mix.load_mus`
+extern class MixMusic
+	redef fun free `{ Mix_FreeMusic(self); `}
+end
+
+# ---
+# Flags & enums
+
+# Flags for `mix.initialize`
+extern class MixInitFlags `{ int `}
+
+	# Binary OR
+	fun | (other: MixInitFlags): MixInitFlags `{ return self | other; `}
+
+	private fun to_i: Int `{ return self; `}
+
+	redef fun ==(o) do return o isa MixInitFlags and o.to_i == to_i
+end
+
+# Sample format for `mix.open_audio`
+extern class MixFormat `{ int `}
+end


### PR DESCRIPTION
Intro a decent implementation of `app::audio` for desktop computers using SDL2 mixer. It supports WAV, MP3, OGG and more. The underlying SDL2 mixer bindings are minimal, they offer only the required features, more can be added as needed.

Clients of the gamnit framework will need to `apt-get install libsdl2-mixer-dev`.