### PR TITLE
frontend: run code generation phases only in engines (and nitmetrics)

### DIFF
--- a/src/frontend/code_gen.nit
+++ b/src/frontend/code_gen.nit
@@ -1,7 +1,5 @@
 # This file is part of NIT ( http://www.nitlanguage.org ).
 #
-# Copyright 2012 Jean Privat <jean@pryen.org>
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# A Nit compiler
-module nitc
+# Main frontend phases plus code generation phases
+module code_gen
 
-import frontend::code_gen
-import compiler
-import transform
-
-redef class ToolContext
-	redef fun process_options(args)
-	do
-		super
-
-		var sum = opt_global.value.to_i + opt_separate.value.to_i + opt_erasure.value.to_i
-		if sum > 1 then
-			print "Options --global, --separate and --erasure are exclusive"
-			exit(1)
-		else if sum == 0 then
-			# --separate by default
-			opt_separate.value = true
-		end
-	end
-end
+import frontend
+import actors_generation_phase
+import serialization_code_gen_phase

--- a/src/frontend/frontend.nit
+++ b/src/frontend/frontend.nit
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 # Collect and orchestration of main frontend phases
+#
+# Import `frontend::code_gen` to also include code generation modules.
 module frontend
 
 import no_warning
@@ -21,7 +23,7 @@ import literal
 import modelize
 import semantize
 import div_by_zero
-import serialization_phase
+import serialization_model_phase
 import deriving
 import check_annotation
 import parse_annotations
@@ -29,7 +31,6 @@ import glsl_validation
 import parallelization_phase
 import i18n_phase
 import regex_phase
-import actors_generation_phase
 import actors_injection_phase
 
 redef class ToolContext

--- a/src/frontend/serialization_code_gen_phase.nit
+++ b/src/frontend/serialization_code_gen_phase.nit
@@ -1,0 +1,208 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Phase generating methods (code) to serialize Nit objects
+module serialization_code_gen_phase
+
+intrude import serialization_model_phase
+
+redef class ToolContext
+
+	# The second phase of the serialization
+	var serialization_phase_post_model: Phase = new SerializationPhasePostModel(self,
+		[modelize_property_phase, serialization_phase_pre_model])
+end
+
+private class SerializationPhasePostModel
+	super Phase
+
+	# Fill the deserialization init `from_deserializer` and `Deserializer.deserialize_class_intern`
+	redef fun process_nmodule(nmodule)
+	do
+		for npropdef in nmodule.inits_to_retype do
+			var nclassdef = npropdef.parent
+			assert nclassdef isa AStdClassdef
+
+			var serialize_by_default = nclassdef.how_serialize
+			assert serialize_by_default != null
+
+			var per_attribute = not serialize_by_default
+			fill_deserialization_init(nclassdef, npropdef, per_attribute)
+		end
+
+		# collect all classes
+		var auto_serializable_nclassdefs = nmodule.auto_serializable_nclassdefs
+		if not auto_serializable_nclassdefs.is_empty then
+			fill_deserialization_method(nmodule, auto_serializable_nclassdefs)
+		end
+	end
+
+	# Fill the constructor to the generated `init_npropdef` of `nclassdef`
+	fun fill_deserialization_init(nclassdef: AClassdef, init_npropdef: AMethPropdef, per_attribute: Bool)
+	do
+		var code = new Array[String]
+		code.add """
+redef init from_deserializer(v: Deserializer)
+do
+	super
+	v.notify_of_creation self
+"""
+
+		for attribute in nclassdef.n_propdefs do
+			if not attribute isa AAttrPropdef then continue
+
+			# Is `attribute` to be skipped?
+			if (per_attribute and not attribute.is_serialize) or
+				attribute.is_noserialize then continue
+
+			var mtype = attribute.mtype
+			if mtype == null then continue
+			var type_name = mtype.to_s
+			var name = attribute.name
+
+			var resolved_type_name = type_name
+			var mclassdef = nclassdef.mclassdef
+			if mclassdef != null then
+				var bound_mtype = mclassdef.bound_mtype
+				var resolved_mtype = mtype.resolve_for(bound_mtype, bound_mtype, mclassdef.mmodule, true)
+				resolved_type_name = resolved_mtype.name
+
+				# TODO Use something like `V.class_name` to get the precise runtime type of virtual types.
+				# We currently use the upper bound of virtual types as static type in generated code
+				# for type suggestion and to prevent loading unexected types.
+				# This leaves a security issue when, for example, `DefaultMap::default_value`
+				# is bound to `nullable Object` and would allow any object to be loaded.
+			end
+
+			if type_name == "nullable Object" then
+				# Don't type check
+				code.add """
+	self.{{{name}}} = v.deserialize_attribute("{{{attribute.serialize_name}}}", "{{{resolved_type_name}}}")
+"""
+			else
+				code.add """
+	var {{{name}}} = v.deserialize_attribute("{{{attribute.serialize_name}}}", "{{{resolved_type_name}}}")
+	if v.deserialize_attribute_missing then
+"""
+				# What to do when an attribute is missing?
+				if attribute.has_value then
+					# Leave it to the default value
+				else if mtype isa MNullableType then
+					code.add """
+		self.{{{name}}} = null"""
+				else code.add """
+		v.errors.add new Error("Deserialization Error: attribute `{class_name}::{{{name}}}` missing from JSON object")"""
+
+				code.add """
+	else if not {{{name}}} isa {{{type_name}}} then
+		v.errors.add new AttributeTypeError(self, "{{{attribute.serialize_name}}}", {{{name}}}, "{{{resolved_type_name}}}")
+		if v.keep_going == false then return
+	else
+		self.{{{name}}} = {{{name}}}
+	end
+"""
+			end
+		end
+
+		code.add "end"
+
+		# Replace the body of the constructor
+		var npropdef = toolcontext.parse_propdef(code.join("\n")).as(AMethPropdef)
+		init_npropdef.n_block = npropdef.n_block
+
+		# Run the literal phase on the generated code
+		var v = new LiteralVisitor(toolcontext)
+		v.enter_visit(npropdef.n_block)
+	end
+
+	# Fill the abstract serialization service
+	fun fill_deserialization_method(nmodule: AModule, nclassdefs: Array[AStdClassdef])
+	do
+		var deserializer_nclassdef = nmodule.deserializer_nclassdef
+		if deserializer_nclassdef == null then return
+		var deserializer_npropdef = deserializer_nclassdef.deserializer_npropdef
+		if deserializer_npropdef == null then return
+
+		# Collect local types expected to be deserialized
+		var types_to_deserialize = new Set[String]
+
+		## Local serializable standard class without parameters
+		for nclassdef in nclassdefs do
+			var mclass = nclassdef.mclass
+			if mclass == null then continue
+
+			if mclass.arity == 0 and mclass.kind == concrete_kind then
+				types_to_deserialize.add mclass.name
+			end
+		end
+
+		## Static parametized types on serializable attributes
+		for nclassdef in nmodule.n_classdefs do
+			if not nclassdef isa AStdClassdef then continue
+
+			for attribute in nclassdef.n_propdefs do
+				if not attribute isa AAttrPropdef then continue
+
+				var serialize_by_default = nclassdef.how_serialize
+				if serialize_by_default == null then continue
+				var per_attribute = not serialize_by_default
+
+				# Is `attribute` to be skipped?
+				if (per_attribute and not attribute.is_serialize) or
+					attribute.is_noserialize then continue
+
+				var mtype = attribute.mtype
+				if mtype == null then continue
+				if mtype isa MNullableType then mtype = mtype.mtype
+
+				if mtype isa MClassType and mtype.mclass.arity > 0 and
+				   mtype.mclass.kind == concrete_kind and not mtype.need_anchor then
+
+					# Check is a `Serializable`
+					var mmodule = nmodule.mmodule
+					if mmodule == null then continue
+
+					var greaters = mtype.mclass.in_hierarchy(mmodule).greaters
+					var is_serializable = false
+					for sup in greaters do if sup.name == "Serializable" then
+						is_serializable = true
+						break
+					end
+
+					if is_serializable then types_to_deserialize.add mtype.to_s
+				end
+			end
+		end
+
+		# Build implementation code
+		var code = new Array[String]
+		code.add "redef fun deserialize_class_intern(name)"
+		code.add "do"
+
+		for name in types_to_deserialize do
+			code.add "	if name == \"{name}\" then return new {name}.from_deserializer(self)"
+		end
+
+		code.add "	return super"
+		code.add "end"
+
+		# Replace the body of the constructor
+		var npropdef = toolcontext.parse_propdef(code.join("\n")).as(AMethPropdef)
+		deserializer_npropdef.n_block = npropdef.n_block
+
+		# Run the literal phase on the generated code
+		var v = new LiteralVisitor(toolcontext)
+		v.enter_visit(npropdef.n_block)
+	end
+end

--- a/src/frontend/serialization_model_phase.nit
+++ b/src/frontend/serialization_model_phase.nit
@@ -16,8 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Phase generating methods to serialize Nit objects to different formats
-module serialization_phase
+# Phase generating methods (model-only) to serialize Nit objects
+module serialization_model_phase
 
 private import parser_util
 import modelize
@@ -32,10 +32,6 @@ redef class ToolContext
 	# Generate serialization and deserialization methods on `auto_serializable` annotated classes.
 	var serialization_phase_pre_model: Phase = new SerializationPhasePreModel(self,
 		[serialization_phase_rename])
-
-	# The second phase of the serialization
-	var serialization_phase_post_model: Phase = new SerializationPhasePostModel(self,
-		[modelize_property_phase, serialization_phase_pre_model])
 end
 
 redef class ANode
@@ -267,189 +263,6 @@ redef init from_deserializer(v: Deserializer) do abort"""
 		else
 			deserializer_nclassdef.n_propdefs.add(toolcontext.parse_propdef(code.join("\n")))
 		end
-	end
-end
-
-private class SerializationPhasePostModel
-	super Phase
-
-	# Fill the deserialization init `from_deserializer` and `Deserializer.deserialize_class_intern`
-	redef fun process_nmodule(nmodule)
-	do
-		for npropdef in nmodule.inits_to_retype do
-			var nclassdef = npropdef.parent
-			assert nclassdef isa AStdClassdef
-
-			var serialize_by_default = nclassdef.how_serialize
-			assert serialize_by_default != null
-
-			var per_attribute = not serialize_by_default
-			fill_deserialization_init(nclassdef, npropdef, per_attribute)
-		end
-
-		# collect all classes
-		var auto_serializable_nclassdefs = nmodule.auto_serializable_nclassdefs
-		if not auto_serializable_nclassdefs.is_empty then
-			fill_deserialization_method(nmodule, auto_serializable_nclassdefs)
-		end
-	end
-
-	# Fill the constructor to the generated `init_npropdef` of `nclassdef`
-	fun fill_deserialization_init(nclassdef: AClassdef, init_npropdef: AMethPropdef, per_attribute: Bool)
-	do
-		var code = new Array[String]
-		code.add """
-redef init from_deserializer(v: Deserializer)
-do
-	super
-	v.notify_of_creation self
-"""
-
-		for attribute in nclassdef.n_propdefs do
-			if not attribute isa AAttrPropdef then continue
-
-			# Is `attribute` to be skipped?
-			if (per_attribute and not attribute.is_serialize) or
-				attribute.is_noserialize then continue
-
-			var mtype = attribute.mtype
-			if mtype == null then continue
-			var type_name = mtype.to_s
-			var name = attribute.name
-
-			var resolved_type_name = type_name
-			var mclassdef = nclassdef.mclassdef
-			if mclassdef != null then
-				var bound_mtype = mclassdef.bound_mtype
-				var resolved_mtype = mtype.resolve_for(bound_mtype, bound_mtype, mclassdef.mmodule, true)
-				resolved_type_name = resolved_mtype.name
-
-				# TODO Use something like `V.class_name` to get the precise runtime type of virtual types.
-				# We currently use the upper bound of virtual types as static type in generated code
-				# for type suggestion and to prevent loading unexected types.
-				# This leaves a security issue when, for example, `DefaultMap::default_value`
-				# is bound to `nullable Object` and would allow any object to be loaded.
-			end
-
-			if type_name == "nullable Object" then
-				# Don't type check
-				code.add """
-	self.{{{name}}} = v.deserialize_attribute("{{{attribute.serialize_name}}}", "{{{resolved_type_name}}}")
-"""
-			else
-				code.add """
-	var {{{name}}} = v.deserialize_attribute("{{{attribute.serialize_name}}}", "{{{resolved_type_name}}}")
-	if v.deserialize_attribute_missing then
-"""
-				# What to do when an attribute is missing?
-				if attribute.has_value then
-					# Leave it to the default value
-				else if mtype isa MNullableType then
-					code.add """
-		self.{{{name}}} = null"""
-				else code.add """
-		v.errors.add new Error("Deserialization Error: attribute `{class_name}::{{{name}}}` missing from JSON object")"""
-
-				code.add """
-	else if not {{{name}}} isa {{{type_name}}} then
-		v.errors.add new AttributeTypeError(self, "{{{attribute.serialize_name}}}", {{{name}}}, "{{{resolved_type_name}}}")
-		if v.keep_going == false then return
-	else
-		self.{{{name}}} = {{{name}}}
-	end
-"""
-			end
-		end
-
-		code.add "end"
-
-		# Replace the body of the constructor
-		var npropdef = toolcontext.parse_propdef(code.join("\n")).as(AMethPropdef)
-		init_npropdef.n_block = npropdef.n_block
-
-		# Run the literal phase on the generated code
-		var v = new LiteralVisitor(toolcontext)
-		v.enter_visit(npropdef.n_block)
-	end
-
-	# Fill the abstract serialization service
-	fun fill_deserialization_method(nmodule: AModule, nclassdefs: Array[AStdClassdef])
-	do
-		var deserializer_nclassdef = nmodule.deserializer_nclassdef
-		if deserializer_nclassdef == null then return
-		var deserializer_npropdef = deserializer_nclassdef.deserializer_npropdef
-		if deserializer_npropdef == null then return
-
-		# Collect local types expected to be deserialized
-		var types_to_deserialize = new Set[String]
-
-		## Local serializable standard class without parameters
-		for nclassdef in nclassdefs do
-			var mclass = nclassdef.mclass
-			if mclass == null then continue
-
-			if mclass.arity == 0 and mclass.kind == concrete_kind then
-				types_to_deserialize.add mclass.name
-			end
-		end
-
-		## Static parametized types on serializable attributes
-		for nclassdef in nmodule.n_classdefs do
-			if not nclassdef isa AStdClassdef then continue
-
-			for attribute in nclassdef.n_propdefs do
-				if not attribute isa AAttrPropdef then continue
-
-				var serialize_by_default = nclassdef.how_serialize
-				if serialize_by_default == null then continue
-				var per_attribute = not serialize_by_default
-
-				# Is `attribute` to be skipped?
-				if (per_attribute and not attribute.is_serialize) or
-					attribute.is_noserialize then continue
-
-				var mtype = attribute.mtype
-				if mtype == null then continue
-				if mtype isa MNullableType then mtype = mtype.mtype
-
-				if mtype isa MClassType and mtype.mclass.arity > 0 and
-				   mtype.mclass.kind == concrete_kind and not mtype.need_anchor then
-
-					# Check is a `Serializable`
-					var mmodule = nmodule.mmodule
-					if mmodule == null then continue
-
-					var greaters = mtype.mclass.in_hierarchy(mmodule).greaters
-					var is_serializable = false
-					for sup in greaters do if sup.name == "Serializable" then
-						is_serializable = true
-						break
-					end
-
-					if is_serializable then types_to_deserialize.add mtype.to_s
-				end
-			end
-		end
-
-		# Build implementation code
-		var code = new Array[String]
-		code.add "redef fun deserialize_class_intern(name)"
-		code.add "do"
-
-		for name in types_to_deserialize do
-			code.add "	if name == \"{name}\" then return new {name}.from_deserializer(self)"
-		end
-
-		code.add "	return super"
-		code.add "end"
-
-		# Replace the body of the constructor
-		var npropdef = toolcontext.parse_propdef(code.join("\n")).as(AMethPropdef)
-		deserializer_npropdef.n_block = npropdef.n_block
-
-		# Run the literal phase on the generated code
-		var v = new LiteralVisitor(toolcontext)
-		v.enter_visit(npropdef.n_block)
 	end
 end
 

--- a/src/nit.nit
+++ b/src/nit.nit
@@ -18,7 +18,7 @@
 module nit
 
 import interpreter
-import frontend
+import frontend::code_gen
 import parser_util
 import vm
 

--- a/src/nitmetrics.nit
+++ b/src/nitmetrics.nit
@@ -30,9 +30,9 @@ toolcontext.process_options(args)
 # Get arguments
 var arguments = toolcontext.option_context.rest
 
-# We need a model to collect stufs
+# We need a model to collect stuff
 var model = new Model
-# An a model builder to parse files
+# And a model builder to parse files
 var modelbuilder = new ModelBuilder(model, toolcontext)
 
 # Here we load an process all modules passed on the command line

--- a/src/nitmetrics.nit
+++ b/src/nitmetrics.nit
@@ -17,7 +17,7 @@
 # A program that collects various metrics on nit programs and libraries
 module nitmetrics
 
-import frontend
+import frontend::code_gen
 import metrics
 
 # Create a tool context to handle options and paths

--- a/src/nitvm.nit
+++ b/src/nitvm.nit
@@ -18,7 +18,7 @@
 module nitvm
 
 import vm
-import frontend
+import frontend::code_gen
 
 # Create a tool context to handle options and paths
 var toolcontext = new ToolContext

--- a/src/test_test_phase.nit
+++ b/src/test_test_phase.nit
@@ -14,14 +14,14 @@
 
 # Example of simple module that aims to do some specific work on nit programs.
 #
-# Fast prototypes can just start with this skeletton.
+# Fast prototypes can just start with this skeleton.
 module test_test_phase
 
-# We need the framework that perfoms standard code for the main-program
+# We need the framework that performs standard code for the main-program
 import test_phase
 
 # We usualy need specific phases
-# NOTE: `frontend` is sufficent in most case (it is often too much)
+# NOTE: `frontend` is sufficient in most case (it is often too much)
 import frontend
 
 # The body of the specific work.


### PR DESCRIPTION
Some frontend phases generate Nit code (usually method implementations) that is ignored by some tools, including `nitpick`, `nitserial` and `nitrestful`. When running `nitpick` on WBTW, a serialization heavy project, the code generation part of `serialization_phase` uselessly took ~10% of the work time. This extra time adds up quickly as `nitpick` is invoked each time we save a file in vim.

This PR extracts some code generation phases from the main frontend. Compilers and interpreters must import the code generation phases (`frontend::code_gen`) but most others only need the main frontend (`frontend`). Analysis tools may import the code generation phases ito analyze the generated code, or import only the main frontend phases to analyze only the user code.

In this PR, only two phases have been moved: half of `serialization_phase` which was the most costly in my use case, and `actors_generation_phase` because it was already nicely decoupled (well done @BlackMinou!). Others phases could be divided and moved to the code generation frontend if they happen to be a performance bottleneck: `i18n_phase`, `parallelization_phase` and maybe `deriving`.

Note that there is no implementation change to the serialization phase, I simply split the module in two.

