### PR TITLE
Make the `do catch` great again

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -757,9 +757,10 @@ abstract class AbstractCompiler
 		self.header.add_decl """
 struct catch_stack_t {
 	int cursor;
-	jmp_buf envs[100];
+	int currentSize;
+	jmp_buf *envs;
 };
-extern struct catch_stack_t catchStack;
+extern __thread struct catch_stack_t catchStack;
 """
 	end
 
@@ -860,7 +861,7 @@ extern void nitni_global_ref_decr( struct nitni_ref *ref );
 		v.add_decl("int glob_argc;")
 		v.add_decl("char **glob_argv;")
 		v.add_decl("val *glob_sys;")
-		v.add_decl("struct catch_stack_t catchStack;")
+		v.add_decl("__thread struct catch_stack_t catchStack = \{-1, 0, NULL\};")
 
 		if self.modelbuilder.toolcontext.opt_typing_test_metrics.value then
 			for tag in count_type_test_tags do
@@ -961,7 +962,6 @@ extern void nitni_global_ref_decr( struct nitni_ref *ref );
 		v.add "#endif"
 
 		v.add("glob_argc = argc; glob_argv = argv;")
-		v.add("catchStack.cursor = -1;")
 		v.add("initialize_gc_option();")
 
 		v.add "initialize_nitni_global_refs();"
@@ -3494,6 +3494,14 @@ redef class ADoExpr
 	redef fun stmt(v)
 	do
 		if self.n_catch != null then
+			v.add("if(catchStack.currentSize == 0) \{")
+			v.add(" 	catchStack.cursor = -1;")
+			v.add("		catchStack.currentSize = 100;")
+			v.add("		catchStack.envs = malloc(sizeof(jmp_buf)*100);")
+			v.add("\} else if(catchStack.cursor == catchStack.currentSize - 1) \{")
+			v.add("		catchStack.currentSize *= 2;")
+			v.add("		catchStack.envs = realloc(catchStack.envs, sizeof(jmp_buf)*catchStack.currentSize);")
+			v.add("\}")
 			v.add("catchStack.cursor += 1;")
 			v.add("if(!setjmp(catchStack.envs[catchStack.cursor]))\{")
 			v.stmt(self.n_block)

--- a/tests/sav/test_catch_multi_threaded.res
+++ b/tests/sav/test_catch_multi_threaded.res
@@ -1,0 +1,10 @@
+caught 100000 aborts
+caught 100000 aborts
+caught 100000 aborts
+caught 100000 aborts
+caught 100000 aborts
+caught 100000 aborts
+caught 100000 aborts
+caught 100000 aborts
+caught 100000 aborts
+caught 100000 aborts

--- a/tests/test_catch_multi_threaded.nit
+++ b/tests/test_catch_multi_threaded.nit
@@ -1,0 +1,56 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test the multi-threaded dynamic `do catch` mechanism
+import pthreads
+
+# A Thread that does a lot of `do catch`
+class CatchThread
+	super Thread
+
+	var x = 100000
+	var caught = 0
+
+	redef fun main do
+		do
+			rec_do_catch
+		catch
+		end
+		print "caught {caught} aborts"
+		return null
+	end
+
+	fun rec_do_catch do
+		do
+			x -= 1
+			if x > 0 then
+				rec_do_catch
+			else
+				abort
+			end
+		catch
+			self.caught += 1
+			abort
+		end
+	end
+end
+
+var ts = new Array[CatchThread]
+var nb_threads = 10
+for i in [0..nb_threads[ do
+	var t = new CatchThread
+	ts.add(t)
+	t.start
+end
+for t in ts do t.join


### PR DESCRIPTION
This PR removes some of the limitations of the `do catch` : 
* Hard-coded limit of 100 jumping environments is gone, the array is now dynamic
* The structure for managing jump environments is now lazy initialized
* Now using gcc's `__thread` specifier so that each thread has it's own jumping stack