### PR TITLE
gamnit: performance improvements for Dawn Arrival

### DIFF
--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -235,7 +235,10 @@ class Sprite
 	fun needs_update
 	do
 		var c = context
-		if c != null then c.sprites_to_update.add self
+		if c == null then return
+		if c.last_sprite_to_update == self then return
+		c.sprites_to_update.add self
+		c.last_sprite_to_update = self
 	end
 
 	# Request a resorting of this sprite in its sprite list
@@ -696,6 +699,7 @@ private class SpriteSet
 
 		context.sprites.add sprite
 		context.sprites_to_update.add sprite
+		context.last_sprite_to_update = sprite
 
 		sprite.context = context
 		sprite.sprite_set = self
@@ -775,6 +779,9 @@ private class SpriteContext
 
 	# Sprites to update since last `draw`
 	var sprites_to_update = new Set[Sprite]
+
+	# Cache of the last `Sprite` added to `sprites_to_update` since the last call to `draw`
+	var last_sprite_to_update: nullable Sprite = null
 
 	# Sprites that have been update and for which `needs_update` can be set to false
 	var updated_sprites = new Array[Sprite]
@@ -1010,6 +1017,7 @@ private class SpriteContext
 
 			for sprite in sprites_to_update do update_sprite(sprite)
 			sprites_to_update.clear
+			last_sprite_to_update = null
 
 			sys.perfs["gamnit flat gpu update"].add app.perf_clock_sprites.lapse
 		end

--- a/lib/gamnit/flat.nit
+++ b/lib/gamnit/flat.nit
@@ -990,6 +990,7 @@ private class SpriteContext
 		glBindBuffer(gl_ELEMENT_ARRAY_BUFFER, buffer_element)
 
 		# Resize GPU buffers?
+		var update_everything = false
 		if sprites.capacity > buffer_capacity then
 			# Try to defragment first
 			var moved = sprites.defragment
@@ -999,6 +1000,7 @@ private class SpriteContext
 				resize
 
 				# We must update everything
+				update_everything = true
 				for s in sprites.items do if s != null then sprites_to_update.add s
 			else
 				# Just update the moved sprites
@@ -1012,10 +1014,17 @@ private class SpriteContext
 		end
 
 		# Update GPU sprites data
-		if sprites_to_update.not_empty then
+		if sprites_to_update.not_empty or update_everything then
 			app.perf_clock_sprites.lapse
 
-			for sprite in sprites_to_update do update_sprite(sprite)
+			if update_everything then
+				for sprite in sprites.items do if sprite != null then
+					update_sprite(sprite)
+				end
+			else
+				for sprite in sprites_to_update do update_sprite(sprite)
+			end
+
 			sprites_to_update.clear
 			last_sprite_to_update = null
 


### PR DESCRIPTION
This PR applies a few tweaks to optimize performances of the 2D API:

* Each sprite now caches its index in the GPU buffers, replacing the use of `index_of`. This one has the largest performance gain, especially when there is a large number of sprites using the same texture.
* Cache the last sprite on which was called `needs_update` to avoid double or triple adding it to the set of sprites to update on the GPU. This provides a small but notable gain as when a sprite's X and Y coordinates are modified, it was added twice to the set.
* Use a boolean flag instead of the set `sprites_to_update` when all sprite must be updated after a buffer resize.

These changes were tested on [Dawn Arrival](https://gitlab.com/jeremlvt/dawn_arrival) and they cut about 25-50% of the computing time.