### PR TITLE
No intrude rope stream

### DIFF
--- a/lib/core/stream.nit
+++ b/lib/core/stream.nit
@@ -11,7 +11,6 @@
 # Input and output streams of characters
 module stream
 
-intrude import text::ropes
 import error
 intrude import bytes
 import codecs
@@ -237,29 +236,7 @@ abstract class Reader
 		var s = read_all_bytes
 		var slen = s.length
 		if slen == 0 then return ""
-		var rets = ""
-		var pos = 0
-		var str = s.items.clean_utf8(slen)
-		slen = str.byte_length
-		var sits = str.items
-		var remsp = slen
-		while pos < slen do
-			# The 129 size was decided more or less arbitrarily
-			# It will require some more benchmarking to compute
-			# if this is the best size or not
-			var chunksz = 129
-			if chunksz > remsp then
-				rets += new FlatString.with_infos(sits, remsp, pos)
-				break
-			end
-			var st = sits.find_beginning_of_char_at(pos + chunksz - 1)
-			var byte_length = st - pos
-			rets += new FlatString.with_infos(sits, byte_length, pos)
-			pos = st
-			remsp -= byte_length
-		end
-		if rets isa Concat then return rets.balance
-		return rets
+		return codec.decode_string(s.items, s.length)
 	end
 
 	# Read all the stream until the eof.

--- a/lib/core/stream.nit
+++ b/lib/core/stream.nit
@@ -29,6 +29,51 @@ end
 
 # Any kind of stream to read/write/both to or from a source
 abstract class Stream
+	# Codec used to transform raw data to text
+	#
+	# Note: defaults to UTF-8
+	var codec: Codec = utf8_codec is protected writable(set_codec)
+
+	# Lookahead buffer for codecs
+	#
+	# Since some codecs are multibyte, a lookahead may be required
+	# to store the next bytes and consume them only if a valid character
+	# is read.
+	protected var lookahead: CString is noinit
+
+	# Capacity of the lookahead
+	protected var lookahead_capacity = 0
+
+	# Current occupation of the lookahead
+	protected var lookahead_length = 0
+
+	# Buffer for writing data to a stream
+	protected var write_buffer: CString is noinit
+
+	init do
+		var lcap = codec.max_lookahead
+		lookahead = new CString(lcap)
+		write_buffer = new CString(lcap)
+		lookahead_length = 0
+		lookahead_capacity = lcap
+	end
+
+	# Change the codec for this stream.
+	fun codec=(c: Codec) do
+		if c.max_lookahead > lookahead_capacity then
+			var lcap = codec.max_lookahead
+			var lk = new CString(lcap)
+			var llen = lookahead_length
+			if llen > 0 then
+				lookahead.copy_to(lk, llen, 0, 0)
+			end
+			lookahead = lk
+			lookahead_capacity = lcap
+			write_buffer = new CString(lcap)
+		end
+		set_codec(c)
+	end
+
 	# Error produced by the file stream
 	#
 	#     var ifs = new FileReader.open("donotmakethisfile.binx")
@@ -64,9 +109,6 @@ end
 # A `Stream` that can be read from
 abstract class Reader
 	super Stream
-
-	# Decoder used to transform input bytes to UTF-8
-	var decoder: Codec = utf8_codec is writable
 
 	# Reads a character. Returns `null` on EOF or timeout
 	fun read_char: nullable Char is abstract
@@ -404,9 +446,6 @@ end
 # A `Stream` that can be written to
 abstract class Writer
 	super Stream
-
-	# The coder from a nit UTF-8 String to the output file
-	var coder: Codec = utf8_codec is writable
 
 	# Writes bytes from `s`
 	fun write_bytes(s: Bytes) is abstract


### PR DESCRIPTION
Two things happening here, in two commits:

* the first commit moves the definition of `decoder` into Stream, and renames it to `codec` since both coding/decoding will be used by streams when dealing with String semantics.
* the second commit removes the `intrude inport ropes` from stream as this was not necessary, and performance-wise did not matter sufficiently to justify this