### PR TITLE
nitunit: some fixes and improvements for the `before_all`, `after_all` annotations

### DIFF
--- a/src/testing/README.md
+++ b/src/testing/README.md
@@ -38,12 +38,14 @@ To test a method you have to instanciate its class:
 	class Foo
 		#    var foo = new Foo
 		#    assert foo.baz(1, 2) == 3
-		fun baz(a, b: Int) do return a + b
+		fun baz(a, b: Int): Int do return a + b
 	end
 
 `nitunit` is used to test Nit files:
 
+~~~sh
 	$ nitunit foo.nit
+~~~
 
 ## Working with `TestSuites`
 
@@ -52,72 +54,82 @@ TestSuites are Nit files that define a set of TestCase for a particular module.
 The test suite module must be declared using the `test` annotation.
 The structure of a test suite is the following:
 
-	# test suite for module `foo`
-	module test_foo is test
+~~~nitish
+# test suite for module `foo`
+module test_foo is test
 
-	import foo # can be intrude to test private things
+import foo # can be intrude to test private things
 
-	class TestFoo
-		test
+class TestFoo
+	test
 
-		# test case for `foo::Foo::baz`
-		fun baz is test do
-			var subject = new Foo
-			assert subject.baz(1, 2) == 3
-		end
+	# test case for `foo::Foo::baz`
+	fun baz is test do
+		var subject = new Foo
+		assert subject.baz(1, 2) == 3
 	end
+end
+~~~
 
 Test suite can be executed using the same `nitunit` command:
 
+~~~sh
 	$ nitunit foo.nit
+~~~
 
 To be started automatically with nitunit, the module must be called `test_`
 followed by the name of the module to test.
 So for the module `foo.nit` the test suite will be called `test_foo.nit`.
 Otherwise, you can use the `-t` option to specify the test suite module name:
 
+~~~sh
 	$ nitunit foo.nit -t my_test_suite.nit
+~~~
 
 `nitunit` will execute a test for each method annotated with `test` in a class also annotated with `test`
 so multiple tests can be executed for a single method:
 
-	class TestFoo
-		test
+~~~nitish
+class TestFoo
+	test
 
-		fun baz_1 is test do
-			var subject = new Foo
-			assert subject.baz(1, 2) == 3
-		end
-
-		fun baz_2 is test do
-			var subject = new Foo
-			assert subject.baz(1, -2) == -1
-		end
+	fun baz_1 is test do
+		var subject = new Foo
+		assert subject.baz(1, 2) == 3
 	end
+
+	fun baz_2 is test do
+		var subject = new Foo
+		assert subject.baz(1, -2) == -1
+	end
+end
+~~~
 
 `TestSuites` also provide methods to configure the test run:
 
 `before` and `after` annotations can be added to methods that must be called before/after each test case.
 They can be used to factorize repetitive tasks:
 
-	class TestFoo
-		test
+~~~nitish
+class TestFoo
+	test
 
-		var subject: Foo is noinit
+	var subject: Foo is noinit
 
-		# Method executed before each test
-		redef fun set_up is before do
-			subject = new Foo
-		end
-
-		fun baz_1 is test do
-			assert subject.baz(1, 2) == 3
-		end
-
-		fun baz_2 is test do
-			assert subject.baz(1, -2) == -1
-		end
+	# Method executed before each test
+	fun set_up is before do
+		subject = new Foo
 	end
+
+	fun baz_1 is test do
+		assert subject.baz(1, 2) == 3
+	end
+
+	fun baz_2 is test do
+		assert subject.baz(1, -2) == -1
+	end
+end
+~~~
 
 When using custom test attributes, a empty init must be declared to allow automatic test running.
 
@@ -149,7 +161,9 @@ They have to be declared at top level:
 Write test suites for big modules can be a pepetitive and boring task...
 To make it easier, `nitunit` can generate test skeletons for Nit modules:
 
+~~~sh
 	$ nitunit --gen-suite foo.nit
+~~~
 
 This will generate the test suite `test_foo` containing test case stubs for all public
 methods found in `foo.nit`.

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -449,18 +449,32 @@ end
 redef class MModule
 	# Methods tagged with `before_all` at the module level (in `Sys`)
 	private fun before_all: Array[MMethodDef] do
-		for mclassdef in mclassdefs do
-			if mclassdef.name == "Sys" then return mclassdef.before_all
+		var res = new Array[MMethodDef]
+		for mmodule in in_importation.greaters do
+			for mclassdef in mmodule.mclassdefs do
+				if mclassdef.name != "Sys" then continue
+				for mpropdef in mclassdef.mpropdefs do
+					if not mpropdef isa MMethodDef or not mpropdef.is_before_all then continue
+					res.add mpropdef
+				end
+			end
 		end
-		return new Array[MMethodDef]
+		return res
 	end
 
 	# Methods tagged with `after_all` at the module level (in `Sys`)
 	private fun after_all: Array[MMethodDef] do
-		for mclassdef in mclassdefs do
-			if mclassdef.name == "Sys" then return mclassdef.after_all
+		var res = new Array[MMethodDef]
+		for mmodule in in_importation.greaters do
+			for mclassdef in mmodule.mclassdefs do
+				if mclassdef.name != "Sys" then continue
+				for mpropdef in mclassdef.mpropdefs do
+					if not mpropdef isa MMethodDef or not mpropdef.is_after_all then continue
+					res.add mpropdef
+				end
+			end
 		end
-		return new Array[MMethodDef]
+		return res
 	end
 end
 

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -383,66 +383,66 @@ end
 redef class MClassDef
 	# Methods tagged with `before` in this class definition
 	private fun before: Array[MMethodDef] do
-		var res = new Array[MMethodDef]
+		var res = new ArraySet[MMethodDef]
 		for mpropdef in mpropdefs do
 			if mpropdef isa MMethodDef and mpropdef.is_before then
 				res.add mpropdef
 			end
 		end
 		var in_hierarchy = self.in_hierarchy
-		if in_hierarchy == null then return res
+		if in_hierarchy == null then return res.to_a
 		for mclassdef in in_hierarchy.direct_greaters do
 			res.add_all mclassdef.before
 		end
-		return res
+		return res.to_a
 	end
 
 	# Methods tagged with `before_all` in this class definition
 	private fun before_all: Array[MMethodDef] do
-		var res = new Array[MMethodDef]
+		var res = new ArraySet[MMethodDef]
 		for mpropdef in mpropdefs do
 			if mpropdef isa MMethodDef and mpropdef.is_before_all then
 				res.add mpropdef
 			end
 		end
 		var in_hierarchy = self.in_hierarchy
-		if in_hierarchy == null then return res
+		if in_hierarchy == null then return res.to_a
 		for mclassdef in in_hierarchy.direct_greaters do
 			res.add_all mclassdef.before_all
 		end
-		return res
+		return res.to_a
 	end
 
 	# Methods tagged with `after` in this class definition
 	private fun after: Array[MMethodDef] do
-		var res = new Array[MMethodDef]
+		var res = new ArraySet[MMethodDef]
 		for mpropdef in mpropdefs do
 			if mpropdef isa MMethodDef and mpropdef.is_after then
 				res.add mpropdef
 			end
 		end
 		var in_hierarchy = self.in_hierarchy
-		if in_hierarchy == null then return res
+		if in_hierarchy == null then return res.to_a
 		for mclassdef in in_hierarchy.direct_greaters do
 			res.add_all mclassdef.after
 		end
-		return res
+		return res.to_a
 	end
 
 	# Methods tagged with `after_all` in this class definition
 	private fun after_all: Array[MMethodDef] do
-		var res = new Array[MMethodDef]
+		var res = new ArraySet[MMethodDef]
 		for mpropdef in mpropdefs do
 			if mpropdef isa MMethodDef and mpropdef.is_after_all then
 				res.add mpropdef
 			end
 		end
 		var in_hierarchy = self.in_hierarchy
-		if in_hierarchy == null then return res
+		if in_hierarchy == null then return res.to_a
 		for mclassdef in in_hierarchy.direct_greaters do
 			res.add_all mclassdef.after_all
 		end
-		return res
+		return res.to_a
 	end
 end
 

--- a/src/testing/testing_suite.nit
+++ b/src/testing/testing_suite.nit
@@ -481,7 +481,9 @@ redef class MClassDef
 		for mclassdef in in_hierarchy.direct_greaters do
 			res.add_all mclassdef.before
 		end
-		return res.to_a
+		var lin = res.to_a
+		mmodule.linearize_mpropdefs(lin)
+		return lin
 	end
 
 	# Methods tagged with `before_all` in this class definition
@@ -497,7 +499,9 @@ redef class MClassDef
 		for mclassdef in in_hierarchy.direct_greaters do
 			res.add_all mclassdef.before_all
 		end
-		return res.to_a
+		var lin = res.to_a
+		mmodule.linearize_mpropdefs(lin)
+		return lin
 	end
 
 	# Methods tagged with `after` in this class definition
@@ -513,7 +517,9 @@ redef class MClassDef
 		for mclassdef in in_hierarchy.direct_greaters do
 			res.add_all mclassdef.after
 		end
-		return res.to_a
+		var lin = res.to_a
+		mmodule.linearize_mpropdefs(lin)
+		return lin.reversed
 	end
 
 	# Methods tagged with `after_all` in this class definition
@@ -529,7 +535,9 @@ redef class MClassDef
 		for mclassdef in in_hierarchy.direct_greaters do
 			res.add_all mclassdef.after_all
 		end
-		return res.to_a
+		var lin = res.to_a
+		mmodule.linearize_mpropdefs(lin)
+		return lin.reversed
 	end
 end
 
@@ -546,7 +554,9 @@ redef class MModule
 				end
 			end
 		end
-		return res
+		var lin = res.to_a
+		linearize_mpropdefs(lin)
+		return lin
 	end
 
 	# Methods tagged with `after_all` at the module level (in `Sys`)
@@ -561,7 +571,9 @@ redef class MModule
 				end
 			end
 		end
-		return res
+		var lin = res.to_a
+		linearize_mpropdefs(lin)
+		return lin.reversed
 	end
 end
 

--- a/tests/nitunit.args
+++ b/tests/nitunit.args
@@ -11,3 +11,4 @@ test_nitunit5.nit --no-color -o $WRITE
 test_nitunit6.nit --no-color -o $WRITE
 test_nitunit7.nit --no-color -o $WRITE
 test_nitunit8.nit --no-color -o $WRITE
+test_nitunit11.nit --no-color -o $WRITE

--- a/tests/nitunit.args
+++ b/tests/nitunit.args
@@ -10,3 +10,4 @@ test_nitunit4 --no-color -o $WRITE
 test_nitunit5.nit --no-color -o $WRITE
 test_nitunit6.nit --no-color -o $WRITE
 test_nitunit7.nit --no-color -o $WRITE
+test_nitunit8.nit --no-color -o $WRITE

--- a/tests/sav/nitunit_args11.res
+++ b/tests/sav/nitunit_args11.res
@@ -5,12 +5,12 @@
 	Runtime error: Assert failed (test_nitunit6.nit:26)
 
 [KO] test_nitunit6$TestNitunit6$test_foo
-     test_nitunit6.nit:20,2--22,4: Nitunit Error: before_module test failed
+     test_nitunit6.nit:20,2--22,4: Nitunit Error: before module test failed
 [KO] test_nitunit6::test_nitunit6$core::Sys$after_module
-     test_nitunit6.nit:29,1--31,3: Nitunit Error: before_module test failed
+     test_nitunit6.nit:29,1--31,3: Nitunit Error: before module test failed
 
 Docunits: Entities: 5; Documented ones: 0; With nitunits: 0
 Test suites: Classes: 1; Test Cases: 3; Failures: 3
 [FAILURE] 3/3 tests failed.
 `nitunit.out` is not removed for investigation.
-<testsuites><testsuite package="test_nitunit6::test_nitunit6"></testsuite><testsuite package="test_nitunit6"><testcase classname="nitunit.test_nitunit6.TestNitunit6" name="test_foo" time="0.0"><failure message="Nitunit Error: before_module test failed"></failure></testcase></testsuite></testsuites>
+<testsuites><testsuite package="test_nitunit6::test_nitunit6"></testsuite><testsuite package="test_nitunit6"><testcase classname="nitunit.test_nitunit6.TestNitunit6" name="test_foo" time="0.0"><failure message="Nitunit Error: before module test failed"></failure></testcase></testsuite></testsuites>

--- a/tests/sav/nitunit_args13.res
+++ b/tests/sav/nitunit_args13.res
@@ -1,0 +1,14 @@
+==== Test-suite of module test_nitunit8::test_nitunit8 | tests: 3
+[OK] test_nitunit7::test_nitunit7$core::Sys$before_module
+[OK] test_nitunit8$TestNitunit8$test_foo
+[KO] test_nitunit7::test_nitunit7$core::Sys$after_module
+     test_nitunit7.nit:29,1--31,3: Runtime Error in file nitunit.out/gen_test_nitunit8.nit
+     Output
+	Runtime error: Assert failed (test_nitunit7.nit:30)
+
+
+Docunits: Entities: 3; Documented ones: 0; With nitunits: 0
+Test suites: Classes: 1; Test Cases: 3; Failures: 1
+[FAILURE] 1/3 tests failed.
+`nitunit.out` is not removed for investigation.
+<testsuites><testsuite package="test_nitunit8::test_nitunit8"></testsuite><testsuite package="test_nitunit8"><testcase classname="nitunit.test_nitunit8.TestNitunit8" name="test_foo" time="0.0"><system-err></system-err></testcase></testsuite></testsuites>

--- a/tests/sav/nitunit_args14.res
+++ b/tests/sav/nitunit_args14.res
@@ -1,0 +1,18 @@
+==== Test-suite of module test_nitunit11::test_nitunit11 | tests: 7
+[OK] test_nitunit9$TestNitunit9$before_class
+[OK] test_nitunit10$TestNitunit10$before_class2
+[OK] test_nitunit11$TestNitunit11$before_class3
+[OK] test_nitunit11$TestNitunit11$test_baz
+[OK] test_nitunit11$TestNitunit11$after_class3
+[OK] test_nitunit10$TestNitunit10$after_class2
+[KO] test_nitunit9$TestNitunit9$after_class
+     test_nitunit9.nit:36,2--38,4: Runtime Error in file nitunit.out/gen_test_nitunit11.nit
+     Output
+	Runtime error: Assert failed (test_nitunit9.nit:37)
+
+
+Docunits: Entities: 7; Documented ones: 0; With nitunits: 0
+Test suites: Classes: 1; Test Cases: 7; Failures: 1
+[FAILURE] 1/7 tests failed.
+`nitunit.out` is not removed for investigation.
+<testsuites><testsuite package="test_nitunit11::test_nitunit11"></testsuite><testsuite package="test_nitunit11"><testcase classname="nitunit.test_nitunit11.TestNitunit11" name="test_baz" time="0.0"><system-err></system-err></testcase></testsuite></testsuites>

--- a/tests/test_nitunit10.nit
+++ b/tests/test_nitunit10.nit
@@ -1,0 +1,42 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module test_nitunit10 is test
+
+import test_nitunit9
+
+class TestNitunit10
+	super TestNitunit9
+	test
+
+	fun before_class2 is before_all do
+		assert true
+	end
+
+	fun before2 is before do
+		assert true
+	end
+
+	fun test_bar is test do
+		assert true
+	end
+
+	fun after2 is after do
+		assert true
+	end
+
+	fun after_class2 is after_all do
+		assert true
+	end
+end

--- a/tests/test_nitunit11.nit
+++ b/tests/test_nitunit11.nit
@@ -1,0 +1,42 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module test_nitunit11 is test
+
+import test_nitunit10
+
+class TestNitunit11
+	super TestNitunit10
+	test
+
+	fun before_class3 is before_all do
+		assert true
+	end
+
+	fun before3 is before do
+		assert true
+	end
+
+	fun test_baz is test do
+		assert true
+	end
+
+	fun after3 is after do
+		assert true
+	end
+
+	fun after_class3 is after_all do
+		assert true
+	end
+end

--- a/tests/test_nitunit8.nit
+++ b/tests/test_nitunit8.nit
@@ -1,0 +1,24 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module test_nitunit8 is test
+import test_nitunit7
+
+class TestNitunit8
+	test
+
+	fun test_foo is test do
+		assert true
+	end
+end

--- a/tests/test_nitunit9.nit
+++ b/tests/test_nitunit9.nit
@@ -1,0 +1,39 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module test_nitunit9 is test
+
+class TestNitunit9
+	test
+
+	fun before_class is before_all do
+		assert true
+	end
+
+	fun before is before do
+		assert true
+	end
+
+	fun test_foo is test do
+		assert true
+	end
+
+	fun after is after do
+		assert true
+	end
+
+	fun after_class is after_all do
+		assert false
+	end
+end


### PR DESCRIPTION
This PR does three things:
* fixes the importation of `before_all` and `after_all` methods
* allows use of `before_all` and `after_all` methods within classes
* changes the test execution order for imported test suites

### Fix the importation of `before_all` and `after_all` methods

First of all, this PR fixes the behavior of nitunit with multiple test_suite importation.

Be two modules `a` and `b`:

~~~nit
module a is test

class TestA
    test

    # some test cases
end

fun setup is before_all do # important things
~~~

~~~nit
module b is test
import module a

class TestB
     super TestA
     test
end
~~~

In this case, because `b` does not introduce any `before_all` method, the method from `a` was not executed.
This is fixed now.

### Class-level `before_all` and `after_all` methods

`before_all` and `after_all` can now be used inside a class definition to indicate methods that must be executed before / after all methods inside the class:

~~~nit
class TestC
    test

    fun setup is before_all do # something before all test cases of `TestC`

    # some test cases
end
~~~

### Tests execution order

Methods with `before*` and `after*` annotations are linearized and called in different ways.

* `before*` methods are called from the least specific to the most specific
* `after*` methods are called from the most specific to the least specific

~~~nit
module test_bdd_connector

import bdd_connector

# Testing the bdd_connector
class TestConnector
	test
	# test cases using a server
end

# Method executed before testing the module
fun setup_db is before_all do
	# start server before all test cases
end

# Method executed after testing the module
fun teardown_db is after_all do
	# stop server after all test cases
end
~~~

When dealing with multiple test suites, niunit allows you to import other test suites to factorize your tests:

~~~nit
module test_bdd_users

import test_bdd_connector

# Testing the user table
class TestUsersTable
	test
	# test cases using the db server from `test_bdd_connector`
end

fun setup_table is before_all do
	# create user table
end

fun teardown_table is after_all do
	# drop user table
end
~~~

In the previous example, the execution order would be:

1. `test_bdd_connector::setup_db`
2. `test_bdd_users::setup_table`
3. `all test cases from test_bdd_users`
4. `test_bdd_users::teardown_table`
5. `test_bdd_connector::teardown_db`