### PR TITLE
Write byte updates

### DIFF
--- a/lib/core/file.nit
+++ b/lib/core/file.nit
@@ -210,13 +210,13 @@ class FileWriter
 	super FileStream
 	super Writer
 
-	redef fun write_bytes(s) do
+	redef fun write_bytes_from_cstring(cs, len) do
 		if last_error != null then return
 		if not _is_writable then
 			last_error = new IOError("cannot write to non-writable stream")
 			return
 		end
-		write_native(s.items, 0, s.length)
+		write_native(cs, 0, len)
 	end
 
 	redef fun write(s)
@@ -510,9 +510,10 @@ class Path
 		var input = open_ro
 		var output = dest.open_wo
 
+		var buffer = new CString(4096)
 		while not input.eof do
-			var buffer = input.read_bytes(4096)
-			output.write_bytes buffer
+			var read = input.read_bytes_to_cstring(buffer, 4096)
+			output.write_bytes_from_cstring(buffer, read)
 		end
 
 		input.close

--- a/lib/core/stream.nit
+++ b/lib/core/stream.nit
@@ -467,17 +467,23 @@ end
 abstract class Writer
 	super Stream
 
-	# Writes bytes from `s`
-	fun write_bytes(s: Bytes) is abstract
+	# Write bytes from `s`
+	fun write_bytes(s: Bytes) do write_bytes_from_cstring(s.items, s.length)
 
-	# write a string
+	# Write `len` bytes from `ns`
+	fun write_bytes_from_cstring(ns: CString, len: Int) is abstract
+
+	# Write a string
 	fun write(s: Text) is abstract
 
 	# Write a single byte
 	fun write_byte(value: Byte) is abstract
 
-	# Writes a single char
-	fun write_char(c: Char) do write(c.to_s)
+	# Write a single char
+	fun write_char(c: Char) do
+		var ln = codec.add_char_to(c, write_buffer)
+		write_bytes_from_cstring(write_buffer, ln)
+	end
 
 	# Can the stream be used to write
 	fun is_writable: Bool is abstract
@@ -776,10 +782,9 @@ class BytesWriter
 		bytes.add value
 	end
 
-	redef fun write_bytes(b)
-	do
+	redef fun write_bytes_from_cstring(ns, len) do
 		if closed then return
-		bytes.append b
+		bytes.append_ns(ns, len)
 	end
 
 	# Is the stream closed?

--- a/lib/libevent.nit
+++ b/lib/libevent.nit
@@ -241,10 +241,10 @@ class Connection
 		native_buffer_event.write_byte(byte)
 	end
 
-	redef fun write_bytes(bytes)
+	redef fun write_bytes_from_cstring(ns, len)
 	do
 		if close_requested then return
-		native_buffer_event.write(bytes.items, bytes.length)
+		native_buffer_event.write(ns, len)
 	end
 
 	# Write a file to the connection

--- a/lib/socket/socket.nit
+++ b/lib/socket/socket.nit
@@ -185,10 +185,9 @@ class TCPStream
 		native.write_byte value
 	end
 
-	redef fun write_bytes(bytes) do
+	redef fun write_bytes_from_cstring(ns, len) do
 		if closed then return
-		var s = bytes.to_s
-		native.write(s.to_cstring, s.length)
+		native.write(ns, len)
 	end
 
 	fun write_ln(msg: Text)

--- a/lib/websocket/websocket.nit
+++ b/lib/websocket/websocket.nit
@@ -250,7 +250,9 @@ class WebsocketConnection
 	# Checks if a connection to a client is available
 	redef fun connected do return client.connected
 
-	redef fun write_bytes(s) do client.write_bytes(frame_message(s.to_s))
+	redef fun write_bytes_from_cstring(ns, len) do
+		client.write_bytes(frame_message(ns.to_s_unsafe(len)))
+	end
 
 	redef fun write(msg) do client.write(frame_message(msg.to_s).to_s)
 


### PR DESCRIPTION
More in the Stream refactor series, this commit adds a low-level byte writing method, to be re-implemented when needed. The read_bytes service can now be defined in writer only, as a wrapper to the lower-level service.