### PR TITLE
gamnit: refactor the `flat` 2D API to include more services by default

### DIFF
--- a/contrib/action_nitro/src/action_nitro.nit
+++ b/contrib/action_nitro/src/action_nitro.nit
@@ -21,8 +21,6 @@ module action_nitro is
 end
 
 import gamnit::depth
-import gamnit::keys
-import gamnit::limit_fps
 
 import game
 

--- a/contrib/asteronits/src/asteronits.nit
+++ b/contrib/asteronits/src/asteronits.nit
@@ -26,7 +26,6 @@ import gamnit::flat
 
 import game_logic
 import spritesheet
-import app::audio
 
 redef class Spritesheet
 	# Largest meteors, organized by color

--- a/contrib/tinks/src/client/client3d.nit
+++ b/contrib/tinks/src/client/client3d.nit
@@ -23,8 +23,6 @@ module client3d is
 end
 
 import gamnit::depth
-import gamnit::keys
-import app::audio
 
 import base
 

--- a/lib/gamnit/depth/depth.nit
+++ b/lib/gamnit/depth/depth.nit
@@ -15,6 +15,7 @@
 # Framework for 3D games in Nit
 module depth
 
+import flat
 intrude import more_materials
 import more_models
 import model_dimensions

--- a/lib/gamnit/depth/depth_core.nit
+++ b/lib/gamnit/depth/depth_core.nit
@@ -15,7 +15,7 @@
 # Base entities of the depth 3D game framework
 module depth_core
 
-intrude import gamnit::flat
+import gamnit::flat_core
 
 # Visible 3D entity in the game world
 #

--- a/lib/gamnit/examples/template/src/template.nit
+++ b/lib/gamnit/examples/template/src/template.nit
@@ -13,9 +13,7 @@ module template is
 	android_api_target 10
 end
 
-import gamnit::flat # For `Texture, Sprite`, etc.
-import gamnit::keys # For `pressed_keys`
-import app::audio # For `Sound`
+import gamnit::flat # The 2D API, use `gamnit::depth` for 3D
 
 redef class App
 

--- a/lib/gamnit/flat/flat.nit
+++ b/lib/gamnit/flat/flat.nit
@@ -1,0 +1,36 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Simple API for 2D games, built around `Sprite` and `App::update`
+#
+# Client programs should implement `App::update` to execute game logic and
+# add instances of `Sprite` to `App::sprites` and `App::ui_sprites`.
+# At each frame, all sprites are drawn to the screen.
+#
+# This system relies on two cameras `App::world_camera` and `App::ui_camera`.
+#
+# * `App::world_camera` applies a perspective effect to draw the game world.
+#   This camera is designed to be moved around to see the world as well as to
+#   zoom in and out. It is used to position the sprites in `App::sprites`.
+#
+# * `App::ui_camera` is a simple orthogonal camera to display UI objects.
+#   This camera should mostly be still, it can still move for chock effects
+#   and the like. It can be used to standardize the size of the UI across
+#   devices. It is used to position the sprites in `App::ui_sprites`.
+#
+# See the sample game at `contrib/asteronits/` and the basic project template
+# at `lib/gamnit/examples/template/`.
+module flat
+
+import gamnit::flat_core

--- a/lib/gamnit/flat/flat.nit
+++ b/lib/gamnit/flat/flat.nit
@@ -34,3 +34,11 @@
 module flat
 
 import gamnit::flat_core
+
+# Extra optional features
+import gamnit::limit_fps
+import gamnit::keys
+import gamnit::camera_control
+import gamnit::tileset
+import gamnit::bmfont
+import app::audio

--- a/lib/gamnit/flat/flat_core.nit
+++ b/lib/gamnit/flat/flat_core.nit
@@ -12,26 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Simple API for 2D games, built around `Sprite` and `App::update`
-#
-# Client programs should implement `App::update` to execute game logic and
-# add instances of `Sprite` to `App::sprites` and `App::ui_sprites`.
-# At each frame, all sprites are drawn to the screen.
-#
-# This system relies on two cameras `App::world_camera` and `App::ui_camera`.
-#
-# * `App::world_camera` applies a perspective effect to draw the game world.
-#   This camera is designed to be moved around to see the world as well as to
-#   zoom in and out. It is used to position the sprites in `App::sprites`.
-#
-# * `App::ui_camera` is a simple orthogonal camera to display UI objects.
-#   This camera should mostly be still, it can still move for chock effects
-#   and the like. It can be used to standardize the size of the UI across
-#   devices. It is used to position the sprites in `App::ui_sprites`.
-#
-# See the sample game at `contrib/asteronits/` and the basic project template
-# at `lib/gamnit/examples/template/`.
-module flat
+# Core services for the `flat` API for 2D games
+module flat_core
 
 import glesv2
 intrude import geometry::points_and_lines # For _x, _y and _z

--- a/lib/gamnit/flat/flat_core.nit
+++ b/lib/gamnit/flat/flat_core.nit
@@ -26,8 +26,6 @@ import gamnit
 intrude import gamnit::cameras
 intrude import gamnit::cameras_cache
 import gamnit::dynamic_resolution
-import gamnit::limit_fps
-import gamnit::camera_control
 
 # Visible 2D entity in the game world or UI
 #

--- a/lib/gamnit/font.nit
+++ b/lib/gamnit/font.nit
@@ -15,7 +15,7 @@
 # Abstract font drawing services, implemented by `bmfont` and `tileset`
 module font
 
-import flat
+import gamnit::flat_core
 
 # Abstract font, drawn by a `TextSprites`
 abstract class Font


### PR DESCRIPTION
The use of `import gamnit::flat` will now include more services useful to most games: `Sound`, `Font`, `pressed_keys`, etc. If a project doesn't want to include them for any reason, it can still `import gamnit::flat_core` and hand pick other services.