### PR TITLE
tests: force a utf8 locale because gradle don't like pure ascii

### DIFF
--- a/tests/sav/test_jvm.res
+++ b/tests/sav/test_jvm.res
@@ -2,13 +2,13 @@ Compilation des classes Java ...
 Initialisation de la JVM ...
 ---------------------Test 1----------------------
 From java, pushing premier
-From java, pushing deuxi?me
-From java, pushing troisi?me
+From java, pushing deuxième
+From java, pushing troisième
 From java, popping premier
 premier
-From java, popping deuxi?me
+From java, popping deuxième
 deuxième
-From java, popping troisi?me
+From java, popping troisième
 troisième
 --------------------Test 2---------------------
 true

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -18,8 +18,8 @@
 # This shell script compile, run and verify Nit program files
 
 # Set lang do default to avoid failed tests because of locale
-export LANG=C
-export LC_ALL=C
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
 export NIT_TESTING=true
 # Use the pid as a collision prevention
 export NIT_TESTING_ID=$$
@@ -708,7 +708,7 @@ END
 			if [ -f "$ff.write" ]; then
 				cat -- "$ff.write" >> "$ff.res"
 			elif [ -d "$ff.write" ]; then
-				LANG=C /bin/ls -F "$ff.write" >> "$ff.res"
+				/bin/ls -F "$ff.write" >> "$ff.res"
 			fi
 			cp -- "$ff.res"  "$ff.res2"
 			cat -- "$ff.cmp.err" "$ff.err" "$ff.res2" > "$ff.res"
@@ -750,7 +750,7 @@ END
 					if [ -f "$fff.write" ]; then
 						cat -- "$fff.write" >> "$fff.res"
 					elif [ -d "$fff.write" ]; then
-						LANG=C /bin/ls -F -- "$fff.write" >> "$fff.res"
+						/bin/ls -F -- "$fff.write" >> "$fff.res"
 					fi
 					if [ -s "$fff.err" ]; then
 						cp -- "$fff.res"  "$fff.res2"


### PR DESCRIPTION
this should fix the CI tests when people with international names make PR.

ref: https://github.com/gradle/gradle/issues/3117