### PR TITLE
json: rename and improve the quick and easy `deserialize_json`

### DIFF
--- a/lib/json/README.md
+++ b/lib/json/README.md
@@ -107,7 +107,7 @@ The type to recreate is either declared or inferred:
 3. If all else fails, `JsonDeserializer` uses the static type of the attribute,
    or the type name passed to `deserialize`.
 
-The method `from_json_string` is a shortcut to `JsonDeserializer` which prints
+The method `deserialize_json` is a shortcut to `JsonDeserializer` which prints
 errors to the console. It is fit only for small scripts and other quick and dirty usage.
 
 ### Example

--- a/lib/json/serialization_read.nit
+++ b/lib/json/serialization_read.nit
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Services to read JSON: `from_json_string` and `JsonDeserializer`
+# Services to read JSON: `deserialize_json` and `JsonDeserializer`
 module serialization_read
 
 import serialization::caching
@@ -364,15 +364,17 @@ redef class Text
 
 	# Deserialize a `nullable Object` from this JSON formatted string
 	#
+	# If a `static_type` is given, only subtypes of the `static_type` are accepted.
+	#
 	# Warning: Deserialization errors are reported with `print_error` and
 	# may be returned as a partial object or as `null`.
 	#
 	# This method is not appropriate when errors need to be handled programmatically,
 	# manually use a `JsonDeserializer` in such cases.
-	fun from_json_string: nullable Object
+	fun deserialize_json(static_type: nullable String): nullable Object
 	do
 		var deserializer = new JsonDeserializer(self)
-		var res = deserializer.deserialize
+		var res = deserializer.deserialize(static_type)
 		if deserializer.errors.not_empty then
 			print_error "Deserialization Errors: {deserializer.errors.join(", ")}"
 		end


### PR DESCRIPTION
Rename the service `String::from_json_string` to a nicer `deserialize_json`. I believe that the old name was counter-intuitive and may explain why the method was used so rarely/never.

Add the argument `static_type` to `deserialize_json` to limit the type of objects that can be deserialized. This argument is passed directly to the JSON deserializer.

The method `deserialize_json` still prints errors to the console, so it should be used for quick prototypes or scripts.

This could make prettier and safer examples in #2655. 