### PR TITLE
gtksourceview: Add the missing `kwnull` context

### DIFF
--- a/misc/gtksourceview/nit.lang
+++ b/misc/gtksourceview/nit.lang
@@ -71,6 +71,10 @@
 			<keyword>import</keyword>
 		</context>
 
+		<context id="kwnull" style-ref="null-value">
+			<keyword>null</keyword>
+		</context>
+
 		<context id="keyword" style-ref="keyword">
 			<keyword>abort</keyword>
 			<keyword>abstract</keyword>
@@ -355,6 +359,7 @@
 				<context ref="string"/>
 				<context ref="reserved"/>
 				<context ref="kwimport"/>
+				<context ref="kwnull"/>
 				<context ref="keyword"/>
 				<context ref="builtin-annotation"/>
 				<context ref="boolean"/>


### PR DESCRIPTION
Renderings for `test_syntax.nit`:
* [Classic](https://github.com/nitlang/nit/files/1148477/gtksourceview-classic.pdf)
* [Kate](https://github.com/nitlang/nit/files/1148476/gtksourceview-kate.pdf)
* [Solarized Clear](https://github.com/nitlang/nit/files/1148474/gtksourceview-solarized-clear.pdf)
* [Tango](https://github.com/nitlang/nit/files/1148475/gtksourceview-tango.pdf)

For comparison, see #2515.

![WHOOPS!!](https://user-images.githubusercontent.com/6044484/28213673-23e5b296-6875-11e7-8a2b-494652afe064.png "WHOOPS!!")

Signed-off-by: Jean-Christophe Beaupré <jcbrinfo@users.noreply.github.com>