### PR TITLE
android: adaptive icons, free memory on demand and use same package in debug mode

### DIFF
--- a/lib/android/README.md
+++ b/lib/android/README.md
@@ -102,6 +102,20 @@ Importing `android::landscape` or `android::portrait` locks the generated
 application in the specified orientation. This can be useful for games and
 other multimedia applications.
 
+## Resources and application icon
+
+Resources specific to the Android platform should be placed in an `android/` folder at the root of the project.
+The folder should adopt the structure of a normal Android project, e.g., a custom XML resource file can be placed
+at `android/res/values/color.xml` to be compiled with the Android application.
+
+The application icon should also be placed in the `android/` folder.
+Place the classic bitmap version at `android/res/mipmap-hdpi/ic_launcher.png` (and others),
+and the adaptive version at `android/res/mipmap-anydpi-v26/ic_launcher.xml`.
+The Nit compiler detects these files and uses them as the application icon.
+
+Additional `android/` folders may be placed next to more specific Nit modules to change the Android resources
+for application variants. The more specific resources will have priority over the project level `android/` files.
+
 # Compilation modes
 
 There are two compilation modes for the Android platform, debug and release.

--- a/lib/android/native_app_glue.nit
+++ b/lib/android/native_app_glue.nit
@@ -195,7 +195,7 @@ redef class App
 	# Notification from the Android framework, the system is running low on memory
 	#
 	# Try to reduce your memory use.
-	fun low_memory do end
+	fun low_memory do force_garbage_collection
 
 	# Notification from the Android framework, the current device configuration has changed
 	fun config_changed do end

--- a/lib/android/nit_activity.nit
+++ b/lib/android/nit_activity.nit
@@ -287,7 +287,7 @@ class Activity
 	# Notification from Android, the system is running low on memory
 	#
 	# Try to reduce your memory use.
-	fun on_low_memory do end
+	fun on_low_memory do force_garbage_collection
 
 	# Notification from Android, the current window of the activity has lost or gained focus
 	fun on_window_focus_changed(has_focus: Bool) do end

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -91,11 +91,7 @@ class AndroidToolchain
 		# ---
 
 		var app_name = project.name
-		if not release then app_name += " Debug"
-
 		var app_package = project.namespace
-		if not release then app_package += "_debug"
-
 		var app_version = project.version
 
 		var app_min_api = project.min_api

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -299,7 +299,7 @@ set(lib_build_DIR ../libgc/outputs)
 file(MAKE_DIRECTORY ${lib_build_DIR})
 
 ## Config
-add_definitions("-DGC_PTHREADS")
+add_definitions("-DALL_INTERIOR_POINTERS -DGC_THREADS -DUSE_MMAP -DUSE_MUNMAP -DJAVA_FINALIZATION -DNO_EXECUTE_PERMISSION -DGC_DONT_REGISTER_MAIN_STATIC_DATA")
 set(enable_threads TRUE)
 set(CMAKE_USE_PTHREADS_INIT TRUE)
 

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -378,19 +378,41 @@ target_link_libraries(nit_app gc-lib
 		# Generate AndroidManifest.xml
 
 		# Is there an icon?
-		var resolutions = ["ldpi", "mdpi", "hdpi", "xhdpi", "xxhdpi", "xxxhdpi"]
-		var icon_available = false
+		var resolutions = ["ldpi", "mdpi", "hdpi", "xhdpi", "xxhdpi", "xxxhdpi", "anydpi", "anydpi-v26"]
+		var icon_name = null
+		var has_round = false
+
 		for res in resolutions do
-			var path = project_root / "android/res/drawable-{res}/icon.png"
-			if path.file_exists then
-				icon_available = true
+			# New style mipmap
+			if "{project_root}/android/res/mipmap-{res}/ic_launcher_round.png".file_exists then
+				has_round = true
+			end
+			if "{project_root}/android/res/mipmap-{res}/ic_launcher.png".file_exists then
+				icon_name = "@mipmap/ic_launcher"
 				break
+			end
+			if "{project_root}/android/res/mipmap-{res}/ic_launcher.xml".file_exists then
+				icon_name = "@mipmap/ic_launcher"
+				break
+			end
+		end
+		if icon_name == null then
+			# Old style drawable-hdpi/icon.png
+			for res in resolutions do
+				var path = project_root / "android/res/drawable-{res}/icon.png"
+				if path.file_exists then
+					icon_name = "@drawable/icon"
+					break
+				end
 			end
 		end
 
 		var icon_declaration
-		if icon_available then
-			icon_declaration = "android:icon=\"@drawable/icon\""
+		if icon_name != null then
+			icon_declaration = "android:icon=\"{icon_name}\""
+			if app_target_api >= 25 and has_round then
+				icon_declaration += "\n\t\tandroid:roundIcon=\"@mipmap/ic_launcher_round\""
+			end
 		else icon_declaration = ""
 
 		# TODO android:roundIcon


### PR DESCRIPTION
This PR extends the new Android compilation toolchain:

* Add support for adaptive icons from Android 8 Oreo (and the older `roundIcon`), see https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive.html. It should detect the icons structure generated by Android Studio 3.

* Tweak the GC compilation options to make it more stable and support releasing memory when the Android system sends the `onLowMemory` message.

* Don't change the app name and package/namespace when compiling in debug mode. While this allowed to easily install both the release and the debug version of the same app on a device, it could be unexpected and it was not compatible with some Google services linked to a precise package name. The old behavior can be reproduced in standard Nit code by using a debug variant like so:
  ~~~
  module asteronits_debug is
      app_name "Asteronits debug"
      app_namespace "org.nitlanguage.asteronits_debug"
  end

  import asteronits
  ~~~