### PR TITLE
Changed nitcorn HTTPResponse body type to Writable

### DIFF
--- a/lib/nitcorn/http_response.nit
+++ b/lib/nitcorn/http_response.nit
@@ -38,7 +38,7 @@ class HttpResponse
 	var header = new HashMap[String, String]
 
 	# Body of this response
-	var body = "" is writable
+	var body : Writable = "" is writable
 
 	# Files appended after `body`
 	var files = new Array[String]
@@ -48,8 +48,14 @@ class HttpResponse
 	do
 		# Set the content length if not already set
 		if not header.keys.has("Content-Length") then
+
+			var len : Int = 0
 			# Size of the body
-			var len = body.byte_length
+			if body isa Text then
+				len = body.as(Text).byte_length
+			else if body isa Bytes then
+				len = body.as(Bytes).length
+			end
 
 			# Size of included files
 			for path in files do

--- a/tests/test_nitcorn.nit
+++ b/tests/test_nitcorn.nit
@@ -30,23 +30,24 @@ class MyAction
 	redef fun answer(request, turi)
 	do
 		var rep = new HttpResponse(200)
-		rep.body = """
+		var body = """
 [Response] Simple answer
 Method: {{{request.method}}}, URI: {{{request.uri}}}, trailing: {{{turi}}}"""
 
 		if request.get_args.not_empty
-		then rep.body += "\nGET args: {request.get_args.join(", ", ":")}"
+		then body += "\nGET args: {request.get_args.join(", ", ":")}"
 
 		if request.post_args.not_empty
-		then rep.body += "\nPOST args: {request.post_args.join(", ", ":")}"
+		then body += "\nPOST args: {request.post_args.join(", ", ":")}"
 
 		if request.uri_params.not_empty
-		then rep.body += "\nParams args: {request.uri_params.join(", ", ":")}"
+		then body += "\nParams args: {request.uri_params.join(", ", ":")}"
 
 		if request.cookie.not_empty
-		then rep.body += "\nCookie: {request.cookie.join(", ", ":")}"
+		then body += "\nCookie: {request.cookie.join(", ", ":")}"
 
-		rep.body += "\n"
+		body += "\n"
+		rep.body=body
 		return rep
 	end
 end


### PR DESCRIPTION
This PR allows to send binaries as bodies in nitcorn's responses.