### PR TITLE
exec: display system error after failed fork

### DIFF
--- a/lib/core/exec.nit
+++ b/lib/core/exec.nit
@@ -327,6 +327,9 @@ class Process
 				close(err_fd[1]);
 			} else
 				result->err_fd = -1;
+		} else {
+			perror("Process:");
+			return NULL;
 		}
 
 		return result;


### PR DESCRIPTION
This PR modifies `basic_exec_execute` to add a call to `perror` to display the error message before exiting when a fork fails.