### PR TITLE
doc/commands: extract CmdCode superclass

### DIFF
--- a/src/doc/api/api_model.nit
+++ b/src/doc/api/api_model.nit
@@ -205,7 +205,7 @@ end
 class APIEntityCode
 	super APICommand
 
-	redef fun command do return new CmdCode(config.view, config.modelbuilder)
+	redef fun command do return new CmdEntityCode(config.view, config.modelbuilder)
 end
 
 # Return the UML diagram for MEntity.

--- a/src/doc/commands/commands_html.nit
+++ b/src/doc/commands/commands_html.nit
@@ -104,9 +104,9 @@ redef class CmdComment
 	end
 end
 
-redef class CmdCode
+redef class CmdEntityCode
 	redef fun to_html do
-		var output = render
+		var output = render_code(node)
 		if output == null then return ""
 		return "<pre>{output.write_to_string}</pre>"
 	end

--- a/src/doc/commands/commands_http.nit
+++ b/src/doc/commands/commands_http.nit
@@ -28,8 +28,6 @@ redef class DocCommand
 end
 
 redef class CmdEntity
-
-
 	redef fun http_init(req) do
 		var name = req.param("id")
 		if name != null then name = name.from_percent_encoding
@@ -124,6 +122,18 @@ redef class CmdCode
 	redef fun http_init(req) do
 		format = req.string_arg("format") or else "raw"
 		return super
+	end
+end
+
+redef class CmdEntityCode
+	# FIXME avoid linearization conflict
+	redef fun http_init(req) do
+		var name = req.param("id")
+		if name != null then name = name.from_percent_encoding
+		mentity_name = name
+
+		format = req.string_arg("format") or else "raw"
+		return init_command
 	end
 end
 

--- a/src/doc/commands/commands_json.nit
+++ b/src/doc/commands/commands_json.nit
@@ -65,7 +65,7 @@ end
 redef class CmdComment
 	redef fun to_json do
 		var obj = new JsonObject
-		var render = self.render
+		var render = self.render_comment
 		if render != null then
 			obj["documentation"] = render.write_to_string
 		end

--- a/src/doc/commands/commands_json.nit
+++ b/src/doc/commands/commands_json.nit
@@ -73,14 +73,14 @@ redef class CmdComment
 	end
 end
 
-redef class CmdCode
+redef class CmdEntityCode
 	redef fun to_json do
 		var obj = new JsonObject
 		var node = self.node
 		if node != null then
 			obj["location"] = node.location
 		end
-		var output = render
+		var output = render_code(node)
 		if output != null then
 			obj["code"] = output.write_to_string
 		end

--- a/src/doc/commands/commands_model.nit
+++ b/src/doc/commands/commands_model.nit
@@ -70,7 +70,7 @@ class CmdComment
 	end
 
 	# Render `mdoc` depending on `full_doc` and `format`
-	fun render: nullable Writable do
+	fun render_comment: nullable Writable do
 		var mdoc = self.mdoc
 		if mdoc == null then return null
 

--- a/src/doc/commands/commands_model.nit
+++ b/src/doc/commands/commands_model.nit
@@ -383,17 +383,14 @@ class WarningNoFeatures
 	redef fun to_s do return "No features for `{mentity.full_name}`"
 end
 
-# Cmd that finds the source code related to an `mentity`
-class CmdCode
-	super CmdEntity
+# Abstract command that returns source-code pieces
+abstract class CmdCode
+	super DocCommand
 
-	autoinit(view, modelbuilder, mentity, mentity_name, format)
+	autoinit(view, modelbuilder, format)
 
 	# ModelBuilder used to get AST nodes
 	var modelbuilder: ModelBuilder
-
-	# AST node to return
-	var node: nullable ANode = null is optional, writable
 
 	# Rendering format
 	#
@@ -405,6 +402,32 @@ class CmdCode
 	# For example you can choose to render code as HTML inside a JSON object response.
 	# Another example is to render raw format to put into a HTML code tag.
 	var format = "raw" is optional, writable
+
+	# Render `node` depending on the selected `format`
+	fun render_code(node: nullable ANode): nullable Writable do
+		if node == null then return null
+		if format == "html" then
+			var hl = new HtmlightVisitor
+			hl.highlight_node node
+			return hl.html
+		else if format == "ansi" then
+			var hl = new AnsiHighlightVisitor
+			hl.highlight_node node
+			return hl.result
+		end
+		return node.location.text
+	end
+end
+
+# Cmd that finds the source code related to an `mentity`
+class CmdEntityCode
+	super CmdEntity
+	super CmdCode
+
+	autoinit(view, modelbuilder, mentity, mentity_name, format)
+
+	# AST node to return
+	var node: nullable ANode = null is optional, writable
 
 	# Same as `CmdEntity::init_mentity`
 	#
@@ -421,24 +444,6 @@ class CmdCode
 		node = modelbuilder.mentity2node(mentity)
 		if node == null then return new WarningNoCode(mentity)
 		return res
-	end
-
-	# Render `node` depending on the selected `format`
-	fun render: nullable Writable do
-		var node = self.node
-		if node == null then return null
-		if format == "html" then
-			var hl = new HtmlightVisitor
-			hl.highlight_node node
-			return hl.html
-		else if format == "ansi" then
-			var hl = new AnsiHighlightVisitor
-			hl.highlight_node node
-			return hl.result
-		end
-		var mentity = self.mentity
-		if mentity == null then return null
-		return mentity.location.text
 	end
 end
 

--- a/src/doc/commands/commands_parser.nit
+++ b/src/doc/commands/commands_parser.nit
@@ -136,7 +136,7 @@ class CommandParser
 	fun new_command(name: String): nullable DocCommand do
 		# CmdEntity
 		if name == "doc" then return new CmdComment(view)
-		if name == "code" then return new CmdCode(view, modelbuilder)
+		if name == "code" then return new CmdEntityCode(view, modelbuilder)
 		if name == "lin" then return new CmdLinearization(view)
 		if name == "defs" then return new CmdFeatures(view)
 		if name == "parents" then return new CmdParents(view)

--- a/src/doc/commands/tests/test_commands_http.nit
+++ b/src/doc/commands/tests/test_commands_http.nit
@@ -175,7 +175,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_code is test do
 		var req = new_request("/test_prog::Career")
-		var cmd = new CmdCode(test_view, test_builder)
+		var cmd = new CmdEntityCode(test_view, test_builder)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.node isa AStdClassdef
@@ -184,7 +184,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_code_format is test do
 		var req = new_request("/test_prog::Career?format=html")
-		var cmd = new CmdCode(test_view, test_builder)
+		var cmd = new CmdEntityCode(test_view, test_builder)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.node isa AStdClassdef
@@ -193,7 +193,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_code_no_code is test do
 		var req = new_request("/test_prog")
-		var cmd = new CmdCode(test_view, test_builder)
+		var cmd = new CmdEntityCode(test_view, test_builder)
 		var res = cmd.http_init(req)
 		assert res isa WarningNoCode
 	end

--- a/src/doc/commands/tests/test_commands_model.nit
+++ b/src/doc/commands/tests/test_commands_model.nit
@@ -151,14 +151,14 @@ class TestCommandsModel
 	# CmdCode
 
 	fun test_cmd_code is test do
-		var cmd = new CmdCode(test_view, test_builder, mentity_name = "test_prog::Career")
+		var cmd = new CmdEntityCode(test_view, test_builder, mentity_name = "test_prog::Career")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.node isa AStdClassdef
 	end
 
 	fun test_cmd_code_no_code is test do
-		var cmd = new CmdCode(test_view, test_builder, mentity_name = "test_prog")
+		var cmd = new CmdEntityCode(test_view, test_builder, mentity_name = "test_prog")
 		var res = cmd.init_command
 		assert res isa WarningNoCode
 	end

--- a/src/doc/commands/tests/test_commands_parser.nit
+++ b/src/doc/commands/tests/test_commands_parser.nit
@@ -141,7 +141,7 @@ class TestCommandsParser
 	fun test_cmd_parser_code is test do
 		var parser = new CommandParser(test_view, test_builder)
 		var cmd = parser.parse("code: test_prog::Character")
-		assert cmd isa CmdCode
+		assert cmd isa CmdEntityCode
 		assert parser.error == null
 		assert cmd.node != null
 	end

--- a/src/doc/term/term.nit
+++ b/src/doc/term/term.nit
@@ -207,7 +207,7 @@ redef class CmdFeatures
 	end
 end
 
-redef class CmdCode
+redef class CmdEntityCode
 
 	redef var format = "ansi" is optional
 
@@ -222,7 +222,7 @@ redef class CmdCode
 			print title
 		end
 		if no_color == null or not no_color then
-			var ansi = render
+			var ansi = render_code(node)
 			if ansi != null then
 				print "~~~"
 				print ansi.write_to_string


### PR DESCRIPTION
Provides a common super class to factorize code rendering services for doc commands.

Changes:
* renamed `CmdComment::render` to `render_comment` to avoid name conflicts with multiple inheritance
* extracted `CmdCode` command to factorize code related services
* introduced new class `CmdEntityCode`, in place of the old `CmdCode` class
* updated nitx/nitweb clients
* updated tests