### PR TITLE
core: add `Sequence::get_or_default` and `get_or_null`

### DIFF
--- a/lib/core/collection/abstract_collection.nit
+++ b/lib/core/collection/abstract_collection.nit
@@ -859,6 +859,36 @@ interface SequenceRead[E]
 		end
 	end
 
+	# Try to get an element, return `null` if the `index` is invalid.
+	#
+	# ~~~
+	# var a = [10,20,30]
+	# assert a.get_or_null(1) == 20
+	# assert a.get_or_null(3) == null
+	# assert a.get_or_null(-1) == null
+	# assert a.get_or_null(-10) == null
+	# ~~~
+	fun get_or_null(index: Int): nullable E
+	do
+		if index >= 0 and index < length then return self[index]
+		return null
+	end
+
+	# Try to get an element, return `default` if the `index` is invalid.
+	#
+	# ~~~
+	# var a = [10,20,30]
+	# assert a.get_or_default(1, -1) == 20
+	# assert a.get_or_default(3, -1) == -1
+	# assert a.get_or_default(-1, -1) == -1
+	# assert a.get_or_default(-10, -1) == -1
+	# ~~~
+	fun get_or_default(index: Int, default: E): E
+	do
+		if index >= 0 and index < length then return self[index]
+		return default
+	end
+
 	# Get the last item.
 	# Is equivalent with `self[length-1]`.
 	#


### PR DESCRIPTION
I though these existed. They do but only for `Map`s.

I just wanted to get an optional commande line argument without having to do an if.

~~~nit
# get the 2th command line argument, or else get null
var arg2 = args.get_nor_null(1)
~~~

I'm not fan of the names, but at least they are. If someone have better. Initially, I named it `try`, like `var arg2 = args.try(1)`.