### PR TITLE
gamnit: dynamic window resize

### DIFF
--- a/contrib/action_nitro/src/action_nitro.nit
+++ b/contrib/action_nitro/src/action_nitro.nit
@@ -561,7 +561,7 @@ redef class Player
 		end
 
 		# Display respawn instructions
-		app.ui_sprites.add new Sprite(app.texts_sheet.respawn, app.ui_camera.center)
+		app.ui_sprites.add new Sprite(app.texts_sheet.respawn, app.ui_camera.center.offset(0.0, 0.0, 0.0))
 	end
 end
 

--- a/lib/app/http_request.nit
+++ b/lib/app/http_request.nit
@@ -126,7 +126,7 @@ end
 #
 # Prints on communication errors and when the server returns an HTTP status code not in the 200s.
 #
-# ~~~
+# ~~~nitish
 # var request = new SimpleAsyncHttpRequest("http://example.com")
 # request.start
 # ~~~

--- a/lib/gamnit/bmfont.nit
+++ b/lib/gamnit/bmfont.nit
@@ -270,7 +270,8 @@ end
 # ~~~
 # redef class App
 #     var font = new BMFontAsset("arial.fnt")
-#     var ui_text = new TextSprites(font, ui_camera.top_left)
+#     var pos: Point3d[Float] = ui_camera.top_left.offset(128.0, -128.0, 0.0)
+#     var ui_text = new TextSprites(font, pos)
 #
 #     redef fun on_create
 #     do

--- a/lib/gamnit/cameras.nit
+++ b/lib/gamnit/cameras.nit
@@ -207,8 +207,8 @@ class UICamera
 	# Clipping wall the farthest of the camera, defaults to -100.0
 	var far: Float = -100.0 is writable
 
-	# Width in world units, defaults to the width in pixels of the screen
-	var width: Float = display.width.to_f is lazy
+	# Width in world units, calculated from `height` and the screen aspect ratio
+	fun width: Float do return height * display.aspect_ratio
 
 	# Height in world units, defaults to 1080.0
 	#
@@ -221,9 +221,7 @@ class UICamera
 	fun reset_height(height: nullable Float)
 	do
 		if height == null then height = display.height.to_f
-
 		self.height = height
-		self.width = height * display.aspect_ratio
 	end
 
 	# Convert the position `x, y` on screen, to UI coordinates

--- a/lib/gamnit/cameras.nit
+++ b/lib/gamnit/cameras.nit
@@ -210,12 +210,12 @@ class UICamera
 	# Width in world units, defaults to the width in pixels of the screen
 	var width: Float = display.width.to_f is lazy
 
-	# Height in world units, defaults to the height in pixels of the screen
-	var height: Float = display.height.to_f is lazy
+	# Height in world units, defaults to 1080.0
+	#
+	# Set this value using `reset_height`.
+	var height = 1080.0
 
 	# Reset the camera position so that `height` world units are visible on the Y axis
-	#
-	# By default, `height` is set to `display.height`.
 	#
 	# This can be used to set standardized UI units independently from the screen resolution.
 	fun reset_height(height: nullable Float)

--- a/lib/gamnit/cameras_cache.nit
+++ b/lib/gamnit/cameras_cache.nit
@@ -110,12 +110,6 @@ redef class UICamera
 		mvp_matrix_cache = null
 	end
 
-	redef fun width=(value)
-	do
-		super
-		mvp_matrix_cache = null
-	end
-
 	redef fun height=(value)
 	do
 		super

--- a/lib/gamnit/depth/depth.nit
+++ b/lib/gamnit/depth/depth.nit
@@ -45,6 +45,7 @@ redef class App
 	# Draw all elements of `actors` and then call `frame_core_flat`
 	protected fun frame_core_depth(display: GamnitDisplay)
 	do
+		glViewport(0, 0, display.width, display.height)
 		frame_core_dynamic_resolution_before display
 
 		# Update cameras on both our programs

--- a/lib/gamnit/display.nit
+++ b/lib/gamnit/display.nit
@@ -34,7 +34,7 @@ class GamnitDisplay
 	fun height: Int is abstract
 
 	# Aspect ratio of the screen, `width / height`
-	var aspect_ratio: Float is lazy do return width.to_f / height.to_f
+	fun aspect_ratio: Float do return width.to_f / height.to_f
 
 	# Is the cursor locked et the center of the screen?
 	var lock_cursor = false is writable

--- a/lib/gamnit/display_linux.nit
+++ b/lib/gamnit/display_linux.nit
@@ -78,7 +78,7 @@ redef class GamnitDisplay
 			print_error "Failed to initialize SDL2 IMG: {sdl.error}"
 		end
 
-		var sdl_window = new SDLWindow(window_title.to_cstring, window_width, window_height, (new SDLWindowFlags).opengl)
+		var sdl_window = new SDLWindow(window_title.to_cstring, window_width, window_height, sdl_window_flags)
 		assert not sdl_window.address_is_null else
 			print_error "Failed to create SDL2 window: {sdl.error}"
 		end
@@ -97,7 +97,12 @@ redef class GamnitDisplay
 		return sdl_window
 	end
 
-	# Initialization flags passed to SDL2 mixer
+	# SDL2 window initialization flags
+	#
+	# The default value supports OpenGL and window resizing.
+	var sdl_window_flags: SDLWindowFlags = (new SDLWindowFlags).opengl.resizable is lazy, writable
+
+	# SDL2 mixer initialization flags
 	#
 	# Defaults to all available formats.
 	var mix_init_flags: MixInitFlags = mix.flac | mix.mod | mix.mp3 | mix.ogg is lazy, writable

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -42,6 +42,7 @@ import performance_analysis
 
 import gamnit
 import gamnit::cameras_cache
+intrude import gamnit::cameras
 import gamnit::dynamic_resolution
 import gamnit::limit_fps
 import gamnit::camera_control
@@ -614,6 +615,26 @@ redef class Point3d[N]
 		if sprites != null then for s in sprites do s.needs_update
 	end
 
+	redef fun x=(v)
+	do
+		if isset _x and v != x then needs_update
+		super
+	end
+
+	redef fun y=(v)
+	do
+		if isset _y and v != y then needs_update
+		super
+	end
+
+	redef fun z=(v)
+	do
+		if isset _z and v != z then needs_update
+		super
+	end
+end
+
+redef class OffsetPoint3d
 	redef fun x=(v)
 	do
 		if isset _x and v != x then needs_update

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -293,8 +293,6 @@ redef class App
 	do
 		texture.load
 
-		ui_camera.reset_height 1080.0
-
 		var splash = new Sprite(texture, ui_camera.center)
 		ui_sprites.add splash
 

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -583,12 +583,6 @@ private class Simple2dProgram
 end
 
 redef class Point3d[N]
-	# Get a new `Point3d[Float]` with an offset of each axis of `x, y, z`
-	fun offset(x, y, z: Numeric): Point3d[Float]
-	do
-		return new Point3d[Float](self.x.to_f+x.to_f, self.y.to_f+y.to_f, self.z.to_f+z.to_f)
-	end
-
 	# ---
 	# Associate each point to its sprites
 

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -41,8 +41,8 @@ import more_collections
 import performance_analysis
 
 import gamnit
-import gamnit::cameras_cache
 intrude import gamnit::cameras
+intrude import gamnit::cameras_cache
 import gamnit::dynamic_resolution
 import gamnit::limit_fps
 import gamnit::camera_control
@@ -294,7 +294,7 @@ redef class App
 	do
 		texture.load
 
-		var splash = new Sprite(texture, ui_camera.center)
+		var splash = new Sprite(texture, ui_camera.center.offset(0.0, 0.0, 0.0))
 		ui_sprites.add splash
 
 		var display = display
@@ -370,6 +370,17 @@ redef class App
 		# Close gamnit
 		var display = display
 		if display != null then display.close
+	end
+
+	redef fun on_resize(display)
+	do
+		super
+
+		world_camera.mvp_matrix_cache = null
+		ui_camera.mvp_matrix_cache = null
+
+		# Update all sprites in the UI
+		for sprite in ui_sprites do sprite.needs_update
 	end
 
 	redef fun frame_core(display)

--- a/lib/gamnit/gamnit.nit
+++ b/lib/gamnit/gamnit.nit
@@ -77,4 +77,9 @@ redef class App
 	# The instances passed as `event` may be freed (or overwritten),
 	# right after this method returns. They should not be preserved.
 	fun accept_event(event: InputEvent): Bool do return false
+
+	# The window has been resized by the user or system
+	#
+	# The framework handles resizing the viewport automatically.
+	fun on_resize(display: GamnitDisplay) do end
 end

--- a/lib/gamnit/gamnit_linux.nit
+++ b/lib/gamnit/gamnit_linux.nit
@@ -18,6 +18,7 @@ module gamnit_linux
 import sdl2::events
 
 intrude import gamnit
+intrude import display_linux
 
 redef class App
 	private var sdl_event_buffer = new SDLEventBuffer.malloc
@@ -33,6 +34,12 @@ redef class App
 
 			# Convert to an SDL event with data
 			var sdl_event = sdl_event_buffer.to_event
+			if sdl_event isa SDLWindowEvent and sdl_event.is_resized then
+				display.width = sdl_event.data1
+				display.height = sdl_event.data2
+				on_resize display
+			end
+
 			# Convert to `mnit::inputs` conforming objects
 			var gamnit_event = sdl_event.to_gamnit_event(sdl_event_buffer)
 			accept_event gamnit_event

--- a/lib/geometry/points_and_lines.nit
+++ b/lib/geometry/points_and_lines.nit
@@ -142,6 +142,17 @@ interface IPoint3d[N: Numeric]
 		var s = dist2_xy(other).add(dz.mul(dz))
 		return x.value_of(s)
 	end
+
+	# Get a new `Point3d[Float]` at an offset of `x, y, z` from `self`
+	#
+	# ~~~
+	# var origin = new Point3d[Float](1.0, 1.0, 1.0)
+	# assert origin.offset(1.0, 2.0, 3.0).to_s == "(2.0, 3.0, 4.0)"
+	# ~~~
+	fun offset(x, y, z: Numeric): Point3d[Float]
+	do return new Point3d[Float](self.x.to_f+x.to_f,
+	                             self.y.to_f+y.to_f,
+	                             self.z.to_f+z.to_f)
 end
 
 # 3D point with `x`, `y` and `z`

--- a/lib/sdl2/events.nit
+++ b/lib/sdl2/events.nit
@@ -50,6 +50,7 @@ extern class SDLEventBuffer `{SDL_Event *`}
 		if is_mouse_wheel then return to_mouse_wheel
 		if is_keydown then return to_keydown
 		if is_keyup then return to_keyup
+		if is_window then return to_window
 		return to_event_direct
 	end
 
@@ -110,6 +111,14 @@ extern class SDLEventBuffer `{SDL_Event *`}
 	#
 	# Require: `is_keyup`
 	fun to_keyup: SDLKeyboardUpEvent `{ return self; `}
+
+	#  Is this a window event?
+	fun is_window: Bool `{ return self->type == SDL_WINDOWEVENT; `}
+
+	# Get a reference to data at `self` as a `SDLWindowEvent`
+	#
+	# Require: `is_window`
+	fun to_window: SDLWindowEvent `{ return self; `}
 
 	# TODO other SDL events:
 	#
@@ -276,4 +285,24 @@ extern class SDLKeysym `{ SDL_Keysym * `}
 	# Modification keys
 	fun mod: Int `{ return self->mod; `}
 	# TODO related masks
+end
+
+# Window event
+extern class SDLWindowEvent
+	super SDLEvent
+
+	# Window identifier
+	fun id: Int `{ return self->window.windowID; `}
+
+	# Is `self` a resized event?
+	fun is_resized: Bool `{ return self->window.event == SDL_WINDOWEVENT_RESIZED; `}
+
+	# Is `self` a size changed event?
+	fun is_size_changed: Bool `{ return self->window.event == SDL_WINDOWEVENT_SIZE_CHANGED; `}
+
+	# `data1` field, depends on the event kind
+	fun data1: Int `{ return self->window.data1; `}
+
+	# `data2` field, depends on the event kind
+	fun data2: Int `{ return self->window.data2; `}
 end


### PR DESCRIPTION
Enable dynamic window resizing on desktop computers. It follows the current behavior to preserve the virtual height of 1080 units while adapting the width to respect the window aspect ratio. This is the foolproof behavior, but clients can redef `on_resize` to configure the display as needed, or disable window resizing by setting a custom `GamnitDisplay::sdl_window_flags`.

As support, move `IPoint3d::offset` out of `gamnit` to `geometry` so it can be used by game logic (not just UI logic). And rework sprite positions derived from a camera anchor (such as `ui_camera.center` or `ui_camera.top_left`) to update them when the display is resized.

If needed, we could add a service to preserve the aspect ratio to the desired value. However, since mobile platforms are first class targets, gamnit games should support different resolutions. So have a range of accepted aspect ratios could be a solution to avoid unexpected ratios.

![screenshot from 2017-06-06 20 06 23](https://user-images.githubusercontent.com/208057/26857006-a295d456-4af5-11e7-9d47-1321319b5887.png)
![screenshot from 2017-06-06 20 06 32](https://user-images.githubusercontent.com/208057/26857008-a587c034-4af5-11e7-9816-358e8999a239.png)
![screenshot from 2017-06-06 20 06 37](https://user-images.githubusercontent.com/208057/26857010-a8c33e9a-4af5-11e7-9c61-3117a68f51ef.png)
![screenshot from 2017-06-06 20 06 40](https://user-images.githubusercontent.com/208057/26857016-aae02224-4af5-11e7-84ff-07f092f0289b.png)


