### PR TITLE
nitc: use ccache again

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -360,8 +360,12 @@ class MakefileToolchain
 		var debug = toolcontext.opt_debug.value
 
 		makefile.write """
-CC ?= ccache cc
-CXX ?= ccache c++
+ifeq ($(origin CC), default)
+        CC = ccache cc
+endif
+ifeq ($(origin CXX), default)
+        CXX = ccache c++
+endif
 CFLAGS ?= -g {{{if not debug then "-O2" else ""}}} -Wno-unused-value -Wno-switch -Wno-attributes -Wno-trigraphs
 CINCL =
 LDFLAGS ?=


### PR DESCRIPTION
c02e04291807cf97228068cc5b52f453d84ab37b unexpectedly disable ccache.
Since CC is set by default [1], the ?= attempt did never assign anything [2].

The solution is to assign unless if CC is set by another mean.
This can be done thanks to the origin function [3].

  [1]: https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
  [2]: https://www.gnu.org/software/make/manual/html_node/Flavors.html
  [3]: https://www.gnu.org/software/make/manual/html_node/Origin-Function.html
