### PR TITLE
lib/config: better tool configuration

### DIFF
--- a/lib/config/config.nit
+++ b/lib/config/config.nit
@@ -188,9 +188,13 @@ class Config
 	# Help option
 	var opt_help = new OptionBool("Show this help message", "-h", "-?", "--help")
 
+	# Option --stub-man
+	var opt_stub_man = new OptionBool("Generate a stub manpage in markdown format", "--stub-man")
+
 	# Redefine this init to add your options
 	init do
-		add_option(opt_help)
+		add_option(opt_help, opt_stub_man)
+		opt_stub_man.hidden = true
 	end
 
 	# Add an option to `self`
@@ -201,6 +205,11 @@ class Config
 	# Initialize `self` options from `args`
 	fun parse_options(args: Collection[String]) do
 		opts.parse(args)
+
+		if opt_stub_man.value then
+			stub_man_options
+			exit 0
+		end
 	end
 
 	# Return the remaining args once options are parsed by `from_args`
@@ -220,7 +229,41 @@ class Config
 	# Display `tool_description` and options usage in console
 	fun usage do
 		print tool_description
+		print "\nOptions:"
 		opts.usage
+	end
+
+	# Generate a manpage stub from `self`
+	fun stub_man_options do
+		var lines = tool_description.split("\n")
+		var name = sys.program_name.basename
+		var syn = lines.shift
+		print "# NAME"
+		print ""
+		if lines.not_empty then
+			printn "{name} - "
+			print lines.join("\n")
+			print ""
+		end
+		print "# SYNOPSIS"
+		print ""
+		print syn.replace("Usage: ", "")
+		print ""
+		print "# OPTIONS"
+		for o in opts.options do
+			if o.hidden then continue
+
+			var first = true
+			print ""
+			printn "### "
+			for n in o.names do
+				if first then first = false else printn ", "
+				printn "`{n}`"
+			end
+			print ""
+			print "{o.helptext}."
+		end
+		exit 0
 	end
 end
 

--- a/lib/config/config.nit
+++ b/lib/config/config.nit
@@ -186,7 +186,7 @@ class Config
 	var opts = new OptionContext
 
 	# Help option
-	var opt_help = new OptionBool("Show this help message", "-h", "--help")
+	var opt_help = new OptionBool("Show this help message", "-h", "-?", "--help")
 
 	# Redefine this init to add your options
 	init do

--- a/lib/github/loader.nit
+++ b/lib/github/loader.nit
@@ -78,7 +78,7 @@ class LoaderConfig
 
 	init do
 		super
-		tool_description = "Usage: loader <repo_name>"
+		tool_description = "Usage: loader <repo_name>\nLoad a GitHub repo into a MongoDb."
 		add_option(opt_db_host, opt_db_name)
 		add_option(opt_tokens, opt_show_wallet)
 		add_option(opt_verbose, opt_no_colors)

--- a/lib/markdown/nitmd.nit
+++ b/lib/markdown/nitmd.nit
@@ -19,22 +19,25 @@ import markdown
 import decorators
 import man
 
-import opts
+import config
 
-var options = new OptionContext
-var opt_help = new OptionBool("Show this help.", "-h", "-?", "--help")
-options.add_option(opt_help)
 var opt_to = new OptionString("Specify output format (html, md, man)", "-t", "--to")
-options.add_option(opt_to)
 
-options.parse(args)
-if options.rest.length != 1 then
-	print "usage: nitmd [-t format] <file.md>"
-	options.usage
+var usage = new Buffer
+usage.append "Usage: nitmd [-t format] <file.md>\n"
+usage.append "Translate Markdown documents to other formats."
+
+var config = new Config
+config.add_option(opt_to)
+config.tool_description = usage.write_to_string
+
+config.parse_options(args)
+if config.args.length != 1 then
+	config.usage
 	exit 1
 end
 
-var file = options.rest.first
+var file = config.args.first
 if not file.file_exists then
 	print "'{file}' not found"
 	exit 1

--- a/tests/sav/example_vsm.res
+++ b/tests/sav/example_vsm.res
@@ -1,4 +1,6 @@
 usage: example_vsm <files>
-  -h, --help             Show this help message
+
+Options:
+  -h, -?, --help         Show this help message
   -w, --whitelist-exts   Allowed file extensions (default is [])
   -b, --blacklist-exts   Allowed file extensions (default is [])

--- a/tests/sav/nlp_index.res
+++ b/tests/sav/nlp_index.res
@@ -1,5 +1,7 @@
 usage: example_index <files>
-  -h, --help             Show this help message
+
+Options:
+  -h, -?, --help         Show this help message
   -s, --server           StanfordNLP server URI (default is https://localhost:9000)
   -l, --lang             Language to use (default is fr)
   -w, --whitelist-exts   Allowed file extensions (default is [])


### PR DESCRIPTION
This PR reworks some aspects of the `lib/config`:
* Add option `-?` as help
* Introduce `--stub-man` option (almost the same thing than in `ToolContext`)
* Make `nitmd` use `config` instead of `opts`
* Define a better `tool_description` for `github/loader`
