### PR TITLE
json::dynamic: extend `get` to support arrays and keys with dots

### DIFF
--- a/lib/json/dynamic.nit
+++ b/lib/json/dynamic.nit
@@ -131,10 +131,7 @@ class JsonValue
 	#     assert "123".to_json_value.to_s == "123"
 	#     assert "true".to_json_value.to_s == "true"
 	#     assert "[1, 2, 3]".to_json_value.to_s == "[1,2,3]"
-	redef fun to_s do
-		if value == null then return "null"
-		return value.to_s
-	end
+	redef fun to_s do return (value or else "null").to_s
 
 	### Objects
 

--- a/lib/json/dynamic.nit
+++ b/lib/json/dynamic.nit
@@ -192,19 +192,6 @@ class JsonValue
 	# require: `self.is_error`
 	fun to_error: Error do return value.as(Error)
 
-	### JsonParseError
-
-	# Is this value a parse error?
-	#
-	#     assert "[".to_json_value.is_parse_error
-	#     assert not "[]".to_json_value.is_parse_error
-	fun is_parse_error: Bool do return value isa JsonParseError
-
-	# Get this value as a `JsonParseError`.
-	#
-	# require: `self.is_parse_error`
-	fun to_parse_error: JsonParseError do return value.as(JsonParseError)
-
 	### Children access
 
 	# Iterator over the values of the array `self`
@@ -311,7 +298,8 @@ class JsonValue
 	# Return a human-readable description of the type.
 	#
 	# For debugging purpose only.
-	fun json_type: String do
+	private fun json_type: String
+	do
 		if is_array then return "array"
 		if is_bool then return "bool"
 		if is_float then return "float"
@@ -319,7 +307,6 @@ class JsonValue
 		if is_null then return "null"
 		if is_map then return "map"
 		if is_string then return "string"
-		if is_parse_error then return "parse_error"
 		if is_error then return "error"
 		return "undefined"
 	end


### PR DESCRIPTION
Extend `JsonValue::get` to support arrays and keys containing the '.' character.

As a general cleanup, remove services specific to parsing errors as clients should check errors only once, and update and standardize the documentation.