### PR TITLE
gamnit: shadow mapping

### DIFF
--- a/contrib/model_viewer/src/globe.nit
+++ b/contrib/model_viewer/src/globe.nit
@@ -98,7 +98,7 @@ class GlobeMaterial
 	init atmo do init(null, false, [0.0, 0.8*atmo_a, 1.0*atmo_a, atmo_a])
 	private var atmo_a = 0.05
 
-	redef fun draw(actor, model)
+	redef fun draw(actor, model, camera)
 	do
 		var gl_error = glGetError
 		assert gl_error == gl_NO_ERROR else print gl_error
@@ -106,9 +106,6 @@ class GlobeMaterial
 		var mesh = model.mesh
 
 		var program = app.globe_program
-		program.use
-
-		# Set constant program values
 		program.use
 
 		# Bind textures
@@ -135,7 +132,7 @@ class GlobeMaterial
 		# Update camera view and light
 		var p = app.world_camera.position
 		program.camera.uniform(p.x, p.y, p.z)
-		program.mvp.uniform app.world_camera.mvp_matrix
+		program.mvp.uniform camera.mvp_matrix
 		program.light_center.uniform(app.light.position.x, app.light.position.y, app.light.position.z)
 
 		# Set attributes

--- a/lib/gamnit/depth/depth.nit
+++ b/lib/gamnit/depth/depth.nit
@@ -21,6 +21,7 @@ import more_models
 import model_dimensions
 import particles
 import selection
+import shadow
 
 redef class App
 
@@ -49,10 +50,18 @@ redef class App
 	# Draw all elements of `actors` and then call `frame_core_flat`
 	protected fun frame_core_depth(display: GamnitDisplay)
 	do
+		frame_core_depth_clock.lapse
+
+		# Compute shadows
+		if light isa LightCastingShadows then
+			frame_core_shadow_prep display
+			perfs["gamnit depth shadows"].add frame_core_depth_clock.lapse
+		end
+
 		glViewport(0, 0, display.width, display.height)
 		frame_core_dynamic_resolution_before display
+		perfs["gamnit depth dynres"].add frame_core_depth_clock.lapse
 
-		frame_core_depth_clock.lapse
 		for actor in actors do
 			for leaf in actor.model.leaves do
 				leaf.material.draw(actor, leaf, app.world_camera)
@@ -73,6 +82,9 @@ redef class App
 		perfs["gamnit depth ui_sprites"].add frame_core_depth_clock.lapse
 
 		frame_core_dynamic_resolution_after display
+
+		# Debug, show the light point of view
+		#frame_core_shadow_debug display
 	end
 
 	private var frame_core_depth_clock = new Clock

--- a/lib/gamnit/depth/depth.nit
+++ b/lib/gamnit/depth/depth.nit
@@ -32,6 +32,9 @@ redef class App
 		world_camera.reset_height(10.0)
 		world_camera.near = 0.1
 
+		# Cull the invisible triangles in the back of the geometries
+		glCullFace gl_BACK
+
 		# Prepare programs
 		var programs = [versatile_program, normals_program, explosion_program, smoke_program, static_program, selection_program: GamnitProgram]
 		for program in programs do

--- a/lib/gamnit/depth/depth.nit
+++ b/lib/gamnit/depth/depth.nit
@@ -52,17 +52,10 @@ redef class App
 		glViewport(0, 0, display.width, display.height)
 		frame_core_dynamic_resolution_before display
 
-		# Update cameras on both our programs
-		versatile_program.use
-		versatile_program.mvp.uniform world_camera.mvp_matrix
-
-		normals_program.use
-		normals_program.mvp.uniform app.world_camera.mvp_matrix
-
 		frame_core_depth_clock.lapse
 		for actor in actors do
 			for leaf in actor.model.leaves do
-				leaf.material.draw(actor, leaf)
+				leaf.material.draw(actor, leaf, app.world_camera)
 			end
 		end
 		perfs["gamnit depth actors"].add frame_core_depth_clock.lapse

--- a/lib/gamnit/depth/depth_core.nit
+++ b/lib/gamnit/depth/depth_core.nit
@@ -165,7 +165,7 @@ abstract class Material
 	# This method is called on many materials for many `actor` and `model` at each frame.
 	# It is expected to use a `GLProgram` and call an equivalent to `glDrawArrays`.
 	# However, it should not call `glClear` nor `GamnitDisplay::flip`.
-	fun draw(actor: Actor, model: LeafModel) do end
+	fun draw(actor: Actor, model: LeafModel, camera: Camera) do end
 end
 
 # Mesh with all geometry data

--- a/lib/gamnit/depth/depth_core.nit
+++ b/lib/gamnit/depth/depth_core.nit
@@ -203,14 +203,23 @@ class Mesh
 end
 
 # Source of light
-#
-# Instances of this class define a light source position and type.
-class Light
-
-	# TODO point light, spotlight, directional light, etc.
+abstract class Light
 
 	# Center of this light source in world coordinates
 	var position = new Point3d[Float](0.0, 1000.0, 0.0)
+end
+
+# Basic light projected from a single point
+class PointLight
+	super Light
+end
+
+# Source of light casting shadows
+abstract class LightCastingShadows
+	super Light
+
+	# View from the camera, used for shadow mapping, implemented by sub-classes
+	fun camera: Camera is abstract
 end
 
 redef class App
@@ -219,7 +228,7 @@ redef class App
 	var actors = new Array[Actor]
 
 	# Single light of the scene
-	var light = new Light
+	var light: Light = new PointLight is writable
 
 	# TODO move `actors & light` to a scene object
 	# TODO support more than 1 light

--- a/lib/gamnit/depth/more_lights.nit
+++ b/lib/gamnit/depth/more_lights.nit
@@ -1,0 +1,75 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# More implementations of `Light`
+module more_lights
+
+import depth_core
+
+# TODO
+#class PointLight
+#class Spotlight
+
+# Sun-like light projecting parallel rays
+class ParallelLight
+	super LightCastingShadows
+
+	# Angle to the light source, around the X axis
+	var pitch = 0.0 is writable
+
+	# Angle to the light source, around the Y axis
+	var yaw = 0.0 is writable
+
+	# Depth texture width, in world coordinates
+	var width = 100.0 is writable
+
+	# Depth texture height, in world coordinates
+	var height = 100.0 is writable
+
+	# Viewport depth, centered on `app.world_camera`
+	var depth = 500.0 is writable
+
+	redef var camera = new ParallelLightCamera(app.display.as(not null), self) is lazy
+end
+
+private class ParallelLightCamera
+	super Camera
+
+	var light: ParallelLight
+
+	# Rotation matrix produced by the current rotation of the camera
+	fun rotation_matrix: Matrix
+	do
+		var view = new Matrix.identity(4)
+		view.rotate(light.yaw,   0.0, 1.0, 0.0)
+		view.rotate(light.pitch, 1.0, 0.0, 0.0)
+		return view
+	end
+
+	redef fun mvp_matrix
+	do
+		# TODO cache
+
+		var near = -light.depth/2.0
+		var far = light.depth/2.0
+
+		var view = new Matrix.identity(4)
+		view.translate(-position.x, -position.y, -position.z)
+		view = view * rotation_matrix
+		var projection = new Matrix.orthogonal(-light.width/2.0, light.width/2.0,
+		                                       -light.height/2.0, light.height/2.0,
+		                                       near, far)
+		return view * projection
+	end
+end

--- a/lib/gamnit/depth/more_materials.nit
+++ b/lib/gamnit/depth/more_materials.nit
@@ -45,10 +45,11 @@ class SmoothMaterial
 	# The RGB values should be premultiplied by the alpha value.
 	var specular_color: Array[Float] is writable
 
-	redef fun draw(actor, model)
+	redef fun draw(actor, model, camera)
 	do
 		var program = app.versatile_program
 		program.use
+		program.mvp.uniform camera.mvp_matrix
 
 		var mesh = model.mesh
 
@@ -74,7 +75,7 @@ class SmoothMaterial
 		program.light_center.uniform(app.light.position.x, app.light.position.y, app.light.position.z)
 
 		# Camera
-		program.camera.uniform(app.world_camera.position.x, app.world_camera.position.y, app.world_camera.position.z)
+		program.camera.uniform(camera.position.x, camera.position.y, camera.position.z)
 
 		# Colors from the material
 		var a = actor.alpha
@@ -110,7 +111,7 @@ class TexturedMaterial
 	# Bump map TODO
 	private var normals_texture: nullable Texture = null is writable
 
-	redef fun draw(actor, model)
+	redef fun draw(actor, model, camera)
 	do
 		var mesh = model.mesh
 
@@ -164,6 +165,7 @@ class TexturedMaterial
 			program.use_map_bump.uniform false
 		end
 
+		program.mvp.uniform camera.mvp_matrix
 		program.translation.uniform(actor.center.x, actor.center.y, actor.center.z, 0.0)
 		program.scale.uniform actor.scale
 
@@ -210,7 +212,9 @@ class TexturedMaterial
 		program.normal.array(mesh.normals, 3)
 
 		program.light_center.uniform(app.light.position.x, app.light.position.y, app.light.position.z)
-		program.camera.uniform(app.world_camera.position.x, app.world_camera.position.y, app.world_camera.position.z)
+
+		# Camera
+		program.camera.uniform(camera.position.x, camera.position.y, camera.position.z)
 
 		if mesh.indices.is_empty then
 			glDrawArrays(mesh.draw_mode, 0, mesh.vertices.length/3)
@@ -227,11 +231,11 @@ end
 class NormalsMaterial
 	super Material
 
-	redef fun draw(actor, model)
+	redef fun draw(actor, model, camera)
 	do
 		var program = app.normals_program
 		program.use
-		program.mvp.uniform app.world_camera.mvp_matrix
+		program.mvp.uniform camera.mvp_matrix
 
 		var mesh = model.mesh
 

--- a/lib/gamnit/depth/more_materials.nit
+++ b/lib/gamnit/depth/more_materials.nit
@@ -393,7 +393,7 @@ class BlinnPhongProgram
 	# Should this program use the texture `map_diffuse`?
 	var use_map_diffuse = uniforms["use_map_diffuse"].as(UniformBool) is lazy
 
-	# Diffuser texture unit
+	# Diffuse texture unit
 	var map_diffuse = uniforms["map_diffuse"].as(UniformSampler2D) is lazy
 
 	# Should this program use the texture `map_specular`?

--- a/lib/gamnit/depth/shadow.nit
+++ b/lib/gamnit/depth/shadow.nit
@@ -1,0 +1,477 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shadow mapping using a depth texture
+#
+# The default light does not cast any shadows. It can be changed to a
+# `ParallelLight` in client games to cast sun-like shadows:
+#
+# ~~~
+# import more_lights
+#
+# var sun = new ParallelLight
+# sun.pitch = 0.25*pi
+# sun.yaw = 0.25*pi
+# app.light = sun
+# ~~~
+module shadow
+
+intrude import gamnit::depth_core
+
+redef class App
+
+	# Resolution of the shadow texture, defaults to 4096 pixels
+	#
+	# TODO make configurable / ask the hardware for gl_MAX_TEXTURE_SIZE
+	var shadow_resolution = 4096
+
+	# Are shadows supported by the current hardware configuration?
+	#
+	# The implementation may change in the future, but it currently relies on
+	# the GL extension `GL_EOS_depth_texture`.
+	var supports_shadows: Bool is lazy do
+		return display.as(not null).gl_extensions.has("GL_OES_depth_texture")
+	end
+
+	# Is `shadow_context.depth_texture` ready to be used?
+	fun shadow_depth_texture_available: Bool
+	do return supports_shadows and shadow_context.depth_texture != -1
+
+	private var shadow_depth_program = new ShadowDepthProgram
+
+	private var perf_clock_shadow = new Clock is lazy
+
+	redef fun on_create
+	do
+		super
+
+		var program = shadow_depth_program
+		program.compile_and_link
+		var error = program.error
+		assert error == null else print_error error
+	end
+
+	private var shadow_context: ShadowContext = create_shadow_context is lazy
+
+	private fun create_shadow_context: ShadowContext
+	do
+		var display = display
+		assert display != null
+
+		var context = new ShadowContext
+		context.prepare_once(display, shadow_resolution)
+		return context
+	end
+
+	# Update the depth texture from the light point of view
+	#
+	# This method updates `shadow_context.depth_texture`.
+	protected fun frame_core_shadow_prep(display: GamnitDisplay)
+	do
+		if not supports_shadows then return
+
+		var light = app.light
+		if not light isa LightCastingShadows then return
+
+		perf_clock_shadow.lapse
+
+		# Make sure there's no errors pending
+		assert glGetError == gl_NO_ERROR
+
+		# Bind the framebuffer and make sure it is OK
+		glBindFramebuffer(gl_FRAMEBUFFER, shadow_context.light_view_framebuffer)
+		assert glGetError == gl_NO_ERROR
+		assert glCheckFramebufferStatus(gl_FRAMEBUFFER) == gl_FRAMEBUFFER_COMPLETE
+
+		# Draw to fill the depth texture and only the depth
+		glViewport(0, 0, shadow_resolution, shadow_resolution)
+		glColorMask(false, false, false, false)
+		glClear gl_COLOR_BUFFER_BIT | gl_DEPTH_BUFFER_BIT
+		assert glGetError == gl_NO_ERROR
+
+		# Update light position
+		var camera = light.camera
+		camera.position.x = app.world_camera.position.x
+		camera.position.y = app.world_camera.position.y
+		camera.position.z = app.world_camera.position.z
+
+		# Draw all actors
+		for actor in actors do
+			for leaf in actor.model.leaves do
+				leaf.material.draw_depth(actor, leaf, camera)
+			end
+		end
+
+		# Take down, bring back default values
+		glBindFramebuffer(gl_FRAMEBUFFER, shadow_context.screen_framebuffer)
+		glColorMask(true, true, true, true)
+
+		perfs["gamnit shadows prep"].add perf_clock_shadow.lapse
+	end
+
+	# ---
+	# Debug: show light view in the bottom left of the screen
+
+	# Lazy load the debugging program
+	private var shadow_debug_program: LightPointOfViewProgram is lazy do
+		var program = new LightPointOfViewProgram
+		program.compile_and_link
+		var error = program.error
+		assert error == null else print_error error
+		return program
+	end
+
+	# Draw the light view in the bottom left of the screen, for debugging only
+	#
+	# The shadow depth texture is a square that can be deformed by this projection.
+	protected fun frame_core_shadow_debug(display: GamnitDisplay)
+	do
+		if not supports_shadows then
+			print_error "Error: Shadows are not supported by the current hardware configuration"
+			return
+		end
+
+		perf_clock_shadow.lapse
+
+		var program = shadow_debug_program
+
+		glBindBuffer(gl_ARRAY_BUFFER, shadow_context.buffer_array)
+		glViewport(0, 0, display.width/3, display.height/3)
+		glClear gl_DEPTH_BUFFER_BIT
+		program.use
+
+		# Uniforms
+		glActiveTexture gl_TEXTURE0
+		glBindTexture(gl_TEXTURE_2D, shadow_context.depth_texture)
+		program.texture.uniform 0
+
+		# Attributes
+		var sizeof_gl_float = 4
+		var n_floats = 3
+		glEnableVertexAttribArray program.coord.location
+		glVertexAttribPointeri(program.coord.location, n_floats, gl_FLOAT, false, 0, 0)
+		var offset = 4 * n_floats * sizeof_gl_float
+
+		n_floats = 2
+		glEnableVertexAttribArray program.tex_coord.location
+		glVertexAttribPointeri(program.tex_coord.location, n_floats, gl_FLOAT, false, 0, offset)
+		var gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
+
+		# Draw
+		glDrawArrays(gl_TRIANGLE_STRIP, 0, 4)
+		gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
+
+		# Take down
+		glBindBuffer(gl_ARRAY_BUFFER, 0)
+		gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
+
+		sys.perfs["gamnit shadow debug"].add app.perf_clock_shadow.lapse
+	end
+end
+
+# Handles to reused GL buffers and texture
+private class ShadowContext
+
+	# Real screen framebuffer
+	var screen_framebuffer: Int = -1
+
+	# Framebuffer for the light point of view
+	var light_view_framebuffer: Int = -1
+
+	# Depth attached to `light_view_framebuffer`
+	var depth_texture: Int = -1
+
+	# Buffer name for vertex data
+	var buffer_array: Int = -1
+
+	# Prepare all attributes once per resolution change
+	fun prepare_once(display: GamnitDisplay, shadow_resolution: Int)
+	do
+		assert display.gl_extensions.has("GL_OES_depth_texture")
+
+		# Set aside the real screen framebuffer name
+		var screen_framebuffer = glGetIntegerv(gl_FRAMEBUFFER_BINDING, 0)
+		self.screen_framebuffer = screen_framebuffer
+
+		# Framebuffer
+		var framebuffer = glGenFramebuffers(1).first
+		glBindFramebuffer(gl_FRAMEBUFFER, framebuffer)
+		assert glIsFramebuffer(framebuffer)
+		self.light_view_framebuffer = framebuffer
+		var gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
+
+		# Depth & texture/color
+		var textures = glGenTextures(1)
+		self.depth_texture = textures[0]
+		gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
+
+		resize(display, shadow_resolution)
+		assert glCheckFramebufferStatus(gl_FRAMEBUFFER) == gl_FRAMEBUFFER_COMPLETE
+
+		# Array buffer
+		buffer_array = glGenBuffers(1).first
+		glBindBuffer(gl_ARRAY_BUFFER, buffer_array)
+		assert glIsBuffer(buffer_array)
+		gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
+
+		## coord
+		var data = new Array[Float]
+		data.add_all([-1.0, -1.0, 0.0,
+	                   1.0, -1.0, 0.0,
+	                  -1.0,  1.0, 0.0,
+	                   1.0,  1.0, 0.0])
+		## tex_coord
+		data.add_all([0.0, 0.0,
+		              1.0, 0.0,
+		              0.0, 1.0,
+		              1.0, 1.0])
+		var c_data = new GLfloatArray.from(data)
+		glBufferData(gl_ARRAY_BUFFER, data.length*4, c_data.native_array, gl_STATIC_DRAW)
+
+		glBindBuffer(gl_ARRAY_BUFFER, 0)
+
+		gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
+	end
+
+	# Init size or resize `depth_texture`
+	fun resize(display: GamnitDisplay, shadow_resolution: Int)
+	do
+		glBindFramebuffer(gl_FRAMEBUFFER, light_view_framebuffer)
+		var gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
+
+		# Depth texture
+		var depth_texture = self.depth_texture
+		glActiveTexture gl_TEXTURE0
+		glBindTexture(gl_TEXTURE_2D, depth_texture)
+		glTexParameteri(gl_TEXTURE_2D, gl_TEXTURE_MIN_FILTER, gl_LINEAR)
+		glTexParameteri(gl_TEXTURE_2D, gl_TEXTURE_MAG_FILTER, gl_NEAREST)
+		glTexParameteri(gl_TEXTURE_2D, gl_TEXTURE_WRAP_S, gl_CLAMP_TO_EDGE)
+		glTexParameteri(gl_TEXTURE_2D, gl_TEXTURE_WRAP_T, gl_CLAMP_TO_EDGE)
+		gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
+
+		# TODO support hardware shadows with GL ES 3.0 or GL_EXT_shadow_samplers
+		#glTexParameteri(gl_TEXTURE_2D, gl_TEXTURE_COMPARE_MODE, ...)
+
+		glTexImage2D(gl_TEXTURE_2D, 0, gl_DEPTH_COMPONENT,
+		             shadow_resolution, shadow_resolution,
+		             0, gl_DEPTH_COMPONENT, gl_UNSIGNED_SHORT, new Pointer.nul)
+		gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
+
+		glFramebufferTexture2D(gl_FRAMEBUFFER, gl_DEPTH_ATTACHMENT, gl_TEXTURE_2D, depth_texture, 0)
+		gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
+
+		# Check if the framebuffer is complete and valid
+		assert glCheckFramebufferStatus(gl_FRAMEBUFFER) == gl_FRAMEBUFFER_COMPLETE
+
+		# Take down
+		glBindTexture(gl_TEXTURE_2D, 0)
+		glBindFramebuffer(gl_FRAMEBUFFER, 0)
+		gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
+	end
+
+	var destroyed = false
+
+	fun destroy
+	do
+		if destroyed then return
+		destroyed = true
+
+		# Free the buffer
+		glDeleteBuffers([buffer_array])
+		var gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
+		buffer_array = -1
+
+		# Free the array and framebuffer plus its attachments
+		glDeleteBuffers([buffer_array])
+		glDeleteFramebuffers([light_view_framebuffer])
+		glDeleteTextures([depth_texture])
+	end
+end
+
+redef class Material
+	# Optimized draw of `model`, a part of `actor`, from the view of `camera`
+	#
+	# This drawing should only produce usable depth data. The default behavior,
+	# uses `shadow_depth_program`.
+	protected fun draw_depth(actor: Actor, model: LeafModel, camera: Camera)
+	do
+		var program = app.shadow_depth_program
+		program.use
+		program.mvp.uniform camera.mvp_matrix
+
+		var mesh = model.mesh
+
+		program.translation.uniform(actor.center.x, actor.center.y, actor.center.z, 0.0)
+		program.scale.uniform actor.scale
+		program.use_map_diffuse.uniform false
+
+		program.tex_coord.array_enabled = true
+		program.tex_coord.array(mesh.texture_coords, 2)
+
+		program.coord.array_enabled = true
+		program.coord.array(mesh.vertices, 3)
+
+		program.rotation.uniform new Matrix.gamnit_euler_rotation(actor.pitch, actor.yaw, actor.roll)
+
+		if mesh.indices.is_empty then
+			glDrawArrays(mesh.draw_mode, 0, mesh.vertices.length/3)
+		else
+			glDrawElements(mesh.draw_mode, mesh.indices.length, gl_UNSIGNED_SHORT, mesh.indices_c.native_array)
+		end
+	end
+
+end
+
+# Efficiently draw actors from the light view
+class ShadowDepthProgram
+	super GamnitProgramFromSource
+
+	redef var vertex_shader_source = """
+		// Vertex coordinates
+		attribute vec4 coord;
+
+		// Vertex translation
+		uniform vec4 translation;
+
+		// Vertex scaling
+		uniform float scale;
+
+		// Vertex coordinates on textures
+		attribute vec2 tex_coord;
+
+		// Vertex normal
+		attribute vec3 normal;
+
+		// Model view projection matrix
+		uniform mat4 mvp;
+
+		// Rotation matrix
+		uniform mat4 rotation;
+
+		// Output for the fragment shader
+		varying vec2 v_tex_coord;
+
+		void main()
+		{
+			vec4 pos = (vec4(coord.xyz * scale, 1.0) * rotation + translation);
+			gl_Position = pos * mvp;
+
+			// Pass varyings to the fragment shader
+			v_tex_coord = vec2(tex_coord.x, 1.0 - tex_coord.y);
+		}
+		""" @ glsl_vertex_shader
+
+	redef var fragment_shader_source = """
+		precision mediump float;
+
+		// Diffuse map
+		uniform bool use_map_diffuse;
+		uniform sampler2D map_diffuse;
+
+		varying vec2 v_tex_coord;
+
+		void main()
+		{
+			if (use_map_diffuse && texture2D(map_diffuse, v_tex_coord).a <= 0.01) {
+				discard;
+			}
+		}
+		""" @ glsl_fragment_shader
+
+	# Vertices coordinates
+	var coord = attributes["coord"].as(AttributeVec4) is lazy
+
+	# Should this program use the texture `map_diffuse`?
+	var use_map_diffuse = uniforms["use_map_diffuse"].as(UniformBool) is lazy
+
+	# Diffuse texture unit
+	var map_diffuse = uniforms["map_diffuse"].as(UniformSampler2D) is lazy
+
+	# Coordinates on the textures, per vertex
+	var tex_coord = attributes["tex_coord"].as(AttributeVec2) is lazy
+
+	# Diffuse color
+	var diffuse_color = uniforms["diffuse_color"].as(UniformVec4) is lazy
+
+	# Translation applied to each vertex
+	var translation = uniforms["translation"].as(UniformVec4) is lazy
+
+	# Rotation matrix
+	var rotation = uniforms["rotation"].as(UniformMat4) is lazy
+
+	# Scaling per vertex
+	var scale = uniforms["scale"].as(UniformFloat) is lazy
+
+	# Model view projection matrix
+	var mvp = uniforms["mvp"].as(UniformMat4) is lazy
+end
+
+# Draw the camera point of view on screen
+private class LightPointOfViewProgram
+	super GamnitProgramFromSource
+
+	redef var vertex_shader_source = """
+		// Vertex coordinates
+		attribute vec3 coord;
+
+		// Vertex coordinates on textures
+		attribute vec2 tex_coord;
+
+		// Output to the fragment shader
+		varying vec2 v_coord;
+
+		void main()
+		{
+			gl_Position = vec4(coord, 1.0);
+			v_coord = tex_coord;
+		}
+		""" @ glsl_vertex_shader
+
+	redef var fragment_shader_source = """
+		precision mediump float;
+
+		// Virtual screen texture / color attachment
+		uniform sampler2D texture0;
+
+		// Input from the vertex shader
+		varying vec2 v_coord;
+
+		void main()
+		{
+			gl_FragColor = texture2D(texture0, v_coord);
+		}
+		""" @ glsl_fragment_shader
+
+	# Vertices coordinates
+	var coord = attributes["coord"].as(AttributeVec3) is lazy
+
+	# Coordinates on the textures, per vertex
+	var tex_coord = attributes["tex_coord"].as(AttributeVec2) is lazy
+
+	# Visible texture
+	var texture = uniforms["texture0"].as(UniformSampler2D) is lazy
+end

--- a/lib/gamnit/display.nit
+++ b/lib/gamnit/display.nit
@@ -72,4 +72,7 @@ class GamnitDisplay
 	#
 	# The implementation varies per platform.
 	fun feed_events do end
+
+	# Extensions to OpenGL ES 2.0 supported by the current configuration
+	var gl_extensions: Array[String] is lazy do return glGetString(gl_EXTENSIONS).split(' ')
 end

--- a/lib/gamnit/dynamic_resolution.nit
+++ b/lib/gamnit/dynamic_resolution.nit
@@ -136,7 +136,11 @@ redef class App
 
 		# Draw
 		glDrawArrays(gl_TRIANGLE_STRIP, 0, 4)
+		gl_error = glGetError
+		assert gl_error == gl_NO_ERROR else print_error gl_error
 
+		# Take down
+		glBindBuffer(gl_ARRAY_BUFFER, 0)
 		gl_error = glGetError
 		assert gl_error == gl_NO_ERROR else print_error gl_error
 

--- a/lib/gamnit/dynamic_resolution.nit
+++ b/lib/gamnit/dynamic_resolution.nit
@@ -159,7 +159,7 @@ redef class App
 	end
 end
 
-# Program drawing the dynamic screen to the real screen
+# Handles to reused GL buffers and texture
 private class DynamicContext
 
 	# Real screen framebuffer
@@ -176,8 +176,6 @@ private class DynamicContext
 
 	# Buffer name for vertex data
 	var buffer_array: Int = -1
-
-	var float_per_vertex: Int is lazy do return 4 + 4 + 3
 
 	# Prepare all attributes once per resolution change
 	fun prepare_once(display: GamnitDisplay, max_dynamic_resolution_ratio: Float)
@@ -248,7 +246,7 @@ private class DynamicContext
 		# Depth
 		glBindRenderbuffer(gl_RENDERBUFFER, depthbuffer)
 		assert glIsRenderbuffer(depthbuffer)
-		glRenderbufferStorage(gl_RENDERBUFFER, gl_DEPTH_COMPNENT16, width, height)
+		glRenderbufferStorage(gl_RENDERBUFFER, gl_DEPTH_COMPONENT16, width, height)
 		glFramebufferRenderbuffer(gl_FRAMEBUFFER, gl_DEPTH_ATTACHMENT, gl_RENDERBUFFER, depthbuffer)
 		var gl_error = glGetError
 		assert gl_error == gl_NO_ERROR else print_error gl_error

--- a/lib/gamnit/gamnit.nit
+++ b/lib/gamnit/gamnit.nit
@@ -36,6 +36,13 @@ redef class App
 		var display = new GamnitDisplay
 		display.setup
 		self.display = display
+
+		# Print the current GL configuration, for debugging
+		print "GL vendor: {glGetString(gl_VENDOR)}"
+		print "GL renderer: {glGetString(gl_RENDERER)}"
+		print "GL version: {glGetString(gl_VERSION)}"
+		print "GLSL version: {glGetString(gl_SHADING_LANGUAGE_VERSION)}"
+		print "GL extensions: {glGetString(gl_EXTENSIONS)}"
 	end
 
 	# Core of the frame logic, executed only when the display is visible

--- a/lib/gamnit/programs.nit
+++ b/lib/gamnit/programs.nit
@@ -162,6 +162,14 @@ class UniformBool
 	fun uniform(val: Bool) do uniform_1i(location, if val then 1 else 0)
 end
 
+# Shader uniform of GLSL type `int`
+class UniformInt
+	super Uniform
+
+	# Set this uniform value
+	fun uniform(val: Int) do uniform_1i(location, val)
+end
+
 # Shader uniform of GLSL type `vec4`
 class UniformFloat
 	super Uniform
@@ -230,6 +238,7 @@ end
 class InactiveUniform
 	super InactiveVariable
 	super UniformBool
+	super UniformInt
 	super UniformFloat
 	super UniformSampler2D
 	super UniformVec2
@@ -408,6 +417,8 @@ abstract class GamnitProgram
 			var uniform
 			if typ == gl_BOOL then
 				uniform = new UniformBool(gl_program, name, location, size)
+			else if typ == gl_INT then
+				uniform = new UniformInt(gl_program, name, location, size)
 			else if typ == gl_SAMPLER_2D then
 				uniform = new UniformSampler2D(gl_program, name, location, size)
 			else if typ == gl_FLOAT then

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -1308,3 +1308,22 @@ fun gl_TEXTURE_BINDING_CUBE_MAP: GLGetParameterName `{ return GL_TEXTURE_BINDING
 fun gl_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING: GLGetParameterName `{ return GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING; `}
 fun gl_FRAMEBUFFER_BINDING: GLGetParameterName `{ return GL_FRAMEBUFFER_BINDING; `}
 fun gl_RENDERBUFFER_BINDING: GLGetParameterName `{ return GL_RENDERBUFFER_BINDING; `}
+
+# Return a string describing the current GL configuration
+fun glGetString(name: GLEnum): String do return glGetString_native(name).to_s
+private fun glGetString_native(name: GLEnum): CString `{ return (char*)glGetString(name); `}
+
+# Company responsible for this GL implementation
+fun gl_VENDOR: GLEnum `{ return GL_VENDOR; `}
+
+# Name of the renderer, typically specific to a particular configuration of the hardware platform
+fun gl_RENDERER: GLEnum `{ return GL_RENDERER; `}
+
+# Version or release number
+fun gl_VERSION: GLEnum `{ return GL_VERSION; `}
+
+# Version or release number for the shading language of the form
+fun gl_SHADING_LANGUAGE_VERSION: GLEnum `{ return GL_SHADING_LANGUAGE_VERSION; `}
+
+# Space-separated list of supported extensions to GL
+fun gl_EXTENSIONS: GLEnum `{ return GL_EXTENSIONS; `}

--- a/lib/glesv2/glesv2.nit
+++ b/lib/glesv2/glesv2.nit
@@ -755,7 +755,7 @@ fun gl_RGB565: GLRenderbufferFormat `{ return GL_RGB565; `}
 fun gl_RGB5_A1: GLRenderbufferFormat `{ return GL_RGB5_A1; `}
 
 # 16 depth bits format
-fun gl_DEPTH_COMPNENT16: GLRenderbufferFormat `{ return GL_DEPTH_COMPONENT16; `}
+fun gl_DEPTH_COMPONENT16: GLRenderbufferFormat `{ return GL_DEPTH_COMPONENT16; `}
 
 # 8 stencil bits format
 fun gl_STENCIL_INDEX8: GLRenderbufferFormat `{ return GL_STENCIL_INDEX8; `}
@@ -1206,6 +1206,7 @@ end
 fun gl_ALPHA: GLPixelFormat `{ return GL_ALPHA; `}
 fun gl_RGB: GLPixelFormat `{ return GL_RGB; `}
 fun gl_RGBA: GLPixelFormat `{ return GL_RGBA; `}
+fun gl_DEPTH_COMPONENT: GLPixelFormat `{ return GL_DEPTH_COMPONENT; `}
 
 # Set of buffers as a bitwise OR mask
 extern class GLBuffer `{ GLbitfield `}


### PR DESCRIPTION
Intro a basic API and the shaders for 3D actors to cast shadows. This feature is off by default, it can be activated by using a sun-like light with: `app.light = new ParallelLight`. This will require additional work to improve the performance, add more kind of lights (point, spotlight, ambient, etc.), support many lights and accept colored lights.

Many values can be tweaked to achieve the best performance tradeoff:

* `ParallelLight` is always centered on the `world_camera` to show shadows only around the player. Its attributes `width, height, depth` are in world coordinates and identify a prism where shadows are computed. Higher values show shadows further away and lower values show shadows in higher resolution.
* `App::shadow_resolution` sets the resolution of the depth texture. Higher is prettier but slower, there's also an upper limit depending on the hardware configuration. It is now hardcoded (but refinable) to 4096x4096 pixels, with is probably too high for some mobiles devices. More experimentation is needed to find a safe default value.
* For softer shadow edges, the shader applies a kind of antialiasing by tapping the depth texture many times for each fragment. It is currently hardcoded to 4 taps per fragment but it could be changed for better performances or smoother edges. I don't know where to expose this value in the API, it could be on the light, the material or even global. It can also be optimized by the hardware.

### Screenshots from Jump 'n' Gun

Looking down at the player's shadow:

![screenshot from 2017-08-29 10-31-48](https://user-images.githubusercontent.com/208057/29829419-62b27cfa-8cad-11e7-9d95-696e594f4490.png)

Complex shadows from a turret and a shield projector:

![screenshot from 2017-08-29 10-35-45](https://user-images.githubusercontent.com/208057/29829415-5f08d5c2-8cad-11e7-87ca-5e4566d2432b.png)