### PR TITLE
tests: mark as TODO all tests failing on missing OpenGL ES 1.0

### DIFF
--- a/tests/sav/Darwin/todo
+++ b/tests/sav/Darwin/todo
@@ -1,5 +1,4 @@
 fatal error: 'endian.h' file not found
-Error: dev package for `glesv1_cm` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.
 Error: dev package for `glesv2` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.
 Error: dev package for `egl` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.
 Error: dev package for `ncurses` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.

--- a/tests/todo
+++ b/tests/todo
@@ -1,1 +1,2 @@
 NOT YET IMPLEMENTED
+Error: dev package for `glesv1_cm` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.


### PR DESCRIPTION
OpenGL ES 1.0 is getting a bit outdated and it is not available on macOS, Windows or some recent GNU/Linux distributions. However, it is still available and supported on Android.

Note that, new projects should not use OpenGL ES 1.0 (as used by `mnit`) and instead use OpenGL ES 2.0 (and `gamnit`).

The resulting message is not ideal, getting a "not yet supported" while it is "not supported anymore", but this is a temporary solution until we simply update or remove all mnit clients from the repo.