### PR TITLE
gamnit: scale text, add custom characters and create links with `BMFont`

### DIFF
--- a/lib/gamnit/bmfont.nit
+++ b/lib/gamnit/bmfont.nit
@@ -366,8 +366,9 @@ class BMFontAsset
 
 		var max_width = text_sprites.max_width
 		var max_height = text_sprites.max_height
+		var scale = text_sprites.scale
 
-		var line_height = desc.line_height
+		var line_height = desc.line_height * scale
 		var partial_line_skip = line_height * partial_line_mod.to_f
 		var line_sprites = new Array[Sprite]
 
@@ -400,7 +401,7 @@ class BMFontAsset
 					else if desc.chars.keys.has('f') then
 						desc.chars['f'].xadvance
 					else 16.0
-				dx += space_advance
+				dx += space_advance * scale
 				word_break = true
 			end
 
@@ -415,7 +416,7 @@ class BMFontAsset
 						var w = text[wi]
 
 						if w == '\n' or w == pld or w == plu or w.is_whitespace then break
-						word_len += advance(prev_w, w)
+						word_len += advance(prev_w, w) * scale
 						prev_w = w
 					end
 
@@ -456,14 +457,15 @@ class BMFontAsset
 			var advance = char_info.xadvance
 			var kerning = desc.kerning(prev_char, c)
 
-			var x = dx + char_info.width/2.0  + char_info.xoffset + kerning
-			var y = dy - char_info.height/2.0 - char_info.yoffset
+			var x = dx + (char_info.width/2.0  + char_info.xoffset + kerning) * scale
+			var y = dy - (char_info.height/2.0 + char_info.yoffset) * scale
 			var pos = text_sprites.anchor.offset(x, y, 0.0)
 			var s = new Sprite(char_info.subtexture, pos)
+			s.scale = scale
 			text_sprites.sprites.add s
 			line_sprites.add s
 
-			dx += advance + kerning
+			dx += (advance + kerning) * scale
 			prev_char = c
 
 			text_width = text_width.max(dx)

--- a/lib/gamnit/bmfont.nit
+++ b/lib/gamnit/bmfont.nit
@@ -139,13 +139,16 @@ class BMFontChar
 	var xadvance: Float
 
 	# Full texture contaning this character and others
-	var page: TextureAsset
+	var page: RootTexture
 
 	# TODO Channel where the image is found
 	#var chnl: Int
 
 	# Subtexture with this character image only
-	var subtexture: Texture = page.subtexture(x, y, width, height) is lazy
+	var subtexture: Texture = page.subtexture(x, y, width, height) is lazy, writable
+
+	# Scale to apply to this char only
+	var scale = 1.0 is writable
 end
 
 redef class Text
@@ -184,7 +187,7 @@ redef class Text
 	# assert fnt.to_s == "<BMFont arial at 72.0 pt, 1 pages, 3 chars>"
 	# assert fnt.line_height == 80.0
 	# assert fnt.kernings['A', 'C'] == -1.0
-	# assert fnt.chars['A'].page.path == "dir_in_assets/arial.png"
+	# assert fnt.chars['A'].page.as(TextureAsset).path == "dir_in_assets/arial.png"
 	# ~~~
 	fun parse_bmfont(dir: String): MaybeError[BMFont, Error]
 	do
@@ -461,7 +464,7 @@ class BMFontAsset
 			var y = dy - (char_info.height/2.0 + char_info.yoffset) * scale
 			var pos = text_sprites.anchor.offset(x, y, 0.0)
 			var s = new Sprite(char_info.subtexture, pos)
-			s.scale = scale
+			s.scale = scale * char_info.scale
 			text_sprites.sprites.add s
 			line_sprites.add s
 

--- a/lib/gamnit/examples/fonts_showcase/src/fonts_showcase.nit
+++ b/lib/gamnit/examples/fonts_showcase/src/fonts_showcase.nit
@@ -46,7 +46,7 @@ redef class App
 
 		# Shared content
 		var description = "The anchor icon identifies the coordinate of TextSprites::anchor."
-		var lorem_ipsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+		var lorem_ipsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et [dolore magna](my_link asdf) aliqua."
 		var color = [0.0, 0.25, 0.5]
 
 		# ---
@@ -77,8 +77,8 @@ redef class App
 
 		texts.add new TextSprites(font,
 			ui_camera.top_left.offset(1000.0, -400.0, 0.0),
-			"Right, max_width=400.0:\n"+lorem_ipsum,
-			align=1.0, max_width=400.0)
+			"Right, max_width=400.0, scale=0.66:\n"+lorem_ipsum,
+			align=1.0, max_width=400.0, scale=0.66)
 
 		texts.add new TextSprites(font,
 			ui_camera.top_left.offset(300.0, -700.0, 0.0),
@@ -119,6 +119,16 @@ redef class App
 			ui_camera.top_left.offset(1500.0, -220.0, 0.0),
 			"align=0.5, valign=0.5:\n"+lorem_ipsum,
 			max_width=400.0, align=0.5, valign=0.5)
+
+		# ---
+		# Links
+
+		for ts in texts do
+			for link_name, sprites in ts.links do
+				print "Link: {link_name}"
+				for s in sprites do s.green = 0.0
+			end
+		end
 
 		# ---
 		# Anchors and background boxes

--- a/lib/gamnit/font.nit
+++ b/lib/gamnit/font.nit
@@ -129,6 +129,19 @@ class TextSprites
 	# Defaults to 1.0.
 	var scale = 1.0 is optional, writable
 
+	# Links in the currently displayed text
+	#
+	# Links are declared in a Markdown-like format:
+	#
+	# * `[my link]` creates a link with the name `my link`.
+	# * `[pretty name](internal name)` creates a link with the
+	#   name `internal_name` while showing the text `pretty name`.
+	#
+	# This `Map` lists the sprites composing each link.
+	# These sprites can be modified as desired by the clients,
+	# by changing their tints or anything else.
+	var links = new Map[String, Array[Sprite]] is lazy
+
 	# Width of the currently displayed text
 	var width = 0.0
 

--- a/lib/gamnit/font.nit
+++ b/lib/gamnit/font.nit
@@ -124,6 +124,11 @@ class TextSprites
 	# Otherwise, lines are cut before overflowing.
 	var wrap = true is optional, writable
 
+	# Scale applied to all sprites and spacing
+	#
+	# Defaults to 1.0.
+	var scale = 1.0 is optional, writable
+
 	# Width of the currently displayed text
 	var width = 0.0
 


### PR DESCRIPTION
This PR adds more customization options when drawing text using `BMFont`:

* Change the size of the text with a simple attribute `TextSprites::scale`.
* Insert artificial chars to a `BMFont` using the more permissive `BMFontChar`. This way, one can set custom textures for a letter, an emojis or any character from the private use areas. 
* Add "links" to the text using Markdown-like syntax (`[my link]` or `[pretty name](internal name)`). Note that the links are not clickable by themselves. However, the client code can access the sprites representing the link to change their style or to get their position. This will work well with a rumored future feature making sprites clickable...

Notice the colored links and the smaller text box in the following screenshot of `fonts_showcase`: 
![screenshot from 2017-07-13 22-09-20](https://user-images.githubusercontent.com/208057/28196740-8f8630b6-6820-11e7-8915-1df02b4edee5.png)

---

Once again, these new features are not implemented for `TileSetFont`. I'm considering keeping the API of `TileSetFont` but replacing its implementation by a `BMFont` for it to gets all the new shiny features.