### PR TITLE
Tests maintenance for macOS

### DIFF
--- a/tests/Darwin.skip
+++ b/tests/Darwin.skip
@@ -7,6 +7,9 @@ emscripten
 ui_test
 readline
 postgres
+nitweb
+langannot
 test_nitcorn
 test_annot_pkgconfig
 test_glsl_validation
+test_restful_annot

--- a/tests/sav/hello_ios.res
+++ b/tests/sav/hello_ios.res
@@ -7,4 +7,5 @@ out/hello_ios.bin/LaunchScreen.storyboardc/UIViewController-01J-lp-oVM.nib
 out/hello_ios.bin/PkgInfo
 out/hello_ios.bin/_CodeSignature
 out/hello_ios.bin/_CodeSignature/CodeResources
+out/hello_ios.bin/assets
 out/hello_ios.bin/hello_ios


### PR DESCRIPTION
Update the expected result of `hello_ios` and blacklist two more tests on macOS. Both gettext and mongoc (the failure behind nitweb) are available on macOS, however, they would require some configuration.