### PR TITLE
app.nit: easier root window selection and other misc improvements

### DIFF
--- a/contrib/benitlux/src/client/views/home_views.nit
+++ b/contrib/benitlux/src/client/views/home_views.nit
@@ -19,24 +19,9 @@ import beer_views
 import social_views
 import user_views
 
+redef fun root_window do return new HomeWindow
+
 redef class App
-	redef fun on_create
-	do
-		if debug then print "App::on_create"
-
-		# Create the main window
-		show_home
-		super
-	end
-
-	# Show the home/main windows
-	fun show_home
-	do
-		var window = new HomeWindow
-		window.refresh
-		push_window window
-	end
-
 	redef fun on_log_in
 	do
 		super

--- a/contrib/tnitter/src/tnitter_app.nit
+++ b/contrib/tnitter/src/tnitter_app.nit
@@ -38,18 +38,7 @@ import model
 # Delay in seconds before the next request after an error
 fun request_delay_on_error: Float do return 60.0
 
-redef class App
-	redef fun on_create
-	do
-		# Create the main window
-		push_window new TnitterWindow
-		super
-	end
-end
-
-# Main window
-class TnitterWindow
-	super Window
+redef class Window
 
 	private var layout = new VerticalLayout(parent=self)
 	private var list_posts = new ListLayout(parent=layout)
@@ -98,7 +87,7 @@ fun tnitter_server_uri: String do return "http://localhost:8080"
 abstract class AsyncTnitterRequest
 	super AsyncHttpRequest
 
-	private var window: TnitterWindow
+	private var window: Window
 
 	redef fun uri_root do return tnitter_server_uri
 

--- a/examples/calculator/art/icon-sci.svg
+++ b/examples/calculator/art/icon-sci.svg
@@ -13,8 +13,8 @@
    height="512"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="icon_sci.svg">
+   inkscape:version="0.92.1 r15371"
+   sodipodi:docname="icon-sci.svg">
   <defs
      id="defs4" />
   <sodipodi:namedview
@@ -25,7 +25,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4"
-     inkscape:cx="164.13268"
+     inkscape:cx="165.56125"
      inkscape:cy="278.8294"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -105,28 +105,16 @@
          id="path2999"
          style="" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-size:190.84666443px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Droid Sans;-inkscape-font-specification:Droid Sans"
-       x="318.1875"
-       y="744.69647"
-       id="text2994"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan2996"
-         x="318.1875"
-         y="744.69647">√</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:190.84666443px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Droid Sans;-inkscape-font-specification:Droid Sans"
-       x="72.978729"
-       y="725.84735"
-       id="text2998"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan3000"
-         x="72.978729"
-         y="725.84735">π</tspan></text>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4504"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:'Noto Sans';-inkscape-font-specification:'Noto Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 376.61565,748.14397 H 364.2218 L 338.40905,675.6446 h -16.77364 v -13.32572 h 27.30375 l 21.52616,62.80794 47.71167,-136.14598 h 13.60528 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4507"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:'Noto Sans';-inkscape-font-specification:'Noto Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       d="m 181.35503,716.1555 q 4.93891,0 8.38682,-1.86373 v 13.13934 q -4.56616,2.42286 -12.58022,2.42286 -21.15342,0 -21.15342,-24.41495 V 639.6491 h -43.33188 v 88.34113 H 96.089068 V 639.6491 H 75.3084 v -7.26857 l 13.698467,-6.70945 H 192.63064 v 13.97802 h -20.03517 v 64.67168 q 0,11.83472 8.75956,11.83472 z" />
     <flowRoot
        xml:space="preserve"
        id="flowRoot3002"
@@ -137,16 +125,15 @@
            height="282.85715"
            x="-225"
            y="-62.285713" /></flowRegion><flowPara
-         id="flowPara3008"></flowPara></flowRoot>    <text
-       xml:space="preserve"
-       style="font-size:190.84666443px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Droid Sans;-inkscape-font-specification:Droid Sans"
-       x="303.01755"
-       y="973.79059"
-       id="text3014"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan3016"
-         x="303.01755"
-         y="973.79059">x²</tspan></text>
+         id="flowPara3008" /></flowRoot>    <path
+       inkscape:connector-curvature="0"
+       id="path4499"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:'Noto Sans';-inkscape-font-specification:'Noto Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       d="m 335.60349,924.36988 -35.31781,-50.04133 h 19.1033 l 26.37188,38.57935 26.09232,-38.57935 h 18.91693 l -35.31782,50.04133 37.27474,52.27783 h -19.1033 l -27.86287,-40.81584 -28.23562,40.81584 h -18.91693 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4501"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:'Noto Sans';-inkscape-font-specification:'Noto Sans';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       d="m 454.6031,922.04021 h -53.862 v -10.25055 l 21.99209,-21.43298 q 11.83473,-11.46198 15.09627,-16.68044 3.35473,-5.31165 3.35473,-11.74154 0,-6.05715 -3.5411,-9.13232 -3.44791,-3.07516 -9.2255,-3.07516 -5.77758,0 -10.43693,2.23648 -4.65934,2.23649 -9.59824,5.96396 l -6.70945,-8.75956 q 12.39385,-10.53012 26.931,-10.53012 12.30066,0 19.19649,6.15034 6.98901,6.05714 6.98901,16.40088 0,4.2866 -1.21143,8.01407 -1.11824,3.63429 -3.5411,7.45495 -2.42286,3.72747 -6.33671,8.01407 -3.82066,4.28659 -26.37187,25.53319 h 37.27474 z" />
   </g>
 </svg>

--- a/examples/calculator/src/calculator.nit
+++ b/examples/calculator/src/calculator.nit
@@ -32,16 +32,7 @@ import calculator_logic
 # Show debug output?
 fun debug: Bool do return false
 
-redef class App
-	redef fun on_create
-	do
-		if debug then print "App::on_create"
-
-		# Create the main window
-		push_window new CalculatorWindow
-		super
-	end
-end
+redef fun root_window do return new CalculatorWindow
 
 # The main (and only) window of this calculator
 class CalculatorWindow

--- a/lib/android/data_store.nit
+++ b/lib/android/data_store.nit
@@ -20,14 +20,9 @@
 module data_store
 
 import app::data_store
-private import shared_preferences
+import shared_preferences
 
-redef class App
-	redef var data_store = new SharedPreferenceView
-end
-
-private class SharedPreferenceView
-	super DataStore
+redef class DataStore
 
 	# The `SharedPreferences` used to implement the `DataStore`
 	var shared_preferences = new SharedPreferences.privately(app, "data_store") is lazy

--- a/lib/android/shared_preferences/shared_preferences_api10.nit
+++ b/lib/android/shared_preferences/shared_preferences_api10.nit
@@ -397,7 +397,16 @@ class SharedPreferences
 		if serialized_string == "" then return null
 
 		var deserializer = new JsonDeserializer(serialized_string)
-		return deserializer.deserialize
+		var deserialized = deserializer.deserialize
+
+		var errors = deserializer.errors
+		if errors.not_empty then
+			# An update may have broken the versioning compatibility
+			print_error "{class_name} error at deserialization: {errors.join(", ")}"
+			return null # Let's be safe
+		end
+
+		return deserialized
 	end
 end
 

--- a/lib/app/data_store.nit
+++ b/lib/app/data_store.nit
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Simple data storage services
+# Key/value storage services
 #
-# The implementation varies per platform.
+# The main services is `App::data_store`, a `DataStore` holding any
+# serializable Nit object.
 module data_store
 
 import app_base
@@ -28,11 +29,60 @@ import android::data_store is conditional(android)
 import ios::data_store is conditional(ios)
 
 redef class App
+
 	# Services to store and load data
+	#
+	# ~~~
+	# import app::ui
+	# import app::data_store
+	#
+	# class MyWindow
+	#     super Window
+	#
+	#     var state = "Simple string or any serializable class"
+	#
+	#     redef fun on_save_state do app.data_store["state"] = state
+	#
+	#     redef fun on_restore_state
+	#     do
+	#         var state = app.data_store["state"]
+	#         if state isa String then self.state = state
+	#     end
+	# end
+	# ~~~
 	var data_store = new DataStore is lazy
 end
 
 # Simple data storage facility
+#
+# Write values with `[]=` and read with `[]`.
+# ~~~
+# import linux::data_store # Needed for testing only
+#
+# class A
+#     serialize
+#
+#     var b = true
+#     var f = 1.234
+# end
+#
+# var data_store = new DataStore
+# data_store["one"] = 1
+# data_store["str"] = "Some string"
+# data_store["a"] = new A
+#
+# assert data_store["one"] == 1
+# assert data_store["str"] == "Some string"
+# assert data_store["a"].as(A).b
+# assert data_store["a"].as(A).f == 1.234
+# assert data_store["other"] == null
+# ~~~
+#
+# Set to `null` to clear a value.
+# ~~~
+# data_store["one"] = null
+# assert data_store["one"] == null
+# ~~~
 class DataStore
 
 	# Get the object stored at `key`, or null if nothing is available

--- a/lib/app/data_store.nit
+++ b/lib/app/data_store.nit
@@ -29,11 +29,11 @@ import ios::data_store is conditional(ios)
 
 redef class App
 	# Services to store and load data
-	fun data_store: DataStore is abstract
+	var data_store = new DataStore is lazy
 end
 
 # Simple data storage facility
-interface DataStore
+class DataStore
 
 	# Get the object stored at `key`, or null if nothing is available
 	fun [](key: String): nullable Object is abstract

--- a/lib/app/examples/ui_example.nit
+++ b/lib/app/examples/ui_example.nit
@@ -16,7 +16,9 @@
 module ui_example is
 	app_name "app.nit UI"
 	app_namespace "org.nitlanguage.ui_example"
-	android_api_target 15
+	android_api_min 21
+	android_api_target 21
+	android_manifest_activity "android:theme=\"@android:style/Theme.Material\""
 end
 
 import app::ui
@@ -31,7 +33,7 @@ class UiExampleWindow
 	var layout = new ListLayout(parent=self)
 
 	# Some label
-	var some_label = new Label(parent=layout, text="This Window uses a ListLayout.")
+	var some_label = new Label(parent=layout, text="Sample Window using a ListLayout.")
 
 	# A checkbox
 	var checkbox = new CheckBox(parent=layout, text="A CheckBox")

--- a/lib/app/examples/ui_example.nit
+++ b/lib/app/examples/ui_example.nit
@@ -84,11 +84,4 @@ class SecondWindow
 	var another_label = new Label(parent=layout, text="Close it by tapping the back button.")
 end
 
-redef class App
-	redef fun on_create
-	do
-		# Create the main window
-		push_window new UiExampleWindow
-		super
-	end
-end
+redef fun root_window do return new UiExampleWindow

--- a/lib/app/http_request.nit
+++ b/lib/app/http_request.nit
@@ -13,6 +13,23 @@
 # limitations under the License.
 
 # HTTP request services: `AsyncHttpRequest` and `Text::http_get`
+#
+# ~~~nitish
+# import app::http_request
+#
+# class MyHttpRequest
+#     super AsyncHttpRequest
+#
+#     redef fun uri do return "http://example.com/"
+#
+#     redef fun on_load(data, status) do print "Received: {data or else "null"}"
+#
+#     redef fun on_fail(error) do print "Connection error: {error}"
+# end
+#
+# var req = new MyHttpRequest
+# req.start
+# ~~~
 module http_request
 
 import app_base
@@ -122,9 +139,14 @@ abstract class AsyncHttpRequest
 	fun after do end
 end
 
-# Minimal implementation of `AsyncHttpRequest` where `uri` is an attribute
+# Simple `AsyncHttpRequest` where `uri` is an attribute
 #
-# Prints on communication errors and when the server returns an HTTP status code not in the 200s.
+# Prints on communication errors and when the remote server returns an
+# HTTP status code not in the 200s.
+#
+# This class can be instantiated to execute a request where the response is
+# ignored by the application. Alternatively, it can be subclassed to implement
+# `on_load`.
 #
 # ~~~nitish
 # var request = new SimpleAsyncHttpRequest("http://example.com")

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Portable UI API for the _app.nit_ framework
+# Portable UI controls from mobiles apps
 module ui
 
 import app_base
@@ -30,10 +30,9 @@ redef class App
 	# This attribute is set by `push_window`.
 	var window: Window is noinit
 
-	# Make visible and push `window` on the top of `pop_window`
+	# Make `window` visible and push it on the top of the `window_stack`
 	#
-	# This method must be called at least once within `App::on_create`.
-	# It can be called at any times while the app is active.
+	# This method can be called at any times while the app is active.
 	fun push_window(window: Window)
 	do
 		window_stack.add window
@@ -185,6 +184,9 @@ class CompositeControl
 end
 
 # A window, root of the `Control` tree
+#
+# Each window should hold a single control, usually a `CompositeControl`,
+# which in turn holds all the displayed controls.
 class Window
 	super CompositeControl
 
@@ -195,7 +197,7 @@ class Window
 	fun on_back_button do app.pop_window
 end
 
-# A viewable `Control`
+# A visible `Control`
 abstract class View
 	super Control
 
@@ -205,7 +207,9 @@ abstract class View
 	var enabled: nullable Bool is writable, abstract, autoinit
 end
 
-# A control with some `text`
+# A control displaying some `text`
+#
+# For a text-only control, see `Label`.
 abstract class TextView
 	super View
 
@@ -245,17 +249,17 @@ class TextInput
 	var is_password: nullable Bool is writable
 end
 
-# A pushable button, raises `ButtonPressEvent`
+# A pressable button, raises `ButtonPressEvent`
 class Button
 	super TextView
 end
 
-# A text label
+# A simple text label
 class Label
 	super TextView
 end
 
-# Toggle control with two states and a label
+# Toggle control between two states, also displays a label
 class CheckBox
 	super TextView
 

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -38,6 +38,7 @@ redef class App
 	do
 		window_stack.add window
 		self.window = window
+		window.on_create
 	end
 
 	# Pop the current `window` from the stack and show the previous one
@@ -54,7 +55,11 @@ redef class App
 	# Stack of active windows
 	var window_stack = new Array[Window]
 
-	redef fun on_create do window.on_create
+	redef fun on_create
+	do
+		var window = root_window
+		push_window window
+	end
 
 	redef fun on_resume do window.on_resume
 
@@ -66,6 +71,13 @@ redef class App
 
 	redef fun on_save_state do window.on_save_state
 end
+
+# Hook to create the first window shown to the user
+#
+# By default, a `Window` is created, which can be refined to customize it.
+# However, most apps should refine this method to return a different window,
+# this way the app can have more than one window.
+fun root_window: Window do return new Window
 
 # An event created by an `AppComponent` and sent to `AppObserver`s
 interface AppEvent

--- a/lib/app/ui.nit
+++ b/lib/app/ui.nit
@@ -12,7 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Portable UI controls from mobiles apps
+# Portable UI controls for mobiles apps
+#
+# ~~~
+# import app::ui
+#
+# class MyWindow
+#     super Window
+#
+#     var layout = new ListLayout(parent=self)
+#     var lbl = new Label(parent=layout, text="Hello world", align=0.5)
+#     var but = new Button(parent=layout, text="Press here")
+#
+#     redef fun on_event(event) do lbl.text = "Pressed!"
+# end
+#
+# redef fun root_window do return new MyWindow
+# ~~~
 module ui
 
 import app_base

--- a/lib/ios/data_store.nit
+++ b/lib/ios/data_store.nit
@@ -32,7 +32,16 @@ redef class DataStore
 
 		# TODO report errors
 		var deserializer = new JsonDeserializer(nsstr.to_s)
-		return deserializer.deserialize
+		var deserialized = deserializer.deserialize
+
+		var errors = deserializer.errors
+		if errors.not_empty then
+			# An update may have broken the versioning compatibility
+			print_error "{class_name} error at deserialization: {errors.join(", ")}"
+			return null # Let's be safe
+		end
+
+		return deserialized
 	end
 
 	redef fun []=(key, value)

--- a/lib/ios/data_store.nit
+++ b/lib/ios/data_store.nit
@@ -19,12 +19,7 @@ import app::data_store
 import cocoa::foundation
 private import json
 
-redef class App
-	redef var data_store = new UserDefaultView
-end
-
-private class UserDefaultView
-	super DataStore
+redef class DataStore
 
 	# The `NSUserDefaults` used to implement `DataStore`
 	var user_defaults = new NSUserDefaults.standard_user_defaults is lazy

--- a/lib/linux/data_store.nit
+++ b/lib/linux/data_store.nit
@@ -66,6 +66,7 @@ redef class DataStore
 
 		# Prepare SELECT statement
 		var stmt = db.select("* FROM {db_table} WHERE key == {key.to_sql_string}")
+		if stmt == null then return null
 
 		# Execute statment
 		for row in stmt do
@@ -76,6 +77,13 @@ redef class DataStore
 			# Deserialize
 			var deserializer = new JsonDeserializer(serialized)
 			var deserialized = deserializer.deserialize
+
+			var errors = deserializer.errors
+			if errors.not_empty then
+				# An update may have broken the versioning compatibility
+				print_error "{class_name} error at deserialization: {errors.join(", ")}"
+				return null # Let's be safe
+			end
 
 			return deserialized
 		end

--- a/lib/linux/data_store.nit
+++ b/lib/linux/data_store.nit
@@ -19,15 +19,10 @@ module data_store
 
 import app::data_store
 private import xdg_basedir
-private import sqlite3
+import sqlite3
 private import json
 
-redef class App
-	redef var data_store = new LinuxStore
-end
-
-private class LinuxStore
-	super DataStore
+redef class DataStore
 
 	# File path of the Sqlite3 DB file
 	fun db_file: String do return "data_store.db"
@@ -35,7 +30,7 @@ private class LinuxStore
 	# Sqlite3 table used
 	fun db_table: String do return "data_store"
 
-	var db_cache: nullable Sqlite3DB = null
+	private var db_cache: nullable Sqlite3DB = null
 
 	# Database to use to implement the `DataStore`
 	fun db: nullable Sqlite3DB

--- a/src/highlight.nit
+++ b/src/highlight.nit
@@ -21,14 +21,16 @@ import pipeline
 import astutil
 import serialization
 
-# Fully process a content as a nit source file.
-fun hightlightcode(hl: HighlightVisitor, content: String): HLCode
+# Fully process `content` as a Nit source file.
+#
+# Set `print_errors = true` to print errors in the code to the console.
+fun hightlightcode(hl: HighlightVisitor, content: String, print_errors: nullable Bool): HLCode
 do
 	# Prepare a stand-alone tool context
 	var tc = new ToolContext
 	tc.nit_dir = tc.locate_nit_dir # still use the common lib to have core
 	tc.keep_going = true # no exit, obviously
-	tc.opt_warn.value = -1 # no output, obviously
+	if print_errors != true then tc.opt_warn.value = -1 # no output
 
 	# Prepare an stand-alone model and model builder.
 	# Unfortunately, models are enclosing and append-only.


### PR DESCRIPTION
Intro the hook `root_window` for clients to set the desired root (or home) window. It is much shorter than the previous redef of `on_create`. Plus, in very simple apps, the client can simple redef `Window` instead of subclassing it.

Refactor `data_store` structure, replacing the interface and subclasses by refinements of a single class. It follows more closely the strategy used by the UI API while not changing anything to the `data_store` API. The data store now drops potentially partially deserialized objects to avoid hard to report crash at runtime, this could be improved upon in the future as the current implementation is not ideal.

Otherwise, this PR brings general improvements to the framework influenced by the creation of [paninit.com](http://paninit.com/): revamp the documentation, add unit tests, fix the scientific calculator icon and add an option to report errors in `hightlightcode`. 