### PR TITLE
Fix Reader::read

### DIFF
--- a/lib/core/codecs/utf8.nit
+++ b/lib/core/codecs/utf8.nit
@@ -68,6 +68,7 @@ private class UTF8Codec
 	end
 
 	redef fun decode_string(ns, len) do
+		assert len >= 0
 		var ret = ns.to_s_unsafe(len, copy=false)
 		var rit = ret.as(FlatString).items
 		if rit == ns then

--- a/lib/core/stream.nit
+++ b/lib/core/stream.nit
@@ -148,13 +148,16 @@ abstract class Reader
 
 	# Reads a String of at most `i` length
 	fun read(i: Int): String do
+		assert i >= 0
 		var cs = new CString(i)
 		var rd = read_bytes_to_cstring(cs, i)
+		if rd < 0 then return ""
 		return codec.decode_string(cs, rd)
 	end
 
 	# Reads up to `max` bytes from source
 	fun read_bytes(max: Int): Bytes do
+		assert max >= 0
 		var cs = new CString(max)
 		var rd = read_bytes_to_cstring(cs, max)
 		return new Bytes(cs, rd, max)


### PR DESCRIPTION
With the stream refactor being developed and tested alongside, some buggy behaviours are being discovered.
This PR fixes one of such, where calling read on a dead stream caused the program to segfault.