### PR TITLE
contrib: generate Makefiles with nitpackage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ csrc2/
 lib/*.log
 lib/*.dot
 
+lib/*/bin
+
 examples/*/doc
 examples/*/bin
 

--- a/contrib/brainfuck/Makefile
+++ b/contrib/brainfuck/Makefile
@@ -1,0 +1,38 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
+
+.PHONY: all
+all: bin/brainfuck
+
+bin/brainfuck: $(shell $(NITLS) -M brainfuck.nit)
+	mkdir -p bin/
+	$(NITC) brainfuck.nit -o bin/brainfuck
+
+.PHONY: check
+check:
+	$(NITUNIT) .
+
+.PHONY: doc
+doc:
+	$(NITDOC) . -o doc/
+
+.PHONY: clean
+clean:
+	rm -rf bin/
+	rm -rf doc/

--- a/contrib/github_merge/Makefile
+++ b/contrib/github_merge/Makefile
@@ -1,0 +1,38 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
+
+.PHONY: all
+all: bin/github_merge
+
+bin/github_merge: $(shell $(NITLS) -M github_merge.nit)
+	mkdir -p bin/
+	$(NITC) github_merge.nit -o bin/github_merge
+
+.PHONY: check
+check:
+	$(NITUNIT) .
+
+.PHONY: doc
+doc:
+	$(NITDOC) . -o doc/
+
+.PHONY: clean
+clean:
+	rm -rf bin/
+	rm -rf doc/

--- a/contrib/github_search_for_jni/Makefile
+++ b/contrib/github_search_for_jni/Makefile
@@ -1,3 +1,38 @@
-default:
-	mkdir -p bin
-	nitc -o bin/github_search_for_jni src/github_search_for_jni.nit
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
+
+.PHONY: all
+all: bin/github_search_for_jni
+
+bin/github_search_for_jni: $(shell $(NITLS) -M src/github_search_for_jni.nit)
+	mkdir -p bin/
+	$(NITC) src/github_search_for_jni.nit -o bin/github_search_for_jni
+
+.PHONY: check
+check:
+	$(NITUNIT) .
+
+.PHONY: doc
+doc:
+	$(NITDOC) . -o doc/
+
+.PHONY: clean
+clean:
+	rm -rf bin/
+	rm -rf doc/

--- a/contrib/header_keeper/Makefile
+++ b/contrib/header_keeper/Makefile
@@ -1,8 +1,43 @@
-bin/header_keeper:
-	mkdir -p bin
-	nitc --dir bin src/header_keeper.nit
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
+
+.PHONY: all
+all: bin/header_keeper
+
+bin/header_keeper: $(shell $(NITLS) -M src/header_keeper.nit)
+	mkdir -p bin/
+	$(NITC) src/header_keeper.nit -o bin/header_keeper
+
+.PHONY: check
 check: tests
+	$(NITUNIT) .
+
+.PHONY: tests
 tests: bin/header_keeper
 	gcc -E /usr/include/SDL/SDL_image.h | bin/header_keeper SDL_image.h
 	gcc -E /usr/include/GLES2/gl2.h | bin/header_keeper gl2.h
+
+.PHONY: doc
+doc:
+	$(NITDOC) . -o doc/
+
+.PHONY: clean
+clean:
+	rm -rf bin/
+	rm -rf doc/

--- a/contrib/inkscape_tools/Makefile
+++ b/contrib/inkscape_tools/Makefile
@@ -1,5 +1,42 @@
-all:
-	mkdir -p bin
-	nitc --dir bin src/svg_to_png_and_nit.nit src/svg_to_icons.nit
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-.PHONY: bin/svg_to_png_and_nit
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
+
+.PHONY: all
+all: bin/svg_to_icons bin/svg_to_png_and_nit
+
+bin/svg_to_icons: $(shell $(NITLS) -M src/svg_to_icons.nit)
+	mkdir -p bin/
+	$(NITC) src/svg_to_icons.nit -o bin/svg_to_icons
+
+bin/svg_to_png_and_nit: $(shell $(NITLS) -M src/svg_to_png_and_nit.nit)
+	mkdir -p bin/
+	$(NITC) src/svg_to_png_and_nit.nit -o bin/svg_to_png_and_nit
+
+.PHONY: check
+check:
+	$(NITUNIT) .
+
+.PHONY: doc
+doc:
+	$(NITDOC) . -o doc/
+
+.PHONY: clean
+clean:
+	rm -rf bin/
+	rm -rf doc/

--- a/contrib/memplot/Makefile
+++ b/contrib/memplot/Makefile
@@ -1,0 +1,38 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
+
+.PHONY: all
+all: bin/memplot
+
+bin/memplot: $(shell $(NITLS) -M memplot.nit)
+	mkdir -p bin/
+	$(NITC) memplot.nit -o bin/memplot
+
+.PHONY: check
+check:
+	$(NITUNIT) .
+
+.PHONY: doc
+doc:
+	$(NITDOC) . -o doc/
+
+.PHONY: clean
+clean:
+	rm -rf bin/
+	rm -rf doc/

--- a/contrib/neo_doxygen/Makefile
+++ b/contrib/neo_doxygen/Makefile
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,30 +12,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NITC=nitc
-NITC_FLAGS=--dir bin
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
+
 NEO4J_DIR=/var/lib/neo4j
 OLD_PWD=${PWD}
 
-.PHONY: bin reset-neo run-tests tests
+.PHONY: all
+all: bin/neo_doxygen
 
-# Compile the tool.
-bin:
-	mkdir -p bin
-	$(NITC) $(NITC_FLAGS) src/neo_doxygen.nit
+bin/neo_doxygen: $(shell $(NITLS) -M src/neo_doxygen.nit)
+	mkdir -p bin/
+	$(NITC) src/neo_doxygen.nit -o bin/neo_doxygen
+
+.PHONY: check
+check:
+	$(NITUNIT) .
 
 # Reset the local graph.
+.PHONY: reset-neo
 reset-neo:
 	sudo -u neo4j "${NEO4J_DIR}/bin/neo4j" stop \
-	&& sudo -u neo4j rm -rf "${NEO4J_DIR}/data/graph.db" \
-	&& sudo -u neo4j "${NEO4J_DIR}/bin/neo4j" start
+		&& sudo -u neo4j rm -rf "${NEO4J_DIR}/data/graph.db" \
+		&& sudo -u neo4j "${NEO4J_DIR}/bin/neo4j" start
 
 # Regenerate the XML documents in `tests`.
+.PHONY: tests
 tests:
 	$(MAKE) -C tests
 
 # Run the tests.
+.PHONY: run-tests
 run-tests:
 	cd ../../tests; \
-	./tests.sh ../contrib/neo_doxygen/src/tests/neo_doxygen_*.nit ; \
-	cd "${OLD_PWD}"
+		./tests.sh ../contrib/neo_doxygen/src/tests/neo_doxygen_*.nit ; \
+		cd "${OLD_PWD}"
+
+.PHONY: doc
+doc:
+	$(NITDOC) . -o doc/
+
+.PHONY: clean
+clean:
+	rm -rf bin/
+	rm -rf doc/

--- a/contrib/nitester/Makefile
+++ b/contrib/nitester/Makefile
@@ -1,3 +1,38 @@
-all:
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
+
+.PHONY: all
+all: bin/nitester
+
+bin/nitester: $(shell $(NITLS) -M src/nitester.nit)
 	mkdir -p bin/
-	nitc src/nitester.nit -o bin/nitester
+	$(NITC) src/nitester.nit -o bin/nitester
+
+.PHONY: check
+check:
+	$(NITUNIT) .
+
+.PHONY: doc
+doc:
+	$(NITDOC) . -o doc/
+
+.PHONY: clean
+clean:
+	rm -rf bin/
+	rm -rf doc/

--- a/contrib/nitin/Makefile
+++ b/contrib/nitin/Makefile
@@ -1,3 +1,38 @@
-all:
-	mkdir -p bin
-	nitc --semi-global nitin.nit -m readline -o bin/nitin
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
+
+.PHONY: all
+all: bin/nitin
+
+bin/nitin: $(shell $(NITLS) -M nitin.nit)
+	mkdir -p bin/
+	$(NITC) --semi-global nitin.nit -m readline -o bin/nitin
+
+.PHONY: check
+check:
+	$(NITUNIT) .
+
+.PHONY: doc
+doc:
+	$(NITDOC) . -o doc/
+
+.PHONY: clean
+clean:
+	rm -rf bin/
+	rm -rf doc/

--- a/contrib/nitiwiki/Makefile
+++ b/contrib/nitiwiki/Makefile
@@ -1,17 +1,43 @@
-all: nitiwiki bin/nitiwiki_server
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-nitiwiki:
-	mkdir -p bin
-	nitc src/nitiwiki.nit -o bin/nitiwiki
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
 
-bin/nitiwiki_server: $(shell nitls -M src/wiki_edit.nit)
-	nitc -o $@ src/wiki_edit.nit
+.PHONY: all
+all: bin/nitiwiki bin/wiki_edit
 
-check: nitiwiki
+bin/nitiwiki: $(shell $(NITLS) -M src/nitiwiki.nit)
+	mkdir -p bin/
+	$(NITC) src/nitiwiki.nit -o bin/nitiwiki
+
+bin/wiki_edit: $(shell $(NITLS) -M src/wiki_edit.nit)
+	mkdir -p bin/
+	$(NITC) src/wiki_edit.nit -o bin/wiki_edit
+
+.PHONY: check
+check: bin/nitiwiki
+	$(NITUNIT) .
 	cd tests; make
 
+.PHONY: doc
 doc:
-	nitdoc -d doc src/nitiwiki.nit
+	$(NITDOC) . -o doc/
 
+.PHONY: clean
 clean:
-	rm -rf bin
+	rm -rf bin/
+	rm -rf doc/

--- a/contrib/nitrpg/Makefile
+++ b/contrib/nitrpg/Makefile
@@ -1,7 +1,5 @@
 # This file is part of NIT ( http://www.nitlanguage.org ).
 #
-# Copyright 2014-2015 Alexandre Terrasa <alexandre@moz-code.org>
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,23 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NITC=nitc
-NITU=nitunit
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
 
-all: listener web
+.PHONY: all
+all: bin/listener bin/web
 
-listener:
-	$(NITC) src/listener.nit
+bin/listener: $(shell $(NITLS) -M src/listener.nit)
+	mkdir -p bin/
+	$(NITC) src/listener.nit -o bin/listener
 
-web:
-	$(NITC) src/web.nit
+bin/web: $(shell $(NITLS) -M src/web.nit)
+	mkdir -p bin/
+	$(NITC) src/web.nit -o bin/web
 
+.PHONY: check
 check:
-	$(NITU) src/game.nit
-	$(NITU) src/events.nit
-	$(NITU) src/statistics.nit
-	$(NITU) src/achievements.nit
-	$(NITU) src/listener.nit
+	$(NITUNIT) .
 
+.PHONY: doc
+doc:
+	$(NITDOC) . -o doc/
+
+.PHONY: clean
 clean:
-	rm listener web
+	rm -rf bin/
+	rm -rf doc/

--- a/contrib/refund/Makefile
+++ b/contrib/refund/Makefile
@@ -1,7 +1,5 @@
 # This file is part of NIT ( http://www.nitlanguage.org ).
 #
-# Copyright 2015 Alexandre Terrasa <alexandre@moz-code.org>
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,15 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-all: refund
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
 
-refund:
-	mkdir -p bin
-	nitc src/refund.nit -o bin/refund
+.PHONY: all
+all: bin/refund
 
-check: refund
+bin/refund: $(shell $(NITLS) -M src/refund.nit)
+	mkdir -p bin/
+	$(NITC) src/refund.nit -o bin/refund
+
+.PHONY: check
+check: bin/refund
+	$(NITUNIT) .
 	cd tests; make
 
+.PHONY: doc
+doc:
+	$(NITDOC) . -o doc/
+
+.PHONY: clean
 clean:
-	rm -rf bin
+	rm -rf bin/
+	rm -rf doc/
 	cd tests; make clean

--- a/contrib/rss_downloader/Makefile
+++ b/contrib/rss_downloader/Makefile
@@ -1,3 +1,38 @@
-all:
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
+
+.PHONY: all
+all: bin/rss_downloader
+
+bin/rss_downloader: $(shell $(NITLS) -M src/rss_downloader.nit)
 	mkdir -p bin/
-	nitc --dir bin/ src/*.nit
+	$(NITC) src/rss_downloader.nit -o bin/rss_downloader
+
+.PHONY: check
+check:
+	$(NITUNIT) .
+
+.PHONY: doc
+doc:
+	$(NITDOC) . -o doc/
+
+.PHONY: clean
+clean:
+	rm -rf bin/
+	rm -rf doc/

--- a/contrib/sort_downloads/Makefile
+++ b/contrib/sort_downloads/Makefile
@@ -1,6 +1,42 @@
-build:
-	mkdir -p bin/
-	nitc --dir bin/ src/*.nit
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+NITC ?= nitc
+NITLS ?= nitls
+NITUNIT ?= nitunit
+NITDOC ?= nitdoc
+
+.PHONY: all
+all: bin/sort_downloads
+
+bin/sort_downloads: $(shell $(NITLS) -M src/sort_downloads.nit)
+	mkdir -p bin/
+	$(NITC) src/sort_downloads.nit -o bin/sort_downloads
+
+.PHONY: install
 install:
 	install bin/sort_downloads /usr/local/bin/
+
+.PHONY: check
+check:
+	$(NITUNIT) .
+
+.PHONY: doc
+doc:
+	$(NITDOC) . -o doc/
+
+.PHONY: clean
+clean:
+	rm -rf bin/
+	rm -rf doc/

--- a/lib/github/Makefile
+++ b/lib/github/Makefile
@@ -18,11 +18,11 @@ NITUNIT ?= nitunit
 NITDOC ?= nitdoc
 
 .PHONY: all
-all: bin/nitmd
+all: bin/loader
 
-bin/nitmd: $(shell $(NITLS) -M nitmd.nit)
+bin/loader: $(shell $(NITLS) -M loader.nit)
 	mkdir -p bin/
-	$(NITC) nitmd.nit -o bin/nitmd
+	$(NITC) loader.nit -o bin/loader
 
 .PHONY: check
 check:

--- a/share/man/Makefile
+++ b/share/man/Makefile
@@ -16,7 +16,7 @@ IN=$(wildcard nit*.md)
 OUT=$(patsubst %.md,man1/%.1,$(IN))
 
 MARKDOWN=../../lib/markdown
-NITMD=$(MARKDOWN)/nitmd
+NITMD=$(MARKDOWN)/bin/nitmd
 
 all: $(OUT)
 

--- a/share/man/nitpackage.md
+++ b/share/man/nitpackage.md
@@ -54,6 +54,12 @@ Generate package.ini files.
 ### `--check-ini`
 Check package.ini files.
 
+### `--gen-makefile`
+Generate Makefile files.
+
+### `--check-makefile`
+Check Makefile files.
+
 ### `-f`, `--force`
 Force update of existing files.
 

--- a/src/nitpackage.nit
+++ b/src/nitpackage.nit
@@ -16,6 +16,7 @@
 module nitpackage
 
 import frontend
+import doc::commands::commands_main
 
 redef class ToolContext
 	# --expand
@@ -30,6 +31,12 @@ redef class ToolContext
 	# --force
 	var opt_force = new OptionBool("Force update of existing files", "-f", "--force")
 
+	# --check-makefile
+	var opt_check_makefile = new OptionBool("Check Makefile files", "--check-makefile")
+
+	# --gen-makefile
+	var opt_gen_makefile = new OptionBool("Generate Makefile files", "--gen-makefile")
+
 	# nitpackage phase
 	var nitpackage_phase: Phase = new NitPackagePhase(self, null)
 
@@ -37,6 +44,7 @@ redef class ToolContext
 		super
 		option_context.add_option(opt_expand, opt_force)
 		option_context.add_option(opt_check_ini, opt_gen_ini)
+		option_context.add_option(opt_check_makefile, opt_gen_makefile)
 	end
 end
 
@@ -60,6 +68,12 @@ private class NitPackagePhase
 				continue
 			end
 
+			# Check package Makefiles
+			if toolcontext.opt_check_makefile.value then
+				mpackage.check_makefile(toolcontext, mainmodule)
+				continue
+			end
+
 			# Expand packages
 			if toolcontext.opt_expand.value and not mpackage.is_expanded then
 				var path = mpackage.expand
@@ -76,6 +90,16 @@ private class NitPackagePhase
 				if not mpackage.has_ini or toolcontext.opt_force.value then
 					var path = mpackage.gen_ini
 					toolcontext.info("generated INI file `{path}`", 0)
+				end
+			end
+
+			# Create Makefile
+			if toolcontext.opt_gen_makefile.value then
+				if not mpackage.has_makefile or toolcontext.opt_force.value then
+					var path = mpackage.gen_makefile(toolcontext.modelbuilder.model, mainmodule)
+					if path != null then
+						toolcontext.info("generated Makefile `{path}`", 0)
+					end
 				end
 			end
 		end
@@ -253,6 +277,94 @@ redef class MPackage
 		ini.save
 		return ini_path
 	end
+
+	# Makefile
+
+	# The path to `self` Makefile
+	fun makefile_path: nullable String do
+		var path = package_path
+		if path == null then return null
+		if not is_expanded then return null
+		return path / "Makefile"
+	end
+
+	# Does `self` have a Makefile?
+	fun has_makefile: Bool do
+		var makefile_path = self.makefile_path
+		if makefile_path == null then return false
+		return makefile_path.file_exists
+	end
+
+	private fun check_makefile(toolcontext: ToolContext, mainmodule: MModule) do
+		var model = toolcontext.modelbuilder.model
+		var filter = new ModelFilter(accept_example = false, accept_test = false)
+		var view = new ModelView(model, mainmodule, filter)
+
+		var cmd_bin = new CmdMains(view, mentity = self)
+		var res_bin = cmd_bin.init_command
+		if not res_bin isa CmdSuccess then return
+
+		for mmodule in cmd_bin.results.as(not null) do
+			if not mmodule isa MModule then continue
+
+			if mmodule.makefile_path == null then
+				toolcontext.warning(location, "missing-makefile",
+					"Warning: no Makefile for executable module `{mmodule.full_name}`")
+			end
+		end
+	end
+
+	private fun gen_makefile(model: Model, mainmodule: MModule): nullable String do
+		var filter = new ModelFilter(accept_example = false, accept_test = false)
+		var view = new ModelView(model, mainmodule, filter)
+
+		var pkg_path = package_path.as(not null)
+		var makefile_path = makefile_path.as(not null)
+
+		var bins = new Array[String]
+		var cmd_bin = new CmdMains(view, mentity = self)
+		var res_bin = cmd_bin.init_command
+		if res_bin isa CmdSuccess then
+			for mmodule in cmd_bin.results.as(not null) do
+				if not mmodule isa MModule then continue
+				var mmodule_makefile = mmodule.makefile_path
+				if mmodule_makefile != null and mmodule_makefile != makefile_path then continue
+
+				var file = mmodule.location.file
+				if file == null then continue
+				# Remove package path prefix
+				var bin_path = file.filename
+				if pkg_path.has_suffix("/") then
+					bin_path = bin_path.replace(pkg_path, "")
+				else
+					bin_path = bin_path.replace("{pkg_path}/", "")
+				end
+				bins.add bin_path
+			end
+		end
+
+		if  bins.is_empty then return null
+
+		var make = new NitMakefile(bins)
+		make.render.write_to_file(makefile_path)
+		return makefile_path
+	end
+end
+
+redef class MModule
+	private fun makefile_path: nullable String do
+		var file = location.file
+		if file == null then return null
+
+		var dir = file.filename.dirname
+		var makefile = (dir / "Makefile")
+		if not makefile.file_exists then return null
+
+		for line in makefile.to_path.read_lines do
+			if line.has_prefix("{name}:") then return makefile
+		end
+		return null
+	end
 end
 
 redef class ConfigTree
@@ -284,6 +396,115 @@ redef class ConfigTree
 				self[key] = value
 			end
 		end
+	end
+end
+
+# A Makefile for the Nit project
+class NitMakefile
+
+	# Nit files to compile
+	var nit_files: Array[String]
+
+	# List of rules to add in the Makefile
+	fun rules: Array[MakeRule] do
+		var rules = new Array[MakeRule]
+
+		var rule_all = new MakeRule("all", is_phony = true)
+		rules.add rule_all
+
+		for file in nit_files do
+			var bin = file.basename.strip_extension
+
+			rule_all.deps.add "bin/{bin}"
+
+			var rule = new MakeRule("bin/{bin}")
+			rule.deps.add "$(shell $(NITLS) -M {file})"
+			rule.lines.add "mkdir -p bin/"
+			rule.lines.add "$(NITC) {file} -o bin/{bin}"
+			rules.add rule
+		end
+
+		var rule_check = new MakeRule("check", is_phony = true)
+		rule_check.lines.add "$(NITUNIT) ."
+		rules.add rule_check
+
+		var rule_doc = new MakeRule("doc", is_phony = true)
+		rule_doc.lines.add "$(NITDOC) . -o doc/"
+		rules.add rule_doc
+
+		var rule_clean = new MakeRule("clean", is_phony = true)
+		if nit_files.not_empty then
+			rule_clean.lines.add "rm -rf bin/"
+		end
+		rule_clean.lines.add "rm -rf doc/"
+		rules.add rule_clean
+
+		return rules
+	end
+
+	# Render `self`
+	fun render: Writable do
+		var tpl = new Template
+		tpl.addn """
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.\n"""
+
+		if nit_files.not_empty then
+			tpl.addn "NITC ?= nitc"
+			tpl.addn "NITLS ?= nitls"
+		end
+		tpl.addn "NITUNIT ?= nitunit"
+		tpl.addn "NITDOC ?= nitdoc"
+
+		for rule in rules do
+			tpl.add "\n{rule.render.write_to_string}"
+		end
+
+		return tpl
+	end
+end
+
+# A rule that goes into a Makefile
+class MakeRule
+
+	# Rule name
+	var name: String
+
+	# Is this rule a `.PHONY` one?
+	var is_phony: Bool = false is optional
+
+	# Rule dependencies
+	var deps = new Array[String]
+
+	# Rule lines
+	var lines = new Array[String]
+
+	# Render `self`
+	fun render: Writable do
+		var tpl = new Template
+		if is_phony then
+			tpl.addn ".PHONY: {name}"
+		end
+		tpl.add "{name}:"
+		if deps.not_empty then
+			tpl.add " {deps.join(" ")}"
+		end
+		tpl.add "\n"
+		for line in lines do
+			tpl.addn "\t{line}"
+		end
+		return tpl
 	end
 end
 

--- a/src/nitpackage.nit
+++ b/src/nitpackage.nit
@@ -30,8 +30,8 @@ redef class ToolContext
 	# --force
 	var opt_force = new OptionBool("Force update of existing files", "-f", "--force")
 
-	# README handling phase
-	var readme_phase: Phase = new ReadmePhase(self, null)
+	# nitpackage phase
+	var nitpackage_phase: Phase = new NitPackagePhase(self, null)
 
 	redef init do
 		super
@@ -40,7 +40,7 @@ redef class ToolContext
 	end
 end
 
-private class ReadmePhase
+private class NitPackagePhase
 	super Phase
 
 	redef fun process_mainmodule(mainmodule, mmodules) do


### PR DESCRIPTION
I applied `nitpackage --gen-makefile` (#2662) on contrib:
* generated Makefile for projects without any (76a17aa)
* replaced some existing Makefiles with their generated counterpart (a95be1e)
* manually merged generated rules into existing Makefiles (3b85ec3)

Please consider only these commits as the rest of them belongs to another PRs.