### PR TITLE
nitweb: show full name in mentities cards

### DIFF
--- a/share/nitweb/directives/entity/card.html
+++ b/share/nitweb/directives/entity/card.html
@@ -17,6 +17,7 @@
 	<div class='card-body' ng-if='mentity.class_name != "MPackage"'>
 		<h5 class='card-heading'>
 			<entity-signature mentity='mentity' />
+			<small><br/><entity-namespace namespace='mentity.namespace' /></small>
 		</h5>
 		<span class='synopsis' ng-bind-html='mentity.html_synopsis' />
 	</div>


### PR DESCRIPTION
This PR shows the full name of a MEntity in all Nitweb cards.

Example:

![screenshot from 2018-06-14 15 10 19](https://user-images.githubusercontent.com/583144/41432831-1fde1be8-6fe5-11e8-88b8-149f3aa86bb6.png)

Closes #2365.

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>