### PR TITLE
Nitcatalog for nitpm

### DIFF
--- a/contrib/nitpm_packages.txt
+++ b/contrib/nitpm_packages.txt
@@ -1,0 +1,6 @@
+# List of official nitpm-compatible repositories
+https://gitlab.com/xymus/gamnit.git
+https://gitlab.com/xymus/hello_nitpm.git
+https://gitlab.com/xymus/nitpm_test_cycle.git
+https://gitlab.com/xymus/nitpm_test_imports.git
+https://gitlab.com/xymus/nitpm_test_versions.git

--- a/contrib/oot.sh
+++ b/contrib/oot.sh
@@ -40,7 +40,8 @@ shift
 
 while read -r repo name; do
 	[[ "$repo" = "#"* ]] && continue
-	[[ "$name" = "" ]] && continue
+	[[ "$repo" = "" ]] && continue
+	[[ "$name" = "" ]] && name=`basename "$repo" .git`
 	dir="oot/$name"
 	case "$cmd" in
 		list) echo "$name";;

--- a/contrib/oot.sh
+++ b/contrib/oot.sh
@@ -38,6 +38,7 @@ trymake_oot() {
 cmd="$1"
 shift
 
+process_list() {
 while read -r repo name; do
 	[[ "$repo" = "#"* ]] && continue
 	[[ "$repo" = "" ]] && continue
@@ -52,4 +53,8 @@ while read -r repo name; do
 		""|help) echo "usage: oot.sh command [arg...]"; exit 0;;
 		*) echo >&2 "unknown command: $cmd"; exit 1;;
 	esac
-done < oot.txt
+done
+}
+
+process_list < oot.txt
+process_list < nitpm_packages.txt

--- a/contrib/oot.txt
+++ b/contrib/oot.txt
@@ -1,9 +1,9 @@
 # List of out-of-tree repositories
 # Format: repo name
-https://github.com/R4PaSs/brewnit.git brewnit
-https://gitlab.com/xymus/darpg.git darpg
-https://gitlab.com/jeremlvt/dawn_arrival.git dawn_arrival
+https://github.com/R4PaSs/brewnit.git
+https://gitlab.com/xymus/darpg.git
+https://gitlab.com/jeremlvt/dawn_arrival.git
 https://github.com/Morriar/Missions.git missions
 https://gitlab.com/Heavyshield/NitGains.git nitgains
 https://github.com/ppepos/pep8-dbg.git pep8dbg
-https://gitlab.com/xymus/sputnit.git sputnit
+https://gitlab.com/xymus/sputnit.git

--- a/contrib/oot.txt
+++ b/contrib/oot.txt
@@ -1,4 +1,5 @@
-# List of out-of-tree repositories
+# List of out-of-tree repositories not good enough to be nitpm-compatible
+# but good enough to be in the catalog
 # Format: repo name
 https://github.com/R4PaSs/brewnit.git
 https://gitlab.com/xymus/darpg.git

--- a/src/nitcatalog.nit
+++ b/src/nitcatalog.nit
@@ -721,6 +721,9 @@ for p in mpackages do
 	var f = "p/{p.name}.html"
 	catalog.package_page(p)
 	catalog.generate_page(p).write_to_file(out/f)
+	# copy ini
+	var ini = p.ini
+	if ini != null then ini.write_to_file(out/"p/{p.name}.ini")
 end
 
 # INDEX

--- a/src/nitpm.nit
+++ b/src/nitpm.nit
@@ -104,11 +104,10 @@ class CommandInstall
 	do
 		if package_id.is_package_name then
 			# Ask a centralized server
-			# TODO choose a future safe URL
 			# TODO customizable server list
 			# TODO parse ini file in memory
 
-			var url = "https://xymus.net/nitpm/{package_id}.ini"
+			var url = "https://nitlanguage.org/catalog/p/{package_id}.ini"
 			var ini_path = "/tmp/{package_id}.ini"
 
 			if verbose then print "Looking for a package description at '{url}'"


### PR DESCRIPTION
This move the packages fetched by nitpm to nitlanguage.org and use the nitcatalog infrastructure to publish and update the ini files.

The list of public packages is now in `contrig/nitpm_packages.txt` (was `oot.txt`) and new public packages can be added to the file trough PR and review by the community.

Note that there is nothing yet to check the sanity of public pagkage (nor do any long run quality assurance).