### PR TITLE
src/model: introduce model_nlp module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ nitunit.xml
 .DS_Store
 
 **/nit_compile/*
+.nlp/

--- a/lib/nlp/nlp.nit
+++ b/lib/nlp/nlp.nit
@@ -30,7 +30,7 @@ class NLPIndex
 	redef fun parse_string(string) do
 		var vector = new Vector
 		if string.trim.is_empty then return vector
-		var doc = nlp_processor.process(string)
+		var doc = nlp_processor.process(string.to_lower)
 		for sentence in doc.sentences do
 			for token in sentence.tokens do
 				if not accept_token(token) then continue

--- a/src/doc/commands/commands_catalog.nit
+++ b/src/doc/commands/commands_catalog.nit
@@ -52,31 +52,31 @@ class CmdCatalogSearch
 		matches = matches.rerank.sort(vis_sorter, score_sorter)
 
 		# lookup by tags
-		var malus = matches.length
+		var malus = matches.length.to_f
 		if catalog.tag2proj.has_key(query) then
 			for mpackage in catalog.tag2proj[query] do
 				matches.add new IndexMatch(mpackage, malus)
-				malus += 1
+				malus += 1.0
 			end
 			matches = matches.uniq.rerank.sort(vis_sorter, score_sorter)
 		end
 
 		# lookup by full_name prefix
-		malus = matches.length
+		malus = matches.length.to_f
 		var full_matches = new IndexMatches
 		for match in index.find_by_full_name_prefix(query).
 			sort(lfname_sorter, fname_sorter) do
-			match.score += 1
+			match.score += 1.0
 			full_matches.add match
 		end
 		matches = matches.uniq
 
 		# lookup by similarity
-		malus = matches.length
+		malus = matches.length.to_f
 		var sim_matches = new IndexMatches
 		for match in index.find_by_similarity(query).sort(score_sorter, lname_sorter, name_sorter) do
-			if match.score > query.length then break
-			match.score += 1
+			if match.score > query.length.to_f then break
+			match.score += 1.0
 			sim_matches.add match
 		end
 		matches.add_all sim_matches

--- a/src/examples/nitnlp.nit
+++ b/src/examples/nitnlp.nit
@@ -1,0 +1,114 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# An example of how to use the `model_nlp` index
+module nitnlp is example
+
+import frontend
+import doc::doc_down
+import model::model_nlp
+import model::model_collect
+import doc::commands::commands_base
+
+redef class ToolContext
+
+	# --server
+	var opt_nlp_server = new OptionString("StanfordNLP server URI (default is https://localhost:9000)", "-s", "--server")
+
+	# --lang
+	var opt_nlp_lang = new OptionString("Language to use (default is en)", "-l", "--lang")
+
+	# --query
+	var opt_nlp_query = new OptionString("Query to perform", "-q", "--query")
+
+	init do
+		super
+		option_context.add_option(opt_nlp_server, opt_nlp_lang, opt_nlp_query)
+	end
+end
+
+# An example of a tool using NLP queries and index
+class NitIndexExample
+
+	# Model view used to access model
+	var view: ModelView
+
+	# NLP server address
+	var host: String
+
+	# NLP language
+	var lang: String
+
+	# NLP client (to connect to the server)
+	var cli: NLPClient is lazy do
+		var cli = new NLPClient(host)
+		cli.language = lang
+		return cli
+	end
+
+	# NLP index
+	var index = new ModelNLPIndex(cli) is lazy
+
+	# Build the NLP index from the view content
+	fun build_index(view: ModelView) do
+		print "Building index..."
+		index.index_model(view)
+		print "Indexed {index.documents.length} documents"
+	end
+
+	# Print results obtained from a NLP query
+	fun perform_query(query: String) do
+		var matches = index.find(query).uniq.sort(new ScoreComparator).limit(10)
+		for match in matches do
+			print "{match.mentity.full_name} ({match.score})"
+		end
+	end
+end
+
+# build toolcontext
+var toolcontext = new ToolContext
+toolcontext.tooldescription = "usage: nitindex <files>"
+toolcontext.process_options(args)
+var arguments = toolcontext.option_context.rest
+
+# build model
+var model = new Model
+var mbuilder = new ModelBuilder(model, toolcontext)
+var mmodules = mbuilder.parse_full(arguments)
+
+# process
+if mmodules.is_empty then return
+mbuilder.run_phases
+toolcontext.run_global_phases(mmodules)
+var mainmodule = toolcontext.make_main_module(mmodules)
+
+# prepare nlp tool
+var tool = new NitIndexExample(
+	view = new ModelView(toolcontext.modelbuilder.model, mainmodule),
+	host = toolcontext.opt_nlp_server.value or else "http://localhost:9000",
+	lang = toolcontext.opt_nlp_lang.value or else "en")
+
+# perform queries
+var query = toolcontext.opt_nlp_query.value
+if query != null then
+	tool.perform_query(query)
+	return
+end
+
+loop
+	print "\nEnter query:"
+	printn "> "
+	query = sys.stdin.read_line
+	tool.perform_query(query)
+end

--- a/src/model/model_index.nit
+++ b/src/model/model_index.nit
@@ -201,7 +201,7 @@ redef class Model
 		var full_matches = new IndexMatches
 		for match in index.find_by_full_name_prefix(query).
 			sort(kind_sorter, lfname_sorter, fname_sorter) do
-			match.score += malus
+			match.score += malus.to_f
 			full_matches.add match
 		end
 		matches = matches.uniq
@@ -215,7 +215,7 @@ redef class Model
 		malus = matches.length
 		var sim_matches = new IndexMatches
 		for match in index.find_by_similarity(query).sort(score_sorter, kind_sorter, lname_sorter, name_sorter) do
-			match.score += malus
+			match.score += malus.to_f
 			sim_matches.add match
 		end
 		matches.add_all sim_matches
@@ -305,7 +305,7 @@ class ModelIndex
 		var score = 1
 		for mentities in array do
 			for mentity in mentities do
-				results.add new IndexMatch(mentity, score)
+				results.add new IndexMatch(mentity, score.to_f)
 			end
 			score += 1
 		end
@@ -330,7 +330,7 @@ class ModelIndex
 		var results = new IndexMatches
 		for mentity in mentities do
 			if mentity isa MClassDef or mentity isa MPropDef then continue
-			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.name))
+			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.name).to_f)
 		end
 		return results
 	end
@@ -343,7 +343,7 @@ class ModelIndex
 		var results = new IndexMatches
 		for mentity in mentities do
 			if mentity isa MClassDef or mentity isa MPropDef then continue
-			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.full_name))
+			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.full_name).to_f)
 		end
 		return results
 	end
@@ -353,8 +353,8 @@ class ModelIndex
 		var results = new IndexMatches
 		for mentity in mentities do
 			if mentity isa MClassDef or mentity isa MPropDef then continue
-			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.name))
-			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.full_name))
+			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.name).to_f)
+			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.full_name).to_f)
 		end
 		return results
 	end
@@ -364,7 +364,7 @@ class ModelIndex
 		var results = find_by_name_prefix(name)
 		for mentity in mentities do
 			if mentity isa MClassDef or mentity isa MPropDef then continue
-			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.name))
+			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.name).to_f)
 		end
 		return results
 	end
@@ -374,7 +374,7 @@ class ModelIndex
 		var results = find_by_full_name_prefix(name)
 		for mentity in mentities do
 			if mentity isa MClassDef or mentity isa MPropDef then continue
-			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.full_name))
+			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.full_name).to_f)
 		end
 		return results
 	end
@@ -394,8 +394,8 @@ class ModelIndex
 
 		for mentity in mentities do
 			if mentity isa MClassDef or mentity isa MPropDef then continue
-			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.name))
-			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.full_name))
+			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.name).to_f)
+			results.add new IndexMatch(mentity, name.levenshtein_distance(mentity.full_name).to_f)
 		end
 		return results
 	end
@@ -479,7 +479,7 @@ class IndexMatches
 		var res = new IndexMatches
 		for match in self do
 			res.add match
-			match.score = res.length
+			match.score = res.length.to_f
 		end
 		return res
 	end
@@ -515,7 +515,7 @@ class IndexMatch
 	# on the search method producing the match and the comparators used to sort
 	# the matches.
 	# The only universal rule is: low score = relevance.
-	var score: Int is writable
+	var score: Float is writable
 
 	# By default matches are compared only on their score
 	redef fun <=>(o) do return score <=> o.score

--- a/src/model/model_nlp.nit
+++ b/src/model/model_nlp.nit
@@ -1,0 +1,173 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ModelIndex based on a NLPIndex
+#
+# Can be used to perform NLP queries on a Model.
+# Model entities are matched by the relevance of the natural language found
+# in their comments.
+module model_nlp
+
+import nlp
+import model::model_index
+import md5
+import markdown::decorators
+
+# A ModelIndex that accepts NLP queries
+class ModelNLPIndex
+	super ModelIndex
+	super NLPIndex
+
+	init do cache_dir.mkdir
+
+	# Cache directory
+	#
+	# Used so we don't need to call the NLP server for already processed vectors.
+	var cache_dir: String = ".nlp"
+
+	# Is there a cached vector for the `md5` representation of a string?
+	fun has_cache(md5: String): Bool do
+		return (cache_dir / md5).file_exists
+	end
+
+	# Cache the `vector` associated with the `md5` representation of a string
+	fun save_cache(md5: String, vector: Vector) do
+		vector.join(", ", ": ").write_to_file(cache_dir / md5)
+	end
+
+	# Load the corresponding vector from a cached `md5` representation of a string
+	fun load_cache(md5: String): Vector do
+		var v = new Vector
+		var content = (cache_dir / md5).to_path.read_all
+		if content.is_empty then return v
+		var parts = content.split(", ")
+		for part in parts do
+			var ps = part.split(": ")
+			v[ps.first.trim] = ps.last.trim.to_f
+		end
+		return v
+	end
+
+	# Index model entities
+	#
+	# By default, we do not index class and property definitions.
+	# Redefine this method if you want to do so.
+	fun index_model(view: ModelView) do
+		for mentity in view.mpackages do index_mentity(mentity)
+		for mentity in view.mgroups do index_mentity(mentity)
+		for mentity in view.mmodules do index_mentity(mentity)
+		for mentity in view.mclasses do index_mentity(mentity)
+		for mentity in view.mproperties do index_mentity(mentity)
+		update_index
+	end
+
+	# Get the NLP vector for a MEntity
+	fun mentity_vector(mentity: MEntity): Vector do
+		var content = ""
+		var mdoc = mentity.mdoc_or_fallback
+		if mdoc != null then
+			var parser = new MarkdownProcessor
+			var decorator = new DocIndexDecorator
+			parser.decorator = decorator
+			parser.process(mdoc.content.join("\n"))
+			content = decorator.raw_md.write_to_string
+		end
+
+		var md5 = content.md5
+		if has_cache(md5) then return load_cache(md5)
+
+		var vector = parse_string(content)
+		save_cache(md5, vector)
+
+		return vector
+	end
+
+	# Add `mentity` to the index
+	fun index_mentity(mentity: MEntity): Document do
+		index mentity
+		var terms = mentity_vector(mentity)
+		var doc = new Document(mentity.full_name, mentity.location.to_s, terms)
+		index_document doc
+
+		return doc
+	end
+
+	# Find mentities using NLP queries
+	#
+	# This implementation redefines the default index behavior to use NLP queries
+	# instead of the name prefix and levenshtein matches.
+	redef fun find(name) do
+		var results = new IndexMatches
+		for match in match_string(name) do
+			var mentity = find_by_full_name(match.document.title).first.mentity
+			results.add new nitc::IndexMatch(mentity, 1.0 - match.similarity)
+		end
+		return results
+	end
+
+	# By default we blacklist things like symbols and numbers
+	redef var blacklist_pos = [".", ",", "''", "``", ":", "POS", "CD", "-RRB-", "-LRB-", "SYM"]
+
+	# Default stoplist includes most of the symbols not recognized by StanfordNLP
+	#
+	# FIXME this should be done by the NLP engine.
+	redef var stoplist = [
+		"=", "==", "&lt;", "&gt;", "*", "/", "\\", "=]", "%", "_", "!=", ">=",
+		"<=", "<=>", "+", "-", ">>", "<<"]
+end
+
+# Custom decorator used to extract raw strings from Markdown constructs
+#
+# Used so we don't index Markdown tokens, only strings.
+private class DocIndexDecorator
+	super MdDecorator
+
+	var raw_md = new FlatBuffer
+
+	redef fun add_headline(v, block) do
+		var first_line = block.block.first_line
+		if first_line != null then raw_md.append first_line.value
+		super
+	end
+
+	redef fun add_paragraph(v, block) do
+		raw_md.append block.block.text
+		super
+	end
+
+	redef fun add_listitem(v, block) do
+		raw_md.append block.block.text
+		super
+	end
+
+	redef fun add_span_code(v, buffer, from, to) do
+		raw_md.add ' '
+		buffer.read(raw_md, from, to)
+		raw_md.add ' '
+		super
+	end
+end
+
+redef class Text
+	# Read `self` between `nstart` and `nend` (excluded) and writte chars to `out`.
+	private fun read(out: FlatBuffer, nstart, nend: Int): Int do
+		var pos = nstart
+		while pos < length and pos < nend do
+			out.add self[pos]
+			pos += 1
+		end
+		if pos == length then return -1
+		return pos
+	end
+end


### PR DESCRIPTION
The `model_nlp` module provides an implementation of the ModelIndex API using NLP queries.
The main idea is to match a natural language query to Model entities comments.

A usage example can be found in `src/examples/nitnlp.nit`:

First, you need to start an implementation of a NLPServer:
~~~sh
nitc lib/nlp/examples/nlp_server.nit
./nlp_server -c "/absolute/path/to/stanfordnlp/library/*"
~~~

Once the NLP server's running, you can start the NLP index tool:

~~~sh
nitc src/examples/nitnlp.nit
./nitnlp --host "http://localhost:8000" --lang "en" lib/popcorn

Building index...
Indexed 2931 documents

Enter query:
> HTTP post request

nitcorn::HttpRequest::method (0.44)
nitcorn::HttpRequest::method= (0.44)
curl::CurlHTTPRequest::data= (0.476)
curl::CurlHTTPRequest::data (0.476)
popcorn::Handler::post (0.503)
nitcorn::HttpRequest::all_args= (0.646)
nitcorn::HttpRequest::all_args (0.646)
curl::CURLOption::postfields (0.661)
curl::CurlRequest (0.685)
nitcorn::HttpRequest::post_args= (0.695)
~~~



