### PR TITLE
nitweb: fix access to query results count

### DIFF
--- a/share/nitweb/directives/ui/search-field.html
+++ b/share/nitweb/directives/ui/search-field.html
@@ -9,7 +9,7 @@
 		<entity-card ng-click='vm.selectEnter()' ng-class='{active: vm.activeItem == $index}' ng-mouseover='vm.setActive($index)' mentity='mentity' ng-repeat='mentity in vm.results.results' />
 		<div class='card' ng-click='vm.selectEnter()' ng-mouseover='vm.setActive(vm.results.results.length)' ng-class='{active: vm.activeItem == vm.results.results.length}'>
 			<div class='card-body'>
-				Show all {{vm.results.total}} results for <a>"{{vm.query}}"</a>
+				Show all {{vm.results.count}} results for <a>"{{vm.query}}"</a>
 			</div>
 		</div>
 	</div>

--- a/share/nitweb/views/catalog/person.html
+++ b/share/nitweb/views/catalog/person.html
@@ -13,7 +13,7 @@
 <br><br>
 <div class='container'>
 	<div ng-if='vm.maintaining.results.length > 0'>
-		<h3 id='maintaining'>{{vm.maintaining.total}} maintained projects</h3>
+		<h3 id='maintaining'>{{vm.maintaining.count}} maintained projects</h3>
 		<div class='card-list'>
 			<entity-card mentity='package' ng-repeat='package in vm.maintaining.results' />
 		</div>
@@ -22,7 +22,7 @@
 		</div>
 	</div>
 	<div ng-if='vm.contributing.results.length > 0'>
-		<h3 id='contributing'>{{vm.contributing.total}} contributed projects</h3>
+		<h3 id='contributing'>{{vm.contributing.count}} contributed projects</h3>
 		<div class='card-list'>
 			<entity-card mentity='package' ng-repeat='package in vm.contributing.results' />
 		</div>

--- a/share/nitweb/views/search.html
+++ b/share/nitweb/views/search.html
@@ -1,6 +1,6 @@
 <div class='container'>
 	<h2>
-		{{vm.entities.total}} matches for
+		{{vm.entities.count}} matches for
 		<a ui-sref='search({q: vm.query})'>{{vm.query}}</a>
 	</h2>
 	<div class='card-list'>


### PR DESCRIPTION
This PR replaces accesses to key `total` by `count` in all Nitweb views.

So the display in not broken.

Signed-off-by: Alexandre Terrasa <alexandre@moz-code.org>