### PR TITLE
nitin: use GPL-3.0 instead of GPL-3

### DIFF
--- a/contrib/nitin/package.ini
+++ b/contrib/nitin/package.ini
@@ -2,7 +2,7 @@
 name=nitin
 tags=devel
 maintainer=Jean Privat <jean@pryen.org>
-license=GPL-3
+license=GPL-3.0
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/nitin/
 git=https://github.com/nitlang/nit.git


### PR DESCRIPTION
the tag is used to fill the catalog, http://nitlanguage.org/catalog/p/nitin.html but the link is broken whereas https://opensource.org/licenses/GPL-3.0 works

Signed-off-by: Jean Privat <jean@pryen.org>