### PR TITLE
nitc: check pkg-config packages availability later

### DIFF
--- a/src/ffi/pkgconfig.nit
+++ b/src/ffi/pkgconfig.nit
@@ -23,11 +23,12 @@ private import annotation
 private import literal
 
 redef class ToolContext
+	# Detects the `pkgconfig` annotation on the module declaration only
 	var pkgconfig_phase: Phase = new PkgconfigPhase(self, [literal_phase])
 end
 
-# Detects the `pkgconfig` annotation on the module declaration only.
-class PkgconfigPhase
+# Detects the `pkgconfig` annotation on the module declaration only
+private class PkgconfigPhase
 	super Phase
 
 	redef fun process_annotated_node(nmoduledecl, nat)
@@ -43,7 +44,7 @@ class PkgconfigPhase
 			return
 		end
 
-		# retreive module
+		# retrieve module
 		var nmodule = nmoduledecl.parent.as(AModule)
 		var mmodule = nmodule.mmodule.as(not null)
 

--- a/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
+++ b/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
@@ -138,19 +138,10 @@ redef class AModule
 		var pkgconfigs = mmodule.pkgconfigs
 		var pkg_cflags = ""
 		if not pkgconfigs.is_empty then
-			var cmd = "which pkg-config >/dev/null"
-			if system(cmd) != 0 then
-				v.fatal "FFI Error: Command `pkg-config` not found. Please install it"
-				return false
-			end
 
-			for p in pkgconfigs do
-				cmd = "pkg-config --exists '{p}'"
-				if system(cmd) != 0 then
-					v.fatal "FFI Error: package {p} is not found by `pkg-config`. Please install it."
-					return false
-				end
-			end
+			# Check if the pkgconfig packages are available
+			v.modelbuilder.toolcontext.check_pkgconfig_packages pkgconfigs
+			if not v.modelbuilder.toolcontext.check_errors then return false
 
 			pkg_cflags = "`pkg-config --cflags {pkgconfigs.join(" ")}`"
 			ldflags += " `pkg-config --libs {pkgconfigs.join(" ")}`"

--- a/src/platform/platform.nit
+++ b/src/platform/platform.nit
@@ -23,8 +23,10 @@ private import parser_util
 private import annotation
 
 redef class ToolContext
+	# Detects the `platform` annotation to set a mobile target platform
 	var platform_phase: Phase = new PlatformPhase(self, [modelize_property_phase])
 
+	# Get platform compilation settings from its `name`
 	protected fun platform_from_name(name: String): nullable Platform
 	do
 		return null

--- a/tests/sav/error_annot_pkgconfig_alt0.res
+++ b/tests/sav/error_annot_pkgconfig_alt0.res
@@ -1,1 +1,1 @@
-alt/error_annot_pkgconfig_alt0.nit:17,38--46: Error: dev package for `error_annot_pkgconfig_alt0` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.
+Error: dev package for `error_annot_pkgconfig_alt0` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.

--- a/tests/sav/error_annot_pkgconfig_alt1.res
+++ b/tests/sav/error_annot_pkgconfig_alt1.res
@@ -1,2 +1,2 @@
-alt/error_annot_pkgconfig_alt1.nit:18,38--82: Error: dev package for `missing-lib` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.
-alt/error_annot_pkgconfig_alt1.nit:18,38--82: Error: dev package for `other missing lib` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.
+Error: dev package for `missing-lib` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.
+Error: dev package for `other missing lib` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.

--- a/tests/sav/test_syntax.res
+++ b/tests/sav/test_syntax.res
@@ -1,1 +1,2 @@
-test_syntax.nit:48,2--39: Error: dev package for `a libray from outer space` unknown by `pkg-config`, install it with `apt-get`, `brew` or similar.
+test_syntax.nit:68,8--27: Warning: superfluous super-class `Object` in class `Blurry`.
+test_syntax.nit:134,8--13: Type Error: `Blurry[ELEM_ENT: nullable Object]` is a generic class.


### PR DESCRIPTION
The `pkgconfig` annotation tells the compiler to use the `pkg-config` command in order to get the C compiler and linker options required to build the user C code. The availability of each package was tested twice, once at reading the annotation and once in the generated Makefile. This PR moves the first check later, with the generation of the Makefile. There is still two checks, one by the Nit compiler with a prettier output, and one by the Makefile in case it is distributed with the generated C source files.

This fixes an issue we've had when compiling for Android and iOS, where the result of the annotation was not used but still blocked the compilation if the host did not have the package. And leaving the check to the Makefile give a chance to the programmer to tweak it before the C compilation when cross-compiling.

The error message thrown by the Makefile is less user-friendly as we lose the reference to the Nit source file and line number. This should not be much on an issue since it is rarely a programming error, more of a system configuration error, but it could be improved upon if it becomes an issue. 