### PR TITLE
Introduce the `subset` class kind as an annotation

### DIFF
--- a/src/doc/model_ext.nit
+++ b/src/doc/model_ext.nit
@@ -117,4 +117,4 @@ end
 fun package_visibility: MVisibility do return once new MVisibility("package", 2)
 
 # A class kind with no equivalent semantic in Nit.
-fun raw_kind(s: String): MClassKind do return new MClassKind(s, false)
+fun raw_kind(s: String): MClassKind do return new MClassKind(s, false, false, false)

--- a/src/frontend/check_annotation.nit
+++ b/src/frontend/check_annotation.nit
@@ -73,6 +73,7 @@ private class CheckAnnotationPhase
 
 	# Raw new-line separated list of primitive annotation
 	# Note: empty-lines will be ignored since there is no annotation named by the empty string.
+	# TODO: Remplace the `subset` annotation by a class kind keyword.
 	var primtives_annotations_list = """
 new_annotation
 
@@ -104,6 +105,8 @@ ldflags
 light_ffi
 
 platform
+
+subset
 """
 
 	# Efficient set build from `primtives_annotations_list`

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -2572,6 +2572,12 @@ end
 class MClassKind
 	redef var to_s
 
+	# Can a class of kind `self` define a membership predicate?
+	var can_customize_isa: Bool
+
+	# Can a class of kind `self` define a constructor?
+	var can_init: Bool
+
 	# Is a constructor required?
 	var need_init: Bool
 
@@ -2597,12 +2603,12 @@ class MClassKind
 end
 
 # The class kind `abstract`
-fun abstract_kind: MClassKind do return once new MClassKind("abstract class", true)
+fun abstract_kind: MClassKind do return once new MClassKind("abstract class", false, true, true)
 # The class kind `concrete`
-fun concrete_kind: MClassKind do return once new MClassKind("class", true)
+fun concrete_kind: MClassKind do return once new MClassKind("class", false, true, true)
 # The class kind `interface`
-fun interface_kind: MClassKind do return once new MClassKind("interface", false)
+fun interface_kind: MClassKind do return once new MClassKind("interface", false, true, false)
 # The class kind `enum`
-fun enum_kind: MClassKind do return once new MClassKind("enum", false)
+fun enum_kind: MClassKind do return once new MClassKind("enum", false, true, false)
 # The class kind `extern`
-fun extern_kind: MClassKind do return once new MClassKind("extern class", false)
+fun extern_kind: MClassKind do return once new MClassKind("extern class", false, true, false)

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -2586,19 +2586,23 @@ class MClassKind
 	# Can a class of kind `self` specializes a class of kind `other`?
 	fun can_specialize(other: MClassKind): Bool
 	do
-		if other == interface_kind then return true # everybody can specialize interfaces
-		if self == interface_kind or self == enum_kind then
-			# no other case for interfaces
+		if other == interface_kind then
+			# everybody can specialize interfaces
+			return true
+		else if self == interface_kind or self == enum_kind then
+			# no other case for interfaces and enums
 			return false
+		else if self == subset_kind then
+			# A subset may specialize anything, except another subset.
+			# TODO: Allow sub-subsets once we can handle them.
+			return other != subset_kind
 		else if self == extern_kind then
 			# only compatible with themselves
 			return self == other
-		else if other == enum_kind or other == extern_kind then
-			# abstract_kind and concrete_kind are incompatible
-			return false
+		else
+			# assert self == abstract_kind or self == concrete_kind
+			return other == abstract_kind or other == concrete_kind
 		end
-		# remain only abstract_kind and concrete_kind
-		return true
 	end
 end
 
@@ -2612,3 +2616,5 @@ fun interface_kind: MClassKind do return once new MClassKind("interface", false,
 fun enum_kind: MClassKind do return once new MClassKind("enum", false, true, false)
 # The class kind `extern`
 fun extern_kind: MClassKind do return once new MClassKind("extern class", false, true, false)
+# The class kind `subset`
+fun subset_kind: MClassKind do return once new MClassKind("subset", true, false, false)

--- a/src/modelize/modelize_class.nit
+++ b/src/modelize/modelize_class.nit
@@ -493,6 +493,9 @@ end
 redef class AExternClasskind
 	redef fun mkind do return extern_kind
 end
+redef class ASubsetClasskind
+	redef fun mkind do return subset_kind
+end
 
 redef class AFormaldef
 	# The associated parameter type

--- a/src/modelize/modelize_class.nit
+++ b/src/modelize/modelize_class.nit
@@ -18,10 +18,13 @@
 module modelize_class
 
 import modelbuilder
+import modelize_subset
 
 redef class ToolContext
 	# Run `AModule::build_classes` on each module
-	var modelize_class_phase: Phase = new ModelizeClassPhase(self, null)
+	var modelize_class_phase: Phase = new ModelizeClassPhase(self, [
+		modelize_subset_phase
+	])
 end
 
 private class ModelizeClassPhase

--- a/src/modelize/modelize_subset.nit
+++ b/src/modelize/modelize_subset.nit
@@ -1,0 +1,56 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Injection of the `subset` class kind.
+#
+# TODO: Will become useless (and wrong) once the `subset` annotation is replaced
+# by a keyword.
+module modelize_subset
+
+import phase
+import subset_visitor
+
+redef class ToolContext
+	# The phase that injects `isa` method definitions.
+	var modelize_subset_phase: Phase = new ModelizeSubsetPhase(self, null)
+end
+
+private class ModelizeSubsetPhase
+	super Phase
+
+	redef fun process_npropdef(npropdef: APropdef)
+	do
+		var v = new ModelizeSubsetVisitor
+		v.enter_visit(npropdef)
+	end
+end
+
+private class ModelizeSubsetVisitor
+	super SubsetVisitor
+
+	redef fun visit_subset(n_classdef, annotation) do
+		# Replace the class kind.
+
+		var n_id = annotation.n_atid.n_id
+
+		var keyword = new TKwsubset
+		keyword.location = n_classdef.n_classkind.location
+		keyword.text = n_id.text
+
+		var kind = new ASubsetClasskind
+		kind.n_kwsubset = keyword
+
+		n_classdef.n_classkind = kind
+	end
+end

--- a/src/modelize/subset_visitor.nit
+++ b/src/modelize/subset_visitor.nit
@@ -1,0 +1,47 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Visitor of classes with the `subset` annotation.
+#
+# TODO: Will become useless (and wrong) once the `subset` annotation is replaced
+# by a keyword.
+module subset_visitor
+
+import parser_nodes
+
+# Visitor of classes with the `subset` annotation.
+abstract class SubsetVisitor
+	super Visitor
+
+	redef fun visit(node) do
+		node.accept_subset_visitor(self)
+	end
+
+	# Process a class subset.
+	#
+	# `annotation` corresponds to the `subset` annotation.
+	protected fun visit_subset(n_classdef: AStdClassdef, annotation: AAnnotPropdef) is abstract
+end
+
+redef class ANode
+	private fun accept_subset_visitor(v: SubsetVisitor) do end
+end
+
+redef class AAnnotPropdef
+	redef fun accept_subset_visitor(v) do
+		if n_atid.n_id.text == "subset" then
+			v.visit_subset(self.parent.as(AStdClassdef), self)
+		end
+	end
+end

--- a/src/parser/parser_nodes.nit
+++ b/src/parser/parser_nodes.nit
@@ -539,6 +539,13 @@ class TKwenum
 	super TokenKeyword
 end
 
+# The keyword `subset`
+#
+# TODO: Make `subset` an actual keyword.
+class TKwsubset
+	super TokenKeyword
+end
+
 # The keyword `end`
 class TKwend
 	super TokenKeyword
@@ -1312,6 +1319,18 @@ class AExternClasskind
 
 	# The `class` keyword.
 	var n_kwclass: nullable TKwclass = null is writable
+end
+
+class ASubsetClasskind
+	super AClasskind
+
+	# The `subset` keyword.
+	var n_kwsubset: TKwsubset is writable, noinit
+
+	redef fun visit_all(v) do
+		# TODO: Remove this redefinition once generated from the grammar.
+		v.enter_visit(n_kwsubset)
+	end
 end
 
 # The definition of a formal generic parameter type. eg `X: Y`

--- a/tests/base_error_class_kind.nit
+++ b/tests/base_error_class_kind.nit
@@ -37,6 +37,10 @@ end
 extern class ExC
 end
 
+class SSet
+	subset
+end
+
 ##
 
 interface SubI
@@ -45,6 +49,7 @@ interface SubI
 	#alt2# super CC
 	#alt3# super EnC
 	#alt4# super ExC
+	#alt16# super SSet
 end
 
 abstract class SubA
@@ -53,6 +58,7 @@ abstract class SubA
 	super CC
 	#alt5# super EnC
 	#alt6# super ExC
+	#alt17# super SSet
 end
 
 class SubC
@@ -61,6 +67,7 @@ class SubC
 	super CC
 	#alt7# super EnC
 	#alt8# super ExC
+	#alt18# super SSet
 end
 
 enum SubEn
@@ -69,6 +76,7 @@ enum SubEn
 	#alt10# super CC
 	#alt11# super EnC
 	#alt12# super ExC
+	#alt19# super SSet
 end
 
 extern class SubEx
@@ -77,4 +85,42 @@ extern class SubEx
 	#alt14# super CC
 	#alt15# super EnC
 	super ExC
+	#alt20# super SSet
 end
+
+# A subset can inherit anything except a subset, and has only one direct parent.
+
+class SSetI
+	subset
+	super IC
+	# TODO: super AC
+	# TODO: super CC
+	# TODO: super EnC
+	# TODO: super ExC
+	# TODO: super SSet
+end
+
+class SSetA
+	subset
+	super AC
+end
+
+class SSetC
+	subset
+	super CC
+end
+
+class SSetEn
+	subset
+	super EnC
+end
+
+class SSetEx
+	subset
+	super ExC
+end
+
+#alt26# class SubSSet
+#alt26# 	subset
+#alt26# 	super SSet
+#alt26# end

--- a/tests/base_error_class_kind2.nit
+++ b/tests/base_error_class_kind2.nit
@@ -29,12 +29,17 @@ end
 extern class ExC2
 end
 
+class SSet2
+	subset
+end
+
 redef class SubI
 	super IC2
 	#alt1# super AC2
 	#alt2# super CC2
 	#alt3# super EnC2
 	#alt4# super ExC2
+	#alt16# super SSet2
 end
 
 redef class SubA
@@ -43,6 +48,7 @@ redef class SubA
 	super CC2
 	#alt5# super EnC2
 	#alt6# super ExC2
+	#alt17# super SSet2
 end
 
 redef class SubC
@@ -51,6 +57,7 @@ redef class SubC
 	super CC2
 	#alt7# super EnC2
 	#alt8# super ExC2
+	#alt18# super SSet2
 end
 
 redef class SubEn
@@ -59,6 +66,7 @@ redef class SubEn
 	#alt10# super CC2
 	#alt11# super EnC2
 	#alt12# super ExC2
+	#alt19# super SSet2
 end
 
 redef class SubEx
@@ -67,4 +75,5 @@ redef class SubEx
 	#alt14# super CC2
 	#alt15# super EnC2
 	super ExC2
+	#alt20# super SSet2
 end

--- a/tests/error_subset_no_new.nit
+++ b/tests/error_subset_no_new.nit
@@ -1,0 +1,29 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import core::kernel
+
+class A
+	var x: Int
+end
+
+class S
+	super A
+	subset do return true
+end
+
+var a = new A(1)
+a.x.output
+var s = new S(2)
+s.x.output

--- a/tests/sav/base_error_class_kind2_alt1.res
+++ b/tests/sav/base_error_class_kind2_alt1.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt1.nit:34,8--10: Error: interface `SubI` cannot specialize abstract class `AC2`.
+alt/base_error_class_kind2_alt1.nit:38,8--10: Error: interface `SubI` cannot specialize abstract class `AC2`.

--- a/tests/sav/base_error_class_kind2_alt10.res
+++ b/tests/sav/base_error_class_kind2_alt10.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt10.nit:59,8--10: Error: enum `SubEn` cannot specialize class `CC2`.
+alt/base_error_class_kind2_alt10.nit:66,8--10: Error: enum `SubEn` cannot specialize class `CC2`.

--- a/tests/sav/base_error_class_kind2_alt11.res
+++ b/tests/sav/base_error_class_kind2_alt11.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt11.nit:60,8--11: Error: enum `SubEn` cannot specialize enum `EnC2`.
+alt/base_error_class_kind2_alt11.nit:67,8--11: Error: enum `SubEn` cannot specialize enum `EnC2`.

--- a/tests/sav/base_error_class_kind2_alt12.res
+++ b/tests/sav/base_error_class_kind2_alt12.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt12.nit:61,8--11: Error: enum `SubEn` cannot specialize extern class `ExC2`.
+alt/base_error_class_kind2_alt12.nit:68,8--11: Error: enum `SubEn` cannot specialize extern class `ExC2`.

--- a/tests/sav/base_error_class_kind2_alt13.res
+++ b/tests/sav/base_error_class_kind2_alt13.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt13.nit:66,8--10: Error: extern class `SubEx` cannot specialize abstract class `AC2`.
+alt/base_error_class_kind2_alt13.nit:74,8--10: Error: extern class `SubEx` cannot specialize abstract class `AC2`.

--- a/tests/sav/base_error_class_kind2_alt14.res
+++ b/tests/sav/base_error_class_kind2_alt14.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt14.nit:67,8--10: Error: extern class `SubEx` cannot specialize class `CC2`.
+alt/base_error_class_kind2_alt14.nit:75,8--10: Error: extern class `SubEx` cannot specialize class `CC2`.

--- a/tests/sav/base_error_class_kind2_alt15.res
+++ b/tests/sav/base_error_class_kind2_alt15.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt15.nit:68,8--11: Error: extern class `SubEx` cannot specialize enum `EnC2`.
+alt/base_error_class_kind2_alt15.nit:76,8--11: Error: extern class `SubEx` cannot specialize enum `EnC2`.

--- a/tests/sav/base_error_class_kind2_alt16.res
+++ b/tests/sav/base_error_class_kind2_alt16.res
@@ -1,0 +1,1 @@
+alt/base_error_class_kind2_alt16.nit:42,8--12: Error: interface `SubI` cannot specialize subset `SSet2`.

--- a/tests/sav/base_error_class_kind2_alt17.res
+++ b/tests/sav/base_error_class_kind2_alt17.res
@@ -1,0 +1,1 @@
+alt/base_error_class_kind2_alt17.nit:51,8--12: Error: abstract class `SubA` cannot specialize subset `SSet2`.

--- a/tests/sav/base_error_class_kind2_alt18.res
+++ b/tests/sav/base_error_class_kind2_alt18.res
@@ -1,0 +1,1 @@
+alt/base_error_class_kind2_alt18.nit:60,8--12: Error: class `SubC` cannot specialize subset `SSet2`.

--- a/tests/sav/base_error_class_kind2_alt19.res
+++ b/tests/sav/base_error_class_kind2_alt19.res
@@ -1,0 +1,1 @@
+alt/base_error_class_kind2_alt19.nit:69,8--12: Error: enum `SubEn` cannot specialize subset `SSet2`.

--- a/tests/sav/base_error_class_kind2_alt2.res
+++ b/tests/sav/base_error_class_kind2_alt2.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt2.nit:35,8--10: Error: interface `SubI` cannot specialize class `CC2`.
+alt/base_error_class_kind2_alt2.nit:39,8--10: Error: interface `SubI` cannot specialize class `CC2`.

--- a/tests/sav/base_error_class_kind2_alt20.res
+++ b/tests/sav/base_error_class_kind2_alt20.res
@@ -1,0 +1,1 @@
+alt/base_error_class_kind2_alt20.nit:78,8--12: Error: extern class `SubEx` cannot specialize subset `SSet2`.

--- a/tests/sav/base_error_class_kind2_alt3.res
+++ b/tests/sav/base_error_class_kind2_alt3.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt3.nit:36,8--11: Error: interface `SubI` cannot specialize enum `EnC2`.
+alt/base_error_class_kind2_alt3.nit:40,8--11: Error: interface `SubI` cannot specialize enum `EnC2`.

--- a/tests/sav/base_error_class_kind2_alt4.res
+++ b/tests/sav/base_error_class_kind2_alt4.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt4.nit:37,8--11: Error: interface `SubI` cannot specialize extern class `ExC2`.
+alt/base_error_class_kind2_alt4.nit:41,8--11: Error: interface `SubI` cannot specialize extern class `ExC2`.

--- a/tests/sav/base_error_class_kind2_alt5.res
+++ b/tests/sav/base_error_class_kind2_alt5.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt5.nit:44,8--11: Error: abstract class `SubA` cannot specialize enum `EnC2`.
+alt/base_error_class_kind2_alt5.nit:49,8--11: Error: abstract class `SubA` cannot specialize enum `EnC2`.

--- a/tests/sav/base_error_class_kind2_alt6.res
+++ b/tests/sav/base_error_class_kind2_alt6.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt6.nit:45,8--11: Error: abstract class `SubA` cannot specialize extern class `ExC2`.
+alt/base_error_class_kind2_alt6.nit:50,8--11: Error: abstract class `SubA` cannot specialize extern class `ExC2`.

--- a/tests/sav/base_error_class_kind2_alt7.res
+++ b/tests/sav/base_error_class_kind2_alt7.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt7.nit:52,8--11: Error: class `SubC` cannot specialize enum `EnC2`.
+alt/base_error_class_kind2_alt7.nit:58,8--11: Error: class `SubC` cannot specialize enum `EnC2`.

--- a/tests/sav/base_error_class_kind2_alt8.res
+++ b/tests/sav/base_error_class_kind2_alt8.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt8.nit:53,8--11: Error: class `SubC` cannot specialize extern class `ExC2`.
+alt/base_error_class_kind2_alt8.nit:59,8--11: Error: class `SubC` cannot specialize extern class `ExC2`.

--- a/tests/sav/base_error_class_kind2_alt9.res
+++ b/tests/sav/base_error_class_kind2_alt9.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind2_alt9.nit:58,8--10: Error: enum `SubEn` cannot specialize abstract class `AC2`.
+alt/base_error_class_kind2_alt9.nit:65,8--10: Error: enum `SubEn` cannot specialize abstract class `AC2`.

--- a/tests/sav/base_error_class_kind_alt1.res
+++ b/tests/sav/base_error_class_kind_alt1.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt1.nit:44,8--9: Error: interface `SubI` cannot specialize abstract class `AC`.
+alt/base_error_class_kind_alt1.nit:48,8--9: Error: interface `SubI` cannot specialize abstract class `AC`.

--- a/tests/sav/base_error_class_kind_alt10.res
+++ b/tests/sav/base_error_class_kind_alt10.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt10.nit:69,8--9: Error: enum `SubEn` cannot specialize class `CC`.
+alt/base_error_class_kind_alt10.nit:76,8--9: Error: enum `SubEn` cannot specialize class `CC`.

--- a/tests/sav/base_error_class_kind_alt11.res
+++ b/tests/sav/base_error_class_kind_alt11.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt11.nit:70,8--10: Error: enum `SubEn` cannot specialize enum `EnC`.
+alt/base_error_class_kind_alt11.nit:77,8--10: Error: enum `SubEn` cannot specialize enum `EnC`.

--- a/tests/sav/base_error_class_kind_alt12.res
+++ b/tests/sav/base_error_class_kind_alt12.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt12.nit:71,8--10: Error: enum `SubEn` cannot specialize extern class `ExC`.
+alt/base_error_class_kind_alt12.nit:78,8--10: Error: enum `SubEn` cannot specialize extern class `ExC`.

--- a/tests/sav/base_error_class_kind_alt13.res
+++ b/tests/sav/base_error_class_kind_alt13.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt13.nit:76,8--9: Error: extern class `SubEx` cannot specialize abstract class `AC`.
+alt/base_error_class_kind_alt13.nit:84,8--9: Error: extern class `SubEx` cannot specialize abstract class `AC`.

--- a/tests/sav/base_error_class_kind_alt14.res
+++ b/tests/sav/base_error_class_kind_alt14.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt14.nit:77,8--9: Error: extern class `SubEx` cannot specialize class `CC`.
+alt/base_error_class_kind_alt14.nit:85,8--9: Error: extern class `SubEx` cannot specialize class `CC`.

--- a/tests/sav/base_error_class_kind_alt15.res
+++ b/tests/sav/base_error_class_kind_alt15.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt15.nit:78,8--10: Error: extern class `SubEx` cannot specialize enum `EnC`.
+alt/base_error_class_kind_alt15.nit:86,8--10: Error: extern class `SubEx` cannot specialize enum `EnC`.

--- a/tests/sav/base_error_class_kind_alt16.res
+++ b/tests/sav/base_error_class_kind_alt16.res
@@ -1,0 +1,1 @@
+alt/base_error_class_kind_alt16.nit:52,8--11: Error: interface `SubI` cannot specialize subset `SSet`.

--- a/tests/sav/base_error_class_kind_alt17.res
+++ b/tests/sav/base_error_class_kind_alt17.res
@@ -1,0 +1,1 @@
+alt/base_error_class_kind_alt17.nit:61,8--11: Error: abstract class `SubA` cannot specialize subset `SSet`.

--- a/tests/sav/base_error_class_kind_alt18.res
+++ b/tests/sav/base_error_class_kind_alt18.res
@@ -1,0 +1,1 @@
+alt/base_error_class_kind_alt18.nit:70,8--11: Error: class `SubC` cannot specialize subset `SSet`.

--- a/tests/sav/base_error_class_kind_alt19.res
+++ b/tests/sav/base_error_class_kind_alt19.res
@@ -1,0 +1,1 @@
+alt/base_error_class_kind_alt19.nit:79,8--11: Error: enum `SubEn` cannot specialize subset `SSet`.

--- a/tests/sav/base_error_class_kind_alt2.res
+++ b/tests/sav/base_error_class_kind_alt2.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt2.nit:45,8--9: Error: interface `SubI` cannot specialize class `CC`.
+alt/base_error_class_kind_alt2.nit:49,8--9: Error: interface `SubI` cannot specialize class `CC`.

--- a/tests/sav/base_error_class_kind_alt20.res
+++ b/tests/sav/base_error_class_kind_alt20.res
@@ -1,0 +1,1 @@
+alt/base_error_class_kind_alt20.nit:88,8--11: Error: extern class `SubEx` cannot specialize subset `SSet`.

--- a/tests/sav/base_error_class_kind_alt26.res
+++ b/tests/sav/base_error_class_kind_alt26.res
@@ -1,0 +1,1 @@
+alt/base_error_class_kind_alt26.nit:125,7--10: Error: subset `SubSSet` cannot specialize subset `SSet`.

--- a/tests/sav/base_error_class_kind_alt3.res
+++ b/tests/sav/base_error_class_kind_alt3.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt3.nit:46,8--10: Error: interface `SubI` cannot specialize enum `EnC`.
+alt/base_error_class_kind_alt3.nit:50,8--10: Error: interface `SubI` cannot specialize enum `EnC`.

--- a/tests/sav/base_error_class_kind_alt4.res
+++ b/tests/sav/base_error_class_kind_alt4.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt4.nit:47,8--10: Error: interface `SubI` cannot specialize extern class `ExC`.
+alt/base_error_class_kind_alt4.nit:51,8--10: Error: interface `SubI` cannot specialize extern class `ExC`.

--- a/tests/sav/base_error_class_kind_alt5.res
+++ b/tests/sav/base_error_class_kind_alt5.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt5.nit:54,8--10: Error: abstract class `SubA` cannot specialize enum `EnC`.
+alt/base_error_class_kind_alt5.nit:59,8--10: Error: abstract class `SubA` cannot specialize enum `EnC`.

--- a/tests/sav/base_error_class_kind_alt6.res
+++ b/tests/sav/base_error_class_kind_alt6.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt6.nit:55,8--10: Error: abstract class `SubA` cannot specialize extern class `ExC`.
+alt/base_error_class_kind_alt6.nit:60,8--10: Error: abstract class `SubA` cannot specialize extern class `ExC`.

--- a/tests/sav/base_error_class_kind_alt7.res
+++ b/tests/sav/base_error_class_kind_alt7.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt7.nit:62,8--10: Error: class `SubC` cannot specialize enum `EnC`.
+alt/base_error_class_kind_alt7.nit:68,8--10: Error: class `SubC` cannot specialize enum `EnC`.

--- a/tests/sav/base_error_class_kind_alt8.res
+++ b/tests/sav/base_error_class_kind_alt8.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt8.nit:63,8--10: Error: class `SubC` cannot specialize extern class `ExC`.
+alt/base_error_class_kind_alt8.nit:69,8--10: Error: class `SubC` cannot specialize extern class `ExC`.

--- a/tests/sav/base_error_class_kind_alt9.res
+++ b/tests/sav/base_error_class_kind_alt9.res
@@ -1,1 +1,1 @@
-alt/base_error_class_kind_alt9.nit:68,8--9: Error: enum `SubEn` cannot specialize abstract class `AC`.
+alt/base_error_class_kind_alt9.nit:75,8--9: Error: enum `SubEn` cannot specialize abstract class `AC`.

--- a/tests/sav/error_subset_no_new.res
+++ b/tests/sav/error_subset_no_new.res
@@ -1,0 +1,1 @@
+error_subset_no_new.nit:28,9--16: Type Error: cannot instantiate subset `S`.

--- a/tests/sav/test_object_class_kind_alt5.res
+++ b/tests/sav/test_object_class_kind_alt5.res
@@ -1,0 +1,1 @@
+alt/test_object_class_kind_alt5.nit:19,7--12: Error: `Object` must be an interface.

--- a/tests/sav/test_subset_out_of_order_alt1.res
+++ b/tests/sav/test_subset_out_of_order_alt1.res
@@ -1,0 +1,1 @@
+alt/test_subset_out_of_order_alt1.nit:18,8: Error: subset `B` cannot specialize subset `A`.

--- a/tests/sav/test_subset_redef_alt1.res
+++ b/tests/sav/test_subset_redef_alt1.res
@@ -1,0 +1,1 @@
+alt/test_subset_redef_alt1.nit:28,13--19: Error: a class `NonZero` is already defined at line 19.

--- a/tests/sav/test_subset_redef_private.res
+++ b/tests/sav/test_subset_redef_private.res
@@ -1,0 +1,1 @@
+test_subset_redef_private.nit:17,21--27: Error: class `test_subset_private::test_subset_private::NonZero` not visible in module `test_subset_redef_private`.

--- a/tests/sav/test_subset_redef_private_alt1.res
+++ b/tests/sav/test_subset_redef_private_alt1.res
@@ -1,0 +1,1 @@
+alt/test_subset_redef_private_alt1.nit:17,7--13: Redef Error: refinement changed the visibility from `public` to `private`

--- a/tests/test_object_class_kind.nit
+++ b/tests/test_object_class_kind.nit
@@ -14,9 +14,10 @@
 
 import end
 
-interface Object #alt1-4#
+interface Object #alt1-5#
 #alt1# abstract class Object
-#alt2# class Object
+#alt2,5# class Object
 #alt3# enum Object
 #alt4# extern class Object
+	#alt5# subset
 end

--- a/tests/test_subset_out_of_order.nit
+++ b/tests/test_subset_out_of_order.nit
@@ -1,0 +1,24 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import core::kernel
+
+class B
+	super A
+	subset
+end
+
+class A
+	#alt1# subset
+end

--- a/tests/test_subset_private.nit
+++ b/tests/test_subset_private.nit
@@ -1,0 +1,20 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import core::kernel
+
+private class NonZero
+	super Int
+	subset do return self != 0
+end

--- a/tests/test_subset_redef.nit
+++ b/tests/test_subset_redef.nit
@@ -1,0 +1,28 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: Actual testing in `test_subset_redef2`.
+
+import core::kernel
+
+class NonZero
+	subset do return not self.is_zero
+	super Numeric
+
+	fun int_inverse: Int do
+		return (1.0 / self.to_f).to_i
+	end
+end
+
+#alt1# redef class NonZero end

--- a/tests/test_subset_redef_private.nit
+++ b/tests/test_subset_redef_private.nit
@@ -1,0 +1,18 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import test_subset_private #alt1# import test_subset_redef
+
+redef private class NonZero
+end


### PR DESCRIPTION
Each time a `subset` annotation is found in a class definition, set the class kind to `subset`. Also, implement the inheritance and instantiation rules.