### PR TITLE
inkscape_tools: fix Inkscape version detection on Ubuntu

### DIFF
--- a/contrib/inkscape_tools/src/svg_to_png_and_nit.nit
+++ b/contrib/inkscape_tools/src/svg_to_png_and_nit.nit
@@ -220,7 +220,7 @@ var p = new ProcessReader("inkscape", "--version")
 var version_string = p.read_all
 p.wait
 p.close
-var version_re = "([0-9]+\).([0-9]+\).[0-9]+".to_re
+var version_re = "([0-9]+)\\.([0-9]+)".to_re
 var match = version_string.search(version_re)
 assert match != null
 var major = match[1]


### PR DESCRIPTION
The regex detecting the Inkscape version was too permissive and expected 3 numbers. This made it wrongly match the revision string on Ubuntu where the version string has only 2 numbers:
`Inkscape 0.91 r13725`

Thanks @BlackMinou!