### PR TITLE
app.nit: fix issues in examples and calculator

### DIFF
--- a/contrib/tnitter/Makefile
+++ b/contrib/tnitter/Makefile
@@ -6,7 +6,7 @@ bin/tnitter_server: $(shell nitls -M src/tnitter.nit)
 	mkdir -p bin/
 	nitc -o bin/tnitter_server src/tnitter.nit -D tnitter_interface=$(SERVER)
 
-bin/tnitter: $(shell nitls -M src/tnitter_app.nit)
+bin/tnitter: $(shell nitls -M src/tnitter_app.nit -m linux)
 	mkdir -p bin/
 	nitc -o bin/tnitter src/tnitter_app.nit -m linux -D tnitter_server_uri=http://$(SERVER)
 
@@ -30,11 +30,11 @@ android/res/: art/icon.svg
 # iOS
 
 ios: bin/tnitter.app
-bin/tnitter.app: $(shell nitls -M src/tnitter_app.nit ios) ios/AppIcon.appiconset/Contents.json
+bin/tnitter.app: $(shell nitls -M src/tnitter_app.nit -m ios) ios/AppIcon.appiconset/Contents.json
 	mkdir -p bin/
 	nitc -o bin/tnitter.app src/tnitter_app.nit -m ios -D tnitter_server_uri=http://$(SERVER)
 
-ios-release: $(shell nitls -M src/tnitter_app.nit ios) ios/AppIcon.appiconset/Contents.json
+ios-release: $(shell nitls -M src/tnitter_app.nit -m ios) ios/AppIcon.appiconset/Contents.json
 	mkdir -p bin/
 	nitc -o bin/tnitter.app src/tnitter_app.nit -m ios -D tnitter_server_uri=http://tnitter.xymus.net
 

--- a/examples/calculator/Makefile
+++ b/examples/calculator/Makefile
@@ -1,7 +1,7 @@
 NITC=../../bin/nitc
 NITLS=../../bin/nitls
 
-all: bin/calculator bin/test
+all: bin/calculator bin/scientific bin/test
 
 bin/calculator: $(shell ${NITLS} -M src/calculator.nit -m linux) ${NITC}
 	mkdir -p bin

--- a/examples/calculator/Makefile
+++ b/examples/calculator/Makefile
@@ -3,11 +3,11 @@ NITLS=../../bin/nitls
 
 all: bin/calculator bin/test
 
-bin/calculator: $(shell ${NITLS} -M src/calculator.nit linux) ${NITC}
+bin/calculator: $(shell ${NITLS} -M src/calculator.nit -m linux) ${NITC}
 	mkdir -p bin
 	${NITC} -o $@ src/calculator.nit -m linux
 
-bin/scientific: $(shell ${NITLS} -M scientific linux) ${NITC}
+bin/scientific: $(shell ${NITLS} -M scientific -m linux) ${NITC}
 	mkdir -p bin
 	${NITC} -o $@ src/scientific -m linux
 
@@ -28,15 +28,15 @@ bin/calculator21.apk: $(shell ${NITLS} -M src/android21) ${NITC} android/res/dra
 	mkdir -p bin
 	${NITC} -o $@ src/android21 -D debug
 
-bin/scientific14.apk: $(shell ${NITLS} -M src/scientific src/android14.nit) ${NITC} src/scientific/android/res/drawable-hdpi/icon.png
+bin/scientific14.apk: $(shell ${NITLS} -M src/scientific -m src/android14.nit) ${NITC} src/scientific/android/res/drawable-hdpi/icon.png
 	mkdir -p bin
 	${NITC} -o $@ src/scientific -m src/android14.nit -D debug
 
-bin/scientific21.apk: $(shell ${NITLS} -M src/scientific src/android21) ${NITC} src/scientific/android/res/drawable-hdpi/icon.png
+bin/scientific21.apk: $(shell ${NITLS} -M src/scientific -m src/android21) ${NITC} src/scientific/android/res/drawable-hdpi/icon.png
 	mkdir -p bin
 	${NITC} -o $@ src/scientific -m src/android21 -D debug
 
-android-release: $(shell ${NITLS} -M src/scientific src/android14.nit) ${NITC} android/res/drawable-hdpi/icon.png
+android-release: $(shell ${NITLS} -M src/scientific -m src/android14.nit) ${NITC} android/res/drawable-hdpi/icon.png
 	mkdir -p bin
 	${NITC} -o bin/calculator14.apk src/android14.nit --release
 	${NITC} -o bin/calculator21.apk src/android21 --release
@@ -66,7 +66,7 @@ bin/calculator.app: $(shell ${NITLS} -M src/ios.nit) ${NITC} ios/AppIcon.appicon
 	mkdir -p bin
 	${NITC} -o $@ src/ios.nit -D debug
 
-bin/scientific.app: $(shell ${NITLS} -M src/scientific src/ios.nit) ${NITC} src/scientific/ios/AppIcon.appiconset/Contents.json
+bin/scientific.app: $(shell ${NITLS} -M src/scientific -m src/ios.nit) ${NITC} src/scientific/ios/AppIcon.appiconset/Contents.json
 	mkdir -p bin
 	${NITC} -o $@ src/scientific -m src/ios.nit -D debug
 

--- a/lib/app/examples/Makefile
+++ b/lib/app/examples/Makefile
@@ -4,22 +4,22 @@ android: http_request_example.apk ui_example.apk
 
 ios: http_request_example.app ui_example.app
 
-http_request_example: $(shell nitls -M http_request_example.nit linux)
+http_request_example: $(shell nitls -M http_request_example.nit -m linux)
 	nitc http_request_example.nit -m linux
 
-http_request_example.apk: $(shell nitls -M http_request_example.nit android)
+http_request_example.apk: $(shell nitls -M http_request_example.nit -m android)
 	nitc http_request_example.nit -m android
 
-http_request_example.app: $(shell nitls -M http_request_example.nit ios)
+http_request_example.app: $(shell nitls -M http_request_example.nit -m ios)
 	nitc http_request_example.nit -m ios
 
-ui_example: $(shell nitls -M ui_example.nit linux)
+ui_example: $(shell nitls -M ui_example.nit -m linux)
 	nitc ui_example.nit -m linux
 
-ui_example.apk: $(shell nitls -M ui_example.nit android)
+ui_example.apk: $(shell nitls -M ui_example.nit -m android)
 	nitc ui_example.nit -m android
 
-ui_example.app: $(shell nitls -M ui_example.nit ios)
+ui_example.app: $(shell nitls -M ui_example.nit -m ios)
 	nitc ui_example.nit -m ios
 
 clean:

--- a/lib/app/examples/http_request_example.nit
+++ b/lib/app/examples/http_request_example.nit
@@ -56,7 +56,7 @@ class MyHttpRequest
 	redef fun after do win.button_request.enabled = true
 end
 
-# Simpe window with a label and a button
+# Simple window with a label and a button
 class HttpRequestClientWindow
 	super Window
 
@@ -81,11 +81,4 @@ class HttpRequestClientWindow
 	end
 end
 
-redef class App
-	redef fun on_create
-	do
-		# Create the main window
-		push_window new HttpRequestClientWindow
-		super
-	end
-end
+redef fun root_window do return new HttpRequestClientWindow


### PR DESCRIPTION
- Fix missing Makefile dependencies by correctly using the -m options in calls to nitls. It would work without the -m for simple programs but misses some files when there are conditional importations.
- Fix crash in `http_request_example` by updating the latest app.nit UI API from #2547. Closes #2577.
- Compile the scientific desktop variant of the calculator with the `all` rule.