### PR TITLE
contrib: apply nitpackage --gen-ini

### DIFF
--- a/contrib/action_nitro/package.ini
+++ b/contrib/action_nitro/package.ini
@@ -3,6 +3,7 @@ name=action_nitro
 tags=example
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Action Nitro! an action platformer where you jump from plane to plane to reach the ISS and defeat the bad guys
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/action_nitro/
 git=https://github.com/nitlang/nit.git

--- a/contrib/asteronits/package.ini
+++ b/contrib/asteronits/package.ini
@@ -3,6 +3,7 @@ name=asteronits
 tags=example
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Sample portable 2D game implemented with the `simple_2d` API of gamnit
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/asteronits/
 git=https://github.com/nitlang/nit.git

--- a/contrib/benitlux/package.ini
+++ b/contrib/benitlux/package.ini
@@ -3,6 +3,7 @@ name=benitlux
 tags=mobile,web
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=An unofficial app and mailing list to keep faithful bargoers informed of the beers available at the excellent Brasserie Bénélux
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/benitlux/
 git=https://github.com/nitlang/nit.git

--- a/contrib/brainfuck/package.ini
+++ b/contrib/brainfuck/package.ini
@@ -3,6 +3,7 @@ name=brainfuck
 tags=language
 maintainer=Lucas Bajolet <r4pass@hotmail.com>
 license=Apache-2.0
+desc=Brainfuck, a simple Brainfuck interpreter written in Nit
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/brainfuck/
 git=https://github.com/nitlang/nit.git

--- a/contrib/github_merge/package.ini
+++ b/contrib/github_merge/package.ini
@@ -3,6 +3,7 @@ name=github_merge
 tags=cli
 maintainer=Jean Privat <jean@pryen.org>
 license=Apache-2.0
+desc=Query the Github PR API to perform a merge
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/github_merge/
 git=https://github.com/nitlang/nit.git

--- a/contrib/github_search_for_jni/package.ini
+++ b/contrib/github_search_for_jni/package.ini
@@ -3,6 +3,7 @@ name=github_search_for_jni
 tags=cli
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Seach Github for repositories possibly using the JNI
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/github_search_for_jni/
 git=https://github.com/nitlang/nit.git

--- a/contrib/header_keeper/package.ini
+++ b/contrib/header_keeper/package.ini
@@ -3,6 +3,7 @@ name=header_keeper
 tags=devel,cli
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Filter preprocessed C-like header files to remove included files
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/header_keeper/
 git=https://github.com/nitlang/nit.git

--- a/contrib/inkscape_tools/package.ini
+++ b/contrib/inkscape_tools/package.ini
@@ -3,6 +3,7 @@ name=inkscape_tools
 tags=devel,cli
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=tools to extract images from SVG files: `svg_to_icons` for app icons and `svg_to_png_and_nit` for game sprites
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/inkscape_tools/
 git=https://github.com/nitlang/nit.git

--- a/contrib/jwrapper/package.ini
+++ b/contrib/jwrapper/package.ini
@@ -3,6 +3,7 @@ name=jwrapper
 tags=java,devel,cli
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Generator of Nit extern classes to wrap Java APIs
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/jwrapper/
 git=https://github.com/nitlang/nit.git

--- a/contrib/memplot/package.ini
+++ b/contrib/memplot/package.ini
@@ -3,6 +3,7 @@ name=memplot
 tags=devel
 maintainer=Jean Privat <jean@pryen.org>
 license=Apache-2.0
+desc=Program to transform `memory.log` files produced by `nitc --trace-memory` into a csv file
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/memplot/
 git=https://github.com/nitlang/nit.git

--- a/contrib/model_viewer/package.ini
+++ b/contrib/model_viewer/package.ini
@@ -3,6 +3,7 @@ name=model_viewer
 tags=example
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Sample portable 3D app implemented with the gamnit depth framework
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/model_viewer/
 git=https://github.com/nitlang/nit.git

--- a/contrib/model_viewer/package.ini
+++ b/contrib/model_viewer/package.ini
@@ -6,7 +6,7 @@ license=Apache-2.0
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/model_viewer/
 git=https://github.com/nitlang/nit.git
-git.directory=contrib/asteronits/
+git.directory=contrib/model_viewer/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues
 apk=http://nitlanguage.org/fdroid/apk/model_viewer.apk

--- a/contrib/neo_doxygen/package.ini
+++ b/contrib/neo_doxygen/package.ini
@@ -3,6 +3,7 @@ name=neo_doxygen
 tags=devel,cli
 maintainer=Jean-Christophe Beaupré <jcbrinfo@users.noreply.github.com>
 license=Apache-2.0
+desc=neo_doxygen, a tool to convert a Doxygen XML output into a Neo4j model
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/neo_doxygen/
 git=https://github.com/nitlang/nit.git

--- a/contrib/nitcc/package.ini
+++ b/contrib/nitcc/package.ini
@@ -3,6 +3,7 @@ name=nitcc
 tags=devel,cli
 maintainer=Jean Privat <jean@pryen.org>
 license=Apache-2.0
+desc=nitcc, a parser and lexer generator for Nit
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/nitcc/
 git=https://github.com/nitlang/nit.git

--- a/contrib/nitester/package.ini
+++ b/contrib/nitester/package.ini
@@ -3,6 +3,7 @@ name=nitester
 tags=devel,cli
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Tester of Nit engines on an MPI cluster
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/nitester/
 git=https://github.com/nitlang/nit.git

--- a/contrib/nitin/package.ini
+++ b/contrib/nitin/package.ini
@@ -3,6 +3,7 @@ name=nitin
 tags=devel
 maintainer=Jean Privat <jean@pryen.org>
 license=GPL-3.0
+desc=An experimental Nit interactive interpreter
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/nitin/
 git=https://github.com/nitlang/nit.git

--- a/contrib/nitiwiki/package.ini
+++ b/contrib/nitiwiki/package.ini
@@ -3,6 +3,7 @@ name=nitiwiki
 tags=web,cli
 maintainer=Alexandre Terrasa <alexandre@moz-code.org>
 license=Apache-2.0
+desc=nitiwiki, a simple wiki manager based on markdown
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/nitiwiki/
 git=https://github.com/nitlang/nit.git

--- a/contrib/nitrpg/package.ini
+++ b/contrib/nitrpg/package.ini
@@ -3,6 +3,7 @@ name=nitrpg
 tags=devel,web,cli
 maintainer=Alexandre Terrasa <alexandre@moz-code.org>
 license=Apache-2.0
+desc=NitRPG, a Role Playing Game that takes place on GitHub
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/nitrpg/
 git=https://github.com/nitlang/nit.git

--- a/contrib/objcwrapper/package.ini
+++ b/contrib/objcwrapper/package.ini
@@ -3,6 +3,7 @@ name=objcwrapper
 tags=devel,cli
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Generator of Nit extern classes to wrap Objective-C services
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/objcwrapper/
 git=https://github.com/nitlang/nit.git

--- a/contrib/opportunity/package.ini
+++ b/contrib/opportunity/package.ini
@@ -3,6 +3,7 @@ name=opportunity
 tags=web
 maintainer=Lucas Bajolet <r4pass@hotmail.com>
 license=Apache-2.0
+desc=Opportunity is a web-application written in Nit to plan meetups with people in real-life (or on the internet, why not !)
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/opportunity/
 git=https://github.com/nitlang/nit.git

--- a/contrib/pep8analysis/package.ini
+++ b/contrib/pep8analysis/package.ini
@@ -3,6 +3,7 @@ name=pep8analysis
 tags=educ,web,cli
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Pep/8 Analysis, a static checker to detect bugs and bad programming practices in Pep/8 programs
 [source]
 exclude=src/parser/parser_abs.nit
 [upstream]

--- a/contrib/physical_interface_for_mpd_on_rpi/package.ini
+++ b/contrib/physical_interface_for_mpd_on_rpi/package.ini
@@ -3,6 +3,7 @@ name=physical_interface_for_mpd_on_rpi
 tags=embedded,cli
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Backend to a hardware interface to control an MPD server from a Raspberry Pi
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/physical_interface_for_mpd_on_rpi/
 git=https://github.com/nitlang/nit.git

--- a/contrib/re_parser/package.ini
+++ b/contrib/re_parser/package.ini
@@ -3,6 +3,7 @@ name=re_parser
 tags=re
 maintainer=Alexandre Terrasa <alexandre@moz-code.org>
 license=Apache-2.0
+desc=RE Parser, a simple API for regular expression parsing
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/re_parser/
 git=https://github.com/nitlang/nit.git

--- a/contrib/refund/package.ini
+++ b/contrib/refund/package.ini
@@ -3,6 +3,7 @@ name=refund
 tags=example,cli
 maintainer=Alexandre Terrasa <alexandre@moz-code.org>
 license=Apache-2.0
+desc=Insurance refunds calculation tool
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/refund/
 git=https://github.com/nitlang/nit.git

--- a/contrib/rss_downloader/package.ini
+++ b/contrib/rss_downloader/package.ini
@@ -3,6 +3,7 @@ name=rss_downloader
 tags=network,cli
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=A tool to download files listed in RSS feeds according to local folders
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/rss_downloader/
 git=https://github.com/nitlang/nit.git

--- a/contrib/shibuqam/package.ini
+++ b/contrib/shibuqam/package.ini
@@ -3,6 +3,7 @@ name=shibuqam
 tags=web
 maintainer=Jean Privat <jean@pryen.org>
 license=Apache-2.0
+desc=Gather the authenticated users on UQAM websites
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/shibuqam/
 git=https://github.com/nitlang/nit.git

--- a/contrib/simplan/package.ini
+++ b/contrib/simplan/package.ini
@@ -3,6 +3,7 @@ name=simplan
 tags=ai,example,cli
 maintainer=Jean Privat <jean@pryen.org>
 license=Apache-2.0
+desc=A simple planning problem solver using A* for a robot that delivers parcels
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/simplan/
 git=https://github.com/nitlang/nit.git

--- a/contrib/sort_downloads/package.ini
+++ b/contrib/sort_downloads/package.ini
@@ -3,6 +3,7 @@ name=sort_downloads
 tags=cli
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Script to sort content of a folder in many folders according to their names
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/sort_downloads/
 git=https://github.com/nitlang/nit.git

--- a/contrib/tinks/package.ini
+++ b/contrib/tinks/package.ini
@@ -3,6 +3,7 @@ name=tinks
 tags=game
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Tinks! a multiplayer crossplatform action game with destructible procedurally generated worlds
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/tinks/
 git=https://github.com/nitlang/nit.git

--- a/contrib/tnitter/package.ini
+++ b/contrib/tnitter/package.ini
@@ -3,6 +3,7 @@ name=tnitter
 tags=web,mobile
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Tnitter, a Twitter-like micro-blogging platform
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/tnitter/
 git=https://github.com/nitlang/nit.git

--- a/contrib/wiringPi/package.ini
+++ b/contrib/wiringPi/package.ini
@@ -3,6 +3,7 @@ name=wiringPi
 tags=embedded,wrapper
 maintainer=Alexandre Terrasa <alexandre@moz-code.org>
 license=Apache-2.0
+desc=wiringPi nit wrapper
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/wiringPi/
 git=https://github.com/nitlang/nit.git

--- a/contrib/xymus_net/package.ini
+++ b/contrib/xymus_net/package.ini
@@ -3,6 +3,7 @@ name=xymus_net
 tags=web,example
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
+desc=Web server source and config of xymus.net
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/contrib/xymus_net/
 git=https://github.com/nitlang/nit.git

--- a/contrib/xymus_net/package.ini
+++ b/contrib/xymus_net/package.ini
@@ -4,8 +4,8 @@ tags=web,example
 maintainer=Alexis Laferrière <alexis.laf@xymus.net>
 license=Apache-2.0
 [upstream]
-browse=https://github.com/nitlang/nit/tree/master/contrib/xymus.net/
+browse=https://github.com/nitlang/nit/tree/master/contrib/xymus_net/
 git=https://github.com/nitlang/nit.git
-git.directory=contrib/xymus.net/
+git.directory=contrib/xymus_net/
 homepage=http://xymus.net/
 issues=https://github.com/nitlang/nit/issues

--- a/src/nitpackage.nit
+++ b/src/nitpackage.nit
@@ -184,7 +184,8 @@ redef class MPackage
 		"package.name", "package.desc", "package.tags", "package.license",
 		"package.maintainer", "package.more_contributors",
 		"upstream.browse", "upstream.git", "upstream.git.directory",
-		"upstream.homepage", "upstream.issues"
+		"upstream.homepage", "upstream.issues", "upstream.apk", "upstream.tryit",
+		"source.exclude"
 		]
 
 	private fun check_ini(toolcontext: ToolContext) do

--- a/src/package.ini
+++ b/src/package.ini
@@ -3,6 +3,7 @@ name=nitc
 tags=devel,cli
 maintainer=Jean Privat <jean@pryen.org>
 license=Apache-2.0
+desc=Nit compiler and tools
 [source]
 exclude=parser/parser_abs.nit:parser/.parser-nofact.nit
 [upstream]

--- a/src/package.ini
+++ b/src/package.ini
@@ -6,8 +6,8 @@ license=Apache-2.0
 [source]
 exclude=parser/parser_abs.nit:parser/.parser-nofact.nit
 [upstream]
-browse=https://github.com/nitlang/nit/tree/master/src
+browse=https://github.com/nitlang/nit/tree/master/src/
 git=https://github.com/nitlang/nit.git
-git.directory=src
+git.directory=src/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues


### PR DESCRIPTION
I ran `nitpackage --gen-ini` on contrib projects.

First of all, I added 3 more accepted keys to nitpackage --check-ini that seem to be used in some projects (04abe90):
* `upstream.apk`
* `upstream.tryit`
* `source.exclude`

I expanded the package `github_merge`, the only one left in the non-expanded form in the Nit project (51df98b).

Then I corrected some `git.directory` keys with incorrect values (a4b53f7). Short note for `src`, I added the trailing `/` to be consistent with all other ini files.

Finally I generated the `package.desc` for all projects from the `mdoc_or_fallback.synopsis` values (051ab50).