### PR TITLE
popcorn: pop_test uses NIT_TESTING_ID to determine test port

### DIFF
--- a/lib/popcorn/pop_tests.nit
+++ b/lib/popcorn/pop_tests.nit
@@ -79,9 +79,11 @@ redef class Sys
 
 	# Return a new port for each instance
 	fun test_port: Int do
-		srand
-		return 10000+20000.rand
+		return testing_id % 20000 + 10000
 	end
+
+	# Nitdoc testing ID
+	fun testing_id: Int do return "NIT_TESTING_ID".environ.to_i
 end
 
 # Thread running the App to test.


### PR DESCRIPTION
This PR modifies the *pop-tests* so they use `NIT_TESTING_ID` to select the listening port.

This should avoid ports conflicts when testing multiple PR at the same time on Jenkins.

Let's try this!

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>