### PR TITLE
nitpackage: generate and check manpages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ csrc2/
 lib/*.log
 lib/*.dot
 
+lib/*/bin
+
 examples/*/doc
 examples/*/bin
 

--- a/contrib/github_merge/man/github_merge.man
+++ b/contrib/github_merge/man/github_merge.man
@@ -1,0 +1,30 @@
+# NAME
+
+github_merge - Query the Github PR API to perform a merge.
+
+# SYNOPSIS
+
+github_merge [OPTION]... <PR number...>
+
+# OPTIONS
+
+### `-h`, `-?`, `--help`
+Show this help message.
+
+### `-r`, `--repo`
+Repository (e.g. nitlang/nit).
+
+### `--auth`
+OAuth token.
+
+### `-q`, `--query`
+Query to get issues (e.g. label=ok_will_merge).
+
+### `--status`
+A status context that must be "success" (e.g. default).
+
+### `-a`, `--all`
+Merge all.
+
+### `-k`, `--keep-going`
+Skip merge conflicts.

--- a/contrib/nitiwiki/man/nitiwiki.man
+++ b/contrib/nitiwiki/man/nitiwiki.man
@@ -1,0 +1,42 @@
+# NAME
+
+nitiwiki - A wiki engine based on markdown files and git.
+
+# SYNOPSIS
+
+nitiwiki [OPTION]...
+
+# OPTIONS
+
+### `-h`, `-?`, `--help`
+Show this help message.
+
+### `-v`
+Verbose level.
+
+### `-c`, `--config`
+Path to config.ini file.
+
+### `--init`
+Initialize a new wiki in the current directory.
+
+### `--status`
+Display wiki status.
+
+### `-r`, `--render`
+Render the out directory from markdown sources.
+
+### `-f`, `--force`
+Force render even if source files are unchanged.
+
+### `--clean`
+Clean the output directory.
+
+### `-s`, `--rsync`
+Synchronize outdir with distant wiki using rsync.
+
+### `--fetch`
+Render local source from git repo.
+
+### `--nit-dir`
+Nit base directory.

--- a/contrib/nitiwiki/man/wiki_edit.man
+++ b/contrib/nitiwiki/man/wiki_edit.man
@@ -1,0 +1,24 @@
+# NAME
+
+wiki_edit - Web server to server generated files and modify the wiki from a web form.
+
+# SYNOPSIS
+
+wiki_edit [OPTION]...
+
+# OPTIONS
+
+### `-h`, `-?`, `--help`
+Show this help message.
+
+### `-c`, `--config`
+Path to config.ini file.
+
+### `--host`
+Host to bind the server to.
+
+### `--port`
+Port to bind the server to.
+
+### `--pass`
+Password file path.

--- a/lib/github/Makefile
+++ b/lib/github/Makefile
@@ -18,11 +18,11 @@ NITUNIT ?= nitunit
 NITDOC ?= nitdoc
 
 .PHONY: all
-all: bin/nitmd
+all: bin/loader
 
-bin/nitmd: $(shell $(NITLS) -M nitmd.nit)
+bin/loader: $(shell $(NITLS) -M loader.nit)
 	mkdir -p bin/
-	$(NITC) nitmd.nit -o bin/nitmd
+	$(NITC) loader.nit -o bin/loader
 
 .PHONY: check
 check:

--- a/lib/github/man/loader.man
+++ b/lib/github/man/loader.man
@@ -1,0 +1,54 @@
+# NAME
+
+loader - Load a GitHub repo into a MongoDb.
+
+# SYNOPSIS
+
+loader <repo_name>
+
+# OPTIONS
+
+### `-h`, `-?`, `--help`
+Show this help message.
+
+### `--config`
+Path to config file.
+
+### `--db-host`
+MongoDb host.
+
+### `--db-name`
+MongoDb database name.
+
+### `--tokens`
+Token list.
+
+### `--show-wallet`
+Show wallet status.
+
+### `-v`, `--verbose`
+Verbosity level.
+
+### `--no-colors`
+Do not use colors in output.
+
+### `--show-jobs`
+Show jobs status.
+
+### `--no-commits`
+Do not load commits from default branch.
+
+### `--no-issues`
+Do not load issues.
+
+### `--no-comments`
+Do not load issue comments.
+
+### `--no-events`
+Do not load issues events.
+
+### `--from`
+Start loading issues from a number.
+
+### `--clear`
+Clear job for given repo name.

--- a/lib/markdown/man/nitmd.man
+++ b/lib/markdown/man/nitmd.man
@@ -1,0 +1,15 @@
+# NAME
+
+nitmd - Translate Markdown documents to other formats.
+
+# SYNOPSIS
+
+nitmd [-t format] <file.md>
+
+# OPTIONS
+
+### `-h`, `-?`, `--help`
+Show this help message.
+
+### `-t`, `--to`
+Specify output format (html, md, man).

--- a/share/man/Makefile
+++ b/share/man/Makefile
@@ -16,7 +16,7 @@ IN=$(wildcard nit*.md)
 OUT=$(patsubst %.md,man1/%.1,$(IN))
 
 MARKDOWN=../../lib/markdown
-NITMD=$(MARKDOWN)/nitmd
+NITMD=$(MARKDOWN)/bin/nitmd
 
 all: $(OUT)
 

--- a/share/man/nitpackage.md
+++ b/share/man/nitpackage.md
@@ -60,6 +60,12 @@ Generate Makefile files.
 ### `--check-makefile`
 Check Makefile files.
 
+### `--check-man`
+Check manpages files.
+
+### `--gen-man`
+Generate manpages files.
+
 ### `-f`, `--force`
 Force update of existing files.
 

--- a/share/man/nitpackage.md
+++ b/share/man/nitpackage.md
@@ -54,6 +54,12 @@ Generate package.ini files.
 ### `--check-ini`
 Check package.ini files.
 
+### `--gen-makefile`
+Generate Makefile files.
+
+### `--check-makefile`
+Check Makefile files.
+
 ### `-f`, `--force`
 Force update of existing files.
 

--- a/src/nitpackage.nit
+++ b/src/nitpackage.nit
@@ -16,6 +16,7 @@
 module nitpackage
 
 import frontend
+import doc::commands::commands_main
 
 redef class ToolContext
 	# --expand
@@ -30,6 +31,12 @@ redef class ToolContext
 	# --force
 	var opt_force = new OptionBool("Force update of existing files", "-f", "--force")
 
+	# --check-makefile
+	var opt_check_makefile = new OptionBool("Check Makefile files", "--check-makefile")
+
+	# --gen-makefile
+	var opt_gen_makefile = new OptionBool("Generate Makefile files", "--gen-makefile")
+
 	# nitpackage phase
 	var nitpackage_phase: Phase = new NitPackagePhase(self, null)
 
@@ -37,6 +44,7 @@ redef class ToolContext
 		super
 		option_context.add_option(opt_expand, opt_force)
 		option_context.add_option(opt_check_ini, opt_gen_ini)
+		option_context.add_option(opt_check_makefile, opt_gen_makefile)
 	end
 end
 
@@ -60,6 +68,12 @@ private class NitPackagePhase
 				continue
 			end
 
+			# Check package Makefiles
+			if toolcontext.opt_check_makefile.value then
+				mpackage.check_makefile(toolcontext, mainmodule)
+				continue
+			end
+
 			# Expand packages
 			if toolcontext.opt_expand.value and not mpackage.is_expanded then
 				var path = mpackage.expand
@@ -76,6 +90,16 @@ private class NitPackagePhase
 				if not mpackage.has_ini or toolcontext.opt_force.value then
 					var path = mpackage.gen_ini
 					toolcontext.info("generated INI file `{path}`", 0)
+				end
+			end
+
+			# Create Makefile
+			if toolcontext.opt_gen_makefile.value then
+				if not mpackage.has_makefile or toolcontext.opt_force.value then
+					var path = mpackage.gen_makefile(toolcontext.modelbuilder.model, mainmodule)
+					if path != null then
+						toolcontext.info("generated Makefile `{path}`", 0)
+					end
 				end
 			end
 		end
@@ -253,6 +277,94 @@ redef class MPackage
 		ini.save
 		return ini_path
 	end
+
+	# Makefile
+
+	# The path to `self` Makefile
+	fun makefile_path: nullable String do
+		var path = package_path
+		if path == null then return null
+		if not is_expanded then return null
+		return path / "Makefile"
+	end
+
+	# Does `self` have a Makefile?
+	fun has_makefile: Bool do
+		var makefile_path = self.makefile_path
+		if makefile_path == null then return false
+		return makefile_path.file_exists
+	end
+
+	private fun check_makefile(toolcontext: ToolContext, mainmodule: MModule) do
+		var model = toolcontext.modelbuilder.model
+		var filter = new ModelFilter(accept_example = false, accept_test = false)
+		var view = new ModelView(model, mainmodule, filter)
+
+		var cmd_bin = new CmdMains(view, mentity = self)
+		var res_bin = cmd_bin.init_command
+		if not res_bin isa CmdSuccess then return
+
+		for mmodule in cmd_bin.results.as(not null) do
+			if not mmodule isa MModule then continue
+
+			if mmodule.makefile_path == null then
+				toolcontext.warning(location, "missing-makefile",
+					"Warning: no Makefile for executable module `{mmodule.full_name}`")
+			end
+		end
+	end
+
+	private fun gen_makefile(model: Model, mainmodule: MModule): nullable String do
+		var filter = new ModelFilter(accept_example = false, accept_test = false)
+		var view = new ModelView(model, mainmodule, filter)
+
+		var pkg_path = package_path.as(not null)
+		var makefile_path = makefile_path.as(not null)
+
+		var bins = new Array[String]
+		var cmd_bin = new CmdMains(view, mentity = self)
+		var res_bin = cmd_bin.init_command
+		if res_bin isa CmdSuccess then
+			for mmodule in cmd_bin.results.as(not null) do
+				if not mmodule isa MModule then continue
+				var mmodule_makefile = mmodule.makefile_path
+				if mmodule_makefile != null and mmodule_makefile != makefile_path then continue
+
+				var file = mmodule.location.file
+				if file == null then continue
+				# Remove package path prefix
+				var bin_path = file.filename
+				if pkg_path.has_suffix("/") then
+					bin_path = bin_path.replace(pkg_path, "")
+				else
+					bin_path = bin_path.replace("{pkg_path}/", "")
+				end
+				bins.add bin_path
+			end
+		end
+
+		if  bins.is_empty then return null
+
+		var make = new NitMakefile(bins)
+		make.render.write_to_file(makefile_path)
+		return makefile_path
+	end
+end
+
+redef class MModule
+	private fun makefile_path: nullable String do
+		var file = location.file
+		if file == null then return null
+
+		var dir = file.filename.dirname
+		var makefile = (dir / "Makefile")
+		if not makefile.file_exists then return null
+
+		for line in makefile.to_path.read_lines do
+			if line.has_prefix("{name}:") then return makefile
+		end
+		return null
+	end
 end
 
 redef class ConfigTree
@@ -284,6 +396,115 @@ redef class ConfigTree
 				self[key] = value
 			end
 		end
+	end
+end
+
+# A Makefile for the Nit project
+class NitMakefile
+
+	# Nit files to compile
+	var nit_files: Array[String]
+
+	# List of rules to add in the Makefile
+	fun rules: Array[MakeRule] do
+		var rules = new Array[MakeRule]
+
+		var rule_all = new MakeRule("all", is_phony = true)
+		rules.add rule_all
+
+		for file in nit_files do
+			var bin = file.basename.strip_extension
+
+			rule_all.deps.add "bin/{bin}"
+
+			var rule = new MakeRule("bin/{bin}")
+			rule.deps.add "$(shell $(NITLS) -M {file})"
+			rule.lines.add "mkdir -p bin/"
+			rule.lines.add "$(NITC) {file} -o bin/{bin}"
+			rules.add rule
+		end
+
+		var rule_check = new MakeRule("check", is_phony = true)
+		rule_check.lines.add "$(NITUNIT) ."
+		rules.add rule_check
+
+		var rule_doc = new MakeRule("doc", is_phony = true)
+		rule_doc.lines.add "$(NITDOC) . -o doc/"
+		rules.add rule_doc
+
+		var rule_clean = new MakeRule("clean", is_phony = true)
+		if nit_files.not_empty then
+			rule_clean.lines.add "rm -rf bin/"
+		end
+		rule_clean.lines.add "rm -rf doc/"
+		rules.add rule_clean
+
+		return rules
+	end
+
+	# Render `self`
+	fun render: Writable do
+		var tpl = new Template
+		tpl.addn """
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.\n"""
+
+		if nit_files.not_empty then
+			tpl.addn "NITC ?= nitc"
+			tpl.addn "NITLS ?= nitls"
+		end
+		tpl.addn "NITUNIT ?= nitunit"
+		tpl.addn "NITDOC ?= nitdoc"
+
+		for rule in rules do
+			tpl.add "\n{rule.render.write_to_string}"
+		end
+
+		return tpl
+	end
+end
+
+# A rule that goes into a Makefile
+class MakeRule
+
+	# Rule name
+	var name: String
+
+	# Is this rule a `.PHONY` one?
+	var is_phony: Bool = false is optional
+
+	# Rule dependencies
+	var deps = new Array[String]
+
+	# Rule lines
+	var lines = new Array[String]
+
+	# Render `self`
+	fun render: Writable do
+		var tpl = new Template
+		if is_phony then
+			tpl.addn ".PHONY: {name}"
+		end
+		tpl.add "{name}:"
+		if deps.not_empty then
+			tpl.add " {deps.join(" ")}"
+		end
+		tpl.add "\n"
+		for line in lines do
+			tpl.addn "\t{line}"
+		end
+		return tpl
 	end
 end
 

--- a/src/nitpackage.nit
+++ b/src/nitpackage.nit
@@ -30,8 +30,8 @@ redef class ToolContext
 	# --force
 	var opt_force = new OptionBool("Force update of existing files", "-f", "--force")
 
-	# README handling phase
-	var readme_phase: Phase = new ReadmePhase(self, null)
+	# nitpackage phase
+	var nitpackage_phase: Phase = new NitPackagePhase(self, null)
 
 	redef init do
 		super
@@ -40,7 +40,7 @@ redef class ToolContext
 	end
 end
 
-private class ReadmePhase
+private class NitPackagePhase
 	super Phase
 
 	redef fun process_mainmodule(mainmodule, mmodules) do


### PR DESCRIPTION
This PR adds two new features to nitpackage:

--check-man: check manpages existence and content for packages and executable modules
--gen-man: create manpages for packages and executable modules

As example I added new manpages (91b9839) to `lib/markdown` and `lib/github`.

Please only consider the 6 last commits as the rest belongs to #2652, #2653, #2656, #2657 and #2662.