### PR TITLE
nit-makepackage: add missing manpage

### DIFF
--- a/bin/nit-makepackage
+++ b/bin/nit-makepackage
@@ -19,6 +19,24 @@
 #
 # Default values are guessed from git and the file system.
 
+while true; do
+	case "$1" in
+		"")
+			break
+			;;
+		-h|--help)
+			echo "nit-makepackage: creates a package.ini in the current directory"
+			echo "There is no option (yet)"
+			exit
+			;;
+		*)
+			echo >&2 "nit-makepackage does not accept options yet"
+			exit 1
+			;;
+	esac
+done
+
+
 name=`basename $PWD`
 maintainer=`git shortlog -esn . | head -n 1 | sed 's/\s*[0-9]*\s*//'`
 dir=`git rev-parse --show-prefix`

--- a/share/man/nit-makepackage.md
+++ b/share/man/nit-makepackage.md
@@ -1,0 +1,18 @@
+# NAME
+
+nit-makepackage - helper script to setup package metadata
+
+# SYNOPSIS
+
+nit-makepackage
+
+# DESCRIPTION
+
+`nit-makepackage` creates (or overrides) a package.ini template file in the current directory.
+The result must be examined and adapted.
+
+Default values are guessed from git and the file system.
+
+# SEE ALSO
+
+The Nit language documentation and the source code of its tools and libraries may be downloaded from <http://nitlanguage.org>


### PR DESCRIPTION
jenkins does not like missing manpages, even for trivial tools.