### PR TITLE
docker: nitpm requires libcurl, move it up from `full`

### DIFF
--- a/misc/docker/Dockerfile
+++ b/misc/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 		git \
 		ca-certificates \
 		curl \
+		libcurl4-openssl-dev \
 		# For nit manpages :)
 		man \
 	&& rm -rf /var/lib/apt/lists/*

--- a/misc/docker/full/Dockerfile
+++ b/misc/docker/full/Dockerfile
@@ -8,7 +8,6 @@ MAINTAINER Jean Privat <jean@pryen.org>
 RUN dpkg --add-architecture i386 \
 	&& apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 		# Packages needed for lib/
-		libcurl4-openssl-dev \
 		libegl1-mesa-dev \
 		libevent-dev \
 		libgles1-mesa-dev \


### PR DESCRIPTION
This PR should fix the compilation of the nitlang/nit Docker which was broken since adding nitpm.

See: https://hub.docker.com/r/nitlang/nit/builds/bgtphmftqbdp9o7eqhqzn9f/

I've activated email alerts on hub.docker.com to hopefully catch these problems sooner next time.