### PR TITLE
location: fix located_in behavior

### DIFF
--- a/src/location.nit
+++ b/src/location.nit
@@ -208,7 +208,7 @@ class Location
 
 		if line_start == loc.line_start then
 			if column_start < loc.column_start then return false
-			if column_start > loc.column_end then return false
+			if line_start == loc.line_end and column_start > loc.column_end then return false
 		end
 
 		if line_end == loc.line_end and column_end > loc.column_end then return false


### PR DESCRIPTION
Before this PR, asking if `1,12--1,12` was in `1,1--2,1` returned `false`.

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>