### PR TITLE
gamnit: fix color buffer clearing issues on some computers

### DIFF
--- a/lib/gamnit/dynamic_resolution.nit
+++ b/lib/gamnit/dynamic_resolution.nit
@@ -73,6 +73,7 @@ redef class App
 			# Draw directly to the screen framebuffer
 			glBindFramebuffer(gl_FRAMEBUFFER, dynamic_context.screen_framebuffer)
 			glViewport(0, 0, display.width, display.height)
+			glClear gl_COLOR_BUFFER_BIT | gl_DEPTH_BUFFER_BIT
 
 			var gl_error = glGetError
 			assert gl_error == gl_NO_ERROR else print_error gl_error
@@ -81,12 +82,13 @@ redef class App
 
 		# Draw to our dynamic framebuffer
 		glBindFramebuffer(gl_FRAMEBUFFER, dynamic_context.dynamic_framebuffer)
-		glClear gl_COLOR_BUFFER_BIT | gl_DEPTH_BUFFER_BIT
 
 		var ratio = dynamic_resolution_ratio
 		ratio = ratio.clamp(min_dynamic_resolution_ratio, max_dynamic_resolution_ratio)
 		glViewport(0, 0, (display.width.to_f*ratio).to_i,
 						 (display.height.to_f*ratio).to_i)
+
+		glClear gl_COLOR_BUFFER_BIT | gl_DEPTH_BUFFER_BIT
 
 		var gl_error = glGetError
 		assert gl_error == gl_NO_ERROR else print_error gl_error

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -375,9 +375,6 @@ redef class App
 
 	redef fun frame_core(display)
 	do
-		# Prepare to draw, clear buffers
-		glClear(gl_COLOR_BUFFER_BIT | gl_DEPTH_BUFFER_BIT)
-
 		# Check errors
 		var gl_error = glGetError
 		assert gl_error == gl_NO_ERROR else print_error gl_error


### PR DESCRIPTION
This PR clear the drawing buffers *after* selecting the target framebuffer, even when the buffer does not change. This should fix the issue @BlackMinou was having (the color buffer not being cleared) when running Tinks! 3D or https://gitlab.com/xymus/jumpngun.

However, this does not fix a similar issue on my desktop computer and I think an issue remained with the depth buffer on @BlackMinou computer.