### PR TITLE
neo4j: fix cypher syntax for `Neo4jClient::nodes_with_labels`

### DIFF
--- a/lib/neo4j/neo4j.nit
+++ b/lib/neo4j/neo4j.nit
@@ -290,7 +290,7 @@ class Neo4jClient
 
 		# Build the query.
 		var buffer = new Buffer
-		buffer.append "match n where \{label_0\} in labels(n)"
+		buffer.append "match (n) where \{label_0\} in labels(n)"
 		for i in [1..labels.length[ do
 			buffer.append " and \{label_{i}\} in labels(n)"
 		end


### PR DESCRIPTION
newer versions of neo4j seem more picky