### PR TITLE
modelbuilder_base: Refactor the signature of `resolve_mtype*`

### DIFF
--- a/src/metrics/detect_covariance.nit
+++ b/src/metrics/detect_covariance.nit
@@ -350,7 +350,6 @@ redef class TypeVisitor
 		if dcp.is_disabled then return res
 
 		var anchor = self.anchor
-		assert anchor != null
 		var supx = sup
 		var subx = sub
 		var p = node.parent.as(not null)

--- a/src/metrics/static_types_metrics.nit
+++ b/src/metrics/static_types_metrics.nit
@@ -54,8 +54,8 @@ private class ATypeCounterVisitor
 		if n isa AAnnotation then return
 
 		if n isa AType then
-			var mclassdef = self.nclassdef.mclassdef
-			var mtype = modelbuilder.resolve_mtype(mclassdef.mmodule, mclassdef, n)
+			var mclassdef = self.nclassdef.mclassdef.as(not null)
+			var mtype = modelbuilder.resolve_mtype(mclassdef, n)
 			if mtype != null then
 				self.typecount.inc(mtype)
 			end

--- a/src/modelbuilder_base.nit
+++ b/src/modelbuilder_base.nit
@@ -300,21 +300,21 @@ class ModelBuilder
 		end
 
 		# Check class
-		var mclass = try_get_mclass_by_qid(qid, mmodule)
-		if mclass != null then
+		var found_class = try_get_mclass_by_qid(qid, mmodule)
+		if found_class != null then
 			var arity = ntype.n_types.length
-			if arity != mclass.arity then
+			if arity != found_class.arity then
 				if arity == 0 then
-					error(ntype, "Type Error: `{mclass.signature_to_s}` is a generic class.")
-				else if mclass.arity == 0 then
+					error(ntype, "Type Error: `{found_class.signature_to_s}` is a generic class.")
+				else if found_class.arity == 0 then
 					error(ntype, "Type Error: `{name}` is not a generic class.")
 				else
-					error(ntype, "Type Error: expected {mclass.arity} formal argument(s) for `{mclass.signature_to_s}`; got {arity}.")
+					error(ntype, "Type Error: expected {found_class.arity} formal argument(s) for `{found_class.signature_to_s}`; got {arity}.")
 				end
 				return null
 			end
 			if arity == 0 then
-				res = mclass.mclass_type
+				res = found_class.mclass_type
 				if ntype.n_kwnullable != null then res = res.as_nullable
 				ntype.mtype = res
 				return res
@@ -325,7 +325,7 @@ class ModelBuilder
 					if mt == null then return null # Forward error
 					mtypes.add(mt)
 				end
-				res = mclass.get_mtype(mtypes)
+				res = found_class.get_mtype(mtypes)
 				if ntype.n_kwnullable != null then res = res.as_nullable
 				ntype.mtype = res
 				return res
@@ -426,9 +426,9 @@ class ModelBuilder
 
 		if ntype.checked_mtype then return mtype
 		if mtype isa MGenericType then
-			var mclass = mtype.mclass
-			for i in [0..mclass.arity[ do
-				var intro = mclass.try_intro
+			var found_class = mtype.mclass
+			for i in [0..found_class.arity[ do
+				var intro = found_class.try_intro
 				if intro == null then return null # skip error
 				var bound = intro.bound_mtype.arguments[i]
 				var nt = ntype.n_types[i]

--- a/src/modelize/modelize_class.nit
+++ b/src/modelize/modelize_class.nit
@@ -179,7 +179,7 @@ redef class ModelBuilder
 				end
 				var nfdt = nfd.n_type
 				if nfdt != null then
-					var bound = resolve_mtype_unchecked(mmodule, null, nfdt, false)
+					var bound = resolve_mtype3_unchecked(mmodule, null, null, nfdt, false)
 					if bound == null then return # Forward error
 					if bound.need_anchor then
 						# No F-bounds!
@@ -256,7 +256,7 @@ redef class ModelBuilder
 			for nsc in nclassdef.n_superclasses do
 				specobject = false
 				var ntype = nsc.n_type
-				var mtype = resolve_mtype_unchecked(mmodule, mclassdef, ntype, false)
+				var mtype = resolve_mtype_unchecked(mclassdef, ntype, false)
 				if mtype == null then continue # Skip because of error
 				if not mtype isa MClassType then
 					error(ntype, "Error: supertypes cannot be a formal type.")
@@ -364,11 +364,21 @@ redef class ModelBuilder
 		for nclassdef in nmodule.n_classdefs do
 			if nclassdef isa AStdClassdef then
 				var mclassdef = nclassdef.mclassdef
+				var mclass
+				var anchor
+				if mclassdef == null then
+					mclass = null
+					anchor = null
+				else
+					mclass = mclassdef.mclass
+					anchor = mclassdef.bound_mtype
+				end
+
 				# check bound of formal parameter
 				for nfd in nclassdef.n_formaldefs do
 					var nfdt = nfd.n_type
 					if nfdt != null and nfdt.mtype != null then
-						var bound = resolve_mtype(mmodule, mclassdef, nfdt)
+						var bound = resolve_mtype3(mmodule, mclass, anchor, nfdt)
 						if bound == null then return # Forward error
 					end
 				end
@@ -376,7 +386,7 @@ redef class ModelBuilder
 				for nsc in nclassdef.n_superclasses do
 					var ntype = nsc.n_type
 					if ntype.mtype != null then
-						var mtype = resolve_mtype(mmodule, mclassdef, ntype)
+						var mtype = resolve_mtype3(mmodule, mclass, anchor, ntype)
 						if mtype == null then return # Forward error
 					end
 				end

--- a/src/modelize/modelize_class.nit
+++ b/src/modelize/modelize_class.nit
@@ -365,7 +365,7 @@ redef class ModelBuilder
 			if nclassdef isa AStdClassdef then
 				var mclassdef = nclassdef.mclassdef
 				# check bound of formal parameter
-				for nfd in  nclassdef.n_formaldefs do
+				for nfd in nclassdef.n_formaldefs do
 					var nfdt = nfd.n_type
 					if nfdt != null and nfdt.mtype != null then
 						var bound = resolve_mtype(mmodule, mclassdef, nfdt)

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -671,14 +671,13 @@ redef class ASignature
 	# Visit and fill information about a signature
 	private fun visit_signature(modelbuilder: ModelBuilder, mclassdef: MClassDef): Bool
 	do
-		var mmodule = mclassdef.mmodule
 		var param_names = self.param_names
 		var param_types = self.param_types
 		for np in self.n_params do
 			param_names.add(np.n_id.text)
 			var ntype = np.n_type
 			if ntype != null then
-				var mtype = modelbuilder.resolve_mtype_unchecked(mmodule, mclassdef, ntype, true)
+				var mtype = modelbuilder.resolve_mtype_unchecked(mclassdef, ntype, true)
 				if mtype == null then return false # Skip error
 				for i in [0..param_names.length-param_types.length[ do
 					param_types.add(mtype)
@@ -695,7 +694,7 @@ redef class ASignature
 		end
 		var ntype = self.n_type
 		if ntype != null then
-			self.ret_type = modelbuilder.resolve_mtype_unchecked(mmodule, mclassdef, ntype, true)
+			self.ret_type = modelbuilder.resolve_mtype_unchecked(mclassdef, ntype, true)
 			if self.ret_type == null then return false # Skip error
 		end
 
@@ -709,14 +708,14 @@ redef class ASignature
 		for np in self.n_params do
 			var ntype = np.n_type
 			if ntype != null then
-				if modelbuilder.resolve_mtype(mclassdef.mmodule, mclassdef, ntype) == null then
+				if modelbuilder.resolve_mtype(mclassdef, ntype) == null then
 					res = false
 				end
 			end
 		end
 		var ntype = self.n_type
 		if ntype != null then
-			if modelbuilder.resolve_mtype(mclassdef.mmodule, mclassdef, ntype) == null then
+			if modelbuilder.resolve_mtype(mclassdef, ntype) == null then
 				res = false
 			end
 		end
@@ -1348,7 +1347,7 @@ redef class AAttrPropdef
 
 		var ntype = self.n_type
 		if ntype != null then
-			mtype = modelbuilder.resolve_mtype_unchecked(mmodule, mclassdef, ntype, true)
+			mtype = modelbuilder.resolve_mtype_unchecked(mclassdef, ntype, true)
 			if mtype == null then return
 		end
 
@@ -1369,9 +1368,9 @@ redef class AAttrPropdef
 		if mtype == null then
 			if nexpr != null then
 				if nexpr isa ANewExpr then
-					mtype = modelbuilder.resolve_mtype_unchecked(mmodule, mclassdef, nexpr.n_type, true)
+					mtype = modelbuilder.resolve_mtype_unchecked(mclassdef, nexpr.n_type, true)
 				else if nexpr isa AAsCastExpr then
-					mtype = modelbuilder.resolve_mtype_unchecked(mmodule, mclassdef, nexpr.n_type, true)
+					mtype = modelbuilder.resolve_mtype_unchecked(mclassdef, nexpr.n_type, true)
 				else if nexpr isa AIntegerExpr then
 					var cla: nullable MClass = null
 					if nexpr.value isa Int then
@@ -1432,7 +1431,7 @@ redef class AAttrPropdef
 			end
 		else if ntype != null and inherited_type == mtype then
 			if nexpr isa ANewExpr then
-				var xmtype = modelbuilder.resolve_mtype_unchecked(mmodule, mclassdef, nexpr.n_type, true)
+				var xmtype = modelbuilder.resolve_mtype_unchecked(mclassdef, nexpr.n_type, true)
 				if xmtype == mtype then
 					modelbuilder.advice(ntype, "useless-type", "Warning: useless type definition")
 				end
@@ -1488,11 +1487,11 @@ redef class AAttrPropdef
 
 		# Check types
 		if ntype != null then
-			if modelbuilder.resolve_mtype(mmodule, mclassdef, ntype) == null then return
+			if modelbuilder.resolve_mtype(mclassdef, ntype) == null then return
 		end
 		var nexpr = n_expr
 		if nexpr isa ANewExpr then
-			if modelbuilder.resolve_mtype(mmodule, mclassdef, nexpr.n_type) == null then return
+			if modelbuilder.resolve_mtype(mclassdef, nexpr.n_type) == null then return
 		end
 
 		# Lookup for signature in the precursor
@@ -1645,11 +1644,10 @@ redef class ATypePropdef
 		var mpropdef = self.mpropdef
 		if mpropdef == null then return # Error thus skipped
 		var mclassdef = mpropdef.mclassdef
-		var mmodule = mclassdef.mmodule
 		var mtype: nullable MType = null
 
 		var ntype = self.n_type
-		mtype = modelbuilder.resolve_mtype_unchecked(mmodule, mclassdef, ntype, true)
+		mtype = modelbuilder.resolve_mtype_unchecked(mclassdef, ntype, true)
 		if mtype == null then return
 
 		mpropdef.bound = mtype
@@ -1671,7 +1669,7 @@ redef class ATypePropdef
 		var anchor = mclassdef.bound_mtype
 
 		var ntype = self.n_type
-		if modelbuilder.resolve_mtype(mmodule, mclassdef, ntype) == null then
+		if modelbuilder.resolve_mtype(mclassdef, ntype) == null then
 			mpropdef.bound = null
 			return
 		end

--- a/src/nitni/nitni_callbacks.nit
+++ b/src/nitni/nitni_callbacks.nit
@@ -304,7 +304,7 @@ redef class AFullPropExternCall
 		var mmodule = npropdef.mpropdef.mclassdef.mmodule
 		var mclassdef = npropdef.mpropdef.mclassdef
 		var mclass_type = mclassdef.bound_mtype
-		var mtype = toolcontext.modelbuilder.resolve_mtype(mmodule, mclassdef, n_type)
+		var mtype = toolcontext.modelbuilder.resolve_mtype(mclassdef, n_type)
 
 		if mtype == null then return
 
@@ -337,7 +337,7 @@ redef class AInitPropExternCall
 	do
 		var mmodule = npropdef.mpropdef.mclassdef.mmodule
 		var mclassdef = npropdef.mpropdef.mclassdef
-		var mtype = toolcontext.modelbuilder.resolve_mtype(mmodule, mclassdef, n_type)
+		var mtype = toolcontext.modelbuilder.resolve_mtype(mclassdef, n_type)
 		if mtype == null then return
 
 		if not mtype isa MClassType then
@@ -398,9 +398,8 @@ redef class ACastAsExternCall
 	redef fun verify_and_collect(npropdef, callback_set, toolcontext)
 	do
 		var mclassdef = npropdef.mpropdef.mclassdef
-		var mmodule = mclassdef.mmodule
-		toolcontext.modelbuilder.resolve_mtype_unchecked(mmodule, mclassdef, n_from_type, true)
-		toolcontext.modelbuilder.resolve_mtype_unchecked(mmodule, mclassdef, n_to_type, true)
+		toolcontext.modelbuilder.resolve_mtype_unchecked(mclassdef, n_from_type, true)
+		toolcontext.modelbuilder.resolve_mtype_unchecked(mclassdef, n_to_type, true)
 		super
 	end
 end
@@ -412,8 +411,7 @@ redef class AAsNullableExternCall
 	redef fun verify_and_collect(npropdef, callback_set, toolcontext)
 	do
 		var mclassdef = npropdef.mpropdef.mclassdef
-		var mmodule = mclassdef.mmodule
-		toolcontext.modelbuilder.resolve_mtype_unchecked(mmodule, mclassdef, n_type, true)
+		toolcontext.modelbuilder.resolve_mtype_unchecked(mclassdef, n_type, true)
 		super
 	end
 end
@@ -429,8 +427,7 @@ redef class AAsNotNullableExternCall
 	redef fun verify_and_collect(npropdef, callback_set, toolcontext)
 	do
 		var mclassdef = npropdef.mpropdef.mclassdef
-		var mmodule = mclassdef.mmodule
-		toolcontext.modelbuilder.resolve_mtype_unchecked(mmodule, mclassdef, n_type, true)
+		toolcontext.modelbuilder.resolve_mtype_unchecked(mclassdef, n_type, true)
 		super
 	end
 end

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -46,7 +46,7 @@ private class TypeVisitor
 	var mclassdef: nullable MClassDef = null
 
 	# The analyzed property
-	var mpropdef: nullable MPropDef
+	var mpropdef: MPropDef
 
 	var selfvariable = new Variable("self")
 
@@ -59,22 +59,19 @@ private class TypeVisitor
 	init
 	do
 		var mpropdef = self.mpropdef
+		var mclassdef = mpropdef.mclassdef
+		self.mclassdef = mclassdef
+		self.anchor = mclassdef.bound_mtype
 
-		if mpropdef != null then
-			var mclassdef = mpropdef.mclassdef
-			self.mclassdef = mclassdef
-			self.anchor = mclassdef.bound_mtype
+		var mclass = mclassdef.mclass
 
-			var mclass = mclassdef.mclass
+		var selfvariable = new Variable("self")
+		self.selfvariable = selfvariable
+		selfvariable.declared_type = mclass.mclass_type
 
-			var selfvariable = new Variable("self")
-			self.selfvariable = selfvariable
-			selfvariable.declared_type = mclass.mclass_type
-
-			var mprop = mpropdef.mproperty
-			if mprop isa MMethod and mprop.is_new then
-				is_toplevel_context = true
-			end
+		var mprop = mpropdef.mproperty
+		if mprop isa MMethod and mprop.is_new then
+			is_toplevel_context = true
 		end
 	end
 

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -275,7 +275,7 @@ private class TypeVisitor
 
 	fun resolve_mtype(node: AType): nullable MType
 	do
-		return self.modelbuilder.resolve_mtype(mmodule, mclassdef, node)
+		return self.modelbuilder.resolve_mtype(mclassdef, node)
 	end
 
 	fun try_get_mclass(node: ANode, name: String): nullable MClass

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -61,7 +61,6 @@ private class TypeVisitor
 		var mpropdef = self.mpropdef
 
 		if mpropdef != null then
-			self.mpropdef = mpropdef
 			var mclassdef = mpropdef.mclassdef
 			self.mclassdef = mclassdef
 			self.anchor = mclassdef.bound_mtype

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -43,7 +43,7 @@ private class TypeVisitor
 	var anchor: nullable MClassType = null
 
 	# The analyzed mclassdef
-	var mclassdef: nullable MClassDef = null
+	var mclassdef: MClassDef is noinit
 
 	# The analyzed property
 	var mpropdef: MPropDef

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -36,7 +36,7 @@ private class TypeVisitor
 
 	# The module of the analysis
 	# Used to correctly query the model
-	var mmodule: MModule
+	var mmodule: MModule is noinit
 
 	# The static type of the receiver
 	# Mainly used for type tests and type resolutions
@@ -60,6 +60,7 @@ private class TypeVisitor
 	do
 		var mpropdef = self.mpropdef
 		var mclassdef = mpropdef.mclassdef
+		mmodule = mclassdef.mmodule
 		self.mclassdef = mclassdef
 		self.anchor = mclassdef.bound_mtype
 
@@ -860,7 +861,7 @@ redef class AMethPropdef
 		var mpropdef = self.mpropdef
 		if mpropdef == null then return # skip error
 
-		var v = new TypeVisitor(modelbuilder, mpropdef.mclassdef.mmodule, mpropdef)
+		var v = new TypeVisitor(modelbuilder, mpropdef)
 		self.selfvariable = v.selfvariable
 
 		var mmethoddef = self.mpropdef.as(not null)
@@ -927,7 +928,7 @@ redef class AAttrPropdef
 		var mpropdef = self.mreadpropdef
 		if mpropdef == null or mpropdef.msignature == null then return # skip error
 
-		var v = new TypeVisitor(modelbuilder, mpropdef.mclassdef.mmodule, mpropdef)
+		var v = new TypeVisitor(modelbuilder, mpropdef)
 		self.selfvariable = v.selfvariable
 
 		var nexpr = self.n_expr

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -40,7 +40,7 @@ private class TypeVisitor
 
 	# The static type of the receiver
 	# Mainly used for type tests and type resolutions
-	var anchor: nullable MClassType = null
+	var anchor: MClassType is noinit
 
 	# The analyzed mclassdef
 	var mclassdef: MClassDef is noinit
@@ -2138,7 +2138,6 @@ redef class ASuperExpr
 	redef fun accept_typing(v)
 	do
 		var anchor = v.anchor
-		assert anchor != null
 		var recvtype = v.get_variable(self, v.selfvariable)
 		assert recvtype != null
 		var mproperty = v.mpropdef.mproperty
@@ -2177,7 +2176,6 @@ redef class ASuperExpr
 	private fun process_superinit(v: TypeVisitor)
 	do
 		var anchor = v.anchor
-		assert anchor != null
 		var recvtype = v.get_variable(self, v.selfvariable)
 		assert recvtype != null
 		var mpropdef = v.mpropdef


### PR DESCRIPTION
Only `modelize_mclass` require support for partial context. Furthermore, in
a future PR, it may need to resolve types just before modeling the class
definition (in a place where the `MClass` is available and must be used).

Also include various related cleanups.

Signed-off-by: Jean-Christophe Beaupré <jcbrinfo@users.noreply.github.com>