### PR TITLE
src/doc/commands: fix test class name for `commands_md`

### DIFF
--- a/src/doc/commands/tests/test_commands_md.nit
+++ b/src/doc/commands/tests/test_commands_md.nit
@@ -18,7 +18,7 @@ import test_commands
 intrude import doc::commands::commands_main
 import doc::commands::commands_md
 
-class TestCommandsHtml
+class TestCommandsMd
 	super TestCommands
 	test
 


### PR DESCRIPTION
Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>