### PR TITLE
Improve lib/html and nitlight

### DIFF
--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -905,25 +905,35 @@ abstract class Text
 	# SEE: <https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet#RULE_.231_-_HTML_Escape_Before_Inserting_Untrusted_Data_into_HTML_Element_Content>
 	fun html_escape: String
 	do
-		var buf = new Buffer
+		var buf: nullable Buffer = null
 
 		for i in [0..length[ do
 			var c = chars[i]
+			var sub = null
 			if c == '&' then
-				buf.append "&amp;"
+				sub = "&amp;"
 			else if c == '<' then
-				buf.append "&lt;"
+				sub = "&lt;"
 			else if c == '>' then
-				buf.append "&gt;"
+				sub = "&gt;"
 			else if c == '"' then
-				buf.append "&#34;"
+				sub = "&#34;"
 			else if c == '\'' then
-				buf.append "&#39;"
+				sub = "&#39;"
 			else if c == '/' then
-				buf.append "&#47;"
-			else buf.add c
+				sub = "&#47;"
+			else
+				if buf != null then buf.add c
+				continue
+			end
+			if buf == null then
+				buf = new Buffer
+				for j in [0..i[ do buf.add chars[j]
+			end
+			buf.append sub
 		end
 
+		if buf == null then return self.to_s
 		return buf.to_s
 	end
 

--- a/lib/html/html.nit
+++ b/lib/html/html.nit
@@ -128,7 +128,7 @@ class HTMLTag
 	end
 
 	# Tag attributes map
-	var attrs: Map[String, String] = new HashMap[String, String] is lazy
+	var attrs: Map[String, String] = new ArrayMap[String, String] is lazy
 
 	# Get the attributed value of 'prop' or null if 'prop' is undifened
 	#
@@ -161,7 +161,7 @@ class HTMLTag
 	end
 
 	# CSS classes
-	var classes: Set[String] = new HashSet[String] is lazy
+	var classes: Set[String] = new ArraySet[String] is lazy
 
 	# Add multiple CSS classes
 	#
@@ -244,7 +244,7 @@ class HTMLTag
 	end
 
 	# List of children HTML elements
-	var children: Set[HTMLTag] = new HashSet[HTMLTag] is lazy
+	var children: Array[HTMLTag] = new Array[HTMLTag] is lazy
 
 	# Clear all child and set the text of element
 	#

--- a/share/man/nitlight.md
+++ b/share/man/nitlight.md
@@ -65,6 +65,9 @@ By default, only the modules indicated on the command line are highlighted.
 
 With the `--full` option, all imported modules (even those in standard) are also precessed.
 
+### `--no-infobox`
+Disable the generation of infoboxes.
+
 ### `--ast`
 Generate specific HTML elements for each Node of the AST.
 

--- a/src/htmlight.nit
+++ b/src/htmlight.nit
@@ -469,6 +469,7 @@ redef class MModule
 	do
 		var res = new HInfoBox(v, "module {name}")
 		res.href = v.hrefto(self)
+		if not v.show_infobox then return res
 		res.new_field("module").add(linkto(v))
 		add_doc_to_infobox(res)
 		if in_importation.greaters.length > 1 then
@@ -489,6 +490,7 @@ redef class MClassDef
 	do
 		var res = new HInfoBox(v, "class {mclass.name}")
 		res.href = v.hrefto(self)
+		if not v.show_infobox then return res
 		if is_intro then
 			res.new_field("class").text(mclass.name)
 		else
@@ -532,6 +534,7 @@ redef class MPropDef
 	do
 		var res = new HInfoBox(v, to_s)
 		res.href = v.hrefto(self)
+		if not v.show_infobox then return res
 		if self isa MMethodDef then
 			var msignature = self.msignature
 			if msignature != null then res.new_field("fun").append(mproperty.name).add msignature.linkto(v)
@@ -566,6 +569,7 @@ redef class MClassType
 	do
 		var res = new HInfoBox(v, to_s)
 		res.href = v.hrefto(self)
+		if not v.show_infobox then return res
 		res.new_field("class").add mclass.intro.linkto(v)
 		add_doc_to_infobox(res)
 		return res
@@ -580,6 +584,7 @@ redef class MVirtualType
 	do
 		var res = new HInfoBox(v, to_s)
 		res.href = v.hrefto(mproperty)
+		if not v.show_infobox then return res
 		var p = mproperty
 		res.new_field("virtual type").add p.intro.linkto(v)
 		add_doc_to_infobox(res)
@@ -594,6 +599,7 @@ redef class MParameterType
 	redef fun infobox(v)
 	do
 		var res = new HInfoBox(v, to_s)
+		if not v.show_infobox then return res
 		res.new_field("parameter type").append("{name} from class ").add mclass.intro.linkto(v)
 		return res
 	end
@@ -672,6 +678,7 @@ redef class CallSite
 	do
 		var res = new HInfoBox(v, "call {mpropdef}")
 		res.href = v.hrefto(mpropdef)
+		if not v.show_infobox then return res
 		res.new_field("call").add(mpropdef.linkto(v)).add(msignature.linkto(v))
 		if mpropdef.is_intro then
 		else

--- a/src/nitlight.nit
+++ b/src/nitlight.nit
@@ -94,8 +94,9 @@ var opt_last_line = new OptionInt("End the source file at this line (default: to
 var opt_dir = new OptionString("Output html files in a specific directory (required if more than one module)", "-d", "--dir")
 var opt_full = new OptionBool("Process also imported modules", "--full")
 var opt_ast = new OptionBool("Generate specific HTML elements for each Node of the AST", "--ast")
+var opt_noinfobox = new OptionBool("Disable the generation of infoboxes", "--no-infobox")
 var opt_txt = new OptionBool("Generate text with ANSI coloring escape sequences", "--txt")
-toolcontext.option_context.add_option(opt_fragment, opt_line_id_prefix, opt_first_line, opt_last_line, opt_dir, opt_full, opt_ast, opt_txt)
+toolcontext.option_context.add_option(opt_fragment, opt_line_id_prefix, opt_first_line, opt_last_line, opt_dir, opt_full, opt_ast, opt_txt, opt_noinfobox)
 toolcontext.tooldescription = "Usage: nitlight [OPTION]... <file.nit>...\nGenerates HTML of highlited code from Nit source files."
 toolcontext.process_options(args)
 
@@ -154,6 +155,7 @@ for mm in mmodules do
 	if opt_first_line.value != 0 then v.first_line = opt_first_line.value
 	if opt_last_line.value != 0 then v.last_line = opt_last_line.value
 	if opt_ast.value then v.with_ast = true
+	if opt_noinfobox.value then v.show_infobox = false
 	var page = null
 	var m = modelbuilder.mmodule2node(mm)
 	assert m != null

--- a/tests/nitlight.args
+++ b/tests/nitlight.args
@@ -2,3 +2,4 @@
 base_simple3.nit
 -f --line-id-prefix XYZ --first-line 38 --last-line 46 base_simple3.nit
 --txt base_simple3.nit
+--no-infobox base_simple3.nit

--- a/tests/sav/nitlight_args5.res
+++ b/tests/sav/nitlight_args5.res
@@ -1,0 +1,109 @@
+<html><head>
+		<meta charset="utf-8">
+		<title>file base_simple3.nit</title>			<style type="text/css">
+			.nitcode a { color: inherit; cursor:pointer; }
+.nitcode .titled:hover { text-decoration: underline; } /* underline titles */
+.nitcode .popupable:hover { text-decoration: underline; cursor:help; } /* underline titles */
+.nitcode .foldable { display: block } /* for block productions*/
+.nitcode .line{ display: block } /* for lines */
+.nitcode .line:hover{ background-color: #FFFFE0; } /* current line */
+.nitcode :target { background-color: #FFF3C2 } /* target highlight*/
+/* lexical raw tokens. independent of usage or semantic: */
+.nitcode .nc_c { color: gray; font-style: italic; } /* comment */
+.nitcode .nc_d { color: #3D8127; font-style: italic; } /* documentation comments */
+.nitcode .nc_k { font-weight: bold; } /* keyword */
+.nitcode .nc_o {} /* operator */
+.nitcode .nc_i {} /* standard identifier */
+.nitcode .nc_t { color: #445588; font-weight: bold; } /* type/class identifier */
+.nitcode .nc_a { color: #445588; font-style: italic; } /* old style attribute identifier */
+.nitcode .nc_l { color: #009999; } /* char and number literal */
+.nitcode .nc_s { color: #8F1546; } /* string literal */
+/* syntactic token usage. added because of their position in the AST */
+.nitcode .nc_ast { color: blue; } /* assert label */
+.nitcode .nc_la { color: blue; } /* break/continue label */
+.nitcode .nc_m { color: #445588; } /* module name */
+/* syntactic groups */
+.nitcode .nc_def { font-weight: bold; color: blue; } /* name used in a definition */
+  .nitcode .nc_def.nc_a { color: blue; } /* name used in a attribute definition */
+  .nitcode .nc_def.nc_t { color: blue; } /* name used in a class or vt definition */
+.nitcode .nc_ss { color: #9E6BEB; } /* superstrings */
+.nitcode .nc_cdef {} /* A whole class definition */
+.nitcode .nc_pdef {} /* A whole property definition */
+/* semantic token usage */
+.nitcode .nc_v { font-style: italic; } /* local variable or parameter */
+.nitcode .nc_vt { font-style: italic; } /* virtual type or formal type */
+
+.nitcode .nc_error { border: 1px red solid;} /* not used */
+.popover { max-width: 800px !important; }
+
+			</style>
+			<link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
+</head><body><pre class='nit_code'><span class="nitcode"><span class="line" id="L1"><span class="nc_c"># This file is part of NIT ( http:&#47;&#47;www.nitlanguage.org ).
+</span></span><span class="line" id="L2"><span class="nc_c">#
+</span></span><span class="line" id="L3"><span class="nc_c"># Copyright 2006-2008 Jean Privat &lt;jean@pryen.org&gt;
+</span></span><span class="line" id="L4"><span class="nc_c">#
+</span></span><span class="line" id="L5"><span class="nc_c"># Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+</span></span><span class="line" id="L6"><span class="nc_c"># you may not use this file except in compliance with the License.
+</span></span><span class="line" id="L7"><span class="nc_c"># You may obtain a copy of the License at
+</span></span><span class="line" id="L8"><span class="nc_c">#
+</span></span><span class="line" id="L9"><span class="nc_c">#     http:&#47;&#47;www.apache.org&#47;licenses&#47;LICENSE-2.0
+</span></span><span class="line" id="L10"><span class="nc_c">#
+</span></span><span class="line" id="L11"><span class="nc_c"># Unless required by applicable law or agreed to in writing, software
+</span></span><span class="line" id="L12"><span class="nc_c"># distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+</span></span><span class="line" id="L13"><span class="nc_c"># WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+</span></span><span class="line" id="L14"><span class="nc_c"># See the License for the specific language governing permissions and
+</span></span><span class="line" id="L15"><span class="nc_c"># limitations under the License.
+</span></span><span class="line" id="L16">
+</span><span class="line" id="L17"><span class="nc_k">import</span> <span class="nc_k">end</span>
+</span><span class="line" id="L18">
+</span><span class="nc_cdef foldable" id="base_simple3$Object"><span class="line" id="L19"><span class="nc_k">interface</span> <span class="nc_t nc_def titled" title="class Object">Object</span>
+</span><span class="line" id="L20"><span class="nc_k">end</span>
+</span></span><span class="line" id="L21">
+</span><span class="nc_cdef foldable" id="base_simple3$Bool"><span class="line" id="L22"><span class="nc_k">enum</span> <span class="nc_t nc_def titled" title="class Bool">Bool</span>
+</span><span class="line" id="L23"><span class="nc_k">end</span>
+</span></span><span class="line" id="L24">
+</span><span class="nc_cdef foldable" id="base_simple3$Int"><span class="line" id="L25"><span class="nc_k">enum</span> <span class="nc_t nc_def titled" title="class Int">Int</span>
+</span><span class="nc_pdef foldable" id="base_simple3$Int$output"><span class="line" id="L26">	<span class="nc_k">fun</span> <span class="nc_def titled" title="base_simple3$Int$output"><span class="nc_i">output</span></span> <span class="nc_k">is</span> <span class="nc_i">intern</span>
+</span></span><span class="line" id="L27"><span class="nc_k">end</span>
+</span></span><span class="line" id="L28">
+</span><span class="nc_cdef foldable" id="base_simple3$A"><span class="line" id="L29"><span class="nc_k">class</span> <span class="nc_t nc_def titled" title="class A">A</span>
+</span><span class="nc_pdef foldable" id="base_simple3$A$init"><span class="line" id="L30">	<span class="nc_k">init</span> <span class="nc_k">do</span> <span class="nc_l titled" title="Int">5</span><span class="titled" title="call base_simple3$Int$output">.</span><span class="nc_i titled" title="call base_simple3$Int$output">output</span>
+</span></span><span class="nc_pdef foldable" id="base_simple3$A$run"><span class="line" id="L31">	<span class="nc_k">fun</span> <span class="nc_def titled" title="base_simple3$A$run"><span class="nc_i">run</span></span> <span class="nc_k">do</span> <span class="nc_l titled" title="Int">6</span><span class="titled" title="call base_simple3$Int$output">.</span><span class="nc_i titled" title="call base_simple3$Int$output">output</span>
+</span></span><span class="line" id="L32"><span class="nc_k">end</span>
+</span></span><span class="line" id="L33">
+</span><span class="nc_cdef foldable" id="base_simple3$B"><span class="line" id="L34"><span class="nc_k">class</span> <span class="nc_t nc_def titled" title="class B">B</span>
+</span><span class="nc_pdef foldable" id="base_simple3$B$_val"><a id="base_simple3$B$val"></a><a id="base_simple3$B$val="></a><span class="line" id="L35">	<span class="nc_k">var</span> <span class="nc_i nc_def titled" title="base_simple3$B$val">val</span><span>:</span> <span class="nc_t titled" title="Int">Int</span>
+</span></span><span class="nc_pdef foldable" id="base_simple3$B$init"><span class="line" id="L36">	<span class="nc_k popupable" style="border-bottom: solid 2px red" title="Messages" data-content="&lt;div&gt;&lt;div class=&#34;dropdown&#34;&gt; &lt;a data-toggle=&#34;dropdown&#34; href=&#34;#&#34;&gt;&lt;b&gt;1 message(s)&lt;&#47;b&gt; &lt;span class=&#34;caret&#34;&gt;&lt;&#47;span&gt;&lt;&#47;a&gt;&lt;ul class=&#34;dropdown-menu&#34; role=&#34;menu&#34; aria-labelledby=&#34;dLabel&#34;&gt;&lt;li&gt;Warning: init with signature in base_simple3$B&lt;&#47;li&gt;&lt;&#47;ul&gt;&lt;&#47;div&gt;&lt;&#47;div&gt;" data-toggle="popover">init</span><span>(</span><span class="nc_i nc_v titled" title="v: Int">v</span><span>:</span> <span class="nc_t titled" title="Int">Int</span><span>)</span>
+</span><span class="line" id="L37">	<span class="nc_k">do</span>
+</span><span class="line" id="L38">		<span class="nc_l titled" title="Int">7</span><span class="titled" title="call base_simple3$Int$output">.</span><span class="nc_i titled" title="call base_simple3$Int$output">output</span>
+</span><span class="line" id="L39">		<span class="nc_k titled" title="B">self</span><span class="titled" title="call base_simple3$B$val=">.</span><span class="nc_i titled" title="call base_simple3$B$val=">val</span> <span class="titled" title="call base_simple3$B$val=">=</span> <span class="nc_i nc_v titled" title="v: Int">v</span>
+</span><span class="line" id="L40">	<span class="nc_k">end</span>
+</span></span><span class="nc_pdef foldable" id="base_simple3$B$run"><span class="line" id="L41">	<span class="nc_k">fun</span> <span class="nc_def titled" title="base_simple3$B$run"><span class="nc_i">run</span></span> <span class="nc_k">do</span> <span class="nc_i titled" title="call base_simple3$B$val">val</span><span class="titled" title="call base_simple3$Int$output">.</span><span class="nc_i titled" title="call base_simple3$Int$output">output</span>
+</span></span><span class="line" id="L42"><span class="nc_k">end</span>
+</span></span><span class="line" id="L43">
+</span><span class="nc_cdef foldable" id="base_simple3$C"><span class="line" id="L44"><span class="nc_k">class</span> <span class="nc_t nc_def titled" title="class C">C</span>
+</span><span class="nc_pdef foldable" id="base_simple3$C$_val1"><a id="base_simple3$C$val1"></a><a id="base_simple3$C$val1="></a><span class="line" id="L45">	<span class="nc_k">var</span> <span class="nc_i nc_def titled" title="base_simple3$C$val1">val1</span><span>:</span> <span class="nc_t titled" title="Int">Int</span>
+</span></span><span class="nc_pdef foldable" id="base_simple3$C$_val2"><a id="base_simple3$C$val2"></a><a id="base_simple3$C$val2="></a><span class="line" id="L46">	<span class="nc_k">var</span> <span class="nc_i nc_def titled" title="base_simple3$C$val2">val2</span><span>:</span> <span class="nc_t titled" title="Int">Int</span> <span>=</span> <span class="nc_l titled" title="Int">10</span>
+</span></span><span class="line" id="L47"><span class="nc_k">end</span>
+</span></span><span class="line" id="L48">
+</span><span class="nc_pdef foldable" id="base_simple3$Sys$foo"><span class="line" id="L49"><span class="nc_k">fun</span> <span class="nc_def titled" title="base_simple3$Sys$foo"><span class="nc_i">foo</span></span> <span class="nc_k">do</span> <span class="nc_l titled" title="Int">2</span><span class="titled" title="call base_simple3$Int$output">.</span><span class="nc_i titled" title="call base_simple3$Int$output">output</span>
+</span></span><span class="nc_pdef foldable" id="base_simple3$Sys$bar"><span class="line" id="L50"><span class="nc_k">fun</span> <span class="nc_def titled" title="base_simple3$Sys$bar"><span class="nc_i">bar</span></span><span>(</span><span class="nc_i nc_v titled" title="i: Int">i</span><span>:</span> <span class="nc_t titled" title="Int">Int</span><span>)</span> <span class="nc_k">do</span> <span class="nc_i nc_v titled" title="i: Int">i</span><span class="titled" title="call base_simple3$Int$output">.</span><span class="nc_i titled" title="call base_simple3$Int$output">output</span>
+</span></span><span class="nc_pdef foldable" id="base_simple3$Sys$baz"><span class="line" id="L51"><span class="nc_k">fun</span> <span class="nc_def titled" title="base_simple3$Sys$baz"><span class="nc_i">baz</span></span><span>:</span> <span class="nc_t titled" title="Int">Int</span> <span class="nc_k">do</span> <span class="nc_k">return</span> <span class="nc_l titled" title="Int">4</span>
+</span></span><span class="line" id="L52">
+</span><span class="nc_pdef foldable" id="base_simple3$Sys$main"><span class="line" id="L53"><span class="nc_l titled" title="Int">1</span><span class="titled" title="call base_simple3$Int$output">.</span><span class="nc_i titled" title="call base_simple3$Int$output">output</span>
+</span><span class="line" id="L54"><span class="nc_i titled" title="call base_simple3$Sys$foo">foo</span>
+</span><span class="line" id="L55"><span class="nc_i titled" title="call base_simple3$Sys$bar">bar</span><span>(</span><span class="nc_l titled" title="Int">3</span><span>)</span>
+</span><span class="line" id="L56"><span class="nc_i titled" title="call base_simple3$Sys$baz">baz</span><span class="titled" title="call base_simple3$Int$output">.</span><span class="nc_i titled" title="call base_simple3$Int$output">output</span>
+</span><span class="line" id="L57">
+</span><span class="line" id="L58"><span class="nc_k">var</span> <span class="nc_i nc_v titled" title="a: A">a</span> <span>=</span> <span class="nc_k titled" title="call base_simple3$A$init">new</span> <span class="nc_t titled" title="A">A</span>
+</span><span class="line" id="L59"><span class="nc_i nc_v titled" title="a: A">a</span><span class="titled" title="call base_simple3$A$run">.</span><span class="nc_i titled" title="call base_simple3$A$run">run</span>
+</span><span class="line" id="L60">
+</span><span class="line" id="L61"><span class="nc_k">var</span> <span class="nc_i nc_v titled" title="b: B">b</span> <span>=</span> <span class="nc_k titled" title="call base_simple3$B$init">new</span> <span class="nc_t titled" title="B">B</span><span>(</span><span class="nc_l titled" title="Int">8</span><span>)</span>
+</span><span class="line" id="L62"><span class="nc_i nc_v titled" title="b: B">b</span><span class="titled" title="call base_simple3$B$run">.</span><span class="nc_i titled" title="call base_simple3$B$run">run</span>
+</span><span class="line" id="L63">
+</span><span class="line" id="L64"><span class="nc_k">var</span> <span class="nc_i nc_v titled" title="c: C">c</span> <span>=</span> <span class="nc_k titled" title="call base_simple3$C$init">new</span> <span class="nc_t titled" title="C">C</span><span>(</span><span class="nc_l titled" title="Int">9</span><span>)</span>
+</span><span class="line" id="L65"><span class="nc_i nc_v titled" title="c: C">c</span><span class="titled" title="call base_simple3$C$val1">.</span><span class="nc_i titled" title="call base_simple3$C$val1">val1</span><span class="titled" title="call base_simple3$Int$output">.</span><span class="nc_i titled" title="call base_simple3$Int$output">output</span>
+</span><span class="line" id="L66"><span class="nc_i nc_v titled" title="c: C">c</span><span class="titled" title="call base_simple3$C$val2">.</span><span class="nc_i titled" title="call base_simple3$C$val2">val2</span><span class="titled" title="call base_simple3$Int$output">.</span><span class="nc_i titled" title="call base_simple3$Int$output">output</span>
+</span></span></span></pre><script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+<script src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+<script>$(".popupable").popover({html:true, placement:'top'})/*initialize bootstrap popover*/</script></body></html>


### PR DESCRIPTION
Various improprement in the whole nitlight chain.

Before: nitlight --keep-going -d tmp ../lib/ ../src
* Elapsed (wall clock) time: 28.71
* User time (seconds): 47.25
* System time (seconds): 1.05
* Maximum resident set size (Gbytes): 2.1311

After: nitlight --keep-going -d tmp ../lib/ ../src
* Elapsed (wall clock) time: 22.97 (-20%)
* User time (seconds): 34.42  (-27%)
* System time (seconds): 1.06
* Maximum resident set size (Gbytes): 1.8924 (-11%)

After + new option: nitlight --keep-going -d tmp ../lib/ ../src --no-infobox
* Elapsed (wall clock) time: 10.71 (-63%)
* User time (seconds): 14.49 (-69%)
* System time (seconds): 0.83
* Maximum resident set size (Gbytes): 1.6713 (-20%)