### PR TITLE
lib/markdown: fix `text` for nested markdown blocks

### DIFF
--- a/lib/markdown/markdown.nit
+++ b/lib/markdown/markdown.nit
@@ -1140,6 +1140,12 @@ class MDBlock
 			text.append "\n"
 			line = line.next
 		end
+		var block = first_block
+		while block != null do
+			text.append block.text
+			text.append "\n"
+			block = block.next
+		end
 		return text.write_to_string
 	end
 end


### PR DESCRIPTION
Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>