### PR TITLE
Read byte rewrite

### DIFF
--- a/lib/bitmap/bitmap.nit
+++ b/lib/bitmap/bitmap.nit
@@ -169,13 +169,14 @@ class Bitmap
 			for x in [0..self.height[
 			do
 				var row = new Array[Int].with_capacity(self.width)
+				var rgb_str = new CString(3)
 				for y in [0..self.width[
 				do
-					var bts = fileReader.read_bytes(3)
-					if bts.length != 3 then return
-					var red = bts[0] << 16
-					var green = bts[1] << 8
-					var blue = bts[2]
+					var bts = fileReader.read_bytes_to_cstring(rgb_str, 3)
+					if bts < 3 then return
+					var red = rgb_str[0] << 16
+					var green = rgb_str[1] << 8
+					var blue = rgb_str[2]
 					row.add(red.to_i + green.to_i + blue.to_i)
 				end
 				self.data.add(row)

--- a/lib/core/exec.nit
+++ b/lib/core/exec.nit
@@ -349,7 +349,7 @@ class ProcessReader
 
 	redef fun read_char do return stream_in.read_char
 
-	redef fun read_byte do return stream_in.read_byte
+	redef fun raw_read_byte do return stream_in.read_byte
 
 	redef fun eof do return stream_in.eof
 

--- a/lib/core/file.nit
+++ b/lib/core/file.nit
@@ -511,7 +511,7 @@ class Path
 		var output = dest.open_wo
 
 		while not input.eof do
-			var buffer = input.read_bytes(1024)
+			var buffer = input.read_bytes(4096)
 			output.write_bytes buffer
 		end
 

--- a/lib/core/stream.nit
+++ b/lib/core/stream.nit
@@ -11,7 +11,6 @@
 # Input and output streams of characters
 module stream
 
-intrude import text::ropes
 import error
 intrude import bytes
 import codecs
@@ -240,29 +239,7 @@ abstract class Reader
 		var s = read_all_bytes
 		var slen = s.length
 		if slen == 0 then return ""
-		var rets = ""
-		var pos = 0
-		var str = s.items.clean_utf8(slen)
-		slen = str.byte_length
-		var sits = str.items
-		var remsp = slen
-		while pos < slen do
-			# The 129 size was decided more or less arbitrarily
-			# It will require some more benchmarking to compute
-			# if this is the best size or not
-			var chunksz = 129
-			if chunksz > remsp then
-				rets += new FlatString.with_infos(sits, remsp, pos)
-				break
-			end
-			var st = sits.find_beginning_of_char_at(pos + chunksz - 1)
-			var byte_length = st - pos
-			rets += new FlatString.with_infos(sits, byte_length, pos)
-			pos = st
-			remsp -= byte_length
-		end
-		if rets isa Concat then return rets.balance
-		return rets
+		return codec.decode_string(s.items, s.length)
 	end
 
 	# Read all the stream until the eof.


### PR DESCRIPTION
As part of the stream refactor series, this patches cleanup msgpack a bit and introduce a lower-level `read_byte` implementation on which `read_byte(s)` will rely for reading data from a source.

In the future, the lowest-level interface to read bytes, and the only one required for implementing a new stream will be the `raw_read_byte(s)` functions.

A cleanup of the current streams will be needed for this to be used properly, coming in the next few PRs.

Note: The first two commits have already been submitted under #2632, therefore disregard them for this PR.