### PR TITLE
contrib: use `config` instead of `opts`

### DIFF
--- a/contrib/github_merge/github_merge.nit
+++ b/contrib/github_merge/github_merge.nit
@@ -17,7 +17,7 @@ module github_merge
 
 import github::github_curl
 import template
-import opts
+import config
 
 redef class Object
 	# Factorize cast
@@ -102,11 +102,23 @@ var opt_query = new OptionString("Query to get issues (e.g. label=ok_will_merge)
 var opt_keepgoing = new OptionBool("Skip merge conflicts", "-k", "--keep-going")
 var opt_all = new OptionBool("Merge all", "-a", "--all")
 var opt_status = new OptionArray("A status context that must be \"success\" (e.g. default)", "--status")
-var opts = new OptionContext
-opts.add_option(opt_repo, opt_auth, opt_query, opt_status, opt_all, opt_keepgoing)
 
-opts.parse(sys.args)
-var args = opts.rest
+var usage = new Buffer
+usage.append "Usage: github_merge [OPTION]... <PR number...>\n"
+usage.append "Query the Github PR API to perform a merge."
+
+var config = new Config
+config.tool_description = usage.write_to_string
+config.add_option(opt_repo, opt_auth, opt_query, opt_status, opt_all, opt_keepgoing)
+
+config.parse_options(sys.args)
+
+if config.opt_help.value then
+	config.usage
+	exit 0
+end
+
+var args = config.args
 
 var auth = opt_auth.value or else ""
 if auth == "" then auth = get_github_oauth

--- a/contrib/github_merge/github_merge.nit
+++ b/contrib/github_merge/github_merge.nit
@@ -183,4 +183,3 @@ for arg in args do
 	print "The merge is made"
 	mergemsg.write_to(stdout)
 end
-

--- a/contrib/github_merge/package.ini
+++ b/contrib/github_merge/package.ini
@@ -4,8 +4,8 @@ tags=cli
 maintainer=Jean Privat <jean@pryen.org>
 license=Apache-2.0
 [upstream]
-browse=https://github.com/nitlang/nit/tree/master/contrib/github_merge.nit
+browse=https://github.com/nitlang/nit/tree/master/contrib/github_merge/
 git=https://github.com/nitlang/nit.git
-git.directory=contrib/github_merge.nit
+git.directory=contrib/github_merge/
 homepage=http://nitlanguage.org
 issues=https://github.com/nitlang/nit/issues

--- a/contrib/nitiwiki/src/nitiwiki.nit
+++ b/contrib/nitiwiki/src/nitiwiki.nit
@@ -17,6 +17,7 @@ module nitiwiki
 
 import wiki_html
 import markdown_highlight
+import config
 
 # Locate nit directory
 private fun compute_nit_dir(opt_nit_dir: OptionString): String do
@@ -68,7 +69,6 @@ private fun check_nit_dir(res: String): Bool do
 	return res.file_exists and "{res}/src/nit.nit".file_exists
 end
 
-var opt_help = new OptionBool("Display this help message", "-h", "--help")
 var opt_verbose = new OptionCount("Verbose level", "-v")
 var opt_config = new OptionString("Path to config.ini file", "-c", "--config")
 var opt_init = new OptionBool("Initialize a new wiki in the current directory", "--init")
@@ -80,19 +80,24 @@ var opt_rsync = new OptionBool("Synchronize outdir with distant wiki using rsync
 var opt_fetch = new OptionBool("Render local source from git repo", "--fetch")
 var opt_nit_dir = new OptionString("Nit base directory", "--nit-dir")
 
-var context = new OptionContext
-context.add_option(opt_help, opt_verbose, opt_config)
-context.add_option(opt_init, opt_status, opt_render, opt_force)
-context.add_option(opt_clean, opt_rsync, opt_fetch, opt_nit_dir)
-context.parse(args)
+var config = new Config
+config.add_option(opt_verbose, opt_config)
+config.add_option(opt_init, opt_status, opt_render, opt_force)
+config.add_option(opt_clean, opt_rsync, opt_fetch, opt_nit_dir)
 
-var config_filename = "config.ini"
+var usage = new Buffer
+usage.append "Usage: nitiwiki [OPTION]...\n"
+usage.append "A wiki engine based on markdown files and git."
+config.tool_description = usage.write_to_string
 
-# --help
-if opt_help.value then
-	context.usage
+config.parse_options(args)
+
+if config.opt_help.value then
+	config.usage
 	exit 0
 end
+
+var config_filename = "config.ini"
 
 # --init
 if opt_init.value then
@@ -128,8 +133,8 @@ if not config_file.file_exists then
 	exit 0
 end
 
-var config = new WikiConfig(config_file)
-var wiki = new Nitiwiki(config)
+var wiki_config = new WikiConfig(config_file)
+var wiki = new Nitiwiki(wiki_config)
 
 # --verbose
 wiki.verbose_level = opt_verbose.value

--- a/contrib/nitiwiki/src/wiki_base.nit
+++ b/contrib/nitiwiki/src/wiki_base.nit
@@ -16,7 +16,6 @@
 module wiki_base
 
 import template::macro
-import opts
 import ini
 
 # A Nitiwiki instance.

--- a/contrib/nitiwiki/src/wiki_edit.nit
+++ b/contrib/nitiwiki/src/wiki_edit.nit
@@ -18,6 +18,7 @@ module wiki_edit
 import nitcorn
 import markdown
 import md5
+import config
 
 intrude import wiki_html
 
@@ -176,9 +177,29 @@ redef class String
 	end
 end
 
-var config_file_path = "config.ini"
-var iface = "localhost:8080"
-var password_file_path = "passwords"
+var opt_config = new OptionString("Path to config.ini file", "-c", "--config")
+var opt_host = new OptionString("Host to bind the server to", "--host")
+var opt_port = new OptionInt("Port to bind the server to", 8000, "--port")
+var opt_pass = new OptionString("Password file path", "--pass")
+
+var config = new Config
+config.add_option(opt_config, opt_host, opt_port, opt_pass)
+
+var usage = new Buffer
+usage.append "Usage: wiki_edit [OPTION]...\n"
+usage.append "Web server to server generated files and modify the wiki from a web form."
+config.tool_description = usage.write_to_string
+
+config.parse_options(args)
+
+if config.opt_help.value then
+	config.usage
+	exit 0
+end
+
+var config_file_path = opt_config.value or else "config.ini"
+var iface = "{opt_host.value or else "localhost"}:{opt_port.value}"
+var password_file_path = opt_pass.value or else "passwords"
 
 # Load passwords for file
 var passwords = if password_file_path.file_exists then


### PR DESCRIPTION
Modified two contrib projects to make then use `config`:
* `github_merge`
* `nitiwiki`

They now automatically provide the `--stub-manpage` option from `config`.