### PR TITLE
Nitweb: boost response time and some improvements

### DIFF
--- a/share/nitweb/directives/entity/card.html
+++ b/share/nitweb/directives/entity/card.html
@@ -11,10 +11,6 @@
 			  ng-class='currentTab == "signature" ? "active" : ""'>
 				<span class='synopsis' ng-bind-html='mentity.mdoc.html_synopsis' />
 			</div>
-			<div id='{{mentity.html_id}}-doc' class='tab-pane'
-			  ng-class='currentTab == "doc" ? "active" : ""'>
-				<entity-doc mentity='mentity' />
-			</div>
 			<div id='{{mentity.html_id}}-grade' class='tab-pane'
 			  ng-class='currentTab == "grade" ? "active" : ""'>
 				<entity-rating mentity='mentity' ratings='ratings'>
@@ -29,9 +25,6 @@
 			<ul class='dropdown-menu dropdown-menu-right'>
 				<li ng-class='currentTab == "signature" ? "active" : ""' ng-if='!noSynopsis'>
 					<a ng-click='currentTab = "signature"'>Signature</a>
-				</li>
-				<li ng-class='currentTab == "doc" ? "active" : ""'>
-					<a ng-click='currentTab = "doc"'>Doc</a>
 				</li>
 				<li ng-class='currentTab == "grade" ? "active" : ""'>
 					<a ng-click='loadEntityStars(); currentTab = "grade"'>Grade</a>

--- a/share/nitweb/directives/entity/tag.html
+++ b/share/nitweb/directives/entity/tag.html
@@ -1,5 +1,64 @@
-<span class="glyphicon glyphicon-tag" ng-class='{
+<span>
+	<!-- package -->
+	<span ng-if='mentity.class_name == "MPackage"'>
+		<span class='glyphicon glyphicon-book text-muted' style='top: 3px' />
+	</span>
+
+	<!-- groups -->
+	<span ng-if='mentity.class_name == "MGroup"'>
+		<span class='glyphicon glyphicon-folder-close text-muted' />
+	</span>
+
+	<!-- modules -->
+	<span ng-if='mentity.class_name == "MModule"'>
+		<span class='glyphicon glyphicon-file text-muted' style='top: 2px' />
+	</span>
+
+	<!-- classes -->
+	<span ng-if='mentity.class_name == "MClass"'>
+		<span class='glyphicon glyphicon-stop' ng-class='{
+			"text-success": mentity.visibility == "public",
+			"text-warning": mentity.visibility == "protected",
+			"text-danger": mentity.visibility == "private",
+		}' />
+	</span>
+
+	<!-- classdefs -->
+	<span ng-if='mentity.class_name == "MClassDef"' ng-class='{
 		"text-success": mentity.visibility == "public",
 		"text-warning": mentity.visibility == "protected",
 		"text-danger": mentity.visibility == "private",
-}' />
+	}'>
+		<span class='glyphicon' style='top: 2px; left:2px' ng-class='{
+			"glyphicon-plus": mentity.is_intro,
+			"glyphicon-asterisk": !mentity.is_intro
+		}' />
+	</span>
+
+	<!-- props -->
+	<span ng-if='mentity.class_name == "MAttribute" ||
+		 mentity.class_name == "MMethod" ||
+		 mentity.class_name == "MVirtualTypeProp"
+	'>
+		<span class='glyphicon glyphicon-tag' ng-class='{
+			"text-success": mentity.visibility == "public",
+			"text-warning": mentity.visibility == "protected",
+			"text-danger": mentity.visibility == "private",
+		}' />
+	</span>
+
+	<!-- propdefs -->
+	<span ng-if='mentity.class_name == "MAttributeDef" ||
+		mentity.class_name == "MMethodDef" ||
+		mentity.class_name == "MVirtualTypePropDef"'
+		ng-class='{
+			"text-success": mentity.visibility == "public",
+			"text-warning": mentity.visibility == "protected",
+			"text-danger": mentity.visibility == "private"
+	}'>
+		<span class='glyphicon' style='top: 2px; left:2px' ng-class='{
+			"glyphicon-plus": mentity.is_intro,
+			"glyphicon-asterisk": !mentity.is_intro
+		}' />
+	</span>
+</span>

--- a/share/nitweb/javascripts/entities.js
+++ b/share/nitweb/javascripts/entities.js
@@ -80,10 +80,19 @@
 									$state.go('404', null, { location: false })
 								});
 							return d.promise;
+						},
+						inh: function(Model, $q, $stateParams, $state) {
+							var d = $q.defer();
+							Model.loadEntityInh($stateParams.id, d.resolve,
+								function() {
+									$state.go('404', null, { location: false })
+								});
+							return d.promise;
 						}
 					},
-					controller: function(graph, $sce) {
+					controller: function(inh, graph, $sce) {
 						this.graph = $sce.trustAsHtml(graph);
+						this.inh = inh;
 					},
 					controllerAs: 'vm',
 				})
@@ -223,6 +232,12 @@
 
 				loadEntityGraph: function(id, cb, cbErr) {
 					$http.get('/api/graph/inheritance/' + id + '?cdepth=3')
+						.success(cb)
+						.error(cbErr);
+				},
+
+				loadEntityInh: function(id, cb, cbErr) {
+					$http.get('/api/inheritance/' + id)
 						.success(cb)
 						.error(cbErr);
 				},

--- a/share/nitweb/javascripts/entities.js
+++ b/share/nitweb/javascripts/entities.js
@@ -53,8 +53,19 @@
 				.state('doc.entity.doc', {
 					url: '',
 					templateUrl: 'views/doc/doc.html',
-					controller: function(mentity) {
+					resolve: {
+						doc: function(Model, $q, $stateParams, $state) {
+							var d = $q.defer();
+							Model.loadEntityDoc($stateParams.id, d.resolve,
+								function() {
+									$state.go('404', null, { location: false })
+								});
+							return d.promise;
+						}
+					},
+					controller: function(mentity, doc) {
 						this.mentity = mentity;
+						this.doc = doc;
 					},
 					controllerAs: 'vm',
 				})
@@ -182,6 +193,12 @@
 
 				loadEntity: function(id, cb, cbErr) {
 					$http.get('/api/entity/' + id)
+						.success(cb)
+						.error(cbErr);
+				},
+
+				loadEntityDoc: function(id, cb, cbErr) {
+					$http.get('/api/entity/' + id + '/doc')
 						.success(cb)
 						.error(cbErr);
 				},

--- a/share/nitweb/views/doc/defs.html
+++ b/share/nitweb/views/doc/defs.html
@@ -1,4 +1,10 @@
 <div>
-	<entity-list list-title='Class definitions'
+	<entity-list list-title='Groups' ng-if='vm.mentity.class_name == "MPackage"'
+		list-entities='vm.defs' list-object-filter='{}' />
+
+	<entity-list list-title='Groups & Modules' ng-if='vm.mentity.class_name == "MGroup"'
+		list-entities='vm.defs' list-object-filter='{}' />
+
+	<entity-list list-title='Class definitions' ng-if='vm.mentity.class_name == "MModule"'
 		list-entities='vm.defs' list-object-filter='{}' />
 </div>

--- a/share/nitweb/views/doc/doc.html
+++ b/share/nitweb/views/doc/doc.html
@@ -14,15 +14,6 @@
 			</div>
 		</div>
 
-		<entity-list list-title='Groups' list-entities='vm.mentity.mgroups'
-			list-object-filter='{}' />
-
-		<entity-list list-title='Subgroups' list-entities='vm.mentity.mgroups'
-			list-object-filter='{}' />
-
-		<entity-list list-title='Modules' list-entities='vm.mentity.mmodules'
-			list-object-filter='{}' />
-
 		<entity-list list-title='Introduced classes' list-entities='vm.mentity.intro_mclasses'
 			list-object-filter='{}' />
 

--- a/share/nitweb/views/doc/doc.html
+++ b/share/nitweb/views/doc/doc.html
@@ -3,7 +3,16 @@
 		<ui-summary target='#summary-content' />
 	</div>
 	<div class='col-xs-9' id='summary-content'>
-		<entity-card mentity='vm.mentity' default-tab='doc' no-synopsis='true' />
+		<div class='card'>
+			<div class='card-body'>
+				<div ng-if='vm.doc'>
+					<div ng-bind-html='vm.doc.documentation'></div>
+				</div>
+				<div ng-if='!vm.doc'>
+					<i class='text-muted'>No documentation for this entity.</i>
+				</div>
+			</div>
+		</div>
 
 		<entity-list list-title='Groups' list-entities='vm.mentity.mgroups'
 			list-object-filter='{}' />

--- a/share/nitweb/views/doc/doc.html
+++ b/share/nitweb/views/doc/doc.html
@@ -17,26 +17,16 @@
 		<entity-list list-title='Groups' list-entities='vm.mentity.mgroups'
 			list-object-filter='{}' />
 
-		<entity-list list-title='Parent group' list-entities='[vm.mentity.parent]'
-			list-object-filter='{}' ng-if='vm.mentity.parent' />
-
 		<entity-list list-title='Subgroups' list-entities='vm.mentity.mgroups'
 			list-object-filter='{}' />
 
 		<entity-list list-title='Modules' list-entities='vm.mentity.mmodules'
 			list-object-filter='{}' />
 
-		<entity-list list-title='Imported modules' list-entities='vm.mentity.imports'
-			list-object-filter='{}' />
-
 		<entity-list list-title='Introduced classes' list-entities='vm.mentity.intro_mclasses'
 			list-object-filter='{}' />
 
 		<entity-list list-title='Class redefinitions' list-entities='vm.mentity.redef_mclassdefs'
-			list-object-filter='{}' />
-
-		<entity-list list-title='Parents'
-			list-entities='vm.mentity.parents'
 			list-object-filter='{}' />
 
 		<entity-list list-title='Constructors'

--- a/share/nitweb/views/doc/entity.html
+++ b/share/nitweb/views/doc/entity.html
@@ -15,6 +15,19 @@
 			</a>
 		</li>
 
+		<!-- definitions -->
+		<li role='presentation' ui-sref-active='active' ng-if='
+				vm.mentity.class_name == "MPackage" ||
+				vm.mentity.class_name == "MGroup" ||
+				vm.mentity.class_name == "MModule"'>
+			<a ui-sref='.defs'>
+				<span class='glyphicon glyphicon-list'/>
+				<span ng-if='vm.mentity.class_name == "MPackage"'>Groups</span>
+				<span ng-if='vm.mentity.class_name == "MGroup"'>Content</span>
+				<span ng-if='vm.mentity.class_name == "MModule"'>Classes</span>
+			</a>
+		</li>
+
 		<!-- graph -->
 		<li role='presentation' ui-sref-active='active' ng-if='
 				vm.mentity.class_name == "MPackage" ||
@@ -35,14 +48,6 @@
 				vm.mentity.class_name == "MModule"'>
 			<a ui-sref='.code'>
 				<span class='glyphicon glyphicon-console'/> Code
-			</a>
-		</li>
-
-		<!-- definitions -->
-		<li role='presentation' ui-sref-active='active' ng-if='
-				vm.mentity.class_name == "MModule"'>
-			<a ui-sref='.defs'>
-				<span class='glyphicon glyphicon-asterisk'/> Class definitions
 			</a>
 		</li>
 

--- a/share/nitweb/views/doc/graph.html
+++ b/share/nitweb/views/doc/graph.html
@@ -1,5 +1,15 @@
-<div class='card'>
-	<div class='card-body text-center'>
-		<entity-graph mentity='mentity' graph='vm.graph' />
+<div>
+	<div class='card'>
+		<div class='card-body text-center'>
+			<entity-graph mentity='mentity' graph='vm.graph' />
+		</div>
 	</div>
+
+	<!-- Parents -->
+	<entity-list list-title='Parents'
+		list-entities='vm.inh.direct_greaters' list-object-filter='{}' />
+
+	<!-- Children -->
+	<entity-list list-title='Children'
+		list-entities='vm.inh.direct_smallers' list-object-filter='{}' />
 </div>

--- a/src/web/api_model.nit
+++ b/src/web/api_model.nit
@@ -211,7 +211,13 @@ class APIEntityDefs
 		var mentity = mentity_from_uri(req, res)
 		if mentity == null then return
 		var mentities: Array[MEntity]
-		if mentity isa MModule then
+		if mentity isa MPackage then
+			mentities = mentity.mgroups.to_a
+		else if mentity isa MGroup then
+			mentities = new Array[MEntity]
+			mentities.add_all mentity.in_nesting.direct_smallers
+			mentities.add_all mentity.mmodules
+		else if mentity isa MModule then
 			mentities = mentity.mclassdefs
 		else if mentity isa MClass then
 			mentities = mentity.mclassdefs

--- a/src/web/api_model.nit
+++ b/src/web/api_model.nit
@@ -26,6 +26,7 @@ redef class APIRouter
 		use("/search", new APISearch(config))
 		use("/random", new APIRandom(config))
 		use("/entity/:id", new APIEntity(config))
+		use("/entity/:id/doc", new APIEntityDoc(config))
 		use("/code/:id", new APIEntityCode(config))
 		use("/uml/:id", new APIEntityUML(config))
 		use("/linearization/:id", new APIEntityLinearization(config))
@@ -144,6 +145,26 @@ class APIEntity
 		var mentity = mentity_from_uri(req, res)
 		if mentity == null then return
 		res.raw_json mentity.to_full_json
+	end
+end
+
+# Return the full MDoc of a MEntity.
+#
+# Example: `GET /entity/core::Array/doc`
+class APIEntityDoc
+	super APIHandler
+
+	redef fun get(req, res) do
+		var mentity = mentity_from_uri(req, res)
+		if mentity == null then return
+
+		var obj = new JsonObject
+		var mdoc = mentity.mdoc_or_fallback
+		if mdoc != null then
+			obj["documentation"] = mdoc.html_documentation.write_to_string
+			obj["location"] = mdoc.location
+		end
+		res.json obj
 	end
 end
 

--- a/src/web/web_base.nit
+++ b/src/web/web_base.nit
@@ -207,6 +207,7 @@ redef class MEntityRef
 		v.serialize_attribute("mdoc", mentity.mdoc_or_fallback)
 		v.serialize_attribute("visibility", mentity.visibility.to_s)
 		v.serialize_attribute("modifiers", mentity.collect_modifiers)
+		v.serialize_attribute("class_name", mentity.class_name)
 		var mentity = self.mentity
 		if mentity isa MMethod then
 			v.serialize_attribute("msignature", mentity.intro.msignature)

--- a/src/web/web_base.nit
+++ b/src/web/web_base.nit
@@ -226,7 +226,6 @@ redef class MDoc
 	# Add doc down processing
 	redef fun core_serialize_to(v) do
 		v.serialize_attribute("html_synopsis", html_synopsis.write_to_string)
-		v.serialize_attribute("html_documentation", html_documentation.write_to_string)
 	end
 end
 

--- a/src/web/web_base.nit
+++ b/src/web/web_base.nit
@@ -341,11 +341,9 @@ end
 redef class POSetElement[E]
 	super Serializable
 
-	redef fun serialize_to(v) do
+	redef fun core_serialize_to(v) do
 		assert self isa POSetElement[MEntity]
-		v.serialize_attribute("greaters", to_mentity_refs(greaters))
 		v.serialize_attribute("direct_greaters", to_mentity_refs(direct_greaters))
 		v.serialize_attribute("direct_smallers", to_mentity_refs(direct_smallers))
-		v.serialize_attribute("smallers", to_mentity_refs(smallers))
 	end
 end


### PR DESCRIPTION
The main objective of this PR is to shorten the frontend response time.
The major culprit was that the full documentation was serialized in each response.
This PR makes nitweb return only the synopsis and lets the frontend ask for the full documentation if needed.

Also uniformizes and cleans tabs for entities:
* Moved data between tabs (such as inheritance data to the inheritance tab)
* Added missing tabs for packages and groups (http://nitweb.moz-code.org/doc/core%3Ecollection%3E/defs)

Demo: http://nitweb.moz-code.org/