### PR TITLE
Gamnit: rewrite Android lifecycle support

### DIFF
--- a/contrib/action_nitro/src/action_nitro.nit
+++ b/contrib/action_nitro/src/action_nitro.nit
@@ -16,11 +16,10 @@ module action_nitro is
 	app_name "Action Nitro"
 	app_namespace "net.xymus.action_nitro"
 	app_version(1, 0, git_revision)
-
-	android_manifest_activity """android:screenOrientation="sensorLandscape""""
 end
 
 import gamnit::depth
+import gamnit::landscape
 
 import game
 

--- a/contrib/asteronits/src/asteronits.nit
+++ b/contrib/asteronits/src/asteronits.nit
@@ -17,12 +17,11 @@ module asteronits is
 	app_name "Asteronits"
 	app_namespace "org.nitlanguage.asteronits"
 	app_version(1, 0, git_revision)
-
-	android_manifest_activity """android:screenOrientation="sensorLandscape""""
-	android_api_target 10
 end
 
 import gamnit::flat
+
+import gamnit::landscape
 
 import game_logic
 import spritesheet

--- a/contrib/model_viewer/src/model_viewer.nit
+++ b/contrib/model_viewer/src/model_viewer.nit
@@ -17,12 +17,10 @@ module model_viewer is
 	app_name "Model Viewer"
 	app_namespace "org.nitlanguage.model_viewer"
 	app_version(1, 0, git_revision)
-
-	android_manifest_activity """android:screenOrientation="landscape""""
-	android_api_target 10
 end
 
 import gamnit::depth
+import gamnit::landscape
 
 import globe
 

--- a/lib/android/native_app_glue.nit
+++ b/lib/android/native_app_glue.nit
@@ -216,12 +216,22 @@ redef class App
 	# Raised when the soft input window being shown or hidden, and similar events.
 	fun content_rect_changed do end
 
-	# Call the `ALooper` to retrieve events and callback the application
+	# Call the `ALooper_pollAll` to retrieve events and callback the application
 	fun poll_looper(timeout_ms: Int) import handle_looper_event `{
 		int ident;
 		int event;
 		void* source;
 		while ((ident=ALooper_pollAll(timeout_ms, NULL, &event, &source)) >= 0) {
+			App_handle_looper_event(self, ident, event, source);
+		}
+	`}
+
+	# Call the `ALooper_pollOnce` to retrieve at most one event and callback the application
+	fun poll_looper_pause(timeout_ms: Int) import handle_looper_event `{
+		int event;
+		void* source;
+		int ident = ALooper_pollOnce(timeout_ms, NULL, &event, &source);
+		if (ident >= 0) {
 			App_handle_looper_event(self, ident, event, source);
 		}
 	`}

--- a/lib/gamnit/android19.nit
+++ b/lib/gamnit/android19.nit
@@ -22,6 +22,7 @@ end
 
 import android
 intrude import display_android
+intrude import gamnit_android
 intrude import android::load_image
 
 in "Java" `{

--- a/lib/gamnit/display_android.nit
+++ b/lib/gamnit/display_android.nit
@@ -39,7 +39,7 @@ redef class GamnitDisplay
 		setup_egl_display native_display
 
 		# We need 8 bits per color for selection by color
-		select_egl_config(red_bits, green_bits, blue_bits, 0, 8, 0, 0)
+		select_egl_config(red_bits, green_bits, blue_bits, 0, 8, 0)
 
 		var format = egl_config.attribs(egl_display).native_visual_id
 		assert not native_window.address_is_null

--- a/lib/gamnit/display_android.nit
+++ b/lib/gamnit/display_android.nit
@@ -14,11 +14,13 @@
 
 # Gamnit display implementation for Android
 #
-# Generated APK files require OpenGL ES 2.0.
+# Gamnit apps on Android require OpenGL ES 3.0 because, even if it uses only
+# the OpenGL ES 2.0 API, the default shaders have more than 8 vertex attributes.
+# OpenGL ES 3.0 ensures at least 8 vertex attributes, while 2.0 ensures only 4.
 #
-# This modules uses `android::native_app_glue` and the Android NDK.
+# This module relies on `android::native_app_glue` and the Android NDK.
 module display_android is
-	android_manifest """<uses-feature android:glEsVersion="0x00020000"/>"""
+	android_manifest """<uses-feature android:glEsVersion="0x00030000" android:required="true" />"""
 end
 
 import ::android::game
@@ -40,6 +42,7 @@ redef class GamnitDisplay
 		select_egl_config(red_bits, green_bits, blue_bits, 0, 8, 0, 0)
 
 		var format = egl_config.attribs(egl_display).native_visual_id
+		assert not native_window.address_is_null
 		native_window.set_buffers_geometry(0, 0, format)
 
 		setup_egl_context native_window

--- a/lib/gamnit/display_linux.nit
+++ b/lib/gamnit/display_linux.nit
@@ -50,7 +50,7 @@ redef class GamnitDisplay
 		setup_egl_display sdl_window.wm_info.display_handle
 
 		if debug_gamnit then print "Setting up EGL context"
-		select_egl_config(red_bits, green_bits, blue_bits, 8, 8, 0, 0)
+		select_egl_config(red_bits, green_bits, blue_bits, 8, 8, 0)
 		setup_egl_context sdl_window.wm_info.window_handle
 	end
 

--- a/lib/gamnit/egl.nit
+++ b/lib/gamnit/egl.nit
@@ -46,7 +46,7 @@ redef class GamnitDisplay
 	end
 
 	# Select an EGL config
-	protected fun select_egl_config(red, green, blue, alpha, depth, stencil, sample: Int)
+	protected fun select_egl_config(red, green, blue, alpha, depth, stencil: Int)
 	do
 		var config_chooser = new EGLConfigChooser
 		config_chooser.renderable_type_egl
@@ -57,7 +57,10 @@ redef class GamnitDisplay
 		if alpha > 0 then config_chooser.alpha_size = alpha
 		if depth > 0 then config_chooser.depth_size = depth
 		if stencil > 0 then config_chooser.stencil_size = stencil
-		if sample > 0 then config_chooser.sample_buffers = sample
+
+		config_chooser.sample_buffers = 1
+		config_chooser.samples = 4
+
 		config_chooser.close
 
 		var configs = config_chooser.choose(egl_display)
@@ -72,6 +75,7 @@ redef class GamnitDisplay
 				print "  Caveats: {attribs.caveat}"
 				print "  Size of RGBA: {attribs.red_size} {attribs.green_size} {attribs.blue_size} {attribs.alpha_size}"
 				print "  Buffer, depth, stencil: {attribs.buffer_size} {attribs.depth_size} {attribs.stencil_size}"
+				print "  Sample buffers, samples: {attribs.sample_buffers} {attribs.samples}"
 			end
 		end
 

--- a/lib/gamnit/gamnit.nit
+++ b/lib/gamnit/gamnit.nit
@@ -33,7 +33,16 @@ redef class App
 	#
 	# The gamnit services redefine this method to prepare optimizations and more.
 	# Clients may also refine this method to prepare custom OpenGL resources.
-	fun create_gamnit
+	fun create_gamnit do end
+
+	# Hook to prepare for recreating the OpenGL context
+	#
+	# Some gamnit services refine this method to reset caches before the
+	# next call to `create_gamnit`.
+	fun recreate_gamnit do end
+
+	# Create and set `self.display`
+	fun create_display
 	do
 		var display = new GamnitDisplay
 		display.setup

--- a/lib/gamnit/gamnit_android.nit
+++ b/lib/gamnit/gamnit_android.nit
@@ -13,20 +13,37 @@
 # limitations under the License.
 
 # Support services for Gamnit on Android
-module gamnit_android
+module gamnit_android is
+	android_api_min 15
+	android_api_target 15
+	android_manifest_activity """android:theme="@android:style/Theme.NoTitleBar.Fullscreen""""
+	android_manifest_activity """android:configChanges="orientation|screenSize|keyboard|keyboardHidden""""
+end
 
 import android
 
 intrude import gamnit
 intrude import android::input_events
+import egl
+
+private import realtime
+
+# Print Android lifecycle events to the log?
+fun print_lifecycle_events: Bool do return true
 
 redef class App
+
+	# ---
+	# User inputs
+
 	redef fun feed_events do app.poll_looper 0
 
 	redef fun native_input_key(event) do return accept_event(event)
 
 	redef fun native_input_motion(event)
 	do
+		if not scene_created then return false
+
 		var ie = new AndroidMotionEvent(event)
 		var handled = accept_event(ie)
 
@@ -34,4 +51,257 @@ redef class App
 
 		return handled
 	end
+
+	# ---
+	# Handle OS lifecycle and set current state flag
+
+	# State between `init_window` and `term_window`
+	private var window_created = false
+
+	# State between `gained_focus` and `lost_focus`
+	private var focused = false
+
+	# State between `resume` and `pause`
+	private var resumed = false
+
+	# Stage after `destroy`
+	private var destroyed = false
+
+	redef fun init_window
+	do
+		if print_lifecycle_events then print "+ init_window"
+		window_created = true
+		set_active
+		super
+	end
+
+	redef fun term_window
+	do
+		if print_lifecycle_events then print "+ term_window"
+		window_created = false
+		set_inactive
+		super
+	end
+
+	redef fun resume
+	do
+		if print_lifecycle_events then print "+ resume"
+		resumed = true
+		set_active
+		super
+	end
+
+	redef fun pause
+	do
+		if print_lifecycle_events then print "+ pause"
+		resumed = false
+		set_inactive
+		super
+	end
+
+	redef fun gained_focus
+	do
+		if print_lifecycle_events then print "+ gained_focus"
+		focused = true
+		set_active
+		super
+	end
+
+	redef fun lost_focus
+	do
+		if print_lifecycle_events then print "+ lost_focus"
+		focused = false
+		super
+	end
+
+	redef fun destroy
+	do
+		if print_lifecycle_events then print "+ destroy"
+		destroyed = true
+		super
+	end
+
+	redef fun start
+	do
+		if print_lifecycle_events then print "+ start"
+		super
+	end
+
+	redef fun stop
+	do
+		if print_lifecycle_events then print "+ stop"
+		set_inactive
+		super
+	end
+
+	redef fun config_changed
+	do
+		if print_lifecycle_events then print "+ config_changed"
+		super
+	end
+
+	redef fun window_resized
+	do
+		if print_lifecycle_events then print "+ window_resized"
+		super
+	end
+
+	redef fun content_rect_changed
+	do
+		if print_lifecycle_events then print "+ content_rect_changed"
+		super
+	end
+
+	# ---
+	# Update gamnit app
+
+	# The app is fully visible and focused
+	private var active = false
+
+	# The scene was set up
+	private var scene_created = false
+
+	private fun set_active
+	do
+		assert not destroyed
+		if window_created and resumed and focused and not active then
+			var display = display
+			if display == null then
+				# Initial create
+				create_display
+				create_gamnit
+				display = self.display
+			else
+				# Try to reuse the EGL context
+				var native_window = app.native_app_glue.window
+				assert not native_window.address_is_null
+				var needs_recreate = display.check_egl_context(native_window)
+				if needs_recreate then
+
+					# Skip frame
+					if display.native_window_is_invalid then
+						print_error "the native window is invalid, skip frame"
+						return
+					end
+
+					# The context was lost, reload everything
+					create_gamnit
+					recreate_gamnit
+				end
+			end
+
+			# Update screen dimensions
+			assert display != null
+			display.update_size
+			app.on_resize display
+
+			if not scene_created then
+				# Initial launch
+				if debug_gamnit then print "set_active: create"
+				create_scene
+				scene_created = true
+				on_restore_state
+			else
+				# Next to first launch, reload
+				if debug_gamnit then print "set_active: recreate"
+			end
+
+			active = true
+		end
+	end
+
+	private fun set_inactive
+	do
+		active = false
+	end
+
+	# ---
+	# Implement gamnit entry points
+
+	redef fun recreate_gamnit
+	do
+		super
+
+		# Reload all textures
+		if debug_gamnit then print "recreate_gamnit: reloading {all_root_textures.length} textures"
+		for texture in all_root_textures do
+			if debug_gamnit then print "recreate_gamnit: loading {texture}"
+			texture.load true
+			var gamnit_error = texture.error
+			if gamnit_error != null then print_error gamnit_error
+		end
+	end
+
+	redef fun run
+	do
+		if debug_gamnit then print "run: start"
+		scene_created = false
+
+		while not destroyed do
+			if not active then
+				if debug_gamnit then print "run: wait"
+				app.poll_looper_pause -1
+
+			else
+				if debug_gamnit then print "run: frame"
+
+				var native_window = app.native_app_glue.window
+				assert not native_window.address_is_null
+
+				var display = display
+				assert display != null
+
+				var needs_recreate = display.check_egl_context(native_window)
+				if needs_recreate then
+					if display.native_window_is_invalid then
+						# This should be rare and may cause more issues, log it
+						print "The native window is invalid, skip frame"
+						set_inactive
+						continue
+					end
+
+					# The context was lost, reload everything
+					create_gamnit
+					recreate_gamnit
+				end
+
+				assert scene_created
+				frame_full
+			end
+		end
+
+		if debug_gamnit then print "run: exit"
+		exit 0
+	end
+end
+
+redef class GamnitDisplay
+
+	redef var width = 1080
+	redef var height = 720
+
+	# Update `width` and `height`
+	private fun update_size
+	do
+		var context = app.native_activity
+		self.width = context.window_width
+		self.height = context.window_height
+	end
+end
+
+redef class NativeActivity
+
+	private fun window_height: Int in "Java" `{
+		android.view.View view = self.getWindow().getDecorView();
+		return view.getBottom() - view.getTop();
+	`}
+
+	private fun window_width: Int in "Java" `{
+		android.view.View view = self.getWindow().getDecorView();
+		return view.getRight() - view.getLeft();
+	`}
+
+	private fun orientation: Int in "Java" `{
+		return self.getResources().getConfiguration().orientation;
+	`}
 end

--- a/lib/gamnit/gamnit_linux.nit
+++ b/lib/gamnit/gamnit_linux.nit
@@ -50,6 +50,7 @@ redef class App
 	redef fun on_create
 	do
 		super
+		create_display
 		create_gamnit
 		create_scene
 	end

--- a/lib/gamnit/landscape.nit
+++ b/lib/gamnit/landscape.nit
@@ -1,0 +1,18 @@
+# This file is part of NIT (http://www.nitlanguage.org).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lock the application in the landscape orientation
+module landscape
+
+import android::landscape is conditional(android)

--- a/lib/gamnit/portrait.nit
+++ b/lib/gamnit/portrait.nit
@@ -1,0 +1,18 @@
+# This file is part of NIT (http://www.nitlanguage.org).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lock the application in the portrait orientation
+module portrait
+
+import android::portrait is conditional(android)

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -173,7 +173,7 @@ android {
         }
         externalNativeBuild {
             cmake {
-                cppFlags ""
+                arguments "-DANDROID_TOOLCHAIN=gcc"
             }
         }
     }
@@ -307,7 +307,7 @@ set(CMAKE_USE_PTHREADS_INIT TRUE)
 add_definitions("-DGC_DONT_DEFINE_LINK_MAP")
 
 ## Silence warning
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-tautological-pointer-compare")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 
 add_subdirectory(${lib_src_DIR} ${lib_build_DIR} )
 include_directories(${lib_src_DIR}/include)

--- a/src/platform/app_annotations.nit
+++ b/src/platform/app_annotations.nit
@@ -39,8 +39,8 @@ class AppProject
 	var version_code: Int is lazy do
 
 		# Get the date and time (down to the minute) as string
-		var local_time = new Tm.localtime
-		var local_time_s = local_time.strftime("%y%m%d%H%M")
+		var gmtime = new Tm.gmtime
+		var local_time_s = gmtime.strftime("%y%m%d%H%M")
 		return local_time_s.to_i
 	end
 


### PR DESCRIPTION
Rewrite much of the Android support to better deal with system state changes. This includes handling out of order lifecycle messages, temporarily invalid OpenGL display surfaces, and recreating the OpenGL context when it is released by the system.

In practice, this PR recreates in `gamnit::gamnit_android` a better version than what is in `android::game`. The old `android::game` could probably be removed with `mnit` and a small clean up.

As a bonus:
* Into portable* services to lock the device orientation. (The iOS variant will be in another PR when #2605 is merged.)
* Ask for 4x antialiasing, it should be available on all target platforms.
* Compile Android apps using gcc, it appears to compile a more stable GC. We can probably tweak a few defines to use clang instead.
* Fix numeric version numbers using the local time, causing surprises when compiled in the cloud.
