### PR TITLE
text: escape_to_mk should not escape =

### DIFF
--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -794,7 +794,7 @@ abstract class Text
 			else if c == ':' or c == ' ' or c == '#' then
 				b.add('\\')
 				b.add(c)
-			else if c.code_point < 32 or c == ';' or c == '|' or c == '\\' or c == '=' then
+			else if c.code_point < 32 or c == ';' or c == '|' or c == '\\' then
 				b.append("?{c.code_point.to_base(16)}")
 			else
 				b.add(c)


### PR DESCRIPTION
Remove the escaping to ASCII hex value for the `=` char in `escape_to_mk`. It doesn't appear to be necessary, it was not documented and it breaks `nitls` support for `nitpm` packages.

Here's the error raised by `make` when it can't parse an escaped `=`.
~~~
make: *** No rule to make target '/home/xymus/.local/lib/nit/gamnit?3ddepth-vbos/lib/gamnit/bmfont.nit'
~~~