### PR TITLE
Added UNIX support to nitcorn

### DIFF
--- a/lib/nitcorn/examples/src/nitcorn_hello_world_unix.nit
+++ b/lib/nitcorn/examples/src/nitcorn_hello_world_unix.nit
@@ -1,0 +1,86 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Copyright 2014 Alexis Laferrière <alexis.laf@xymus.net>
+# Copyright 2018 Matthieu Le Guellaut <leguellaut.matthieu@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Hello World Web server example
+#
+# The main page, `index.html`, is served dynamicly with `MyAction`.
+# The rest of the Web site fetches files from the local directory
+# `www/hello_world/`.
+module nitcorn_hello_world is example
+
+import nitcorn::unix
+
+# An action that responds by displaying a static html content.
+class StaticAction
+	super Action
+
+	redef fun answer(http_request, turi)
+	do
+		var response = new HttpResponse(200)
+		var title = "Hello World from Nitcorn!"
+		response.body = """
+<!DOCTYPE html>
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+	<title>{{{title}}}</title>
+</head>
+<body>
+	<div class="container">
+		<h1>{{{title}}}</h1>
+		<p>See also a <a href="/dir/">directory</a>.</p>
+	</div>
+</body>
+</html>"""
+		return response
+	end
+end
+
+# An action that uses parameterized uris to customize the output.
+class ParamAction
+	super Action
+
+	redef fun answer(http_request, turi)
+	do
+		var response = new HttpResponse(200)
+		var name = http_request.param("name")
+		if name == null then
+			response.body = "No name..."
+		else
+			response.body = "Hello {name}"
+		end
+		return response
+	end
+end
+
+
+var vh = new VirtualHost("localhost")
+
+# Serve index.html with our custom handler
+vh.routes.add new Route("/index.html", new StaticAction)
+vh.routes.add new Route("/hello/:name", new ParamAction)
+
+# Serve everything else with a standard `FileServer` with a root at "www/hello_world/"
+vh.routes.add new Route(null, new FileServer("www/hello_world/"))
+
+# Set server in UNIX mode
+vh.unix("/tmp/example.sock")
+
+var factory = new HttpFactory.and_libevent
+factory.config.virtual_hosts.add vh
+factory.run

--- a/lib/nitcorn/unix.nit
+++ b/lib/nitcorn/unix.nit
@@ -1,0 +1,115 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Copyright 2018 Matthieu Le Guellaut <leguellaut.matthieu@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+module unix
+
+intrude import nitcorn::reactor
+import nitcorn::file_server
+import nitcorn::sessions
+import nitcorn::signal_handler
+import core::file
+import libevent
+intrude import core::array
+
+redef class Interface
+	# Path of UNIX socket file
+	var unix_path= "" is lazy, optional, writable
+end
+
+redef class Interfaces
+	redef fun add(e)
+	do
+		super
+		var config = virtual_host.server_config
+		if config != null then sys.listen_on(e, config.factory)
+	end
+end
+
+redef class VirtualHosts
+	redef fun add(e)
+	do
+		var l = _length
+		if _capacity <= l then
+			enlarge(l + 1)
+		end
+		_length = l + 1
+		_items.as(not null)[l] = e
+		for i in e.interfaces do sys.listen_on(i, config.factory)
+	end
+end
+
+redef class VirtualHost
+
+	# Defines unix socket's file location
+	fun unix(path:String)
+	do
+		for i in interfaces do	i.unix_path=path
+	end
+end
+
+
+redef class Sys
+	private var unix_listeners = new HashMap2[String,String, ConnectionListener]
+	private var unix_listeners_count = new HashMap2[String, String, Int]
+
+	# Activate unix and TCP listeners
+	redef fun listen_on(interfac: Interface, factory: HttpFactory)
+	do
+		if interfac.registered then return
+
+		var name = interfac.name
+		var file = interfac.unix_path
+		var port = interfac.port
+
+		if file!="" then
+			unix_listen(name, file, factory)
+		else
+			tcp_listen(name, port, factory)
+		end
+		interfac.registered = true
+	end
+
+	# Activate TCP listeners
+	private fun tcp_listen(name: String, port: Int, factory: HttpFactory)
+	do
+		var listener = listeners[name, port]
+		if listener == null then
+			listener = factory.bind_to(name, port)
+			if listener != null then
+				sys.listeners[name, port] = listener
+				listeners_count[name, port] = 1
+			end
+		else
+			var value = listeners_count[name, port].as(not null)
+			listeners_count[name, port] = value + 1
+		end
+	end
+
+	# Activate UNIX listeners
+	private fun unix_listen(name: String, file: String, factory: HttpFactory)
+	do
+		var listener = unix_listeners[name,file]
+		if listener == null then
+			listener = factory.bind_to_unix(name,file)
+			if listener != null then
+				sys.unix_listeners[name,file] = listener
+				sys.unix_listeners_count[name,file] = 1
+			end
+		else
+			var value = unix_listeners_count[name,file].as(not null)
+			unix_listeners_count[name,file] = value + 1
+		end
+	end
+end

--- a/tests/sav/test_nitcorn_unix.res
+++ b/tests/sav/test_nitcorn_unix.res
@@ -1,0 +1,260 @@
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/simple_answer
+[Response] Simple answer
+Method: GET, URI: /simple_answer, trailing: /
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/simple_answer/
+[Response] Simple answer
+Method: GET, URI: /simple_answer/, trailing: /
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/simple_answer/trailing/path
+[Response] Simple answer
+Method: GET, URI: /simple_answer/trailing/path, trailing: /trailing/path
+
+[Client] curl --unix-socket /tmp/example.sock -s 'localhost:*****/simple_answer?i=0123&s=asdf'
+[Response] Simple answer
+Method: GET, URI: /simple_answer, trailing: /
+GET args: i:0123, s:asdf
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/simple_answer --data 'i=0123&s=asdf'
+[Response] Simple answer
+Method: POST, URI: /simple_answer, trailing: /
+POST args: i:0123, s:asdf
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/simple_answer --cookie 'i=0123; s=asdf'
+[Response] Simple answer
+Method: GET, URI: /simple_answer, trailing: /
+Cookie: i:0123, s:asdf
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/simple_answer --get --data-urlencode 's=b b'
+[Response] Simple answer
+Method: GET, URI: /simple_answer, trailing: /
+GET args: s:b b
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/params_answer/0123/asdf
+[Response] Simple answer
+Method: GET, URI: /params_answer/0123/asdf, trailing: /
+Params args: i:0123, s:asdf
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/params_answer/0123/
+[Response] Simple answer
+Method: GET, URI: /params_answer/0123/, trailing: /
+Params args: i:0123, s:
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/params_answer/0123/asdf/trailing/path
+[Response] Simple answer
+Method: GET, URI: /params_answer/0123/asdf/trailing/path, trailing: /trailing/path
+Params args: i:0123, s:asdf
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/params_answer/0123 --head
+HTTP/1.0 404 Not Found
+Content-Length: 0
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/file_server/
+<!DOCTYPE html>
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+	<script>
+		
+	</script>
+	<title>/</title>
+</head>
+<body>
+	
+	<div class="container">
+		<h1>/</h1>
+		<ul>
+			<li><a href="a.txt">a.txt</a></li>
+			<li><a href="b.txt">b.txt</a></li>
+			<li><a href="binary_file.png">binary_file.png</a></li>
+		</ul>
+	</div>
+</body>
+</html>
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/file_server/ --head
+HTTP/1.0 200 OK
+Content-Type: text/html
+Content-Length: 467
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/file_server --head
+HTTP/1.0 303 See Other
+Location: /file_server/
+Content-Length: 0
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/file_server/a.txt
+aaaAAAAAaaaa
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/file_server/a.txt --head
+HTTP/1.0 200 OK
+Content-Type: text/plain
+cache-control: public, max-age=360
+Content-Length: 13
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/file_server/binary_file.png --head
+HTTP/1.0 200 OK
+Content-Type: image/png
+cache-control: public, max-age=360
+Content-Length: 2503
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/file_server/binary_file.png | diff - .../binary_file.png
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/file_server/unknown_file.txt --head
+HTTP/1.0 404 Not Found
+Content-Length: 329
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+
+[Client] curl --unix-socket /tmp/example.sock -s localhost:*****/invalid_route --head
+HTTP/1.0 404 Not Found
+Content-Length: 0
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+
+[Client] curl -s localhost:*****/simple_answer
+[Response] Simple answer
+Method: GET, URI: /simple_answer, trailing: /
+
+[Client] curl -s localhost:*****/simple_answer/
+[Response] Simple answer
+Method: GET, URI: /simple_answer/, trailing: /
+
+[Client] curl -s localhost:*****/simple_answer/trailing/path
+[Response] Simple answer
+Method: GET, URI: /simple_answer/trailing/path, trailing: /trailing/path
+
+[Client] curl -s 'localhost:*****/simple_answer?i=0123&s=asdf'
+[Response] Simple answer
+Method: GET, URI: /simple_answer, trailing: /
+GET args: i:0123, s:asdf
+
+[Client] curl -s localhost:*****/simple_answer --data 'i=0123&s=asdf'
+[Response] Simple answer
+Method: POST, URI: /simple_answer, trailing: /
+POST args: i:0123, s:asdf
+
+[Client] curl -s localhost:*****/simple_answer --cookie 'i=0123; s=asdf'
+[Response] Simple answer
+Method: GET, URI: /simple_answer, trailing: /
+Cookie: i:0123, s:asdf
+
+[Client] curl -s localhost:*****/simple_answer --get --data-urlencode 's=b b'
+[Response] Simple answer
+Method: GET, URI: /simple_answer, trailing: /
+GET args: s:b b
+
+[Client] curl -s localhost:*****/params_answer/0123/asdf
+[Response] Simple answer
+Method: GET, URI: /params_answer/0123/asdf, trailing: /
+Params args: i:0123, s:asdf
+
+[Client] curl -s localhost:*****/params_answer/0123/
+[Response] Simple answer
+Method: GET, URI: /params_answer/0123/, trailing: /
+Params args: i:0123, s:
+
+[Client] curl -s localhost:*****/params_answer/0123/asdf/trailing/path
+[Response] Simple answer
+Method: GET, URI: /params_answer/0123/asdf/trailing/path, trailing: /trailing/path
+Params args: i:0123, s:asdf
+
+[Client] curl -s localhost:*****/params_answer/0123 --head
+HTTP/1.0 404 Not Found
+Content-Length: 0
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+
+[Client] curl -s localhost:*****/file_server/
+<!DOCTYPE html>
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+	<script>
+		
+	</script>
+	<title>/</title>
+</head>
+<body>
+	
+	<div class="container">
+		<h1>/</h1>
+		<ul>
+			<li><a href="a.txt">a.txt</a></li>
+			<li><a href="b.txt">b.txt</a></li>
+			<li><a href="binary_file.png">binary_file.png</a></li>
+		</ul>
+	</div>
+</body>
+</html>
+[Client] curl -s localhost:*****/file_server/ --head
+HTTP/1.0 200 OK
+Content-Type: text/html
+Content-Length: 467
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+
+[Client] curl -s localhost:*****/file_server --head
+HTTP/1.0 303 See Other
+Location: /file_server/
+Content-Length: 0
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+
+[Client] curl -s localhost:*****/file_server/a.txt
+aaaAAAAAaaaa
+
+[Client] curl -s localhost:*****/file_server/a.txt --head
+HTTP/1.0 200 OK
+Content-Type: text/plain
+cache-control: public, max-age=360
+Content-Length: 13
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+
+[Client] curl -s localhost:*****/file_server/binary_file.png --head
+HTTP/1.0 200 OK
+Content-Type: image/png
+cache-control: public, max-age=360
+Content-Length: 2503
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+
+[Client] curl -s localhost:*****/file_server/binary_file.png | diff - .../binary_file.png
+
+[Client] curl -s localhost:*****/file_server/unknown_file.txt --head
+HTTP/1.0 404 Not Found
+Content-Length: 329
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+
+
+[Client] curl -s localhost:*****/invalid_route --head
+HTTP/1.0 404 Not Found
+Content-Length: 0
+Server: nitcorn
+Set-Cookie: nitcorn_session=; HttpOnly; expires=Thu, 01 Jan 1970 00:00:00 GMT
+

--- a/tests/test_nitcorn_unix.nit
+++ b/tests/test_nitcorn_unix.nit
@@ -1,0 +1,175 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nitcorn::unix
+import pthreads
+
+redef class Sys
+	var iface: String is lazy do
+		var testid = "NIT_TESTING_ID".environ.to_i
+		return "localhost:8080"
+	end
+
+	var fs_path: String = getcwd / "../lib/nitcorn/examples/www/hello_world/dir" is lazy
+end
+
+class MyAction
+	super Action
+
+	redef fun answer(request, turi)
+	do
+		var rep = new HttpResponse(200)
+		rep.body = """
+[Response] Simple answer
+Method: {{{request.method}}}, URI: {{{request.uri}}}, trailing: {{{turi}}}"""
+
+		if request.get_args.not_empty
+		then rep.body += "\nGET args: {request.get_args.join(", ", ":")}"
+
+		if request.post_args.not_empty
+		then rep.body += "\nPOST args: {request.post_args.join(", ", ":")}"
+
+		if request.uri_params.not_empty
+		then rep.body += "\nParams args: {request.uri_params.join(", ", ":")}"
+
+		if request.cookie.not_empty
+		then rep.body += "\nCookie: {request.cookie.join(", ", ":")}"
+
+		rep.body += "\n"
+		return rep
+	end
+end
+
+class ServerThread
+	super Thread
+
+	redef fun main
+	do
+		# Hide testing concept to force nitcorn to actually run
+		"NIT_TESTING".setenv("false")
+
+		# UNIX Setup
+		var unix_vh = new VirtualHost(iface)
+		unix_vh.routes.add new Route("file_server", new FileServer(fs_path.simplify_path))
+		unix_vh.routes.add new Route("simple_answer", new MyAction)
+		unix_vh.routes.add new Route("params_answer/:i/:s", new MyAction)
+
+		unix_vh.unix("/tmp/example.sock")
+
+		# TCP Setup
+		var tcp_vh = new VirtualHost(iface)
+		tcp_vh.routes.add new Route("file_server", new FileServer(fs_path.simplify_path))
+		tcp_vh.routes.add new Route("simple_answer", new MyAction)
+		tcp_vh.routes.add new Route("params_answer/:i/:s", new MyAction)
+
+
+
+		# Launch
+		var factory = new HttpFactory.and_libevent
+		factory.config.virtual_hosts.add unix_vh
+		factory.config.virtual_hosts.add tcp_vh
+		factory.run
+
+		return null
+	end
+end
+
+class ClientThread
+	super Thread
+
+	redef fun main
+	do
+
+		# UNIX tests
+		system "curl --unix-socket /tmp/example.sock -s {iface}/simple_answer"
+		system "curl --unix-socket /tmp/example.sock -s {iface}/simple_answer/"
+		system "curl --unix-socket /tmp/example.sock -s {iface}/simple_answer/trailing/path"
+
+		system "curl --unix-socket /tmp/example.sock -s '{iface}/simple_answer?i=0123&s=asdf'"
+		system "curl --unix-socket /tmp/example.sock -s {iface}/simple_answer --data 'i=0123&s=asdf'"
+		system "curl --unix-socket /tmp/example.sock -s {iface}/simple_answer --cookie 'i=0123; s=asdf'"
+		system "curl --unix-socket /tmp/example.sock -s {iface}/simple_answer --get --data-urlencode 's=b b'"
+
+		system "curl --unix-socket /tmp/example.sock -s {iface}/params_answer/0123/asdf"
+		system "curl --unix-socket /tmp/example.sock -s {iface}/params_answer/0123/"
+		system "curl --unix-socket /tmp/example.sock -s {iface}/params_answer/0123/asdf/trailing/path"
+		system "curl --unix-socket /tmp/example.sock -s {iface}/params_answer/0123 --head"
+
+		system "curl --unix-socket /tmp/example.sock -s {iface}/file_server/"
+		system "curl --unix-socket /tmp/example.sock -s {iface}/file_server/ --head"
+		system "curl --unix-socket /tmp/example.sock -s {iface}/file_server --head"
+		system "curl --unix-socket /tmp/example.sock -s {iface}/file_server/a.txt"
+		system "curl --unix-socket /tmp/example.sock -s {iface}/file_server/a.txt --head"
+		system "curl --unix-socket /tmp/example.sock -s {iface}/file_server/binary_file.png --head"
+		system("curl --unix-socket /tmp/example.sock -s {iface}/file_server/binary_file.png | diff - {fs_path.escape_to_sh}/binary_file.png",
+		       "curl --unix-socket /tmp/example.sock -s {iface}/file_server/binary_file.png | diff - .../binary_file.png")
+		system "curl --unix-socket /tmp/example.sock -s {iface}/file_server/unknown_file.txt --head"
+
+		system "curl --unix-socket /tmp/example.sock -s {iface}/invalid_route --head"
+
+		# TCP tests
+		system "curl -s {iface}/simple_answer"
+		system "curl -s {iface}/simple_answer/"
+		system "curl -s {iface}/simple_answer/trailing/path"
+
+		system "curl -s '{iface}/simple_answer?i=0123&s=asdf'"
+		system "curl -s {iface}/simple_answer --data 'i=0123&s=asdf'"
+		system "curl -s {iface}/simple_answer --cookie 'i=0123; s=asdf'"
+		system "curl -s {iface}/simple_answer --get --data-urlencode 's=b b'"
+
+		system "curl -s {iface}/params_answer/0123/asdf"
+		system "curl -s {iface}/params_answer/0123/"
+		system "curl -s {iface}/params_answer/0123/asdf/trailing/path"
+		system "curl -s {iface}/params_answer/0123 --head"
+
+		system "curl -s {iface}/file_server/"
+		system "curl -s {iface}/file_server/ --head"
+		system "curl -s {iface}/file_server --head"
+		system "curl -s {iface}/file_server/a.txt"
+		system "curl -s {iface}/file_server/a.txt --head"
+		system "curl -s {iface}/file_server/binary_file.png --head"
+		system("curl -s {iface}/file_server/binary_file.png | diff - {fs_path.escape_to_sh}/binary_file.png",
+		       "curl -s {iface}/file_server/binary_file.png | diff - .../binary_file.png")
+		system "curl -s {iface}/file_server/unknown_file.txt --head"
+
+		system "curl -s {iface}/invalid_route --head"
+
+		return null
+	end
+
+	# Regex to catch and hide the port from the output to get consistent results
+	var host_re: Regex = "localhost:\[0-9\]+".to_re
+
+	fun system(cmd: String, title: nullable String)
+	do
+		title = title or else cmd
+		title = title.replace(host_re, "localhost:*****")
+		print "\n[Client] {title}"
+		sys.system cmd
+	end
+end
+
+# First, launch a server in the background
+var server = new ServerThread
+server.start
+0.1.sleep
+
+# Then, launch a client running test requests
+var client = new ClientThread
+client.start
+client.join
+0.1.sleep
+
+# Force quit the server
+exit 0


### PR DESCRIPTION
**DO NOT MERGE BEFORE PR #2708** 

As requested in #2678 

- Added new module `nitcorn::unix` to add unix support
- Added tests&example code for new module `unix`
- Multiple dirty redifinitions of reactor's class for unix support (because of dirty redefinity of `Sys` in reactor)
- Implementation of unix support for libevent added in PR #2708 
