### PR TITLE
parse_examples: minor fixes

### DIFF
--- a/src/frontend/parse_examples.nit
+++ b/src/frontend/parse_examples.nit
@@ -172,6 +172,7 @@ redef class ASuperPropdef
 			v.counter.inc mtype.mclass
 			v.counter.inc mtype.mclass.intro
 		end
+		visit_all(v)
 	end
 end
 
@@ -183,5 +184,6 @@ redef class ASendExpr
 		v.counter.inc callsite.mpropdef.mproperty
 		v.counter.inc callsite.mpropdef.mclassdef
 		v.counter.inc callsite.mpropdef.mclassdef.mclass
+		visit_all(v)
 	end
 end

--- a/src/frontend/parse_examples.nit
+++ b/src/frontend/parse_examples.nit
@@ -118,6 +118,7 @@ redef class ANewExpr
 	redef fun accept_example_visitor(v) do
 		var recvtype = self.recvtype
 		if recvtype != null then
+			v.counter.inc recvtype.mclass
 			v.counter.inc recvtype.mclass.intro
 		end
 		visit_all(v)


### PR DESCRIPTION
This PR fixes two things:
1. call `visit_all` so statements are all visited
2. also count newly instanciated mclasses