### PR TITLE
android: remove the deprecated armeabi target platform

### DIFF
--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -169,7 +169,7 @@ android {
         versionCode {{{project.version_code}}}
         versionName "{{{app_version}}}"
         ndk {
-            abiFilters 'armeabi', 'armeabi-v7a', 'x86'
+            abiFilters 'armeabi-v7a', 'x86'
         }
         externalNativeBuild {
             cmake {


### PR DESCRIPTION
Android NDK tools do not support the armeabi target platform anymore, breaking the compilation of all Nit app for Android. This PR removes this target, fixing our compilation issues. This platform version should not be active anywhere, it was widely replaced by armeabi-v7a.

Unless you update the Android SDK tool, compiling Nit apps for Android should still work on your machine and the CI server. However, it fails on the Nit docker, as with: 
https://gitlab.com/xymus/darpg/-/jobs/67649353
https://gitlab.com/Skyline76/memory_gamnit/-/jobs/67571796