### PR TITLE
gitignore: ignore nit_compile folders and contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ nitunit.xml
 .metadata/*
 .github_data
 .DS_Store
+
+**/nit_compile/*


### PR DESCRIPTION
nit_compile are a series of generated intermediate C files that should
not be versioned.

We therefore add them to the .gitignore to eliminate them from the
index.

Signed-off-by: Lucas Bajolet <lucas.bajolet@gmail.com>