### PR TITLE
Android: fix issues in the audio support

### DIFF
--- a/lib/android/audio.nit
+++ b/lib/android/audio.nit
@@ -557,6 +557,7 @@ redef class Sound
 				self.error = new Error("Failed to get file descriptor for " + path)
 			else
 				var retval_assets = app.default_soundpool.load_asset_fd_rid(nam)
+				nam.close
 				if retval_assets == -1 then
 					self.error = new Error("Failed to load " + path)
 				else
@@ -631,6 +632,7 @@ redef class Music
 				self.error = new Error("Failed to get file descriptor for " + path)
 			else
 				var mp_sound_assets = app.default_mediaplayer.data_source_fd(nam)
+				nam.close
 				if mp_sound_assets.error != null then
 					self.error = mp_sound_assets.error
 				else

--- a/lib/android/audio.nit
+++ b/lib/android/audio.nit
@@ -28,8 +28,8 @@
 #
 # ~~~nitish
 # # Note that you need to specify the path from "assets" folder and the extension
-# var s = app.load_sound("sounds/test_sound.ogg")
-# var m = app.load_music("sounds/test_music.ogg")
+# var s = new Sound("sounds/test_sound.ogg")
+# var m = new Music("sounds/test_music.ogg")
 # s.play
 # m.play
 # ~~~


### PR DESCRIPTION
Refactor the loading of sounds and music to use the same logic and order, and to fix trying to load invalid resource ids (the errors on 0x00000000). Update the documentation to the currently recommended usage. And close the file descriptors after use/dup.

