### PR TITLE
compiler: Clean `autobox`

### DIFF
--- a/src/compiler/global_compiler.nit
+++ b/src/compiler/global_compiler.nit
@@ -317,7 +317,7 @@ class GlobalCompilerVisitor
 			self.add("{res} = BOX_{valtype.c_name}({value}); /* autobox from {value.mtype} to {mtype} */")
 			return res
 		else
-			# Bad things will appen!
+			# Bad things will happen!
 			var res = self.new_var(mtype)
 			self.add("/* {res} left unintialized (cannot convert {value.mtype} to {mtype}) */")
 			self.add("PRINT_ERROR(\"Cast error: Cannot cast %s to %s.\\n\", \"{value.mtype}\", \"{mtype}\"); fatal_exit(1);")

--- a/src/compiler/global_compiler.nit
+++ b/src/compiler/global_compiler.nit
@@ -316,8 +316,6 @@ class GlobalCompilerVisitor
 			end
 			self.add("{res} = BOX_{valtype.c_name}({value}); /* autobox from {value.mtype} to {mtype} */")
 			return res
-		else if value.mtype.ctype == "void*" and mtype.ctype == "void*" then
-			return value
 		else
 			# Bad things will appen!
 			var res = self.new_var(mtype)

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -1252,7 +1252,7 @@ class SeparateCompilerVisitor
 			self.add("{res} = BOX_{valtype.c_name}({value}); /* autobox from {value.mtype} to {mtype} */")
 			return res
 		else
-			# Bad things will appen!
+			# Bad things will happen!
 			var res = self.new_var(mtype)
 			self.add("/* {res} left unintialized (cannot convert {value.mtype} to {mtype}) */")
 			self.add("PRINT_ERROR(\"Cast error: Cannot cast %s to %s.\\n\", \"{value.mtype}\", \"{mtype}\"); fatal_exit(1);")

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -1251,10 +1251,6 @@ class SeparateCompilerVisitor
 			self.require_declaration("BOX_{valtype.c_name}")
 			self.add("{res} = BOX_{valtype.c_name}({value}); /* autobox from {value.mtype} to {mtype} */")
 			return res
-		else if (value.mtype.ctype == "void*" and mtype.ctype == "void*") or
-			(value.mtype.ctype == "char*" and mtype.ctype == "void*") or
-			(value.mtype.ctype == "void*" and mtype.ctype == "char*") then
-			return value
 		else
 			# Bad things will appen!
 			var res = self.new_var(mtype)


### PR DESCRIPTION
Remove a case that is unnecessary since PR #715 (in particular, see <https://github.com/nitlang/nit/commit/12aa16093122a9f55976585b76b01869d6899634#diff-a1c289b937bbc8f1bb71dcd50cd8eddcL1642>).

Signed-off-by: Jean-Christophe Beaupré <jcbrinfo@users.noreply.github.com>