### PR TITLE
macOS: skip one of the nitpm tests because of locale issues

### DIFF
--- a/tests/Darwin.skip
+++ b/tests/Darwin.skip
@@ -8,6 +8,7 @@ ui_test
 readline
 postgres
 nitweb
+nitpm_arg3
 langannot
 test_nitcorn
 test_annot_pkgconfig


### PR DESCRIPTION
The test `nitpm_arg3` exposes an output from Git. It looks like there is locale issue on the macOS CI server changing the output and breaking the tests.

Test diff:
~~~
--- sav//nitpm_args3.res	2018-04-05 22:14:54.000000000 -0400
+++ out/nitpm_args3.res	2018-05-11 02:59:58.000000000 -0400
@@ -1 +1 @@
-Already up-to-date.
+Already up to date.
~~~

I didn't find a clear cause after a quick investigation. This PR as a temporary workaround, feel free to investigate and PR a real fix!