### PR TITLE
model_filter: introduce `is_broken` and `is_generated` filters

### DIFF
--- a/src/model/model_filters.nit
+++ b/src/model/model_filters.nit
@@ -44,6 +44,7 @@ class ModelFilter
 	#
 	# If one of the filter returns `false` then the `mentity` is not accepted.
 	fun accept_mentity(mentity: MEntity): Bool do
+		if not accept_mentity_broken(mentity) then return false
 		if not accept_mentity_visibility(mentity) then return false
 		if not accept_mentity_fictive(mentity) then return false
 		if not accept_mentity_test(mentity) then return false
@@ -206,5 +207,16 @@ class ModelFilter
 		var string = accept_full_name
 		if string == null then return true
 		return mentity.full_name.has(string)
+	end
+
+	# Accept broken classes and properties?
+	#
+	# Default is `false`.
+	var accept_broken = false is optional, writable
+
+	# Accept only non broken entities
+	fun accept_mentity_broken(mentity: MEntity): Bool do
+		if accept_broken then return true
+		return not mentity.is_broken
 	end
 end

--- a/src/model/model_filters.nit
+++ b/src/model/model_filters.nit
@@ -15,6 +15,7 @@
 module model_filters
 
 import model_examples
+import parse_annotations
 
 # A list of filters that can be applied on a MEntity
 #
@@ -47,6 +48,7 @@ class ModelFilter
 		if not accept_mentity_broken(mentity) then return false
 		if not accept_mentity_visibility(mentity) then return false
 		if not accept_mentity_fictive(mentity) then return false
+		if not accept_mentity_generated(mentity) then return false
 		if not accept_mentity_test(mentity) then return false
 		if not accept_mentity_redef(mentity) then return false
 		if not accept_mentity_extern(mentity) then return false
@@ -79,6 +81,28 @@ class ModelFilter
 	fun accept_mentity_fictive(mentity: MEntity): Bool do
 		if accept_fictive then return true
 		return not mentity.is_fictive
+	end
+
+	# Accept generated entities?
+	#
+	# Default is `true`.
+	var accept_generated = true is optional, writable
+
+	# Accept only non-generated entities
+	#
+	# See `MEntity::is_generated`.
+	fun accept_mentity_generated(mentity: MEntity): Bool do
+		if accept_generated then return true
+		if mentity isa MClass then mentity = mentity.intro
+		if mentity isa MProperty then mentity = mentity.intro
+		if mentity isa MModule then
+			return not mentity.has_annotation("generated")
+		else if mentity isa MClassDef then
+			return not mentity.has_annotation("generated")
+		else if mentity isa MPropDef then
+			return not mentity.has_annotation("generated")
+		end
+		return true
 	end
 
 	# Accept nitunit test suites?

--- a/tests/sav/nitmetrics_args1.res
+++ b/tests/sav/nitmetrics_args1.res
@@ -240,6 +240,22 @@ Average size of table by runtime class: 3.83
 Values never redefined: 17 (73.91%)
 generating package_hierarchy.dot
 generating module_hierarchy.dot
+--- Metrics of the explitic static types ---
+Total number of explicit static types: 9
+Statistics of type usage:
+ population: 4
+ minimum value: 1
+ maximum value: 6
+ total value: 9
+ average value: 2.25
+ distribution:
+  <=1: sub-population=3 (75.00%); cumulated value=3 (33.33%)
+  <=8: sub-population=1 (25.00%); cumulated value=6 (66.66%)
+ list:
+  Int: 6 (66.66%)
+  C: 1 (11.11%)
+  B: 1 (11.11%)
+  A: 1 (11.11%)
 
 # MClasses metrics
 
@@ -720,22 +736,6 @@ Warning: no source file for `base_simple3`
 	  min: base_simple3 (0.143)
 	  std: 0.0
 	  sum: 0.143
---- Metrics of the explitic static types ---
-Total number of explicit static types: 9
-Statistics of type usage:
- population: 4
- minimum value: 1
- maximum value: 6
- total value: 9
- average value: 2.25
- distribution:
-  <=1: sub-population=3 (75.00%); cumulated value=3 (33.33%)
-  <=8: sub-population=1 (25.00%); cumulated value=6 (66.66%)
- list:
-  Int: 6 (66.66%)
-  C: 1 (11.11%)
-  B: 1 (11.11%)
-  A: 1 (11.11%)
 
 # Mendel metrics
 	large mclasses (threshold: 3.915)


### PR DESCRIPTION
Introduce two new model filter options: `is_broken` and `is_generated`.

Nothing new here, only using already defined attributes.