### PR TITLE
nitcc: add nfa transformation to remove epsilon

### DIFF
--- a/contrib/nitcc/src/autom.nit
+++ b/contrib/nitcc/src/autom.nit
@@ -526,7 +526,7 @@ class Automaton
 						f.append("s{names[s]}->s{names[s2]} [label=\"{labe.escape_to_dot}\"];\n")
 					end
 				end
-				if merge_transitions == null or merge_transitions == true then
+				if merge_transitions or else true then
 					f.append("s{names[s]}->s{names[s2]} [label=\"{labe.escape_to_c}\"];\n")
 				end
 			end

--- a/contrib/nitcc/src/autom.nit
+++ b/contrib/nitcc/src/autom.nit
@@ -367,6 +367,7 @@ class Automaton
 		# Keep only the good stuff
 		states.clear
 		states.add_all(goods)
+		states.add(start)
 	end
 
 	# Generate a minimal DFA

--- a/contrib/nitcc/src/autom.nit
+++ b/contrib/nitcc/src/autom.nit
@@ -386,10 +386,9 @@ class Automaton
 
 		# split accept states.
 		# An accept state is distinct with a non accept state.
-		for s1 in states do
+		for s1 in accept do
 			for s2 in states do
 				if distincts[s1].has(s2) then continue
-				if not accept.has(s1) then continue
 				if not accept.has(s2) then
 					distincts[s1].add(s2)
 					distincts[s2].add(s1)

--- a/contrib/nitcc/src/nitcc.nit
+++ b/contrib/nitcc/src/nitcc.nit
@@ -112,8 +112,15 @@ f.close
 var nfa = v2.nfa
 print "NFA automaton: {nfa.states.length} states (see {name}.nfa.dot)"
 nfa.to_dot.write_to_file("{name}.nfa.dot")
+var nfanoe = nfa.to_nfa_noe
+nfanoe.to_dot.write_to_file("{name}.nfanoe.dot")
+print "NFA automaton without epsilon: {nfanoe.states.length} states (see {name}.nfanoe.dot)"
 
-var dfa = nfa.to_dfa.to_minimal_dfa
+var dfa = nfa.to_dfa
+dfa.to_dot.write_to_file("{name}.dfanomin.dot")
+print "DFA automaton (non minimal): {dfa.states.length} states (see {name}.dfanomin.dot)"
+
+dfa = dfa.to_minimal_dfa
 
 dfa.solve_token_inclusion
 


### PR DESCRIPTION
A NFA can be transformed to another NFA without epsilon-transition.
This is mostly useless but can make large NFA more readable.

Also add some bugfixes