### PR TITLE
interactive nit: main variables are preserved

### DIFF
--- a/contrib/nitin/nitin.nit
+++ b/contrib/nitin/nitin.nit
@@ -42,6 +42,7 @@ redef class ToolContext
 	fun p_module(string: String): ANode
 	do
 		var source_name = opt_source_name.value or else ""
+		string = "\n" * last_line + string
 		var source = new SourceFile.from_string(source_name, string)
 		var lexer = new Lexer(source)
 		var parser = new Parser(lexer)
@@ -69,6 +70,9 @@ redef class ToolContext
 	# With the default implementation, the history is dropped
 	fun readline_add_history(text: String) do end
 
+	# The last line number read by `i_parse`
+	var last_line = 0
+
 	# Parse the input of the user as a module
 	fun i_parse(prompt: String): nullable ANode
 	do
@@ -83,7 +87,14 @@ redef class ToolContext
 				s = readline(prompt)
 			end
 			if s == null then return null
-			if s == "" then continue
+			if s == "" then
+				if oldtext != "" then
+					oldtext += "\n"
+				else
+					last_line += 1
+				end
+				continue
+			end
 
 			if s.chars.first == ':' then
 				var res = new TString
@@ -102,6 +113,7 @@ redef class ToolContext
 				continue
 			end
 
+			last_line = n.location.file.line_starts.length - 1
 			readline_add_history(text.chomp)
 			return n
 		end

--- a/contrib/nitin/nitin.nit
+++ b/contrib/nitin/nitin.nit
@@ -189,6 +189,13 @@ loop
 	l += 1
 	var newmodule = modelbuilder.load_rt_module(mainmodule, amodule, "input-{l}")
 	if newmodule == null then continue
+
+	var main_method = null
+	if amodule.n_classdefs.not_empty and amodule.n_classdefs.last isa AMainClassdef then
+		main_method = amodule.n_classdefs.last.n_propdefs.first
+		assert main_method isa AMethPropdef
+	end
+
 	modelbuilder.run_phases
 	if not toolcontext.check_errors then
 		toolcontext.error_count = 0
@@ -199,7 +206,7 @@ loop
 	interpreter.mainmodule = mainmodule
 
 	# Run the main if the AST contains a main
-	if amodule.n_classdefs.not_empty and amodule.n_classdefs.last isa AMainClassdef then
+	if main_method != null then
 		do
 			interpreter.catch_count += 1
 			interpreter.send(mainprop, [mainobj])

--- a/contrib/nitin/nitin.nit
+++ b/contrib/nitin/nitin.nit
@@ -28,9 +28,12 @@ redef class ToolContext
 	# --no-prompt
 	var opt_no_prompt = new OptionBool("Disable writing a prompt.", "--no-prompt")
 
+	# --source-name
+	var opt_source_name = new OptionString("Set a name for the input source.", "--source-name")
+
 	redef init do
 		super
-		option_context.add_option(opt_no_prompt)
+		option_context.add_option(opt_no_prompt, opt_source_name)
 	end
 
 	# Parse a full module given as a string
@@ -38,7 +41,8 @@ redef class ToolContext
 	# Return a AModule or a AError
 	fun p_module(string: String): ANode
 	do
-		var source = new SourceFile.from_string("", string)
+		var source_name = opt_source_name.value or else ""
+		var source = new SourceFile.from_string(source_name, string)
 		var lexer = new Lexer(source)
 		var parser = new Parser(lexer)
 		var tree = parser.parse

--- a/contrib/nitin/nitin.nit
+++ b/contrib/nitin/nitin.nit
@@ -176,7 +176,7 @@ loop
 
 	# An error
 	if n isa AError then
-		print "{n.location.colored_line("0;31")}: {n.message}"
+		modelbuilder.error(n, n.message)
 		continue
 	end
 

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -825,7 +825,7 @@ class InterpreterFrame
 	super Frame
 
 	# Mapping between a variable and the current value
-	private var map: Map[Variable, Instance] = new HashMap[Variable, Instance]
+	var map: Map[Variable, Instance] = new HashMap[Variable, Instance]
 end
 
 redef class ANode
@@ -874,7 +874,10 @@ redef class AMethPropdef
 		return res
 	end
 
-	private fun call_commons(v: NaiveInterpreter, mpropdef: MMethodDef, arguments: Array[Instance], f: Frame): nullable Instance
+	# Execution of the body of the method
+	#
+	# It handle the common special cases: super, intern, extern
+	fun call_commons(v: NaiveInterpreter, mpropdef: MMethodDef, arguments: Array[Instance], f: Frame): nullable Instance
 	do
 		v.frames.unshift(f)
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -636,7 +636,7 @@ END
 			echo 0.0 > "$ff.time.out"
 		elif [ -n "$isinteractive" ]; then
 			cat > "$ff.bin" <<END
-exec $NITC --no-color --no-prompt $OPT $includes < $(printf '%q' "$i") "\$@"
+exec $NITC --no-color --no-prompt --source-name $(printf '%q' "$i") $OPT $includes < $(printf '%q' "$i") "\$@"
 END
 			chmod +x "$ff.bin"
 			> "$ff.cmp.err"


### PR DESCRIPTION
This hacks (by refinement) the scope and interpretation services to load and save the states of the local variables of the main method.

`nitin` is now usable for everyday usages:

~~~raw
-->var sum=0
-->for i in [0..5[ do
...print i
...sum += i
...end
0
1
2
3
4
-->print sum
10
~~~