### PR TITLE
gamnit::network: add server discovery via UDP

### DIFF
--- a/contrib/tinks/src/client/base.nit
+++ b/contrib/tinks/src/client/base.nit
@@ -35,22 +35,10 @@ redef class App
 		else
 			print "Looking for a server..."
 
-			var s = new UDPSocket
-			s.enable_broadcast = true
-			s.blocking = false
-			s.broadcast(discovery_port, "Server? {handshake_app_name}")
-			nanosleep(0, 100_000_000)
-
-			var ptr = new Ref[nullable SocketAddress](null)
-			var resp = s.recv_from(1024, ptr)
-			var src = ptr.item
-
-			if not resp.is_empty then
-				var words = resp.split(" ")
-				if words.length == 3 and words[0] == "Server!" and words[1] == handshake_app_name and words[2].is_numeric then
-					address = src.address
-					port = words[2].to_i
-				end
+			var servers = discover_local_servers
+			if servers.not_empty then
+				address = servers.first.address
+				port = servers.first.port
 			end
 		end
 

--- a/contrib/tinks/src/client/base.nit
+++ b/contrib/tinks/src/client/base.nit
@@ -48,7 +48,7 @@ redef class App
 			# No command line
 			return new LocalServerContext
 		else
-			print "Connecting to:{address}:{port}"
+			print "Connecting to {address}:{port}"
 
 			# Args are: tinks server_address {port}
 			if args.length > 1 then port = args[1].to_i

--- a/contrib/tinks/src/common.nit
+++ b/contrib/tinks/src/common.nit
@@ -26,6 +26,5 @@ redef class Sys
 	# Default listening port of the server
 	fun default_listening_port: Int do return 18721
 
-	# Port to which clients send discovery requests
-	fun discovery_port: Int do return 18722
+	redef fun discovery_port do return 18722
 end

--- a/contrib/tinks/src/server/server.nit
+++ b/contrib/tinks/src/server/server.nit
@@ -68,8 +68,6 @@ redef class Server
 			client.writer.serialize game
 			client.writer.serialize client.player
 			client.socket.flush
-
-			clients.add client
 		end
 
 		if dedicated and clients.is_empty then

--- a/contrib/tinks/src/server/server.nit
+++ b/contrib/tinks/src/server/server.nit
@@ -26,13 +26,6 @@ redef class RemoteClient
 end
 
 redef class Server
-	# `UDPSocket` to which clients send discovery requests
-	var discovery_socket: UDPSocket do
-		var s = new UDPSocket
-		s.blocking = false
-		s.bind(null, discovery_port)
-		return s
-	end
 
 	# The current game
 	var game = new TGame is lazy, writable
@@ -62,24 +55,8 @@ redef class Server
 		# Do game logic
 		var turn = game.do_turn
 
-		# Respond to discovery requests
-		loop
-			var ptr = new Ref[nullable SocketAddress](null)
-			var read = discovery_socket.recv_from(1024, ptr)
-
-			# No sender means there is no request (an error would also do it)
-			var sender = ptr.item
-			if sender == null then break
-
-			var words = read.split(" ")
-			if words.length != 2 or words[0] != "Server?" or words[1] != handshake_app_name then
-				print "Server Warning: Rejected discovery request '{read}'"
-				continue
-			end
-
-			discovery_socket.send_to(sender.address, sender.port,
-				"Server! {handshake_app_name} {self.port}")
-		end
+		# Respond to discovery requests sent over UDP
+		answer_discovery_requests
 
 		# Setup clients
 		var new_clients = accept_clients

--- a/lib/gamnit/network/common.nit
+++ b/lib/gamnit/network/common.nit
@@ -33,3 +33,14 @@ fun handshake_app_name: String do return program_name
 #
 # Both client and server refuse connections with a different version.
 fun handshake_app_version: String do return "0.0"
+
+# Server port listening for discovery requests
+#
+# This name must be the same between client/server.
+fun discovery_port: Int do return 18722
+
+# First word in discovery requests
+private fun discovery_request_message: String do return "gamnit::network?"
+
+# First word in discovery responses
+private fun discovery_response_message: String do return "gamnit::network!"

--- a/lib/gamnit/network/common.nit
+++ b/lib/gamnit/network/common.nit
@@ -22,8 +22,9 @@ import binary::serialization
 #
 # This name must be the same between client/server and
 # it should not be used by other programs that may interfere.
-#
 # Both client and server refuse connections with a different name.
+#
+# This value must not contain spaces.
 fun handshake_app_name: String do return program_name
 
 # Version of the communication protocol to use in the handshake
@@ -32,6 +33,8 @@ fun handshake_app_name: String do return program_name
 # that different versions indicates incompatible protocols.
 #
 # Both client and server refuse connections with a different version.
+#
+# This value must not contain spaces.
 fun handshake_app_version: String do return "0.0"
 
 # Server port listening for discovery requests

--- a/lib/gamnit/network/network.nit
+++ b/lib/gamnit/network/network.nit
@@ -13,6 +13,57 @@
 # limitations under the License.
 
 # Easy client/server logic for games and simple distributed applications
+#
+# Both `gamnit::client` and `gamnit::server` can be used separately or
+# together by importing `gamnit::network`.
+# Use both modules to create an program that discover local servers
+# or create one if none is found:
+#
+# ~~~
+# redef fun handshake_app_name do return "network_test"
+#
+# # Discover local servers
+# var servers = discover_local_servers
+# if servers.not_empty then
+#     # Try to connect to the first local server
+#     var server_info = servers.first
+#     var server = new RemoteServer(server_info)
+#
+#     if not server.connect then
+#         print_error "Failed to connect to {server_info.address}:{server_info.port}"
+#     else if not server.handshake then
+#         print_error "Failed handshake with {server_info.address}:{server_info.port}"
+#     else
+#         # Connected!
+#         print "Connected to {server_info.address}:{server_info.port}"
+#
+#         # Write something and close connection
+#         server.writer.serialize "hello server"
+#         server.socket.as(not null).close
+#     end
+# else
+#     # Create a local server
+#     var connect_port = 33729
+#     print "Launching server: connect on {connect_port}, discovery on {discovery_port}"
+#     var server = new Server(connect_port)
+#
+#     # Don't loop if testing
+#     if "NIT_TESTING".environ == "true" then exit 0
+#
+#     loop
+#         # Respond to discovery requests
+#         server.answer_discovery_requests
+#
+#         # Accept new clients
+#         var new_clients = server.accept_clients
+#         for client in new_clients do
+#             # Read something and close connection
+#             assert client.reader.deserialize == "hello server"
+#             client.socket.close
+#         end
+#     end
+# end
+# ~~~
 module network
 
 import server

--- a/lib/gamnit/network/server.nit
+++ b/lib/gamnit/network/server.nit
@@ -39,7 +39,7 @@
 #
 #     # `accept_clients` in non-blocking,
 #     # sleep before tying again, or do something else.
-#     nanosleep(0, 50000000)
+#     0.5.sleep
 #     printn "."
 # end
 # ~~~
@@ -168,7 +168,7 @@ class RemoteClient
 	# Check for compatibility with the client
 	fun handshake: Bool
 	do
-		print "Server: Handshake requested by {socket.address}"
+		print "Server: Handshake initiated by {socket.address}"
 
 		# Make sure it is the same app
 		var server_app = sys.handshake_app_name


### PR DESCRIPTION
Move server discovery logic from Tinks! up to `gamnit::network` and extend existing services with more options. These new services allow for an easy discovery of local servers over UDP, as in the following example which also creates a server if none is found:

~~~nit
import gamnit::network

# Discover local servers
var servers = discover_local_servers
if servers.not_empty then
	# Try to connect to the first local server
	var server_info = servers.first
	var server = new RemoteServer(server_info)

	if not server.connect then
		print_error "Failed to connect to {server_info.address}:{server_info.port}"
	else if not server.handshake then
		print_error "Failed handshake with {server_info.address}:{server_info.port}"
	else
		# Connected!
		print "Connected to {server_info.address}:{server_info.port}"

		# Write something and close connection
		server.writer.serialize "hello server"
		server.socket.as(not null).close
	end
else
	# Create a local server
	var connect_port = 38271
	print "Launching server: connect on {connect_port}, discovery on {discovery_port}"
	var server = new Server(connect_port)

	# Don't loop if testing
	if "NIT_TESTING".environ == "true" then exit 0

	loop
		# Respond to discovery requests
		server.answer_discovery_requests

		# Accept new clients
		var new_clients = server.accept_clients
		for client in new_clients do
			# Read something and close connection
			assert client.reader.deserialize == "hello server"
			client.socket.close
		end
	end
end
~~~