### PR TITLE
share: shallow clone bdwgc for Android and iOS

### DIFF
--- a/share/android-bdwgc/setup.sh
+++ b/share/android-bdwgc/setup.sh
@@ -20,9 +20,9 @@ cd "`dirname "${BASH_SOURCE[0]}"`"
 
 # Download or redownload
 rm -rf bdwgc
-git clone -b android https://github.com/xymus/bdwgc.git || exit 1
+git clone --depth=1 -b android https://github.com/xymus/bdwgc.git || exit 1
 
 # Setup libatomic_ops too
 cd bdwgc || exit 1
 git submodule init || exit 1
-git submodule update || exit 1
+git submodule update --depth=1 || exit 1


### PR DESCRIPTION
When compiling a Nit app for Android, a specific branch of bdwgc/libgc/boehm-gc is cloned locally. Using a shallow clone only fetches the last commit, for a faster download and to use less disk space.

Closes #2621.