### PR TITLE
model: group parameter types in `MSignature::to_s`

### DIFF
--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -1975,16 +1975,34 @@ class MSignature
 		var b = new FlatBuffer
 		if not mparameters.is_empty then
 			b.append("(")
+			var last_mtype = null
 			for i in [0..mparameters.length[ do
 				var mparameter = mparameters[i]
+
+				# Group types that are common to contiguous parameters
+				if mparameter.mtype != last_mtype and last_mtype != null then
+					b.append(": ")
+					b.append(last_mtype.to_s)
+				end
+
 				if i > 0 then b.append(", ")
 				b.append(mparameter.name)
-				b.append(": ")
-				b.append(mparameter.mtype.to_s)
+
 				if mparameter.is_vararg then
+					b.append(": ")
+					b.append(mparameter.mtype.to_s)
 					b.append("...")
+					last_mtype = null
+				else
+					last_mtype = mparameter.mtype
 				end
 			end
+
+			if last_mtype != null then
+				b.append(": ")
+				b.append(last_mtype.to_s)
+			end
+
 			b.append(")")
 		end
 		var ret = self.return_mtype

--- a/tests/sav/base_arg_default_alt1.res
+++ b/tests/sav/base_arg_default_alt1.res
@@ -1,8 +1,8 @@
-alt/base_arg_default_alt1.nit:81,3--5: Error: expected at least 4 argument(s) for `foo(a: nullable Int, b: nullable Int, c: Int, d: Int, e: nullable Int, f: nullable Int)`; got 0. See introduction at `base_arg_default_alt1::A::foo`.
-alt/base_arg_default_alt1.nit:82,3--5: Error: expected at least 4 argument(s) for `foo(a: nullable Int, b: nullable Int, c: Int, d: Int, e: nullable Int, f: nullable Int)`; got 1. See introduction at `base_arg_default_alt1::A::foo`.
-alt/base_arg_default_alt1.nit:83,3--5: Error: expected at least 4 argument(s) for `foo(a: nullable Int, b: nullable Int, c: Int, d: Int, e: nullable Int, f: nullable Int)`; got 2. See introduction at `base_arg_default_alt1::A::foo`.
-alt/base_arg_default_alt1.nit:84,3--5: Error: expected at least 4 argument(s) for `foo(a: nullable Int, b: nullable Int, c: Int, d: Int, e: nullable Int, f: nullable Int)`; got 3. See introduction at `base_arg_default_alt1::A::foo`.
-alt/base_arg_default_alt1.nit:88,3--5: Error: expected 6 argument(s) for `foo(a: nullable Int, b: nullable Int, c: Int, d: Int, e: nullable Int, f: nullable Int)`; got 7. See introduction at `base_arg_default_alt1::A::foo`.
-alt/base_arg_default_alt1.nit:94,3--5: Error: expected 3 argument(s) for `bar(a: nullable Int, b: nullable Int, c: nullable Int)`; got 4. See introduction at `base_arg_default_alt1::A::bar`.
-alt/base_arg_default_alt1.nit:99,3--5: Error: expected 3 argument(s) for `bar=(a: nullable Int, b: nullable Int, c: nullable Int)`; got 4. See introduction at `base_arg_default_alt1::A::bar=`.
-alt/base_arg_default_alt1.nit:110,1--13: Error: expected 3 argument(s) for `[]=(a: nullable Int, b: nullable Int, c: nullable Int): Int`; got 4. See introduction at `base_arg_default_alt1::A::[]=`.
+alt/base_arg_default_alt1.nit:81,3--5: Error: expected at least 4 argument(s) for `foo(a, b: nullable Int, c, d: Int, e, f: nullable Int)`; got 0. See introduction at `base_arg_default_alt1::A::foo`.
+alt/base_arg_default_alt1.nit:82,3--5: Error: expected at least 4 argument(s) for `foo(a, b: nullable Int, c, d: Int, e, f: nullable Int)`; got 1. See introduction at `base_arg_default_alt1::A::foo`.
+alt/base_arg_default_alt1.nit:83,3--5: Error: expected at least 4 argument(s) for `foo(a, b: nullable Int, c, d: Int, e, f: nullable Int)`; got 2. See introduction at `base_arg_default_alt1::A::foo`.
+alt/base_arg_default_alt1.nit:84,3--5: Error: expected at least 4 argument(s) for `foo(a, b: nullable Int, c, d: Int, e, f: nullable Int)`; got 3. See introduction at `base_arg_default_alt1::A::foo`.
+alt/base_arg_default_alt1.nit:88,3--5: Error: expected 6 argument(s) for `foo(a, b: nullable Int, c, d: Int, e, f: nullable Int)`; got 7. See introduction at `base_arg_default_alt1::A::foo`.
+alt/base_arg_default_alt1.nit:94,3--5: Error: expected 3 argument(s) for `bar(a, b, c: nullable Int)`; got 4. See introduction at `base_arg_default_alt1::A::bar`.
+alt/base_arg_default_alt1.nit:99,3--5: Error: expected 3 argument(s) for `bar=(a, b, c: nullable Int)`; got 4. See introduction at `base_arg_default_alt1::A::bar=`.
+alt/base_arg_default_alt1.nit:110,1--13: Error: expected 3 argument(s) for `[]=(a, b, c: nullable Int): Int`; got 4. See introduction at `base_arg_default_alt1::A::[]=`.

--- a/tests/sav/base_arg_default_autoinit_alt1.res
+++ b/tests/sav/base_arg_default_autoinit_alt1.res
@@ -1,9 +1,9 @@
 alt/base_arg_default_autoinit_alt1.nit:59,5--7: Error: expected at least 1 argument(s) for `init(mandatory: Int, optional: nullable Int)`; got 0. See introduction at `core::Object::init`.
 alt/base_arg_default_autoinit_alt1.nit:68,5--7: Error: expected 2 argument(s) for `init(mandatory: Int, optional: nullable Int)`; got 3. See introduction at `core::Object::init`.
-alt/base_arg_default_autoinit_alt1.nit:71,5--7: Error: expected 4 argument(s) for `init(mandatory: Int, optional: nullable Int, optional_b: nullable Int, mandatory_b: Int)`; got 1. See introduction at `core::Object::init`.
-alt/base_arg_default_autoinit_alt1.nit:74,5--7: Error: expected 4 argument(s) for `init(mandatory: Int, optional: nullable Int, optional_b: nullable Int, mandatory_b: Int)`; got 2. See introduction at `core::Object::init`.
-alt/base_arg_default_autoinit_alt1.nit:77,5--7: Error: expected 4 argument(s) for `init(mandatory: Int, optional: nullable Int, optional_b: nullable Int, mandatory_b: Int)`; got 3. See introduction at `core::Object::init`.
-alt/base_arg_default_autoinit_alt1.nit:83,5--7: Error: expected 4 argument(s) for `init(mandatory: Int, optional: nullable Int, optional_b: nullable Int, mandatory_b: Int)`; got 5. See introduction at `core::Object::init`.
-alt/base_arg_default_autoinit_alt1.nit:86,5--7: Error: expected 3 argument(s) for `init(optional_b: nullable Int, mandatory_b: Int, mandatory: Int)`; got 1. See introduction at `core::Object::init`.
-alt/base_arg_default_autoinit_alt1.nit:89,5--7: Error: expected 3 argument(s) for `init(optional_b: nullable Int, mandatory_b: Int, mandatory: Int)`; got 2. See introduction at `core::Object::init`.
-alt/base_arg_default_autoinit_alt1.nit:95,5--7: Error: expected 3 argument(s) for `init(optional_b: nullable Int, mandatory_b: Int, mandatory: Int)`; got 4. See introduction at `core::Object::init`.
+alt/base_arg_default_autoinit_alt1.nit:71,5--7: Error: expected 4 argument(s) for `init(mandatory: Int, optional, optional_b: nullable Int, mandatory_b: Int)`; got 1. See introduction at `core::Object::init`.
+alt/base_arg_default_autoinit_alt1.nit:74,5--7: Error: expected 4 argument(s) for `init(mandatory: Int, optional, optional_b: nullable Int, mandatory_b: Int)`; got 2. See introduction at `core::Object::init`.
+alt/base_arg_default_autoinit_alt1.nit:77,5--7: Error: expected 4 argument(s) for `init(mandatory: Int, optional, optional_b: nullable Int, mandatory_b: Int)`; got 3. See introduction at `core::Object::init`.
+alt/base_arg_default_autoinit_alt1.nit:83,5--7: Error: expected 4 argument(s) for `init(mandatory: Int, optional, optional_b: nullable Int, mandatory_b: Int)`; got 5. See introduction at `core::Object::init`.
+alt/base_arg_default_autoinit_alt1.nit:86,5--7: Error: expected 3 argument(s) for `init(optional_b: nullable Int, mandatory_b, mandatory: Int)`; got 1. See introduction at `core::Object::init`.
+alt/base_arg_default_autoinit_alt1.nit:89,5--7: Error: expected 3 argument(s) for `init(optional_b: nullable Int, mandatory_b, mandatory: Int)`; got 2. See introduction at `core::Object::init`.
+alt/base_arg_default_autoinit_alt1.nit:95,5--7: Error: expected 3 argument(s) for `init(optional_b: nullable Int, mandatory_b, mandatory: Int)`; got 4. See introduction at `core::Object::init`.

--- a/tests/sav/base_arg_named_alt1.res
+++ b/tests/sav/base_arg_named_alt1.res
@@ -1,4 +1,4 @@
-alt/base_arg_named_alt1.nit:22,3--5: Error: expected at least 5 argument(s) for `foo(a: nullable Int, b: nullable Int, c: Int, d: Int, e: nullable Int, f: nullable Int)`; got 4. See introduction at `base_arg_default::A::foo`.
-alt/base_arg_named_alt1.nit:45,3--5: Error: expected 3 argument(s) for `bar(a: nullable Int, b: nullable Int, c: nullable Int)`; got 4. See introduction at `base_arg_default::A::bar`.
-alt/base_arg_named_alt1.nit:46,7--10: Error: no parameter `fail` for `bar(a: nullable Int, b: nullable Int, c: nullable Int)`.
-alt/base_arg_named_alt1.nit:47,11--13: Error: parameter `a` already associated with argument #0 for `bar(a: nullable Int, b: nullable Int, c: nullable Int)`.
+alt/base_arg_named_alt1.nit:22,3--5: Error: expected at least 5 argument(s) for `foo(a, b: nullable Int, c, d: Int, e, f: nullable Int)`; got 4. See introduction at `base_arg_default::A::foo`.
+alt/base_arg_named_alt1.nit:45,3--5: Error: expected 3 argument(s) for `bar(a, b, c: nullable Int)`; got 4. See introduction at `base_arg_default::A::bar`.
+alt/base_arg_named_alt1.nit:46,7--10: Error: no parameter `fail` for `bar(a, b, c: nullable Int)`.
+alt/base_arg_named_alt1.nit:47,11--13: Error: parameter `a` already associated with argument #0 for `bar(a, b, c: nullable Int)`.

--- a/tests/sav/base_arg_named_inherit_alt1.res
+++ b/tests/sav/base_arg_named_inherit_alt1.res
@@ -1,4 +1,4 @@
-alt/base_arg_named_inherit_alt1.nit:27,7: Error: no parameter `a` for `foo(x: nullable Int, y: nullable Int, z: Int, t: Int, u: nullable Int, v: nullable Int)`.
-alt/base_arg_named_inherit_alt1.nit:28,7: Error: no parameter `f` for `foo(x: nullable Int, y: nullable Int, z: Int, t: Int, u: nullable Int, v: nullable Int)`.
-alt/base_arg_named_inherit_alt1.nit:32,7: Error: no parameter `x` for `foo(a: nullable Int, b: nullable Int, c: Int, d: Int, e: nullable Int, f: nullable Int)`.
-alt/base_arg_named_inherit_alt1.nit:33,7: Error: no parameter `v` for `foo(a: nullable Int, b: nullable Int, c: Int, d: Int, e: nullable Int, f: nullable Int)`.
+alt/base_arg_named_inherit_alt1.nit:27,7: Error: no parameter `a` for `foo(x, y: nullable Int, z, t: Int, u, v: nullable Int)`.
+alt/base_arg_named_inherit_alt1.nit:28,7: Error: no parameter `f` for `foo(x, y: nullable Int, z, t: Int, u, v: nullable Int)`.
+alt/base_arg_named_inherit_alt1.nit:32,7: Error: no parameter `x` for `foo(a, b: nullable Int, c, d: Int, e, f: nullable Int)`.
+alt/base_arg_named_inherit_alt1.nit:33,7: Error: no parameter `v` for `foo(a, b: nullable Int, c, d: Int, e, f: nullable Int)`.

--- a/tests/sav/base_arg_named_inherit_alt2.res
+++ b/tests/sav/base_arg_named_inherit_alt2.res
@@ -1,2 +1,2 @@
-alt/base_arg_named_inherit_alt2.nit:27,7: Error: no parameter `a` for `foo(x: nullable Int, y: nullable Int, z: Int, t: Int, u: nullable Int, v: nullable Int)`.
-alt/base_arg_named_inherit_alt2.nit:28,7: Error: no parameter `f` for `foo(x: nullable Int, y: nullable Int, z: Int, t: Int, u: nullable Int, v: nullable Int)`.
+alt/base_arg_named_inherit_alt2.nit:27,7: Error: no parameter `a` for `foo(x, y: nullable Int, z, t: Int, u, v: nullable Int)`.
+alt/base_arg_named_inherit_alt2.nit:28,7: Error: no parameter `f` for `foo(x, y: nullable Int, z, t: Int, u, v: nullable Int)`.

--- a/tests/sav/base_arg_named_inherit_alt3.res
+++ b/tests/sav/base_arg_named_inherit_alt3.res
@@ -1,2 +1,2 @@
-alt/base_arg_named_inherit_alt3.nit:29,3--5: Error: expected at least 5 argument(s) for `foo(a: nullable Int, b: nullable Int, c: Int, d: Int, e: nullable Int, f: nullable Int)`; got 4. See introduction at `base_arg_default::A::foo`.
-alt/base_arg_named_inherit_alt3.nit:34,3--5: Error: expected at least 5 argument(s) for `foo(x: nullable Int, y: nullable Int, z: Int, t: Int, u: nullable Int, v: nullable Int)`; got 4. See introduction at `base_arg_default::A::foo`.
+alt/base_arg_named_inherit_alt3.nit:29,3--5: Error: expected at least 5 argument(s) for `foo(a, b: nullable Int, c, d: Int, e, f: nullable Int)`; got 4. See introduction at `base_arg_default::A::foo`.
+alt/base_arg_named_inherit_alt3.nit:34,3--5: Error: expected at least 5 argument(s) for `foo(x, y: nullable Int, z, t: Int, u, v: nullable Int)`; got 4. See introduction at `base_arg_default::A::foo`.

--- a/tests/sav/base_init_basic_alt5.res
+++ b/tests/sav/base_init_basic_alt5.res
@@ -1,1 +1,1 @@
-alt/base_init_basic_alt5.nit:79,9--11: Error: expected 2 argument(s) for `init(c: Int, b: Int)`; got 1. See introduction at `core::Object::init`.
+alt/base_init_basic_alt5.nit:79,9--11: Error: expected 2 argument(s) for `init(c, b: Int)`; got 1. See introduction at `core::Object::init`.

--- a/tests/sav/base_init_combine_alt1.res
+++ b/tests/sav/base_init_combine_alt1.res
@@ -1,1 +1,1 @@
-alt/base_init_combine_alt1.nit:59,9--11: Error: expected 2 argument(s) for `init(i: Int, z: Int)`; got 1. See introduction at `core::Object::init`.
+alt/base_init_combine_alt1.nit:59,9--11: Error: expected 2 argument(s) for `init(i, z: Int)`; got 1. See introduction at `core::Object::init`.

--- a/tests/sav/base_vararg_alt2.res
+++ b/tests/sav/base_vararg_alt2.res
@@ -1,1 +1,1 @@
-alt/base_vararg_alt2.nit:54,1--3: Error: expected at least 2 argument(s) for `bar(b: Char, a: Char...)`; got 0. See introduction at `base_vararg_alt2::base_vararg_alt2::Sys::bar`.
+alt/base_vararg_alt2.nit:54,1--3: Error: expected at least 2 argument(s) for `bar(b, a: Char...)`; got 0. See introduction at `base_vararg_alt2::base_vararg_alt2::Sys::bar`.

--- a/tests/sav/base_vararg_alt3.res
+++ b/tests/sav/base_vararg_alt3.res
@@ -1,1 +1,1 @@
-alt/base_vararg_alt3.nit:55,1--3: Error: expected at least 2 argument(s) for `bar(b: Char, a: Char...)`; got 1. See introduction at `base_vararg_alt3::base_vararg_alt3::Sys::bar`.
+alt/base_vararg_alt3.nit:55,1--3: Error: expected at least 2 argument(s) for `bar(b, a: Char...)`; got 1. See introduction at `base_vararg_alt3::base_vararg_alt3::Sys::bar`.

--- a/tests/sav/base_vararg_alt6.res
+++ b/tests/sav/base_vararg_alt6.res
@@ -1,1 +1,1 @@
-alt/base_vararg_alt6.nit:62,1--6: Error: expected at least 3 argument(s) for `foobar(b: Char, a: Char..., c: Char)`; got 0. See introduction at `base_vararg_alt6::base_vararg_alt6::Sys::foobar`.
+alt/base_vararg_alt6.nit:62,1--6: Error: expected at least 3 argument(s) for `foobar(b, a: Char..., c: Char)`; got 0. See introduction at `base_vararg_alt6::base_vararg_alt6::Sys::foobar`.

--- a/tests/sav/base_vararg_alt7.res
+++ b/tests/sav/base_vararg_alt7.res
@@ -1,1 +1,1 @@
-alt/base_vararg_alt7.nit:63,1--6: Error: expected at least 3 argument(s) for `foobar(b: Char, a: Char..., c: Char)`; got 1. See introduction at `base_vararg_alt7::base_vararg_alt7::Sys::foobar`.
+alt/base_vararg_alt7.nit:63,1--6: Error: expected at least 3 argument(s) for `foobar(b, a: Char..., c: Char)`; got 1. See introduction at `base_vararg_alt7::base_vararg_alt7::Sys::foobar`.

--- a/tests/sav/base_vararg_alt8.res
+++ b/tests/sav/base_vararg_alt8.res
@@ -1,1 +1,1 @@
-alt/base_vararg_alt8.nit:64,1--6: Error: expected at least 3 argument(s) for `foobar(b: Char, a: Char..., c: Char)`; got 2. See introduction at `base_vararg_alt8::base_vararg_alt8::Sys::foobar`.
+alt/base_vararg_alt8.nit:64,1--6: Error: expected at least 3 argument(s) for `foobar(b, a: Char..., c: Char)`; got 2. See introduction at `base_vararg_alt8::base_vararg_alt8::Sys::foobar`.

--- a/tests/sav/error_init_auto_alt2.res
+++ b/tests/sav/error_init_auto_alt2.res
@@ -1,4 +1,4 @@
-alt/error_init_auto_alt2.nit:34,5--7: Error: expected 2 argument(s) for `init(x: Int, y: Int)`; got 0. See introduction at `core::Object::init`.
-alt/error_init_auto_alt2.nit:35,5--7: Error: expected 2 argument(s) for `init(x: Int, y: Int)`; got 1. See introduction at `core::Object::init`.
-alt/error_init_auto_alt2.nit:37,5--7: Error: expected 2 argument(s) for `init(x: Int, y: Int)`; got 3. See introduction at `core::Object::init`.
+alt/error_init_auto_alt2.nit:34,5--7: Error: expected 2 argument(s) for `init(x, y: Int)`; got 0. See introduction at `core::Object::init`.
+alt/error_init_auto_alt2.nit:35,5--7: Error: expected 2 argument(s) for `init(x, y: Int)`; got 1. See introduction at `core::Object::init`.
+alt/error_init_auto_alt2.nit:37,5--7: Error: expected 2 argument(s) for `init(x, y: Int)`; got 3. See introduction at `core::Object::init`.
 alt/error_init_auto_alt2.nit:38,11--13: Error: method `foo` does not exists in `A`.


### PR DESCRIPTION
Modify `MSignature::to_s` to make its output a shorter valid Nit signature. This helps readability and shortens error messages allowing them to fit more easily on a single line or within a text editor.

Example program:
~~~nit
import geometry
var b = new Box3d[Float] # <- error
~~~

Previous error message:
~~~
Error: expected 6 argument(s) for `init(left: Float, right: Float, top: Float, bottom: Float, front: Float, back: Float)`; got 0. See introduction at `core::Object::init`.
~~~

New error message:
~~~
Error: expected 6 argument(s) for `init(left, right, top, bottom, front, back: Float)`; got 0. See introduction at `core::Object::init`.
~~~