### PR TITLE
gamnit: fix README and docker latest-full references to the use of SDL2 mixer

### DIFF
--- a/lib/gamnit/README.md
+++ b/lib/gamnit/README.md
@@ -9,7 +9,7 @@ To compile the _gamnit_ apps packaged with the Nit repositoy on GNU/Linux you ne
 Under Debian 8.2, this command should install everything needed:
 
 ~~~
-apt-get install libgles2-mesa-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev inkscape mpg123
+apt-get install libgles2-mesa-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev inkscape
 ~~~
 
 Under Windows 64 bits, using msys2, you can install the required packages with:

--- a/misc/docker/full/Dockerfile
+++ b/misc/docker/full/Dockerfile
@@ -21,6 +21,7 @@ RUN dpkg --add-architecture i386 \
 		libsdl1.2-dev \
 		libsdl2-dev \
 		libsdl2-image-dev \
+		libsdl2-mixer-dev \
 		libsqlite3-dev \
 		libx11-dev \
 		libxdg-basedir-dev \


### PR DESCRIPTION
Update gamnit README and latest-full docker for #2466.