### PR TITLE
gamnit: replace missing textures by a checker texture

### DIFF
--- a/lib/gamnit/textures.nit
+++ b/lib/gamnit/textures.nit
@@ -209,6 +209,9 @@ class TextureAsset
 
 		load_from_platform
 
+		# If no pixel data was loaded, load the pixel default texture
+		if gl_texture == -1 then load_checker 32
+
 		loaded = true
 	end
 

--- a/lib/gamnit/textures.nit
+++ b/lib/gamnit/textures.nit
@@ -170,6 +170,29 @@ class CustomTexture
 		for i in [0..4[ do cpixels[offset+i] = bytes[i]
 	end
 
+	# Overwrite all pixels with `color`
+	#
+	# The argument `color` should be an array of up to 4 floats (RGBA).
+	# If `color` has less than 4 items, the missing items are replaced by 1.0.
+	#
+	# Require: `not loaded`
+	fun fill(color: Array[Float])
+	do
+		assert not loaded else print_error "{class_name}::fill already loaded"
+
+		# Simple conversion from [0.0..1.0] to [0..255]
+		var bytes = [for c in color do (c*255.0).round.to_i.clamp(0, 255).to_bytes.last]
+		while bytes.length < 4 do bytes.add 255u8
+
+		var i = 0
+		for x in [0..width.to_i[ do
+			for y in [0..height.to_i[ do
+				for j in [0..4[ do cpixels[i+j] = bytes[j]
+				i += 4
+			end
+		end
+	end
+
 	redef fun load(force)
 	do
 		if loaded then return

--- a/lib/gamnit/textures.nit
+++ b/lib/gamnit/textures.nit
@@ -96,6 +96,22 @@ abstract class Texture
 
 	# Offset of the bottom border on `root` from 0.0 to 1.0
 	fun offset_bottom: Float do return 1.0
+
+	# Should this texture be drawn pixelated when magnified? otherwise it is interpolated
+	#
+	# This setting affects all the textures based on the same pixel data, or `root`.
+	#
+	# Must be set after a successful call to `load`.
+	fun pixelated=(pixelated: Bool)
+	do
+		if root.gl_texture == -1 then return
+
+		# TODO do not modify `root` by using *sampler objects* in glesv3
+		glBindTexture(gl_TEXTURE_2D, root.gl_texture)
+
+		var param = if pixelated then gl_NEAREST else gl_LINEAR
+		glTexParameteri(gl_TEXTURE_2D, gl_TEXTURE_MAG_FILTER, param)
+	end
 end
 
 # Colorful small texture of 32x32 pixels by default
@@ -226,18 +242,6 @@ class RootTexture
 		load_from_pixels(cpixels.native_array, size, size, gl_RGB)
 
 		cpixels.destroy
-	end
-
-	# Set whether this texture should be pixelated when drawn, otherwise it is interpolated
-	fun pixelated=(pixelated: Bool)
-	do
-		# TODO this service could be made available in `Texture` when using
-		# the kind of texture wrapper of gles v2 or maybe 3
-
-		glBindTexture(gl_TEXTURE_2D, gl_texture)
-
-		var param = if pixelated then gl_NEAREST else gl_LINEAR
-		glTexParameteri(gl_TEXTURE_2D, gl_TEXTURE_MAG_FILTER, param)
 	end
 
 	# Has this resource been deleted?


### PR DESCRIPTION
Use a checker texture to replace textures that fail to load. This replaces the previous behavior where an invalid texture name was passed to OpenGL ES which displayed it as full black.

In support, revamp the implementation of `CheckerTexture` to be only black and white and to have a size of 32 pixels by default. The new color is more neutral while being easier to spot and report by an end user (see the tower in the screenshot below). And the new size will make it easier to see than the previous 2x2 on non-scaled 2D sprites.

Also intro `CustomTexture`, a texture build programmatically by setting the color of each pixel. This can be used to create very simple textures (like the crosshair or the fuel indicator in the screenshot) or to represent end user drawings. This API is not very optimized, but clients can still subclass `Texture` for performance critical textures.

![screenshot from 2017-06-10 14 30 13](https://user-images.githubusercontent.com/208057/27045782-11600cde-4f70-11e7-80ac-742e3ab96204.png)
