### PR TITLE
gamnit: control drawing order

### DIFF
--- a/lib/more_collections.nit
+++ b/lib/more_collections.nit
@@ -244,6 +244,61 @@ class HashMap3[K1, K2, K3, V]
 	fun clear do level1.clear
 end
 
+# Simple way to store an `HashMap[K1, HashMap[K2, HashMap[K3, HashMap[K4, V]]]]`
+#
+# ~~~~
+# var hm4 = new HashMap4[Int, String, Int, String, Float]
+# hm4[1, "one", 11, "un"] = 1.0
+# hm4[2, "two", 22, "deux"] = 2.0
+# assert hm4[1, "one", 11, "un"] == 1.0
+# assert hm4[2, "not-two", 22, "deux"] == null
+# ~~~~
+class HashMap4[K1, K2, K3, K4, V]
+
+	private var level1 = new HashMap[K1, HashMap3[K2, K3, K4, V]]
+
+	# Return the value associated to the keys `k1`, `k2`, `k3` and `k4`.
+	# Return `null` if no such a value.
+	fun [](k1: K1, k2: K2, k3: K3, k4: K4): nullable V
+	do
+		var level1 = self.level1
+		var level2 = level1.get_or_null(k1)
+		if level2 == null then return null
+		return level2[k2, k3, k4]
+	end
+
+	# Set `v` the value associated to the keys `k1`, `k2`, `k3` and `k4`.
+	fun []=(k1: K1, k2: K2, k3: K3, k4: K4, v: V)
+	do
+		var level1 = self.level1
+		var level2 = level1.get_or_null(k1)
+		if level2 == null then
+			level2 = new HashMap3[K2, K3, K4, V]
+			level1[k1] = level2
+		end
+		level2[k2, k3, k4] = v
+	end
+
+	# Remove the item at `k1`, `k2`, `k3` and `k4`
+	fun remove_at(k1: K1, k2: K2, k3: K3, k4: K4)
+	do
+		var level1 = self.level1
+		var level2 = level1.get_or_null(k1)
+		if level2 == null then return
+		level2.remove_at(k2, k3, k4)
+	end
+
+	# Is there a value at `k1, k2, k3, k4`?
+	fun has(k1: K1, k2: K2, k3: K3, k4: K4): Bool
+	do
+		if not level1.keys.has(k1) then return false
+		return level1[k1].has(k2, k3, k4)
+	end
+
+	# Remove all items
+	fun clear do level1.clear
+end
+
 # A map with a default value.
 #
 # ~~~~


### PR DESCRIPTION
When two sprites are overlapped, a non-opaque pixel drawn before the sprite behind it may be blended with the wrong color. The only solution is to control the draw order to ensure that sprites in the back are drawn first. However, this is hard to automate when grouping sprites in buffers to optimize the drawing of a very large number of sprites (as gamnit does). It requires to break off groups in layers and this may be very costly if the sprites move on the Z axis.

The solution it to let the programmer choose a draw order only when needed. This works pretty well in 2D games where some objects stay on the same relative depth layer.

> Example artifacts on the left, and the fixed result (with a `sprite.draw_order = 1`) on the right:
>
> ![bug1](https://user-images.githubusercontent.com/208057/28196073-3e0ec6fc-681c-11e7-98d0-019e25a7f9c3.png) ![fixed1](https://user-images.githubusercontent.com/208057/28196072-3dfe075e-681c-11e7-9f4d-8d08a45b9661.png)

This PR introduces the attribute `Sprite::draw_order` that can be set to a higher value (default at 0) for the sprite to be drawn later. In general, sprites with a non-opaque `texture` and sprites closer to the camera should have a higher value to be drawn last.

Sprites sharing a `draw_order` are drawn in the same pass. The sprite to sprite draw order is undefined and may change when adding and removing sprites, or changing their attributes. A future improvement could sort sprites in the same group automatically if it becomes an issue.

Note that changing the `draw_order` may have a negative performance impact if there are many different `draw_order` values across many sprites. This may break the grouping optimization by creating too many small groups.

---

I plan on adding the draw order to `gamnit::depth` actors too. This will be useful for games than mix 2D with 3D. However, I would have to apply a different strategy for pure 3D games, implementing two main passes, one for opaque objects and one for non-opaque objects.
