### PR TITLE
lib/core/text: add memset to `CString`

### DIFF
--- a/lib/core/text/native.nit
+++ b/lib/core/text/native.nit
@@ -30,6 +30,9 @@ in "C" `{
 #ifndef be32toh
 	#define be32toh(val) betoh32(val)
 #endif
+
+#include <assert.h>
+#include <string.h>
 `}
 
 redef class Byte
@@ -313,4 +316,10 @@ extern class CString `{ char* `}
 	fun lshift(sh, len, pos: Int) do
 		copy_to(self, len, pos, pos - sh)
 	end
+
+	# Sets the contents of `self` to `value` for `len` bytes
+	fun memset(value, len: Int) `{
+		assert(len >= 0);
+		memset(self, value, len);
+	`}
 end

--- a/tests/sav/test_memset.res
+++ b/tests/sav/test_memset.res
@@ -1,0 +1,1 @@
+AAAAAAA

--- a/tests/test_memset.nit
+++ b/tests/test_memset.nit
@@ -1,0 +1,15 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# This file is free software, which comes along with NIT.  This software is
+# distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without  even  the implied warranty of  MERCHANTABILITY or  FITNESS FOR A
+# PARTICULAR PURPOSE.  You can modify it is you want,  provided this header
+# is kept unaltered, and a notification of the changes is added.
+# You  are  allowed  to  redistribute it and sell it, alone or is a part of
+# another product.
+
+var in_value = b"BBBBBBB"
+
+in_value.items.memset(0x41, in_value.length)
+
+print in_value


### PR DESCRIPTION
Memset is an operation used for setting bytes to a particular value.

Since it was not defined on CStrings, we add it.

Signed-off-by: Lucas Bajolet <lucas.bajolet@gmail.com>