### PR TITLE
gamnit: Blinn-Phong specular lighting, 3 axes of rotation and more

### DIFF
--- a/contrib/action_nitro/src/action_nitro.nit
+++ b/contrib/action_nitro/src/action_nitro.nit
@@ -140,6 +140,7 @@ redef class App
 
 		# Load 3d models
 		iss_model.load
+		if iss_model.errors.not_empty then print_error iss_model.errors.join("\n")
 
 		# Setup cameras
 		world_camera.reset_height 60.0

--- a/contrib/action_nitro/src/action_nitro.nit
+++ b/contrib/action_nitro/src/action_nitro.nit
@@ -507,7 +507,7 @@ end
 redef class Boss
 	redef var actor is lazy do
 		var actor = new Actor(app.iss_model, center)
-		actor.rotation = pi/2.0
+		actor.yaw = pi/2.0
 		return actor
 	end
 
@@ -556,7 +556,7 @@ redef class Player
 			var splatter = new Actor(app.splatter_model,
 				new Point3d[Float](center.x, 0.05 & 0.04, center.y))
 			splatter.scale = 32.0
-			splatter.rotation = 2.0 * pi.rand
+			splatter.yaw = 2.0*pi.rand
 			app.actors.add splatter
 		end
 

--- a/contrib/model_viewer/src/globe.nit
+++ b/contrib/model_viewer/src/globe.nit
@@ -148,7 +148,7 @@ class GlobeMaterial
 
 		# Set uniforms
 		program.scale.uniform 1.0
-		program.rotation.uniform new Matrix.rotation(actor.rotation, 0.0, 1.0, 0.0)
+		program.rotation.uniform new Matrix.gamnit_euler_rotation(actor.pitch, actor.yaw, actor.roll)
 		program.translation.uniform(actor.center.x, -actor.center.y, actor.center.z, 0.0)
 		program.color.uniform(color[0], color[1], color[2], color[3])
 		program.is_surface.uniform is_surface

--- a/contrib/model_viewer/src/model_viewer.nit
+++ b/contrib/model_viewer/src/model_viewer.nit
@@ -67,8 +67,10 @@ redef class App
 		world_camera.near = 0.1
 		world_camera.far = 100.0
 
-		for model in models do model.load
-		for texture in asset_textures_by_name.values do texture.load
+		for model in models do
+			model.load
+			if model.errors.not_empty then print_error model.errors.join("\n")
+		end
 
 		# Display the first model
 		model = models[model_index]

--- a/contrib/model_viewer/src/model_viewer.nit
+++ b/contrib/model_viewer/src/model_viewer.nit
@@ -146,7 +146,7 @@ redef class App
 		var t = clock.total.to_f
 
 		# Rotate the model
-		actors.first.rotation = t
+		actors.first.yaw = t
 
 		# Move the light source
 		var dist_to_light = 20.0

--- a/contrib/tinks/assets/models/debris1.mtl
+++ b/contrib/tinks/assets/models/debris1.mtl
@@ -9,7 +9,7 @@ Ks 0.287480 0.287480 0.287480
 Ni 1.000000
 d 1.000000
 illum 2
-map_Kd textures/tread.jpg
+map_Kd textures/TTread.jpg
 
 newmtl Treads
 Ns 178.431373

--- a/contrib/tinks/src/client/client3d.nit
+++ b/contrib/tinks/src/client/client3d.nit
@@ -359,7 +359,7 @@ redef class Feature
 		# Apply a random model and rotation to new features
 		actor = new Actor(rule.models.rand,
 			new Point3d[Float](pos.x, 0.0, pos.y))
-		actor.rotation = 2.0*pi.rand
+		actor.yaw = 2.0*pi.rand
 		actor.scale = 0.75
 
 		self.actor = actor
@@ -426,7 +426,7 @@ redef class ExplosionEvent
 		# Blast mark on the ground
 		var blast = new Actor(app.blast_model, new Point3d[Float](pos.x, 0.05 & 0.04, pos.y))
 		blast.scale = 3.0
-		blast.rotation = 2.0*pi.rand
+		blast.yaw = 2.0*pi.rand
 		app.actors.add blast
 
 		# Smoke
@@ -474,8 +474,8 @@ redef class TankMoveEvent
 			actor.center.z = pos.y
 		end
 
-		tank.actors[0].rotation = tank.heading + pi
-		tank.actors[1].rotation = tank.turret.heading + pi
+		tank.actors[0].yaw = -tank.heading + pi
+		tank.actors[1].yaw = -tank.turret.heading + pi
 
 		# Keep going only for the local tank
 		var local_player = app.context.local_player

--- a/contrib/tinks/src/client/client3d.nit
+++ b/contrib/tinks/src/client/client3d.nit
@@ -122,8 +122,15 @@ redef class App
 		show_splash_screen logo
 
 		# Load everything
-		for model in models do model.load
-		for texture in all_root_textures do texture.load
+		for texture in all_root_textures do
+			texture.load
+			var error = texture.error
+			if error != null then print_error error
+		end
+		for model in models do
+			model.load
+			if model.errors.not_empty then print_error model.errors.join("\n")
+		end
 
 		# Modify all textures so they have a higher ambient color
 		for model in models do

--- a/lib/gamnit/depth/depth_core.nit
+++ b/lib/gamnit/depth/depth_core.nit
@@ -105,6 +105,9 @@ abstract class Model
 	# Load this model in memory
 	fun load do end
 
+	# Errors raised at loading
+	var errors = new Array[Error]
+
 	# All `LeafModel` composing this model
 	#
 	# Usually, there is one `LeafModel` per material.

--- a/lib/gamnit/depth/depth_core.nit
+++ b/lib/gamnit/depth/depth_core.nit
@@ -46,8 +46,30 @@ class Actor
 	# Position of this sprite in world coordinates
 	var center: Point3d[Float] is writable
 
-	# Rotation on the Z axis
-	var rotation = 0.0 is writable
+	# Rotation around the X axis (+ looks up, - looks down)
+	#
+	# Positive values look up, and negative look down.
+	#
+	# All actor rotations follow the right hand rule.
+	# The default orientation of the model should look towards -Z.
+	var pitch = 0.0 is writable
+
+	# Rotation around the Y axis (+ turns left, - turns right)
+	#
+	# Positive values turn `self` to the left, and negative values to the right.
+	#
+	# All actor rotations follow the right hand rule.
+	# The default orientation of the model should look towards -Z.
+	var yaw = 0.0 is writable
+
+	# Rotation around the Z axis (looking to -Z: + turns counterclockwise, - clockwise)
+	#
+	# From the default camera point of view, looking down on the Z axis,
+	# positive values turn `self` counterclockwise, and negative values clockwise.
+	#
+	# All actor rotations follow the right hand rule.
+	# The default orientation of the model should look towards -Z.
+	var roll = 0.0 is writable
 
 	# Scale applied to the model
 	var scale = 1.0 is writable

--- a/lib/gamnit/depth/more_materials.nit
+++ b/lib/gamnit/depth/more_materials.nit
@@ -49,7 +49,7 @@ class SmoothMaterial
 		# Actor specs
 		program.translation.uniform(actor.center.x, actor.center.y, actor.center.z, 0.0)
 		program.scale.uniform actor.scale
-		program.rotation.uniform new Matrix.rotation(actor.rotation, 0.0, 1.0, 0.0)
+		program.rotation.uniform new Matrix.gamnit_euler_rotation(actor.pitch, actor.yaw, actor.roll)
 
 		# From mesh
 		program.coord.array_enabled = true
@@ -171,7 +171,8 @@ class TexturedMaterial
 
 		program.coord.array_enabled = true
 		program.coord.array(mesh.vertices, 3)
-		program.rotation.uniform new Matrix.rotation(actor.rotation, 0.0, 1.0, 0.0)
+
+		program.rotation.uniform new Matrix.gamnit_euler_rotation(actor.pitch, actor.yaw, actor.roll)
 
 		program.ambient_color.uniform(ambient_color[0], ambient_color[1], ambient_color[2], ambient_color[3]*actor.alpha)
 		program.diffuse_color.uniform(diffuse_color[0], diffuse_color[1], diffuse_color[2], diffuse_color[3]*actor.alpha)
@@ -216,7 +217,8 @@ class NormalsMaterial
 
 		program.coord.array_enabled = true
 		program.coord.array(mesh.vertices, 3)
-		program.rotation.uniform new Matrix.rotation(actor.rotation, 0.0, 1.0, 0.0)
+
+		program.rotation.uniform new Matrix.gamnit_euler_rotation(actor.pitch, actor.yaw, actor.roll)
 
 		program.normal.array_enabled = true
 		program.normal.array(mesh.normals, 3)

--- a/lib/gamnit/depth/more_meshes.nit
+++ b/lib/gamnit/depth/more_meshes.nit
@@ -79,22 +79,31 @@ class Plane
 	# TODO use gl_TRIANGLE_FAN instead
 end
 
-# Cube, with 6 faces
+# Cuboid, or rectangular prism, with 6 faces and right angles
 #
-# Occupies `[-0.5..0.5]` on all three axes.
-class Cube
+# Can be created from a `Boxed3d` using `to_mesh`.
+class Cuboid
 	super Mesh
 
-	redef var vertices is lazy do
-		var a = [-0.5, -0.5, -0.5]
-		var b = [ 0.5, -0.5, -0.5]
-		var c = [-0.5,  0.5, -0.5]
-		var d = [ 0.5,  0.5, -0.5]
+	# Width, on the X axis
+	var width: Float
 
-		var e = [-0.5, -0.5,  0.5]
-		var f = [ 0.5, -0.5,  0.5]
-		var g = [-0.5,  0.5,  0.5]
-		var h = [ 0.5,  0.5,  0.5]
+	# Height, on the Y axis
+	var height: Float
+
+	# Depth, on the Z axis
+	var depth: Float
+
+	redef var vertices is lazy do
+		var a = [-0.5*width, -0.5*height, -0.5*depth]
+		var b = [ 0.5*width, -0.5*height, -0.5*depth]
+		var c = [-0.5*width,  0.5*height, -0.5*depth]
+		var d = [ 0.5*width,  0.5*height, -0.5*depth]
+
+		var e = [-0.5*width, -0.5*height,  0.5*depth]
+		var f = [ 0.5*width, -0.5*height,  0.5*depth]
+		var g = [-0.5*width,  0.5*height,  0.5*depth]
+		var h = [ 0.5*width,  0.5*height,  0.5*depth]
 
 		var vertices = new Array[Float]
 		for v in [a, c, d, a, d, b, # front
@@ -133,6 +142,35 @@ class Cube
 	end
 
 	redef var center = new Point3d[Float](0.0, 0.0, 0.0) is lazy
+end
+
+# Cube, with 6 faces, edges of equal length and square angles
+#
+# Occupies `[-0.5..0.5]` on all three axes.
+class Cube
+	super Cuboid
+
+	noautoinit
+
+	init
+	do
+		width = 1.0
+		height = 1.0
+		depth = 1.0
+	end
+end
+
+redef class Boxed3d[N]
+	# Create a `Cuboid` mesh with the dimension of `self`
+	#
+	# Does not use the position of `self`, but it can be given to an `Actor`.
+	fun to_mesh: Cuboid
+	do
+		var width = right.to_f-left.to_f
+		var height = top.to_f-bottom.to_f
+		var depth = front.to_f-back.to_f
+		return new Cuboid(width, height, depth)
+	end
 end
 
 # Sphere with `radius` and a number of faces set by `n_meridians` and `n_parallels`

--- a/lib/gamnit/depth/more_models.nit
+++ b/lib/gamnit/depth/more_models.nit
@@ -113,12 +113,11 @@ private class ModelFromObj
 		end
 
 		# Load material libs
-		# TODO do not load each libs more than once
-		var mtl_libs = new Map[String, Map[String, MtlDef]]
+		var mtl_libs = sys.mtl_libs
 		var lib_names = obj_def.material_libs
 		for name in lib_names do
-			var lib_path = self.path.dirname / name
-			var lib_asset = new TextAsset(lib_path)
+			var asset_path = self.path.dirname / name
+			var lib_asset = new TextAsset(asset_path)
 			lib_asset.load
 
 			var error = lib_asset.error
@@ -129,7 +128,7 @@ private class ModelFromObj
 
 			var mtl_parser = new MtlFileParser(lib_asset.to_s)
 			var mtl_lib = mtl_parser.parse
-			mtl_libs[name] = mtl_lib
+			mtl_libs[asset_path] = mtl_lib
 		end
 
 		# Create 1 mesh per material, and prepare materials
@@ -149,7 +148,8 @@ private class ModelFromObj
 			var mtl_lib_name = faces.first.material_lib
 			var mtl_name = faces.first.material_name
 			if mtl_lib_name != null and mtl_name != null then
-				var mtl_lib = mtl_libs[mtl_lib_name]
+				var asset_path = self.path.dirname / mtl_lib_name
+				var mtl_lib = mtl_libs[asset_path]
 				var mtl = mtl_lib.get_or_null(mtl_name)
 				if mtl != null then
 					mtl_def = mtl
@@ -380,6 +380,9 @@ end
 redef class Sys
 	# Textures loaded from .mtl files for models
 	var asset_textures_by_name = new Map[String, TextureAsset]
+
+	# Loaded .mtl material definitions, sorted by path in assets and material name
+	private var mtl_libs = new Map[String, Map[String, MtlDef]]
 
 	# All instantiated asset models
 	var models = new Set[ModelAsset]

--- a/lib/gamnit/depth/selection.nit
+++ b/lib/gamnit/depth/selection.nit
@@ -157,7 +157,7 @@ redef class Material
 
 		program.coord.array_enabled = true
 		program.coord.array(mesh.vertices, 3)
-		program.rotation.uniform new Matrix.rotation(actor.rotation, 0.0, 1.0, 0.0)
+		program.rotation.uniform new Matrix.gamnit_euler_rotation(actor.pitch, actor.yaw, actor.roll)
 
 		var display = app.display
 		assert display != null

--- a/lib/gamnit/display_linux.nit
+++ b/lib/gamnit/display_linux.nit
@@ -36,6 +36,10 @@ redef class GamnitDisplay
 
 	redef fun show_cursor=(val) do sdl.show_cursor = val
 
+	redef fun lock_cursor=(val) do sdl.relative_mouse_mode = val
+
+	redef fun lock_cursor do return sdl.relative_mouse_mode
+
 	# Setup SDL, wm, EGL in order
 	redef fun setup
 	do

--- a/lib/gamnit/examples/template/src/template.nit
+++ b/lib/gamnit/examples/template/src/template.nit
@@ -63,8 +63,8 @@ redef class App
 		# cause glitches on mobiles devices with small depth buffer.
 		world_camera.near = 1.0
 
-		# Make the background blue and opaque.
-		glClearColor(0.0, 0.0, 1.0, 1.0)
+		# Make the background sky blue and opaque.
+		glClearColor(0.5, 0.8, 1.0, 1.0)
 
 		# If the first command line argument is an integer, add extra sprites.
 		if args.not_empty and args.first.is_int then
@@ -109,8 +109,9 @@ redef class App
 		if event isa QuitEvent or
 		  (event isa KeyEvent and event.name == "escape" and event.is_up) then
 			# When window close button, escape or back key is pressed
-			# show the average FPS over the last few seconds.
-			print "{current_fps} fps"
+			print "Ran at {current_fps} FPS in the last few seconds"
+
+			print "Performance statistics to detect bottlenecks:"
 			print sys.perfs
 
 			# Quit abruptly

--- a/lib/gamnit/model_parsers/obj.nit
+++ b/lib/gamnit/model_parsers/obj.nit
@@ -155,7 +155,7 @@ class ObjDef
 	# Faces
 	var faces = new Array[ObjFace]
 
-	# Referenced material libraries
+	# Relative paths to referenced material libraries
 	fun material_libs: Set[String] do
 		var libs = new Set[String]
 		for face in faces do

--- a/lib/geometry/angles.nit
+++ b/lib/geometry/angles.nit
@@ -31,8 +31,7 @@ redef class Point[N]
 	do
 		var dx = other.x.to_f - x.to_f
 		var dy = other.y.to_f - y.to_f
-		var a = sys.atan2(dy.to_f, dx.to_f)
-		return a
+		return sys.atan2(dy.to_f, dx.to_f)
 	end
 end
 
@@ -52,19 +51,21 @@ redef universal Float
 		return s
 	end
 
-	# Linear interpolation on the arc delimited by `self` and `other` at `p` out of 1.0
+	# Linear interpolation of between the angles `a` and `b`, in radians
 	#
 	# The result is normalized with `angle_normalize`.
 	#
 	# ~~~
-	# assert 0.0.angle_lerp(pi, 0.5).is_approx(0.5*pi, 0.0001)
-	# assert 0.0.angle_lerp(pi, 8.5).is_approx(0.5*pi, 0.0001)
-	# assert 0.0.angle_lerp(pi, 7.5).is_approx(-0.5*pi, 0.0001)
+	# assert 0.5.angle_lerp(0.0, pi).is_approx(0.5*pi, 0.0001)
+	# assert 8.5.angle_lerp(0.0, pi).is_approx(0.5*pi, 0.0001)
+	# assert 7.5.angle_lerp(0.0, pi).is_approx(-0.5*pi, 0.0001)
+	# assert 0.5.angle_lerp(0.2, 2.0*pi-0.1).is_approx(0.05, 0.0001)
 	# ~~~
-	fun angle_lerp(other, p: Float): Float
+	fun angle_lerp(a, b: Float): Float
 	do
-		var d = other - self
-		var a = self + d*p
-		return a.angle_normalize
+		var d = b - a
+		while d > pi do d -= 2.0*pi
+		while d < -pi do d += 2.0*pi
+		return (a + d*self).angle_normalize
 	end
 end

--- a/lib/matrix/projection.nit
+++ b/lib/matrix/projection.nit
@@ -150,4 +150,27 @@ redef class Matrix
 		var rotated = self * rotation
 		self.items = rotated.items
 	end
+
+	# Rotation matrix from Euler angles `pitch`, `yaw` and `roll` in radians
+	#
+	# Apply a composition of intrinsic rotations around the axes x-y'-z''.
+	# Or `pitch` around the X axis, `yaw` around Y and `roll` around Z,
+	# applied successively. All rotations follow the right hand rule.
+	#
+	# This service aims to respect the world axes and logic of `gamnit`,
+	# it may not correspond to all needs.
+	new gamnit_euler_rotation(pitch, yaw, roll: Float)
+	do
+		var c1 = pitch.cos
+		var s1 = pitch.sin
+		var c2 = yaw.cos
+		var s2 = yaw.sin
+		var c3 = roll.cos
+		var s3 = roll.sin
+		return new Matrix.from(
+			[[          c2*c3,          -c2*s3,   -s2, 0.0],
+			 [ c1*s3+c3*s1*s2,  c1*c3-s1*s2*s3, c2*s1, 0.0],
+			 [-s1*s3+c1*c3*s2, -c3*s1-c1*s2*s3, c1*c2, 0.0],
+			 [            0.0,             0.0,   0.0, 1.0]])
+	end
 end


### PR DESCRIPTION
Implement a Blinn-Phong specular lighting shader to replace the previous Lamber diffuse lighting. It creates a reflection effect either from `specular_color` (as on the shields) or `specular_texture` (as on the gold tower).

![screenshot from 2017-05-31 10 16 13](https://cloud.githubusercontent.com/assets/208057/26636318/5a017ffc-45ea-11e7-8571-0918f13f6d9c.png)
![screenshot from 2017-05-30 23 13 32](https://cloud.githubusercontent.com/assets/208057/26636316/59c940c4-45ea-11e7-9106-99f9344cecbf.png)

The required material attributes for the specular effect were already present but not implemented. This PR adds similar attributes for normal maps, but leave them as a TODO. The new shader is fine but not optimal, I'll probably need to rewrite it to gain some performance, support normal maps and improve normals per vertex.

Add two angles of rotation to actors for full 3D rotation with Euler angles. All rotation angles follow the right-hand rule and are consistent between the camera and actors.

Other changes:
* Intro `Cuboid` that can be created by `Boxed3d::to_mesh`.
* Better error management when loading models.
* Fix missing `lock_cursor` implementation on desktop. It allows creating FPS like cameras.
* Fix and update `angle_lerp` to follow the style of `lerp` (where `self` is the weight).
* Improve the template project so 3D objects don't blend in the background and explain the printed performance statistics.

In a future PR, I'll standardize the assets classes and move some service up to `Asset`. This would allow for easier loading of all assets at once, no matter their type, and offer a standard behavior regarding errors and lazy loading.