### PR TITLE
serialization: safe formal types, fix warnings in generated code and more

### DIFF
--- a/lib/a_star.nit
+++ b/lib/a_star.nit
@@ -211,8 +211,8 @@ class Node
 	do
 		deserializer.notify_of_creation self
 
-		var graph = deserializer.deserialize_attribute("graph")
-		assert graph isa Graph[N, Link]
+		var graph = deserializer.deserialize_attribute("graph", (new GetName[Graph[N, Link]]).to_s)
+		if not graph isa Graph[N, Link] then graph = new Graph[N, Link]
 		self.graph = graph
 	end
 end
@@ -247,10 +247,10 @@ class Graph[N: Node, L: Link]
 	super Serializable
 
 	# Nodes in this graph
-	var nodes: Set[N] = new HashSet[N]
+	var nodes = new Set[N]
 
 	# Links in this graph
-	var links: Set[L] = new HashSet[L]
+	var links = new Set[L]
 
 	# Add a `node` to this graph
 	fun add_node(node: N): N
@@ -283,13 +283,17 @@ class Graph[N: Node, L: Link]
 	do
 		deserializer.notify_of_creation self
 
-		var nodes = deserializer.deserialize_attribute("nodes")
-		assert nodes isa HashSet[N]
-		self.nodes = nodes
+		var nodes = deserializer.deserialize_attribute("nodes", (new GetName[Set[N]]).to_s)
+		if deserializer.deserialize_attribute_missing then
+			deserializer.errors.add new AttributeMissingError(self, "nodes")
+		end
+		if nodes isa Set[N] then self.nodes = nodes
 
-		var links = deserializer.deserialize_attribute("links")
-		assert links isa HashSet[L]
-		for link in links do add_link link
+		var links = deserializer.deserialize_attribute("links", (new GetName[Set[L]]).to_s)
+		if deserializer.deserialize_attribute_missing then
+			deserializer.errors.add new AttributeMissingError(self, "links")
+		end
+		if links isa Set[L] then for link in links do add_link link
 	end
 end
 

--- a/lib/gen_nit.nit
+++ b/lib/gen_nit.nit
@@ -55,8 +55,12 @@ class NitModule
 	# Annotations on the module declaration
 	var annotations = new Array[Writable]
 
-	# Imports from this module
-	var imports = new Array[Writable]
+	# Importation declarations
+	#
+	# Accepts two formats:
+	# * Module name only, short or qualified: `json`, `gamnit::flat`, etc.
+	# * Full importation declaration: `import json`, `private import gamnit::flat`, etc.
+	var imports = new Set[Writable]
 
 	# Main content of this module
 	var content = new Array[Writable]
@@ -75,7 +79,15 @@ class NitModule
 			add "end\n\n"
 		end
 
-		for i in imports do add "import {i}\n"
+		for i in imports do
+			if i.to_s.has("import ") then
+				add i
+			else
+				add "import "
+				add i
+			end
+			add "\n"
+		end
 		add "\n"
 
 		for l in content do

--- a/lib/json/serialization_read.nit
+++ b/lib/json/serialization_read.nit
@@ -518,6 +518,8 @@ redef class Map[K, V]
 				return
 			end
 
+			# First, convert all keys to follow the order of the serialization
+			var converted_keys = new Array[K]
 			for i in length.times do
 				var key = v.convert_object(keys[i], keys_type_name)
 
@@ -526,6 +528,12 @@ redef class Map[K, V]
 					continue
 				end
 
+				converted_keys.add key
+			end
+
+			# Then convert the values and build the map
+			for i in length.times do
+				var key = converted_keys[i]
 				var value = v.convert_object(values[i], values_type_name)
 
 				if not value isa V then

--- a/lib/json/serialization_read.nit
+++ b/lib/json/serialization_read.nit
@@ -138,18 +138,18 @@ class JsonDeserializer
 			# ref?
 			if kind == "ref" then
 				if not object.keys.has("__id") then
-					errors.add new Error("Serialization Error: JSON object reference does not declare a `__id`.")
+					errors.add new Error("Deserialization Error: JSON object reference does not declare a `__id`.")
 					return object
 				end
 
 				var id = object["__id"]
 				if not id isa Int then
-					errors.add new Error("Serialization Error: JSON object reference declares a non-integer `__id`.")
+					errors.add new Error("Deserialization Error: JSON object reference declares a non-integer `__id`.")
 					return object
 				end
 
 				if not cache.has_id(id) then
-					errors.add new Error("Serialization Error: JSON object reference has an unknown `__id`.")
+					errors.add new Error("Deserialization Error: JSON object reference has an unknown `__id`.")
 					return object
 				end
 
@@ -163,12 +163,12 @@ class JsonDeserializer
 					id = object["__id"]
 
 					if not id isa Int then
-						errors.add new Error("Serialization Error: JSON object declaration declares a non-integer `__id`.")
+						errors.add new Error("Deserialization Error: JSON object declaration declares a non-integer `__id`.")
 						return object
 					end
 
 					if cache.has_id(id) then
-						errors.add new Error("Serialization Error: JSON object with `__id` {id} is deserialized twice.")
+						errors.add new Error("Deserialization Error: JSON object with `__id` {id} is deserialized twice.")
 						# Keep going
 					end
 				end
@@ -188,12 +188,12 @@ class JsonDeserializer
 				end
 
 				if class_name == null then
-					errors.add new Error("Serialization Error: JSON object declaration does not declare a `__class`.")
+					errors.add new Error("Deserialization Error: JSON object declaration does not declare a `__class`.")
 					return object
 				end
 
 				if not class_name isa String then
-					errors.add new Error("Serialization Error: JSON object declaration declares a non-string `__class`.")
+					errors.add new Error("Deserialization Error: JSON object declaration declares a non-string `__class`.")
 					return object
 				end
 
@@ -227,21 +227,21 @@ class JsonDeserializer
 			# char?
 			if kind == "char" then
 				if not object.keys.has("__val") then
-					errors.add new Error("Serialization Error: JSON `char` object does not declare a `__val`.")
+					errors.add new Error("Deserialization Error: JSON `char` object does not declare a `__val`.")
 					return object
 				end
 
 				var val = object["__val"]
 
 				if not val isa String or val.is_empty then
-					errors.add new Error("Serialization Error: JSON `char` object does not declare a single char in `__val`.")
+					errors.add new Error("Deserialization Error: JSON `char` object does not declare a single char in `__val`.")
 					return object
 				end
 
 				return val.chars.first
 			end
 
-			errors.add new Error("Serialization Error: JSON object has an unknown `__kind`.")
+			errors.add new Error("Deserialization Error: JSON object has an unknown `__kind`.")
 			return object
 		end
 

--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -113,8 +113,7 @@ abstract class Deserializer
 
 	# Deserialize the attribute with `name` from the object open for deserialization
 	#
-	# The `static_type` can be used as last resort if the deserialized object
-	# desn't have any metadata declaring the dynamic type.
+	# The `static_type` restricts what kind of object can be deserialized.
 	#
 	# Return the deserialized value or null on error, and set
 	# `deserialize_attribute_missing` to whether the attribute was missing.

--- a/lib/serialization/serialization.nit
+++ b/lib/serialization/serialization.nit
@@ -169,17 +169,22 @@ abstract class Deserializer
 	var errors = new Array[Error]
 end
 
-# Error on invalid dynamic type for a deserialized attribute
-class AttributeTypeError
+# Deserialization error related to an attribute of `receiver`
+abstract class AttributeError
 	super Error
-
-	autoinit receiver, attribute_name, attribute, expected_type
 
 	# Parent object of the problematic attribute
 	var receiver: Object
 
 	# Name of the problematic attribute in `receiver`
 	var attribute_name: String
+end
+
+# Invalid dynamic type for a deserialized attribute
+class AttributeTypeError
+	super AttributeError
+
+	autoinit receiver, attribute_name, attribute, expected_type
 
 	# Deserialized object that isn't of the `expected_type`
 	var attribute: nullable Object
@@ -193,6 +198,17 @@ class AttributeTypeError
 
 		return "Deserialization Error: {
 		}Wrong type on `{receiver.class_name}::{attribute_name}` expected `{expected_type}`, got `{found_type}`"
+	end
+end
+
+# Missing attribute at deserialization
+class AttributeMissingError
+	super AttributeError
+
+	autoinit receiver, attribute_name
+
+	redef var message is lazy do
+		return "Deserialization Error: Missing attribute `{receiver.class_name}::{attribute_name}`"
 	end
 end
 

--- a/src/frontend/serialization_code_gen_phase.nit
+++ b/src/frontend/serialization_code_gen_phase.nit
@@ -110,7 +110,7 @@ do
 			v.errors.add new AttributeMissingError(self, "{{{name}}}")
 		end"""
 				else code.add """
-		v.errors.add new Error("Deserialization Error: attribute `{class_name}::{{{name}}}` missing from JSON object")"""
+		v.errors.add new AttributeMissingError(self, "{{{name}}}")"""
 
 				code.add """
 	else if not {{{name}}} isa {{{type_name}}} then

--- a/src/frontend/serialization_code_gen_phase.nit
+++ b/src/frontend/serialization_code_gen_phase.nit
@@ -53,7 +53,7 @@ private class SerializationPhasePostModel
 	do
 		var code = new Array[String]
 		code.add """
-redef init from_deserializer(v: Deserializer)
+redef init from_deserializer(v)
 do
 	super
 	v.notify_of_creation self

--- a/src/nitserial.nit
+++ b/src/nitserial.nit
@@ -57,25 +57,24 @@ redef class MModule
 end
 
 redef class MType
-	# Is this type fully visible from `mmodule`?
-	fun is_visible_from(mmodule: MModule): Bool is abstract
+	# List classes composing this type
+	private fun related_mclasses(mmodule: MModule): Array[MClass] is abstract
 end
 
 redef class MClassType
-	redef fun is_visible_from(mmodule) do
-		return mmodule.is_visible(mclass.intro_mmodule, mclass.visibility)
-	end
+	redef fun related_mclasses(mmodule) do return [mclass]
 end
 
-redef class MNullableType
-	redef fun is_visible_from(mmodule) do return mtype.is_visible_from(mmodule)
+redef class MProxyType
+	redef fun related_mclasses(mmodule) do return undecorate.related_mclasses(mmodule)
 end
 
 redef class MGenericType
-	redef fun is_visible_from(mmodule)
+	redef fun related_mclasses(mmodule)
 	do
-		for arg_mtype in arguments do if not arg_mtype.is_visible_from(mmodule) then return false
-		return super
+		var mods = super
+		for arg_mtype in arguments do mods.add_all(arg_mtype.related_mclasses(mmodule))
+		return mods
 	end
 end
 
@@ -189,9 +188,24 @@ redef class Deserializer
 			# and which are visible.
 			if mtype isa MGenericType and
 			   mtype.is_subtype(m, null, serializable_type) and
-			   mtype.is_visible_from(mmodule) and
 			   mtype.mclass.kind == concrete_kind and
 			   not compiled_types.has(mtype) then
+
+				# Intrude import the modules declaring private classes
+				var related_mclasses = mtype.related_mclasses(mmodule)
+				for mclass in related_mclasses do
+					if not mmodule.is_visible(mclass.intro_mmodule, mclass.visibility) then
+						var intro_mmodule = mclass.intro_mmodule
+						var intro_mgroup = intro_mmodule.mgroup
+
+						var to_import = intro_mmodule.full_name
+						if intro_mgroup == null or intro_mgroup.default_mmodule == intro_mmodule then
+							to_import = intro_mmodule.name
+						end
+
+						nit_module.imports.add "intrude import {to_import}"
+					end
+				end
 
 				compiled_types.add mtype
 				nit_module.content.add """

--- a/tests/sav/nitce/test_json_deserialization_safe.res
+++ b/tests/sav/nitce/test_json_deserialization_safe.res
@@ -1,0 +1,23 @@
+Deserialization Error: `DangerSub` is not a subtype of the static type `nullable A`
+Deserialization Error: `DangerSub` is not a subtype of the static type ``
+<A other:null next:null>
+---
+DANGER 'My text 1'
+DANGER 'My text 2'
+Deserialization Error: Wrong type on `A::other` expected `nullable A`, got `DangerSub`
+Deserialization Error: Wrong type on `A::next` expected `C`, got `DangerSub`
+<A other:null next:null>
+---
+Deserialization Error: `B` is not a subtype of the static type ``
+<B other:null next:null>
+---
+Deserialization Error: `A` is not a subtype of the static type ``
+<B other:null next:null>
+---
+Deserialization Error: `A` is not a subtype of the static type ``
+Deserialization Error: Wrong type on `G::e` expected `E`, got `null`
+<G e:not-set>
+---
+Deserialization Error: `A` is not a subtype of the static type ``
+Deserialization Error: Wrong type on `G::e` expected `E`, got `null`
+<G e:not-set>

--- a/tests/sav/niti/test_json_deserialization_plain_alt2.res
+++ b/tests/sav/niti/test_json_deserialization_plain_alt2.res
@@ -1,3 +1,3 @@
 Runtime error: Uninitialized attribute _s (alt/test_json_deserialization_plain_alt2.nit:27)
 # JSON: {"__class": "MyClass", "i": 123, "o": null}
-# Errors: 'Deserialization Error: attribute `MyClass::s` missing from JSON object', 'Deserialization Error: attribute `MyClass::f` missing from JSON object', 'Deserialization Error: attribute `MyClass::a` missing from JSON object'
+# Errors: 'Deserialization Error: Missing attribute `MyClass::s`', 'Deserialization Error: Missing attribute `MyClass::f`', 'Deserialization Error: Missing attribute `MyClass::a`'

--- a/tests/sav/nitserial_args1.res
+++ b/tests/sav/nitserial_args1.res
@@ -7,6 +7,7 @@ end
 
 import test_serialization
 import serialization
+intrude import serialization::engine_tools
 
 redef class Deserializer
 	redef fun deserialize_class(name)
@@ -15,6 +16,7 @@ redef class Deserializer
 		if name == "Array[Text]" then return new Array[Text].from_deserializer(self)
 		if name == "Array[Map[String, nullable Object]]" then return new Array[Map[String, nullable Object]].from_deserializer(self)
 		if name == "Array[String]" then return new Array[String].from_deserializer(self)
+		if name == "StrictHashMap[Int, Object]" then return new StrictHashMap[Int, Object].from_deserializer(self)
 		if name == "Array[Error]" then return new Array[Error].from_deserializer(self)
 		if name == "POSet[String]" then return new POSet[String].from_deserializer(self)
 		if name == "Array[Int]" then return new Array[Int].from_deserializer(self)
@@ -27,6 +29,7 @@ redef class Deserializer
 		if name == "Array[Float]" then return new Array[Float].from_deserializer(self)
 		if name == "Array[Object]" then return new Array[Object].from_deserializer(self)
 		if name == "Array[Serializable]" then return new Array[Serializable].from_deserializer(self)
+		if name == "StrictHashMap[Serializable, Int]" then return new StrictHashMap[Serializable, Int].from_deserializer(self)
 		if name == "POSetElement[String]" then return new POSetElement[String].from_deserializer(self)
 		if name == "HashMap[String, POSetElement[String]]" then return new HashMap[String, POSetElement[String]].from_deserializer(self)
 		if name == "Array[Match]" then return new Array[Match].from_deserializer(self)

--- a/tests/sav/test_json_deserialization_plain.res
+++ b/tests/sav/test_json_deserialization_plain.res
@@ -18,7 +18,7 @@
 # Nit: <MyClass i:123 s:hello f:123.456 a:[one, two] o:<MyClass i:456 s:world f:654.321 a:[1, 2] o:<null>>>
 
 # JSON: {"i": 123, "s": "hello", "f": 123.456, "a": ["one", "two"], "o": null}
-# Errors: 'Serialization Error: JSON object declaration does not declare a `__class`.'
+# Errors: 'Deserialization Error: JSON object declaration does not declare a `__class`.'
 # Nit: <JsonObject i:123, s:hello, f:123.456, a:[one,two], o:<null>>
 
 # JSON: {"__class": "MyClass", "i": 123, "s": "hello", "f": 123.456, "a": ["one", "two"], "o": "Not the right type"}

--- a/tests/sav/test_json_deserialization_plain_alt2.res
+++ b/tests/sav/test_json_deserialization_plain_alt2.res
@@ -1,3 +1,3 @@
 Runtime error: Uninitialized attribute _s (alt/test_json_deserialization_plain_alt2.nit:22)
 # JSON: {"__class": "MyClass", "i": 123, "o": null}
-# Errors: 'Deserialization Error: attribute `MyClass::s` missing from JSON object', 'Deserialization Error: attribute `MyClass::f` missing from JSON object', 'Deserialization Error: attribute `MyClass::a` missing from JSON object'
+# Errors: 'Deserialization Error: Missing attribute `MyClass::s`', 'Deserialization Error: Missing attribute `MyClass::f`', 'Deserialization Error: Missing attribute `MyClass::a`'

--- a/tests/sav/test_json_deserialization_safe.res
+++ b/tests/sav/test_json_deserialization_safe.res
@@ -1,4 +1,22 @@
-Deserialization Error: `DangerSub` is not a subtype of the static type `MyClass`
-Deserialization Error: Wrong type on `MyClass::other` expected `MyClass`, got `null`
-Deserialization Error: `DangerSub` is not a subtype of the static type `MyClass`
-Deserialization Error: Wrong type on `MyClass::next` expected `MyClass`, got `null`
+Deserialization Error: `DangerSub` is not a subtype of the static type `nullable A`
+Deserialization Error: `DangerSub` is not a subtype of the static type `nullable A`
+<A other:null next:null>
+---
+DANGER 'My text 1'
+DANGER 'My text 2'
+Deserialization Error: Wrong type on `A::other` expected `nullable A`, got `DangerSub`
+Deserialization Error: Wrong type on `A::next` expected `C`, got `DangerSub`
+<A other:null next:null>
+---
+
+<B other:null next:<B other:null next:null>>
+---
+Deserialization Error: `A` is not a subtype of the static type `nullable B`
+<B other:null next:null>
+---
+
+<G[A] e:<A other:null next:null>>
+---
+Deserialization Error: `A` is not a subtype of the static type `B`
+Deserialization Error: Wrong type on `G[B]::e` expected `E`, got `null`
+<G[B] e:not-set>

--- a/tests/sav/test_json_deserialization_safe_alt1.res
+++ b/tests/sav/test_json_deserialization_safe_alt1.res
@@ -1,4 +1,0 @@
-DANGER 'My text 1'
-DANGER 'My text 2'
-Deserialization Error: Wrong type on `MyClass::other` expected `MyClass`, got `DangerSub`
-Deserialization Error: Wrong type on `MyClass::next` expected `MyClass`, got `DangerSub`

--- a/tests/test_deserialization.nit
+++ b/tests/test_deserialization.nit
@@ -125,5 +125,5 @@ class TestEntities
 	var with_generics: Array[Serializable] = [a, b, c, d, e, fi, ff, g: Serializable]
 end
 
-# We instanciate it here so that `nitserial` detects generic types as being alive
+# We instantiate it here so that `nitserial` detects generic types as being alive
 var entities = new TestEntities


### PR DESCRIPTION
* Use `GetName` to better restrict the accepted static type for attributes with formal types. This should complete the protection against the injection of unexpected types through deserialization (reported by @ppepos).
* Update `nitserial` to intrude import modules with private serializable classes, instead of skipping them. Serializing private classes from the lib should probably be avoided, but at least now we support them and we can see them.
* Fix the deserialization of maps from JSON with metadata and cycles. A difference in the deserialization order could cause a reference to be read before the referenced object. This issue may still be caused by versionning, so a foolproof solution should probably be added to the JSON deserializer.
* Fix a warning in generated code, it was generated for each `serialize` class (quite a lot). It caused 25 warnings just in lib/github/api.nit.
* Implement serialization for the private classes of `core::queue` and don't crash on deserialization errors in `a_star`.

