### PR TITLE
gamnit audio: control sound channels and don't crash if there's no sound card

### DIFF
--- a/lib/gamnit/display_linux.nit
+++ b/lib/gamnit/display_linux.nit
@@ -89,12 +89,12 @@ redef class GamnitDisplay
 
 		# Audio support
 		var inited = mix.initialize(mix_init_flags)
-		assert inited != mix_init_flags else
+		if inited != mix_init_flags then
 			print_error "Failed to load SDL2 mixer format supports: {mix.error}"
 		end
 
-		var opened = mix.open_audio(44100, mix.default_format, 2, 1024)
-		assert opened else
+		var open = mix.open_audio(44100, mix.default_format, 2, 1024)
+		if not open then
 			print_error "Failed to initialize SDL2 mixer: {mix.error}"
 		end
 
@@ -108,8 +108,8 @@ redef class GamnitDisplay
 
 	# SDL2 mixer initialization flags
 	#
-	# Defaults to all available formats.
-	var mix_init_flags: MixInitFlags = mix.flac | mix.mod | mix.mp3 | mix.ogg is lazy, writable
+	# Defaults to FLAC, MP3 and OGG.
+	var mix_init_flags: MixInitFlags = mix.flac | mix.mp3 | mix.ogg is lazy, writable
 
 	# Close the SDL display
 	fun close_sdl

--- a/lib/linux/audio.nit
+++ b/lib/linux/audio.nit
@@ -56,7 +56,13 @@ redef class Sound
 		self.native = native
 	end
 
-	redef fun play
+	redef fun play do play_channel(-1, 0)
+
+	# Play this sound on `channel` (or any channel if -1) and return the channel
+	#
+	# Repeat the sound `loops` times, `loops == 0` plays it once,
+	# `loops == 1` plays it twice and `loops == -1` loops infinitely.
+	fun play_channel(channel, loops: Int): Int
 	do
 		var native = native
 
@@ -70,12 +76,12 @@ redef class Sound
 		end
 
 		# If there's an error, silently skip
-		if error != null then return
+		if error != null then return -1
 		native = self.native
 		assert native != null
 
 		# Play on any available channel
-		mix.play_channel(-1, native, 0)
+		return mix.play_channel(channel, native, loops)
 	end
 end
 

--- a/lib/sdl2/mixer.nit
+++ b/lib/sdl2/mixer.nit
@@ -91,17 +91,71 @@ class Mix
 	# Play `chunk` on `channel`
 	#
 	# If `channel == -1` the first unreserved channel is used.
-	# The sound is repeated `loops` times, `loops == 0` plays it once and
-	# `loops == -1` loops infinitely.
-	fun play_channel(channel: Int, chunk: MixChunk, loops: Int): Bool `{
-		return Mix_PlayChannel(channel, chunk, loops) == 0;
+	# The sound is repeated `loops` times, `loops == 0` plays it once,
+	# `loops == 1` plays it twice and `loops == -1` loops infinitely.
+	#
+	# Returns the channel used, or `-1` on error.
+	fun play_channel(channel: Int, chunk: MixChunk, loops: Int): Int `{
+		return Mix_PlayChannel(channel, chunk, loops);
 	`}
 
-	# Set the chunk volume out of `mix.max_volume` and return the previous value
+	# Play `chunk` on `channel`
 	#
-	# Use `volume = -1` to only read the previous value.
+	# If `channel == -1` the first unreserved channel is used.
+	# The sound is repeated `loops` times, `loops == 0` plays it once,
+	# `loops == 1` plays it twice and `loops == -1` loops infinitely.
+	# If `ticks != -1`, the sample plays for at most `ticks` milliseconds.
+	fun play_channel_timed(channel: Int, chunk: MixChunk, loops, ticks: Int): Int `{
+		return Mix_PlayChannelTimed(channel, chunk, loops, ticks);
+	`}
+
+	# Halt/stop `channel` playback
+	#
+	# If `channel == -1`, halt all channels.
+	fun halt_channel(channel: Int) `{
+		Mix_HaltChannel(channel);
+	`}
+
+	# Halt `channel` in `ticks` milliseconds and return the number of channels set to expire
+	#
+	# If `channel == -1`, halt all channels.
+	fun expire_channel(channel, ticks: Int): Int `{
+		return Mix_ExpireChannel(channel, ticks);
+	`}
+
+	# Reserve `num` channels from being used by `play_channel(-1...)`
+	#
+	# Returns the number of of channels reserved.
+	fun reserve_channels(num: Int): Int `{
+		return Mix_ReserveChannels(num);
+	`}
+
+	# Set the `volume` of `channel`, out of `mix.max_volume`
+	#
+	# If `channel == -1`, set the volume of all channels.
+	#
+	# Returns the current volume of the channel, or if `channel == -1` the average volume.
+	fun volume(channel, volume: Int): Int `{
+		return Mix_Volume(channel, volume);
+	`}
+
+	# Set the `volume` for `chunk`, out of `mix.max_volume`
+	#
+	# If `volume == -1`, only read the previous value.
+	#
+	# Returns the previous volume value.
 	fun volume_chunk(chunk: MixChunk, volume: Int) `{
 		Mix_VolumeChunk(chunk, volume);
+	`}
+
+	# Pause `channel`, or all playing channels if -1
+	fun pause(channel: Int) `{
+		Mix_Pause(channel);
+	`}
+
+	# Unpause `channel`, or all paused channels if -1
+	fun resume(channel: Int) `{
+		Mix_Resume(channel);
 	`}
 
 	# ---


### PR DESCRIPTION
Desktop clients can now control playing sounds with the new services from SDL2 mixer. The equivalent was already implemented for Android but not GNU/Linux. The new services still need to be fully exposed in the `app::audio` API.

This PR also removes the requirement to have a working sound card to launch a gamnit game.