### PR TITLE
Nitunit: mass compile non-simple docunits

### DIFF
--- a/src/testing/testing_doc.nit
+++ b/src/testing/testing_doc.nit
@@ -215,19 +215,28 @@ class NitUnitExecutor
 		end
 	end
 
-	# Executes a single doc-unit in its own program.
-	# Used for docunits larger than a single block of code (with modules, classes, functions etc.)
-	fun test_single_docunit(du: DocUnit)
+	# Produce a single unit file for the docunit `du`.
+	fun generate_single_docunit(du: DocUnit): String
 	do
 		cpt += 1
 		var file = "{prefix}-{cpt}.nit"
-
-		toolcontext.info("Execute doc-unit {du.full_name} in {file}", 1)
 
 		var f
 		f = create_unitfile(file)
 		f.write(du.block)
 		f.close
+
+		du.test_file = file
+		return file
+	end
+
+	# Executes a single doc-unit in its own program.
+	# Used for docunits larger than a single block of code (with modules, classes, functions etc.)
+	fun test_single_docunit(du: DocUnit)
+	do
+		var file = generate_single_docunit(du)
+
+		toolcontext.info("Compile doc-unit {du.full_name} in {file}", 1)
 
 		if toolcontext.opt_noact.value then return
 

--- a/src/testing/testing_doc.nit
+++ b/src/testing/testing_doc.nit
@@ -119,7 +119,7 @@ class NitUnitExecutor
 		for du in docunits do
 			if du.error != null then
 				# Nothing to execute. Conclude
-			else if du.test_file != null then
+			else if du.is_compiled then
 				# Already compiled. Execute it.
 				execute_simple_docunit(du)
 			else
@@ -186,6 +186,7 @@ class NitUnitExecutor
 			i += 1
 			du.test_file = file
 			du.test_arg = i
+			du.is_compiled = true
 		end
 	end
 
@@ -402,6 +403,9 @@ class DocUnit
 	# Note that a same generated file can be used for multiple tests.
 	# See `test_arg` that is used to distinguish them
 	var test_file: nullable String = null
+
+	#  Was `test_file` successfully compiled?
+	var is_compiled = false
 
 	# The command-line argument to use when executing the test, if any.
 	var test_arg: nullable Int = null

--- a/tests/sav/nitunit_args1.res
+++ b/tests/sav/nitunit_args1.res
@@ -1,7 +1,7 @@
 ==== Docunits of module test_nitunit::test_nitunit | tests: 4
 [OK] test_nitunit::test_nitunit
 [KO] test_nitunit$X
-     test_nitunit.nit:21,7--22,0: Runtime error in nitunit.out/test_nitunit-2.nit
+     test_nitunit.nit:21,7--22,0: Runtime error in nitunit.out/test_nitunit-2.nit with argument 0
      Output
 	Runtime error: Assert failed (nitunit.out/test_nitunit-2.nit:5)
 
@@ -27,7 +27,7 @@ Test suites: Classes: 1; Test Cases: 3; Failures: 1
 [FAILURE] 4/7 tests failed.
 `nitunit.out` is not removed for investigation.
 <testsuites><testsuite package="test_nitunit::test_nitunit"><testcase classname="nitunit.test_nitunit::test_nitunit.&lt;module&gt;" name="&lt;module&gt;" time="0.0"><system-err></system-err><system-out>assert true
-</system-out></testcase><testcase classname="nitunit.test_nitunit.X" name="&lt;class&gt;" time="0.0"><error message="Runtime error in nitunit.out&#47;test_nitunit-2.nit">Runtime error: Assert failed (nitunit.out&#47;test_nitunit-2.nit:5)
+</system-out></testcase><testcase classname="nitunit.test_nitunit.X" name="&lt;class&gt;" time="0.0"><error message="Runtime error in nitunit.out&#47;test_nitunit-2.nit with argument 0">Runtime error: Assert failed (nitunit.out&#47;test_nitunit-2.nit:5)
 </error><system-out>assert false
 </system-out></testcase><testcase classname="nitunit.test_nitunit.X" name="foo" time="0.0"><failure message="Compilation error in nitunit.out&#47;test_nitunit-3.nit">nitunit.out&#47;test_nitunit-3.nit:5,8--27: Error: method or variable `undefined_identifier` unknown in `Sys`.
 </failure><system-out>assert undefined_identifier


### PR DESCRIPTION
When docunits are simple (just statements), a single module is generated for all.
Unfortunately, when docunits contains classes or importations, a specific module must be generated for each one of them.
Compiling all these module takes most of the nitunit elapsed time.

This PR tries to compile these non-simple modules at once, thanks to nitc that features invoking it with multiple programs.

Testing with `nitunit lib/popcorn/README.md`

Before:
* cold ccache: 1m3,832s
* hot ccache: 0m23,063s

After:
* cold ccache: 0m44,517s (-30%)
* hot ccache: 0m17,778s (-23%)