### PR TITLE
Model filters: extract filters from ModelVisitor

### DIFF
--- a/src/doc/doc_base.nit
+++ b/src/doc/doc_base.nit
@@ -28,6 +28,8 @@ import model::model_views
 class DocModel
 	super ModelView
 
+	autoinit model, mainmodule, filter
+
 	# `DocPage` composing the documentation associated to their ids.
 	#
 	# This is where `DocPhase` store and access pages to produce documentation.

--- a/src/doc/doc_phases/doc_html.nit
+++ b/src/doc/doc_phases/doc_html.nit
@@ -318,7 +318,9 @@ redef class MModulePage
 	redef fun init_topmenu(v, doc) do
 		super
 		var mpackage = mentity.mpackage
-		topmenu.add_li new ListItem(new Link(mpackage.nitdoc_url, mpackage.html_name))
+		if mpackage != null then
+			topmenu.add_li new ListItem(new Link(mpackage.nitdoc_url, mpackage.html_name))
+		end
 		topmenu.add_li new ListItem(new Link(mentity.nitdoc_url, mentity.html_name))
 		topmenu.active_item = topmenu.items.last
 	end

--- a/src/metrics/codesmells_metrics.nit
+++ b/src/metrics/codesmells_metrics.nit
@@ -34,7 +34,8 @@ class CodeSmellsMetricsPhase
 	redef fun process_mainmodule(mainmodule, given_mmodules) do
 		print toolcontext.format_h1("--- Code Smells Metrics ---")
 
-		var view = new ModelView(toolcontext.modelbuilder.model, mainmodule)
+		var filter = new ModelFilter(private_visibility)
+		var view = new ModelView(toolcontext.modelbuilder.model, mainmodule, filter)
 		self.set_all_average_metrics(view)
 		var mclass_codesmell = new BadConceptonController(view)
 		var collect = new Counter[MClassDef]

--- a/src/metrics/mclasses_metrics.nit
+++ b/src/metrics/mclasses_metrics.nit
@@ -37,7 +37,8 @@ private class MClassesMetricsPhase
 		out.mkdir
 
 		var model = toolcontext.modelbuilder.model
-		var model_view = new ModelView(model, mainmodule)
+		var filter = new ModelFilter(private_visibility)
+		var model_view = new ModelView(model, mainmodule, filter)
 
 		print toolcontext.format_h1("\n# MClasses metrics")
 

--- a/src/metrics/mendel_metrics.nit
+++ b/src/metrics/mendel_metrics.nit
@@ -67,8 +67,8 @@ private class MendelMetricsPhase
 		print toolcontext.format_h1("\n# Mendel metrics")
 
 		var model = toolcontext.modelbuilder.model
-		var model_view = new ModelView(model, mainmodule)
-		model_view.min_visibility = protected_visibility
+		var filter = new ModelFilter(min_visibility = protected_visibility)
+		var model_view = new ModelView(model, mainmodule, filter)
 
 		var mclasses = new HashSet[MClass]
 		for mclass in model_view.mclasses do

--- a/src/metrics/nullables_metrics.nit
+++ b/src/metrics/nullables_metrics.nit
@@ -40,7 +40,8 @@ private class NullablesMetricsPhase
 		print toolcontext.format_h1("\n# Nullable metrics")
 
 		var model = toolcontext.modelbuilder.model
-		var model_view = new ModelView(model, mainmodule)
+		var filter = new ModelFilter(private_visibility)
+		var model_view = new ModelView(model, mainmodule, filter)
 
 		var metrics = new MetricSet
 		metrics.register(new CNBA(model_view))

--- a/src/metrics/rta_metrics.nit
+++ b/src/metrics/rta_metrics.nit
@@ -38,8 +38,8 @@ private class RTAMetricsPhase
 		out.mkdir
 
 		var model = toolcontext.modelbuilder.model
-		var model_view = new ModelView(model, mainmodule)
-		model_view.min_visibility = protected_visibility
+		var filter = new ModelFilter(min_visibility = protected_visibility)
+		var model_view = new ModelView(model, mainmodule, filter)
 
 		print toolcontext.format_h1("\n# RTA metrics")
 

--- a/src/model/model.nit
+++ b/src/model/model.nit
@@ -159,6 +159,14 @@ class ConcernsTree
 	super OrderedTree[MConcern]
 end
 
+redef class MGroup
+	redef var is_test is lazy do
+		var parent = self.parent
+		if parent != null and parent.is_test then return true
+		return name == "tests"
+	end
+end
+
 redef class MModule
 	# All the classes introduced in the module
 	var intro_mclasses = new Array[MClass]

--- a/src/model/model_filters.nit
+++ b/src/model/model_filters.nit
@@ -1,0 +1,198 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module model_filters
+
+import model
+
+# A list of filters that can be applied on a MEntity
+#
+#
+# By default ModelFilter accepts all mentity.
+#
+# ~~~nitish
+# var filter = new ModelFilter
+# assert filter.accept_mentity(my_mentity) == true
+# ~~~
+#
+# To quickly configure the filters, options can be passed to the constructor:
+# ~~~
+# var filter = new ModelFilter(
+#	min_visibility = protected_visibility,
+#	accept_fictive = false,
+#	accept_test = false,
+#	accept_redef = false,
+#	accept_extern = false,
+#	accept_attribute = false,
+#	accept_empty_doc = false
+# )
+# ~~~
+class ModelFilter
+
+	# Accept `mentity` based on all the options from `self`?
+	#
+	# If one of the filter returns `false` then the `mentity` is not accepted.
+	fun accept_mentity(mentity: MEntity): Bool do
+		if not accept_mentity_visibility(mentity) then return false
+		if not accept_mentity_fictive(mentity) then return false
+		if not accept_mentity_test(mentity) then return false
+		if not accept_mentity_redef(mentity) then return false
+		if not accept_mentity_extern(mentity) then return false
+		if not accept_mentity_attribute(mentity) then return false
+		if not accept_mentity_empty_doc(mentity) then return false
+		if not accept_mentity_inherited(mentity) then return false
+		if not accept_mentity_full_name(mentity) then return false
+		return true
+	end
+
+	# Minimum visibility an entity must have to be accepted
+	#
+	# Default is `private_visibility`.
+	var min_visibility: MVisibility = private_visibility is optional, writable
+
+	# Accept `mentity` if its visibility is above `min_visibility`
+	fun accept_mentity_visibility(mentity: MEntity): Bool do
+		return mentity.visibility >= min_visibility
+	end
+
+	# Accept fictive entities?
+	#
+	# Default is `true`.
+	var accept_fictive = true is optional, writable
+
+	# Accept only non-fictive entities
+	#
+	# See `MEntity::is_fictive`.
+	fun accept_mentity_fictive(mentity: MEntity): Bool do
+		if accept_fictive then return true
+		return not mentity.is_fictive
+	end
+
+	# Accept nitunit test suites?
+	#
+	# Default is `true`.
+	var accept_test = true is optional, writable
+
+	# Accept only entities that are not `nitunit` related
+	fun accept_mentity_test(mentity: MEntity): Bool do
+		if accept_test then return true
+		if mentity isa MProperty then return accept_mentity(mentity.intro)
+		if mentity isa MMethodDef then
+			if mentity.is_before then return false
+			if mentity.is_before_all then return false
+			if mentity.is_after then return false
+			if mentity.is_after_all then return false
+		end
+		return not mentity.is_test
+	end
+
+	# Accept redef classdefs and propdefs?
+	#
+	# Default is `true`.
+	var accept_redef = true is optional, writable
+
+	# Accept a MClassDefs and MPropeDefs onyl if they are an introduction
+	#
+	# See `MClassDef::is_intro` and `MPropDef::is_intro`.
+	fun accept_mentity_redef(mentity: MEntity): Bool do
+		if accept_redef then return true
+		if mentity isa MClassDef then
+			return mentity.is_intro
+		else if mentity isa MPropDef then
+			return mentity.is_intro
+		end
+		return true
+	end
+
+	# Accept extern entities?
+	#
+	# Default is `true`.
+	var accept_extern = true is optional, writable
+
+	# Accept only non- extern entities
+	#
+	# See `MEntity::is_extern`.
+	fun accept_mentity_extern(mentity: MEntity): Bool do
+		if accept_extern then return true
+		if mentity isa MMethodDef then
+			return not mentity.is_extern
+		end
+		return true
+	end
+
+	# Accept `MAttribute` and `MAttributeDef` instances?
+	#
+	# Default is `true`.
+	var accept_attribute = true is optional, writable
+
+	# Accept only entities that are not a `MAttribute` or `MAttributeDef`
+	fun accept_mentity_attribute(mentity: MEntity): Bool do
+		if accept_attribute then return true
+		if mentity isa MAttribute then return false
+		if mentity isa MAttributeDef then return false
+		return true
+	end
+
+	# Accept entities with empty documentation?
+	#
+	# Default is `true`.
+	var accept_empty_doc = true is optional, writable
+
+	# Accept only entities with documentation
+	fun accept_mentity_empty_doc(mentity: MEntity): Bool do
+		if accept_empty_doc then return true
+		return mentity.mdoc_or_fallback != null
+	end
+
+	# If set, accept only entities local to `accept_inherited`
+	var accept_inherited: nullable MEntity = null is optional
+
+	# Accept only entities local to `accept_inherited`
+	#
+	# This means no imported or inherited entities.
+	fun accept_mentity_inherited(mentity: MEntity): Bool do
+		var context = accept_inherited
+		if context == null then return true
+		if context isa MPackage then
+			if mentity isa MGroup then return mentity.mpackage == context
+			if mentity isa MModule then return mentity.mpackage == context
+		end
+		if context isa MGroup then
+			if mentity isa MModule then return mentity.mgroup == context
+		end
+		if context isa MModule then
+			if mentity isa MClass then return mentity.intro.mmodule == context
+			if mentity isa MClassDef then return mentity.mmodule == context
+		end
+		if context isa MClass then
+			if mentity isa MProperty then return mentity.intro_mclassdef.mclass == context
+			if mentity isa MPropDef then return mentity.mclassdef.mclass == context
+		end
+		if context isa MClassDef then
+			if mentity isa MProperty then return mentity.intro_mclassdef == context
+			if mentity isa MPropDef then return mentity.mclassdef == context
+		end
+		return true
+	end
+
+	# If set, accept only entities where `MEntity::full_name` contains `string`
+	var accept_full_name: nullable String = null is optional, writable
+
+	# Accept only entities where `MEntity::full_name` contains `string`
+	fun accept_mentity_full_name(mentity: MEntity): Bool do
+		var string = accept_full_name
+		if string == null then return true
+		return mentity.full_name.has(string)
+	end
+end

--- a/src/model/model_json.nit
+++ b/src/model/model_json.nit
@@ -162,7 +162,8 @@ redef class MClass
 		super
 		v.serialize_attribute("mparameters", mparameters)
 		if v isa FullJsonSerializer then
-			var view = new ModelView(model, v.mainmodule)
+			var filter = new ModelFilter(private_visibility)
+			var view = new ModelView(model, v.mainmodule, filter)
 			v.serialize_attribute("intro", to_mentity_ref(intro))
 			v.serialize_attribute("intro_mmodule", to_mentity_ref(intro_mmodule))
 			v.serialize_attribute("mpackage", to_mentity_ref(intro_mmodule.mpackage))
@@ -181,7 +182,8 @@ redef class MClassDef
 		v.serialize_attribute("is_intro", is_intro)
 		v.serialize_attribute("mparameters", mclass.mparameters)
 		if v isa FullJsonSerializer then
-			var view = new ModelView(model, v.mainmodule)
+			var filter = new ModelFilter(private_visibility)
+			var view = new ModelView(model, v.mainmodule, filter)
 			v.serialize_attribute("mmodule", to_mentity_ref(mmodule))
 			v.serialize_attribute("mclass", to_mentity_ref(mclass))
 			v.serialize_attribute("mpropdefs", to_mentity_refs(sort_entities(mpropdefs)))

--- a/src/model/model_views.nit
+++ b/src/model/model_views.nit
@@ -25,6 +25,8 @@ import model_visitor
 class ModelView
 	super ModelVisitor
 
+	autoinit(model, mainmodule, filter)
+
 	# The model to view through `self`.
 	var model: Model
 
@@ -120,14 +122,6 @@ class ModelView
 		return res
 	end
 
-	private fun init_visitor(v: ModelVisitor) do
-		v.min_visibility = self.min_visibility
-		v.include_fictive = self.include_fictive
-		v.include_empty_doc = self.include_empty_doc
-		v.include_attribute = self.include_attribute
-		v.include_test = self.include_test
-	end
-
 	# Searches the MEntity that matches `full_name`.
 	fun mentity_by_full_name(full_name: String): nullable MEntity do
 		for mentity in mentities do
@@ -139,7 +133,7 @@ class ModelView
 	# Build an concerns tree with from `self`
 	fun to_tree: MEntityTree do
 		var v = new ModelTreeVisitor
-		init_visitor(v)
+		v.filter = self.filter
 		for mpackage in mpackages do
 			v.enter_visit(mpackage)
 		end
@@ -178,7 +172,6 @@ class ModelTreeVisitor
 end
 
 redef class MEntity
-
 	private fun accept_namespace_visitor(v: LookupNamespaceVisitor) do
 		if v.parts.is_empty then return
 		if name != v.parts.first then return

--- a/src/model/model_visitor.nit
+++ b/src/model/model_visitor.nit
@@ -41,12 +41,13 @@
 # ~~~
 module model_visitor
 
-import model
+import model_filters
 
 # The abstract model visitor template.
 #
 # Specific visitor must implement the `visit` method to perform the work.
 abstract class ModelVisitor
+
 	# Visit the entity `e`.
 	#
 	# This method setups `current_entity` and call `visit`.
@@ -68,81 +69,30 @@ abstract class ModelVisitor
 	# It should not be called directly but used by `enter_visit`
 	protected fun visit(e: MEntity) is abstract
 
-	# Filter classes and method on the visibility.
+	# Filters to apply when visiting the model.
 	#
-	# If set, only the classes and method with at least the given
-	# visibility level will be visited.
-	var min_visibility: nullable MVisibility = null is writable
-
-	# Can we accept this `mentity` in the view regarding its visibility?
-	fun accept_visibility(mentity: MEntity): Bool do
-		return mentity.accept_visibility(min_visibility)
-	end
-
-	# Include fictive entities?
-	#
-	# By default, fictive entities (see `MEntity::is_fictive`) are not visited.
-	var include_fictive = false is writable
-
-	# Can we accept this `mentity` in the view regarding its fictivity?
-	fun accept_fictive(mentity: MEntity): Bool do
-		if include_fictive then return true
-		return not mentity.is_fictive
-	end
-
-	# Should we accept mentities with empty documentation?
-	#
-	# Default is `true`.
-	var include_empty_doc = true is writable
-
-	# Can we accept this `mentity` regarding its documentation?
-	fun accept_empty_doc(mentity: MEntity): Bool do
-		if include_empty_doc then return true
-		return mentity.mdoc != null
-	end
-
-	# Should we accept nitunit test suites?
-	#
-	# Default is `false`.
-	var include_test = false is writable
-
-	# Can we accept this `mentity` regarding its test suite status?
-	fun accept_test(mentity: MEntity): Bool do
-		if include_test then return true
-		if mentity isa MProperty then
-			if mentity.is_before or mentity.is_before_all then return false
-			if mentity.is_after or mentity.is_after_all then return false
-		end
-		if mentity isa MPropDef then
-			if mentity.is_before or mentity.is_before_all then return false
-			if mentity.is_after or mentity.is_after_all then return false
-		end
-		return not mentity.is_test
-	end
-
-	# Should we accept `MAttribute` instances?
-	#
-	# Default is `true`.
-	var include_attribute = true is writable
-
-	# Can we accept this `mentity` regarding its type?
-	fun accept_attribute(mentity: MEntity): Bool do
-		if include_attribute then return true
-		if mentity isa MAttribute then return false
-		if mentity isa MAttributeDef then return false
-		return true
+	# See ModelFilters for configuration.
+	var filter: ModelFilter is lazy, writable, optional do
+		return new ModelFilter(
+			min_visibility = protected_visibility,
+			accept_fictive = false,
+			accept_test = false,
+			accept_redef = true,
+			accept_extern = true,
+			accept_attribute = true,
+			accept_empty_doc = true
+		)
 	end
 
 	# Should we accept this `mentity` from the view?
-	fun accept_mentity(mentity: MEntity): Bool do
-		if not accept_visibility(mentity) then return false
-		if not accept_fictive(mentity) then return false
-		if not accept_empty_doc(mentity) then return false
-		if not accept_test(mentity) then return false
-		if not accept_attribute(mentity) then return false
-		return true
+	#
+	# If no `override_filter` is passed then use `self.filter`.
+	fun accept_mentity(mentity: MEntity, override_filter: nullable ModelFilter): Bool do
+		if override_filter != null then
+			return override_filter.accept_mentity(mentity)
+		end
+		return filter.accept_mentity(mentity)
 	end
-
 end
 
 redef class MEntity
@@ -150,11 +100,6 @@ redef class MEntity
 	#
 	# See the specific implementation in the subclasses.
 	fun visit_all(v: ModelVisitor) do end
-
-	private fun accept_visibility(min_visibility: nullable MVisibility): Bool do
-		if min_visibility == null then return true
-		return visibility >= min_visibility
-	end
 end
 
 redef class Model

--- a/src/nitdoc.nit
+++ b/src/nitdoc.nit
@@ -46,7 +46,10 @@ private class Nitdoc
 		var accept_attribute = true
 		if toolcontext.opt_no_attributes.value then accept_attribute = false
 
-		var filters = new ModelFilter(min_visibility, accept_attribute = accept_attribute)
+		var filters = new ModelFilter(
+			min_visibility,
+			accept_attribute = accept_attribute,
+			accept_fictive = false)
 		var doc = new DocModel(mainmodule.model, mainmodule, filters)
 
 		var phases = [

--- a/src/nitdoc.nit
+++ b/src/nitdoc.nit
@@ -41,9 +41,13 @@ private class Nitdoc
 	super Phase
 	redef fun process_mainmodule(mainmodule, mmodules)
 	do
-		var doc = new DocModel(mainmodule.model, mainmodule)
-		if not toolcontext.opt_private.value then doc.min_visibility = protected_visibility
-		if not toolcontext.opt_no_attributes.value then doc.include_attribute = false
+		var min_visibility = private_visibility
+		if not toolcontext.opt_private.value then min_visibility = protected_visibility
+		var accept_attribute = true
+		if toolcontext.opt_no_attributes.value then accept_attribute = false
+
+		var filters = new ModelFilter(min_visibility, accept_attribute = accept_attribute)
+		var doc = new DocModel(mainmodule.model, mainmodule, filters)
 
 		var phases = [
 			new IndexingPhase(toolcontext, doc),

--- a/src/nituml.nit
+++ b/src/nituml.nit
@@ -41,11 +41,12 @@ private class UMLPhase
 	super Phase
 	redef fun process_mainmodule(mainmodule, mmodules)
 	do
-		var view = new ModelView(mainmodule.model, mainmodule)
+		var filters = new ModelFilter
 		if not toolcontext.opt_privacy.value then
-			view.min_visibility = protected_visibility
+			filters.min_visibility = protected_visibility
 		end
 
+		var view = new ModelView(mainmodule.model, mainmodule, filters)
 		var d = new UMLModel(view, mainmodule)
 		if toolcontext.opt_gen.value == 0 then
 			print d.generate_class_uml.write_to_string

--- a/src/test_model_index.nit
+++ b/src/test_model_index.nit
@@ -65,8 +65,12 @@ toolcontext.run_global_phases(mmodules)
 var mainmodule = toolcontext.make_main_module(mmodules)
 
 # Build index
+var filters = new ModelFilter(
+	private_visibility,
+	accept_fictive = false,
+	accept_test = false)
+var view = new ModelView(model, mainmodule, filters)
 var index = new ModelIndex
-var view = new ModelView(model, mainmodule)
 for mentity in view.mentities do
 	if mentity isa MClassDef or mentity isa MPropDef then continue
 	index.index(mentity)

--- a/src/test_model_visitor.nit
+++ b/src/test_model_visitor.nit
@@ -55,42 +55,39 @@ do
 	var model = modelbuilder.model
 
 	print "All entities, including fictive ones:"
-	var v = new TestModelVisitor
-	v.min_visibility = private_visibility
-	v.include_fictive = true
+	var filters = new ModelFilters(private_visibility, accept_fictive = true)
+	var v = new TestModelVisitor(filters)
 	v.enter_visit(model)
 	v.cpt.print_elements(10)
 	var names = v.names
 
 	print "All entities:"
-	v = new TestModelVisitor
-	v.min_visibility = private_visibility
+	filters = new ModelFilters(private_visibility)
+	v = new TestModelVisitor(filters)
 	v.enter_visit(model)
 	v.cpt.print_elements(10)
 
 	print "\nAll non-private entities:"
-	v = new TestModelVisitor
-	v.min_visibility = protected_visibility
+	filters = new ModelFilters(protected_visibility)
+	v = new TestModelVisitor(filters)
 	v.enter_visit(model)
 	v.cpt.print_elements(10)
 
 	print "\nAll documented non-private entities:"
-	v = new TestModelVisitor
-	v.min_visibility = protected_visibility
-	v.include_empty_doc = false
+	filters = new ModelFilters(protected_visibility, accept_empty_doc = false)
+	v = new TestModelVisitor(filters)
 	v.enter_visit(model)
 	v.cpt.print_elements(10)
 
 	print "\nAll public entities:"
-	v = new TestModelVisitor
-	v.min_visibility = public_visibility
+	filters = new ModelFilters(public_visibility)
+	v = new TestModelVisitor(filters)
 	v.enter_visit(model)
 	v.cpt.print_elements(10)
 
 	print "\nAll documented public entities:"
-	v = new TestModelVisitor
-	v.min_visibility = public_visibility
-	v.include_empty_doc = false
+	filters = new ModelFilters(public_visibility, accept_empty_doc = false)
+	v = new TestModelVisitor(filters)
 	v.enter_visit(model)
 	v.cpt.print_elements(10)
 

--- a/src/test_model_visitor.nit
+++ b/src/test_model_visitor.nit
@@ -55,38 +55,38 @@ do
 	var model = modelbuilder.model
 
 	print "All entities, including fictive ones:"
-	var filters = new ModelFilters(private_visibility, accept_fictive = true)
+	var filters = new ModelFilter(private_visibility, accept_fictive = true)
 	var v = new TestModelVisitor(filters)
 	v.enter_visit(model)
 	v.cpt.print_elements(10)
 	var names = v.names
 
 	print "All entities:"
-	filters = new ModelFilters(private_visibility)
+	filters = new ModelFilter(private_visibility)
 	v = new TestModelVisitor(filters)
 	v.enter_visit(model)
 	v.cpt.print_elements(10)
 
 	print "\nAll non-private entities:"
-	filters = new ModelFilters(protected_visibility)
+	filters = new ModelFilter(protected_visibility)
 	v = new TestModelVisitor(filters)
 	v.enter_visit(model)
 	v.cpt.print_elements(10)
 
 	print "\nAll documented non-private entities:"
-	filters = new ModelFilters(protected_visibility, accept_empty_doc = false)
+	filters = new ModelFilter(protected_visibility, accept_empty_doc = false)
 	v = new TestModelVisitor(filters)
 	v.enter_visit(model)
 	v.cpt.print_elements(10)
 
 	print "\nAll public entities:"
-	filters = new ModelFilters(public_visibility)
+	filters = new ModelFilter(public_visibility)
 	v = new TestModelVisitor(filters)
 	v.enter_visit(model)
 	v.cpt.print_elements(10)
 
 	print "\nAll documented public entities:"
-	filters = new ModelFilters(public_visibility, accept_empty_doc = false)
+	filters = new ModelFilter(public_visibility, accept_empty_doc = false)
 	v = new TestModelVisitor(filters)
 	v.enter_visit(model)
 	v.cpt.print_elements(10)

--- a/src/web/api_graph.nit
+++ b/src/web/api_graph.nit
@@ -46,6 +46,8 @@ end
 class InheritanceGraph
 	super ModelVisitor
 
+	autoinit center, view, filter
+
 	# MEntity at the center of this graph
 	var center: MEntity
 

--- a/src/web/api_model.nit
+++ b/src/web/api_model.nit
@@ -70,10 +70,19 @@ class APIList
 		return mentities
 	end
 
+	# Filter mentities based on the config view filters
+	fun filter_mentities(req: HttpRequest, mentities: Array[MEntity]): Array[MEntity] do
+		var res = new Array[MEntity]
+		for mentity in mentities do
+			if config.view.filter.accept_mentity(mentity) then res.add mentity
+		end
+		return res
+	end
+
 	# Sort mentities by lexicographic order
 	#
 	# TODO choose order from request
-	fun sort_mentities(req: HttpRequest, mentities: Array[MEntity]) : Array[MEntity] do
+	fun sort_mentities(req: HttpRequest, mentities: Array[MEntity]): Array[MEntity] do
 		var sorted = mentities.to_a
 		var sorter = new MEntityNameSorter
 		sorter.sort(sorted)
@@ -135,6 +144,7 @@ class APIRandom
 
 	redef fun get(req, res) do
 		var mentities = list_mentities(req)
+		mentities = filter_mentities(req, mentities)
 		mentities = randomize_mentities(req, mentities)
 		mentities = limit_mentities(req, mentities)
 		res.json new JsonArray.from(mentities)
@@ -235,6 +245,7 @@ class APIEntityDefs
 			res.api_error(404, "No definition list for mentity `{mentity.full_name}`")
 			return
 		end
+		mentities = filter_mentities(req, mentities)
 		mentities = sort_mentities(req, mentities)
 		mentities = limit_mentities(req, mentities)
 		res.json new JsonArray.from(mentities)

--- a/src/web/web_base.nit
+++ b/src/web/web_base.nit
@@ -38,18 +38,8 @@ class NitwebConfig
 	# Modelbuilder used to access sources.
 	var modelbuilder: ModelBuilder
 
-	# The JSON API does not filter anything by default.
-	#
-	# So we can cache the model view.
-	var view: ModelView is lazy do
-		var view = new ModelView(model, mainmodule)
-		view.min_visibility = private_visibility
-		view.include_fictive = true
-		view.include_empty_doc = true
-		view.include_attribute = true
-		view.include_test = true
-		return view
-	end
+	# ModelView used to access model.
+	var view: ModelView
 end
 
 # Specific handler for the nitweb API.
@@ -62,7 +52,10 @@ abstract class APIHandler
 	# Find the MEntity ` with `full_name`.
 	fun find_mentity(model: ModelView, full_name: nullable String): nullable MEntity do
 		if full_name == null then return null
-		return model.mentity_by_full_name(full_name.from_percent_encoding)
+		var mentity = model.mentity_by_full_name(full_name.from_percent_encoding)
+		if mentity == null then return null
+		if config.view.accept_mentity(mentity) then return mentity
+		return null
 	end
 
 	# Try to load the mentity from uri with `/:id`.

--- a/tests/nitdoc.args
+++ b/tests/nitdoc.args
@@ -1,4 +1,4 @@
 module_1.nit -d $WRITE
 base_attr_nullable.nit -d $WRITE
---private base_attr_nullable.nit -d $WRITE
+--private base_attr_nullable.nit --no-attributes -d $WRITE
 --no-render --test test_prog -d $WRITE


### PR DESCRIPTION
A list of filters that can be applied on a MEntity

By default ModelFilter accepts all mentity.

~~~nit
var filter = new ModelFilter
assert filter.accept_mentity(my_mentity) == true
~~~

To quickly configure the filters, options can be passed to the constructor:
~~~nit
var filter = new ModelFilter(
        min_visibility = protected_visibility,
	accept_fictive = false,
	accept_test = false,
	accept_redef = false,
	accept_extern = false,
	accept_attribute = false,
	accept_empty_doc = false
)
~~~

With this, one can use temporary filters with the model visitors and views:

~~~nit
var default_filter = new ModelFilter(private_visibility)
var view = new ModelView(view, default_filter)
# ...
if view.accept_mentity(mentity) then
   # ...
end
# ...
var custom_filter = new ModelFilter(public_visibility)
if view.accept_mentity(mentity, custom_filter) then
   # ...
end
~~~