### PR TITLE
vim plugin: list introduction and redefinition locations to goto files

### DIFF
--- a/misc/vim/plugin/nit.vim
+++ b/misc/vim/plugin/nit.vim
@@ -358,12 +358,13 @@ endfun
 
 " Call `git grep` on the word under the cursor
 "
-" Shows declarations first, then all matches, in the preview window.
+" In the preview window, list introductions, declarations and then all matches.
 fun NitGitGrep()
 	let word = expand("<cword>")
 	let out = tempname()
-	execute 'silent !(git grep "\\(module\\|class\\|universal\\|interface\\|var\\|fun\\) '.word.'";'.
-		\'echo; git grep '.word.') > '.out
+	execute 'silent !(git grep -n -e "\<\\(module\\|class\\|universal\\|interface\\|subset\\|var\\|fun\\)\> \<'.word.'\>" --and --not -e redef -- ''*.nit'';'.
+		\'git grep -n "redef \<\\(class\\|universal\\|interface\\|subset\\|var\\|fun\\)\> \<'.word.'\>" -- ''*.nit'';'.
+		\'echo; git grep -n -e "\<'.word.'\>" --and --not -e "\<\\(module\\|class\\|universal\\|interface\\|subset\\|var\\|fun\\)\> \<'.word.'\>" -- ''*.nit'') > '.out
 
 	" Open the preview window on a temp file
 	execute "silent pedit " . out


### PR DESCRIPTION
This PR improves the functions `:Nitdoc` and `:NitGitGrep` for easier navigation in large Nit projects.

### :Nitdoc

When calling `:Nitdoc write_and_make`, or simply `:Nitdoc` with the cursor above the word `write_and_make`, or even using the recommended shortcut Ctrl-D, the preview window now lists the relevant files after the doc of the two different methods accessible from `nitc`:

~~~markdown
# nitc::abstract_compiler$ModelBuilder$write_and_make(compiler: AbstractCompiler)

Simple indirection to `Toolchain::write_and_make`

## Location of introduction and refinements
* src/compiler/abstract_compiler.nit:112,2--119,4
* src/compiler/compiler_serialization.nit:22,2--38,4

# nitc$Toolchain$write_and_make

Write all C files and compile them

## Location of introduction and refinements
* src/compiler/abstract_compiler.nit:154,2--155,31 (1 more)
~~~

The path format is supported by Vim, so you can move the cursor above a path and hit `gF` (goto file) to open the file at the first line. There are alternatives to `gF`, I personally mapped `Ctrl-W gF` to `Ctrl-A` to open the file in a new tab.

### :NitGitGrep 

Calling `:NitGitGrep` (or using the recommended Ctrl-G) search for the word under the cursor in Nit files in the local Git repo. This PR changes a few settings are in order to:

* Print line number after the file path, so you can use `gF` here too.
* Show the introduction(s) before the redefs.
* Search for the complete word under the cursor.
* Search only in Nit source files.
* Avoid duplicating results.

When called above `write_and_make` the preview window lists the intros first, then the redefs and then the other references after a blank line: 
~~~
src/compiler/abstract_compiler.nit:113:	protected fun write_and_make(compiler: AbstractCompiler)
src/compiler/abstract_compiler.nit:155:	fun write_and_make is abstract
src/compiler/java_compiler.nit:64:	fun write_and_make(compiler: JavaCompiler) do
src/compiler/abstract_compiler.nit:162:	redef fun write_and_make
src/compiler/compiler_serialization.nit:22:	redef fun write_and_make(compiler)

src/compiler/abstract_compiler.nit:112:	# Simple indirection to `Toolchain::write_and_make`
src/compiler/abstract_compiler.nit:118:		toolchain.write_and_make
src/compiler/abstract_compiler.nit:578:	# Set by `modelbuilder.write_and_make` and permit sub-routines to access the current toolchain if required.
src/compiler/global_compiler.nit:67:		write_and_make(compiler)
src/compiler/java_compiler.nit:60:		write_and_make(compiler)
src/compiler/separate_compiler.nit:126:		write_and_make(compiler)
src/compiler/separate_erasure_compiler.nit:77:		write_and_make(compiler)
~~~

Note that searching only for the word itselt, the result doesn't distinguish between the 3 versions of `write_and_make`, including one not imported by `nitc`.