### PR TITLE
contrib/wiringPi: fix `shift` module name

### DIFF
--- a/contrib/wiringPi/examples/shift.nit
+++ b/contrib/wiringPi/examples/shift.nit
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module wiringPi is example
+module shift is example
 
 import wiringPi
 


### PR DESCRIPTION
Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>