### PR TITLE
modelize_class: Remove the `useless-bound` warning

### DIFF
--- a/src/modelize/modelize_class.nit
+++ b/src/modelize/modelize_class.nit
@@ -188,9 +188,6 @@ redef class ModelBuilder
 						bounds.add(bound)
 						nfd.bound = bound
 					end
-					if bound isa MClassType and bound.mclass.kind == enum_kind then
-						warning(nfdt, "useless-bound", "Warning: useless formal parameter type since `{bound}` cannot have subclasses.")
-					end
 				else if mclass.mclassdefs.is_empty then
 					if objectclass == null then
 						error(nfd, "Error: formal parameter type `{pname}` unbounded but no `Object` class exists.")

--- a/tests/sav/base_gen_final_bound.res
+++ b/tests/sav/base_gen_final_bound.res
@@ -1,1 +1,0 @@
-base_gen_final_bound.nit:23,16--18: Warning: useless formal parameter type since `Int` cannot have subclasses.

--- a/tests/sav/error_class_generic_alt2.res
+++ b/tests/sav/error_class_generic_alt2.res
@@ -1,2 +1,1 @@
-alt/error_class_generic_alt2.nit:18,22--26: Warning: useless formal parameter type since `Float` cannot have subclasses.
 alt/error_class_generic_alt2.nit:25,8--12: Type Error: `Array[E: nullable Object]` is a generic class.

--- a/tests/sav/test_gen_inh.res
+++ b/tests/sav/test_gen_inh.res
@@ -1,5 +1,3 @@
-test_gen_inh.nit:29,15--17: Warning: useless formal parameter type since `Int` cannot have subclasses.
-test_gen_inh.nit:34,15--17: Warning: useless formal parameter type since `Int` cannot have subclasses.
 11
 22
 33

--- a/tests/sav/test_super_gen.res
+++ b/tests/sav/test_super_gen.res
@@ -1,4 +1,3 @@
-test_super_gen.nit:27,12--14: Warning: useless formal parameter type since `Int` cannot have subclasses.
 1
 0
 5

--- a/tests/sav/test_super_gen_raf.res
+++ b/tests/sav/test_super_gen_raf.res
@@ -1,4 +1,2 @@
-test_super_gen.nit:27,12--14: Warning: useless formal parameter type since `Int` cannot have subclasses.
-test_super_gen_raf.nit:19,12--14: Warning: useless formal parameter type since `Int` cannot have subclasses.
 0
 20


### PR DESCRIPTION
With class subsets, there is no bound that is useless.

Signed-off-by: Jean-Christophe Beaupré <jcbrinfo@users.noreply.github.com>