### PR TITLE
src/doc/commands: use filters

### DIFF
--- a/src/doc/api/api_docdown.nit
+++ b/src/doc/api/api_docdown.nit
@@ -21,7 +21,7 @@ import commands::commands_docdown
 redef class NitwebConfig
 	# Specific Markdown processor to use within Nitweb
 	var md_processor: MarkdownProcessor is lazy do
-		var parser = new CommandParser(model, mainmodule, modelbuilder, catalog, filter)
+		var parser = new CommandParser(model, mainmodule, modelbuilder, catalog)
 		var proc = new CmdMarkdownProcessor(parser)
 		proc.decorator = new CmdDecorator(model)
 		return proc

--- a/src/doc/commands/commands_base.nit
+++ b/src/doc/commands/commands_base.nit
@@ -70,6 +70,13 @@ abstract class DocCommand
 	#
 	# Warnings are generally used to distinguish empty list or mdoc from no data at all.
 	fun init_command: CmdMessage do return new CmdSuccess
+
+	# Return a new filter for that command execution.
+	fun cmd_filter: ModelFilter do
+		var filter = self.filter
+		if filter == null then return new ModelFilter
+		return new ModelFilter.from(filter)
+	end
 end
 
 # Command message

--- a/src/doc/commands/commands_http.nit
+++ b/src/doc/commands/commands_http.nit
@@ -80,15 +80,18 @@ redef class CmdComment
 	redef fun http_init(req) do
 		full_doc = req.bool_arg("full_doc") or else true
 		fallback = req.bool_arg("fallback") or else true
-		format = req.string_arg("format") or else "raw"
+		var opt_format = req.string_arg("format")
+		if opt_format != null then format = opt_format
 		return super
 	end
 end
 
 redef class CmdEntityLink
 	redef fun http_init(req) do
-		text = req.string_arg("text")
-		title = req.string_arg("title")
+		var opt_text = req.string_arg("text")
+		if opt_text != null then text = opt_text
+		var opt_title = req.string_arg("title")
+		if opt_title != null then title = opt_title
 		return super
 	end
 end
@@ -121,14 +124,16 @@ end
 
 redef class CmdModelEntities
 	redef fun http_init(req) do
-		kind = req.string_arg("kind") or else "all"
+		var opt_kind = req.string_arg("kind")
+		if opt_kind != null then kind = opt_kind
 		return super
 	end
 end
 
 redef class CmdCode
 	redef fun http_init(req) do
-		format = req.string_arg("format") or else "raw"
+		var opt_format = req.string_arg("format")
+		if opt_format != null then format = opt_format
 		return super
 	end
 end
@@ -140,7 +145,8 @@ redef class CmdEntityCode
 		if name != null then name = name.from_percent_encoding
 		mentity_name = name
 
-		format = req.string_arg("format") or else "raw"
+		var opt_format = req.string_arg("format")
+		if opt_format != null then format = opt_format
 		return init_command
 	end
 end
@@ -149,7 +155,8 @@ end
 
 redef class CmdGraph
 	redef fun http_init(req) do
-		format = req.string_arg("format") or else "dot"
+		var opt_format = req.string_arg("format")
+		if opt_format != null then format = opt_format
 		return super
 	end
 end

--- a/src/doc/commands/commands_http.nit
+++ b/src/doc/commands/commands_http.nit
@@ -80,8 +80,10 @@ end
 
 redef class CmdComment
 	redef fun http_init(req) do
-		full_doc = req.bool_arg("full_doc") or else true
-		fallback = req.bool_arg("fallback") or else true
+		var opt_full_doc = req.bool_arg("full_doc")
+		if opt_full_doc != null then full_doc = opt_full_doc
+		var opt_fallback = req.bool_arg("fallback")
+		if opt_fallback != null then fallback = opt_fallback
 		var opt_format = req.string_arg("format")
 		if opt_format != null then format = opt_format
 		return super
@@ -100,14 +102,16 @@ end
 
 redef class CmdAncestors
 	redef fun http_init(req) do
-		parents = req.bool_arg("parents") or else true
+		var opt_parents = req.bool_arg("parents")
+		if opt_parents != null then parents = opt_parents
 		return super
 	end
 end
 
 redef class CmdDescendants
 	redef fun http_init(req) do
-		children = req.bool_arg("children") or else true
+		var opt_children = req.bool_arg("children")
+		if opt_children != null then children = opt_children
 		return super
 	end
 end

--- a/src/doc/commands/commands_http.nit
+++ b/src/doc/commands/commands_http.nit
@@ -39,8 +39,10 @@ end
 
 redef class CmdList
 	redef fun http_init(req) do
-		limit = req.int_arg("l")
-		page = req.int_arg("p")
+		var opt_limit = req.int_arg("l")
+		if opt_limit != null then limit = opt_limit
+		var opt_page = req.int_arg("p")
+		if opt_page != null then page = opt_page
 		return super
 	end
 end
@@ -163,8 +165,10 @@ end
 
 redef class CmdInheritanceGraph
 	redef fun http_init(req) do
-		pdepth = req.int_arg("pdepth")
-		cdepth = req.int_arg("cdepth")
+		var opt_pdepth = req.int_arg("pdepth")
+		if opt_pdepth != null then pdepth = opt_pdepth
+		var opt_cdepth = req.int_arg("cdepth")
+		if opt_cdepth != null then cdepth = opt_cdepth
 		return super
 	end
 end

--- a/src/doc/commands/commands_parser.nit
+++ b/src/doc/commands/commands_parser.nit
@@ -269,7 +269,10 @@ end
 
 redef class CmdList
 	redef fun parser_init(mentity_name, options) do
-		if options.has_key("limit") and options["limit"].is_int then limit = options["limit"].to_i
+		var opt_page = options.opt_int("page")
+		if opt_page != null then page = opt_page
+		var opt_limit = options.opt_int("limit")
+		if opt_limit != null then limit = opt_limit
 		return super
 	end
 end
@@ -307,7 +310,6 @@ end
 redef class CmdSearch
 	redef fun parser_init(mentity_name, options) do
 		query = mentity_name
-		if options.has_key("page") and options["page"].is_int then page = options["page"].to_i
 		return super
 	end
 end
@@ -343,12 +345,10 @@ end
 
 redef class CmdInheritanceGraph
 	redef fun parser_init(mentity_name, options) do
-		if options.has_key("pdepth") and options["pdepth"].is_int then
-			pdepth = options["pdepth"].to_i
-		end
-		if options.has_key("cdepth") and options["cdepth"].is_int then
-			cdepth = options["cdepth"].to_i
-		end
+		var opt_pdepth = options.opt_int("pdepth")
+		if opt_pdepth != null then pdepth = opt_pdepth
+		var opt_cdepth = options.opt_int("cdepth")
+		if opt_cdepth != null then cdepth = opt_cdepth
 		return super
 	end
 end
@@ -383,6 +383,16 @@ class CmdOptions
 		var value = self[key]
 		if value.is_empty then return null
 		return value
+	end
+
+	# Get option value for `key` as Int
+	#
+	# Return `null` if no option with that `key` or if value is not an Int.
+	fun opt_int(key: String): nullable Int do
+		if not has_key(key) then return null
+		var value = self[key]
+		if not value.is_int then return null
+		return value.to_i
 	end
 end
 

--- a/src/doc/commands/commands_parser.nit
+++ b/src/doc/commands/commands_parser.nit
@@ -39,9 +39,6 @@ class CommandParser
 	# Catalog used for catalog commands
 	var catalog: nullable Catalog
 
-	# Filter to apply on model if any
-	var filter: nullable ModelFilter
-
 	# List of allowed command names for this parser
 	var allowed_commands: Array[String] = [
 	"link", "doc", "code", "lin", "uml", "graph", "search",
@@ -163,7 +160,7 @@ class CommandParser
 		# Build the command
 		var command
 		if is_short_link then
-			command = new CmdEntityLink(model, filter)
+			command = new CmdEntityLink(model)
 		else
 			command = new_command(name)
 		end
@@ -184,56 +181,56 @@ class CommandParser
 	# You must redefine this method to add new custom commands.
 	fun new_command(name: String): nullable DocCommand do
 		# CmdEntity
-		if name == "link" then return new CmdEntityLink(model, filter)
-		if name == "doc" then return new CmdComment(model, filter)
-		if name == "code" then return new CmdEntityCode(model, modelbuilder, filter)
-		if name == "lin" then return new CmdLinearization(model, mainmodule, filter)
-		if name == "defs" then return new CmdFeatures(model, filter)
-		if name == "parents" then return new CmdParents(model, mainmodule, filter)
-		if name == "ancestors" then return new CmdAncestors(model, mainmodule, filter)
-		if name == "children" then return new CmdChildren(model, mainmodule, filter)
-		if name == "descendants" then return new CmdDescendants(model, mainmodule, filter)
-		if name == "param" then return new CmdParam(model, filter)
-		if name == "return" then return new CmdReturn(model, filter)
-		if name == "new" then return new CmdNew(model, modelbuilder, filter)
-		if name == "call" then return new CmdCall(model, modelbuilder, filter)
+		if name == "link" then return new CmdEntityLink(model)
+		if name == "doc" then return new CmdComment(model)
+		if name == "code" then return new CmdEntityCode(model, modelbuilder)
+		if name == "lin" then return new CmdLinearization(model, mainmodule)
+		if name == "defs" then return new CmdFeatures(model)
+		if name == "parents" then return new CmdParents(model, mainmodule)
+		if name == "ancestors" then return new CmdAncestors(model, mainmodule)
+		if name == "children" then return new CmdChildren(model, mainmodule)
+		if name == "descendants" then return new CmdDescendants(model, mainmodule)
+		if name == "param" then return new CmdParam(model)
+		if name == "return" then return new CmdReturn(model)
+		if name == "new" then return new CmdNew(model, modelbuilder)
+		if name == "call" then return new CmdCall(model, modelbuilder)
 		# CmdGraph
-		if name == "uml" then return new CmdUML(model, mainmodule, filter)
-		if name == "graph" then return new CmdInheritanceGraph(model, mainmodule, filter)
+		if name == "uml" then return new CmdUML(model, mainmodule)
+		if name == "graph" then return new CmdInheritanceGraph(model, mainmodule)
 		# CmdModel
-		if name == "list" then return new CmdModelEntities(model, filter)
-		if name == "random" then return new CmdRandomEntities(model, filter)
+		if name == "list" then return new CmdModelEntities(model)
+		if name == "random" then return new CmdRandomEntities(model)
 		# Ini
-		if name == "ini-desc" then return new CmdIniDescription(model, filter)
-		if name == "ini-git" then return new CmdIniGitUrl(model, filter)
-		if name == "ini-issues" then return new CmdIniIssuesUrl(model, filter)
-		if name == "ini-license" then return new CmdIniLicense(model, filter)
-		if name == "ini-maintainer" then return new CmdIniMaintainer(model, filter)
-		if name == "ini-contributors" then return new CmdIniContributors(model, filter)
-		if name == "license-file" then return new CmdLicenseFile(model, filter)
-		if name == "license-content" then return new CmdLicenseFileContent(model, filter)
-		if name == "contrib-file" then return new CmdContribFile(model, filter)
-		if name == "contrib-content" then return new CmdContribFileContent(model, filter)
-		if name == "git-clone" then return new CmdIniCloneCommand(model, filter)
+		if name == "ini-desc" then return new CmdIniDescription(model)
+		if name == "ini-git" then return new CmdIniGitUrl(model)
+		if name == "ini-issues" then return new CmdIniIssuesUrl(model)
+		if name == "ini-license" then return new CmdIniLicense(model)
+		if name == "ini-maintainer" then return new CmdIniMaintainer(model)
+		if name == "ini-contributors" then return new CmdIniContributors(model)
+		if name == "license-file" then return new CmdLicenseFile(model)
+		if name == "license-content" then return new CmdLicenseFileContent(model)
+		if name == "contrib-file" then return new CmdContribFile(model)
+		if name == "contrib-content" then return new CmdContribFileContent(model)
+		if name == "git-clone" then return new CmdIniCloneCommand(model)
 		# CmdMain
-		if name == "mains" then return new CmdMains(model, filter)
-		if name == "main-compile" then return new CmdMainCompile(model, filter)
-		if name == "main-run" then return new CmdManSynopsis(model, filter)
-		if name == "main-opts" then return new CmdManOptions(model, filter)
-		if name == "testing" then return new CmdTesting(model, filter)
+		if name == "mains" then return new CmdMains(model)
+		if name == "main-compile" then return new CmdMainCompile(model)
+		if name == "main-run" then return new CmdManSynopsis(model)
+		if name == "main-opts" then return new CmdManOptions(model)
+		if name == "testing" then return new CmdTesting(model)
 		# CmdCatalog
 		var catalog = self.catalog
 		if catalog != null then
-			if name == "catalog" then return new CmdCatalogPackages(model, catalog, filter)
-			if name == "stats" then return new CmdCatalogStats(model, catalog, filter)
-			if name == "tags" then return new CmdCatalogTags(model, catalog, filter)
-			if name == "tag" then return new CmdCatalogTag(model, catalog, filter)
-			if name == "person" then return new CmdCatalogPerson(model, catalog, filter)
-			if name == "contrib" then return new CmdCatalogContributing(model, catalog, filter)
-			if name == "maintain" then return new CmdCatalogMaintaining(model, catalog, filter)
-			if name == "search" then return new CmdCatalogSearch(model, catalog, filter)
+			if name == "catalog" then return new CmdCatalogPackages(model, catalog)
+			if name == "stats" then return new CmdCatalogStats(model, catalog)
+			if name == "tags" then return new CmdCatalogTags(model, catalog)
+			if name == "tag" then return new CmdCatalogTag(model, catalog)
+			if name == "person" then return new CmdCatalogPerson(model, catalog)
+			if name == "contrib" then return new CmdCatalogContributing(model, catalog)
+			if name == "maintain" then return new CmdCatalogMaintaining(model, catalog)
+			if name == "search" then return new CmdCatalogSearch(model, catalog)
 		else
-			if name == "search" then return new CmdSearch(model, filter)
+			if name == "search" then return new CmdSearch(model)
 		end
 		return null
 	end

--- a/src/doc/commands/commands_parser.nit
+++ b/src/doc/commands/commands_parser.nit
@@ -281,8 +281,10 @@ end
 
 redef class CmdComment
 	redef fun parser_init(mentity_name, options) do
-		full_doc = not options.has_key("only-synopsis")
-		fallback = not options.has_key("no-fallback")
+		var opt_full_doc = options.opt_bool("only-synopsis")
+		if opt_full_doc != null then full_doc = not opt_full_doc
+		var opt_fallback = options.opt_bool("no-fallback")
+		if opt_fallback != null then fallback = not opt_fallback
 		var opt_format = options.opt_string("format")
 		if opt_format != null then format = opt_format
 		return super
@@ -316,14 +318,16 @@ end
 
 redef class CmdAncestors
 	redef fun parser_init(mentity_name, options) do
-		if options.has_key("parents") and options["parents"] == "false" then parents = false
+		var opt_parents = options.opt_bool("no-parents")
+		if opt_parents != null then parents = not opt_parents
 		return super
 	end
 end
 
 redef class CmdDescendants
 	redef fun parser_init(mentity_name, options) do
-		if options.has_key("children") and options["children"] == "false" then children = false
+		var opt_children = options.opt_bool("no-children")
+		if opt_children != null then children = not opt_children
 		return super
 	end
 end
@@ -393,6 +397,19 @@ class CmdOptions
 		var value = self[key]
 		if not value.is_int then return null
 		return value.to_i
+	end
+
+	# Get option value as bool
+	#
+	# Return `true` if the value with that `key` is empty or equals `"true"`.
+	# Return `false` if the value with that `key` equals `"false"`.
+	# Return `null` in any other case.
+	fun opt_bool(key: String): nullable Bool do
+		if not has_key(key) then return null
+		var value = self[key]
+		if value.is_empty or value == "true" then return true
+		if value == "false" then return false
+		return null
 	end
 end
 

--- a/src/doc/commands/commands_parser.nit
+++ b/src/doc/commands/commands_parser.nit
@@ -140,7 +140,7 @@ class CommandParser
 		end
 
 		# Parse command options
-		var opts = new HashMap[String, String]
+		var opts = new CmdOptions
 		while pos < string.length do
 			# Parse option name
 			tmp.clear
@@ -255,7 +255,7 @@ end
 redef class DocCommand
 
 	# Initialize the command from the CommandParser data
-	fun parser_init(arg: String, options: Map[String, String]): CmdMessage do
+	fun parser_init(arg: String, options: CmdOptions): CmdMessage do
 		return init_command
 	end
 end
@@ -280,22 +280,26 @@ redef class CmdComment
 	redef fun parser_init(mentity_name, options) do
 		full_doc = not options.has_key("only-synopsis")
 		fallback = not options.has_key("no-fallback")
-		if options.has_key("format") then format = options["format"]
+		var opt_format = options.opt_string("format")
+		if opt_format != null then format = opt_format
 		return super
 	end
 end
 
 redef class CmdEntityLink
 	redef fun parser_init(mentity_name, options) do
-		if options.has_key("text") then text = options["text"]
-		if options.has_key("title") then title = options["title"]
+		var opt_text = options.opt_string("text")
+		if opt_text != null then text = opt_text
+		var opt_title = options.opt_string("title")
+		if opt_title != null then title = opt_title
 		return super
 	end
 end
 
 redef class CmdCode
 	redef fun parser_init(mentity_name, options) do
-		if options.has_key("format") then format = options["format"]
+		var opt_format = options.opt_string("format")
+		if opt_format != null then format = opt_format
 		return super
 	end
 end
@@ -331,7 +335,8 @@ end
 
 redef class CmdGraph
 	redef fun parser_init(mentity_name, options) do
-		if options.has_key("format") then format = options["format"]
+		var opt_format = options.opt_string("format")
+		if opt_format != null then format = opt_format
 		return super
 	end
 end
@@ -365,6 +370,21 @@ redef class CmdCatalogPerson
 end
 
 # Utils
+
+# Commands options
+class CmdOptions
+	super HashMap[String,  String]
+
+	# Get option value for `key` as String
+	#
+	# Return `null` if no option with that `key` or if value is empty.
+	fun opt_string(key: String): nullable String do
+		if not has_key(key) then return null
+		var value = self[key]
+		if value.is_empty then return null
+		return value
+	end
+end
 
 redef class Text
 	# Read `self` as raw text until `nend` and append it to the `out` buffer.

--- a/src/doc/commands/commands_parser.nit
+++ b/src/doc/commands/commands_parser.nit
@@ -256,6 +256,28 @@ redef class DocCommand
 
 	# Initialize the command from the CommandParser data
 	fun parser_init(arg: String, options: CmdOptions): CmdMessage do
+		var filter = cmd_filter
+		var opt_vis = options.opt_visibility("min-visibility")
+		if opt_vis != null then filter.min_visibility = opt_vis
+		var opt_fictive = options.opt_bool("no-fictive")
+		if opt_fictive != null then filter.accept_fictive = not opt_fictive
+		var opt_test = options.opt_bool("no-test")
+		if opt_test != null then filter.accept_test = not opt_test
+		var opt_redef = options.opt_bool("no-redef")
+		if opt_redef != null then filter.accept_redef = not opt_redef
+		var opt_extern = options.opt_bool("no-extern")
+		if opt_extern != null then filter.accept_extern = not opt_extern
+		var opt_example = options.opt_bool("no-example")
+		if opt_example != null then filter.accept_example = not opt_example
+		var opt_attr = options.opt_bool("no-attribute")
+		if opt_attr != null then filter.accept_attribute = not opt_attr
+		var opt_doc = options.opt_bool("no-empty-doc")
+		if opt_doc != null then filter.accept_empty_doc = not opt_doc
+		var opt_inh = options.opt_mentity(model, "inherit")
+		if opt_inh != null then filter.accept_inherited = opt_inh
+		var opt_match = options.opt_string("match")
+		if opt_match != null then filter.accept_full_name = opt_match
+		self.filter = filter
 		return init_command
 	end
 end
@@ -379,6 +401,15 @@ end
 class CmdOptions
 	super HashMap[String,  String]
 
+	# Map String visiblity name to MVisibility object
+	var allowed_visibility: HashMap[String, MVisibility] is lazy do
+		var res = new HashMap[String, MVisibility]
+		res["public"] = public_visibility
+		res["protected"] = protected_visibility
+		res["private"] = private_visibility
+		return res
+	end
+
 	# Get option value for `key` as String
 	#
 	# Return `null` if no option with that `key` or if value is empty.
@@ -410,6 +441,33 @@ class CmdOptions
 		if value.is_empty or value == "true" then return true
 		if value == "false" then return false
 		return null
+	end
+
+	# Get option as a MVisibility
+	#
+	# Return `null` if no option with that `key` or if the value is not in
+	# `allowed_visibility`.
+	fun opt_visibility(key: String): nullable MVisibility do
+		var value = opt_string(key)
+		if value == null then return null
+		if not allowed_visibility.keys.has(key) then return null
+		return allowed_visibility[value]
+	end
+
+	# Get option as a MEntity
+	#
+	# Lookup first by `MEntity::full_name` then by `MEntity::name`.
+	# Return `null` if the mentity name does not exist or return a conflict.
+	private fun opt_mentity(model: Model, key: String): nullable MEntity do
+		var value = opt_string(key)
+		if value == null or value.is_empty then return null
+
+		var mentity = model.mentity_by_full_name(value)
+		if mentity != null then return mentity
+
+		var mentities = model.mentities_by_name(value)
+		if mentities.is_empty or mentities.length > 1 then return null
+		return mentities.first
 	end
 end
 

--- a/src/doc/commands/tests/test_commands.nit
+++ b/src/doc/commands/tests/test_commands.nit
@@ -17,6 +17,7 @@ module test_commands
 
 import commands_base
 import frontend
+import frontend::parse_examples
 
 # Nitunit test suite specific to commands
 class TestCommands

--- a/src/doc/commands/tests/test_commands.nit
+++ b/src/doc/commands/tests/test_commands.nit
@@ -40,12 +40,6 @@ class TestCommands
 	# Mainmodule used for tests
 	var test_main: MModule is noinit
 
-	# Filters used for tests
-	var test_filter = new ModelFilter(
-		private_visibility,
-		accept_fictive = false,
-		accept_test = false)
-
 	# Initialize test variables
 	#
 	# Must be called before test execution.

--- a/src/doc/commands/tests/test_commands_catalog.nit
+++ b/src/doc/commands/tests/test_commands_catalog.nit
@@ -50,14 +50,14 @@ class TestCommandsCatalog
 	end
 
 	fun test_cmd_catalog is test do
-		var cmd = new CmdCatalogPackages(test_model, test_catalog, test_filter)
+		var cmd = new CmdCatalogPackages(test_model, test_catalog)
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).first.full_name == "test_prog"
 	end
 
 	fun test_cmd_catalog_search is test do
-		var cmd = new CmdCatalogSearch(test_model, test_catalog, test_filter, "testprog")
+		var cmd = new CmdCatalogSearch(test_model, test_catalog, query = "testprog")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).first.full_name == "test_prog"
@@ -65,21 +65,21 @@ class TestCommandsCatalog
 	end
 
 	fun test_cmd_catalog_stats is test do
-		var cmd = new CmdCatalogStats(test_model, test_catalog, test_filter)
+		var cmd = new CmdCatalogStats(test_model, test_catalog)
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.stats != null
 	end
 
 	fun test_cmd_catalog_tags is test do
-		var cmd = new CmdCatalogTags(test_model, test_catalog, test_filter)
+		var cmd = new CmdCatalogTags(test_model, test_catalog)
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.packages_count_by_tags.as(not null).length == 2
 	end
 
 	fun test_cmd_catalog_tag is test do
-		var cmd = new CmdCatalogTag(test_model, test_catalog, test_filter, "test")
+		var cmd = new CmdCatalogTag(test_model, test_catalog, tag = "test")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.tag == "test"
@@ -87,7 +87,7 @@ class TestCommandsCatalog
 	end
 
 	fun test_cmd_catalog_person is test do
-		var cmd = new CmdCatalogPerson(test_model, test_catalog, test_filter,
+		var cmd = new CmdCatalogPerson(test_model, test_catalog,
 			person_name = "Alexandre Terrasa")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
@@ -95,7 +95,7 @@ class TestCommandsCatalog
 	end
 
 	fun test_cmd_catalog_contributing is test do
-		var cmd = new CmdCatalogContributing(test_model, test_catalog, test_filter,
+		var cmd = new CmdCatalogContributing(test_model, test_catalog,
 			person_name = "Alexandre Terrasa")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
@@ -104,7 +104,7 @@ class TestCommandsCatalog
 	end
 
 	fun test_cmd_catalog_maintaining is test do
-		var cmd = new CmdCatalogMaintaining(test_model, test_catalog, test_filter,
+		var cmd = new CmdCatalogMaintaining(test_model, test_catalog,
 			person_name = "Alexandre Terrasa")
 		var res = cmd.init_command
 		assert res isa CmdSuccess

--- a/src/doc/commands/tests/test_commands_catalog.nit
+++ b/src/doc/commands/tests/test_commands_catalog.nit
@@ -64,6 +64,23 @@ class TestCommandsCatalog
 		assert cmd.results.as(not null).first isa MPackage
 	end
 
+	fun test_cmd_catalog_search_without_filter is test do
+		var cmd = new CmdCatalogSearch(test_model, test_catalog, query = "MyGame")
+		var res = cmd.init_command
+		assert res isa CmdSuccess
+		assert cmd.results.as(not null).first.full_name == "test_prog::MyGame"
+		assert cmd.results.as(not null).first isa MClass
+	end
+
+	fun test_cmd_catalog_search_with_filter is test do
+		var filter = new ModelFilter(accept_example = false)
+		var cmd = new CmdCatalogSearch(test_model, test_catalog, filter, query = "MyGame")
+		var res = cmd.init_command
+		assert res isa CmdSuccess
+		assert cmd.results.as(not null).first.full_name == "test_prog::Game" # not MyGame
+		assert cmd.results.as(not null).first isa MClass
+	end
+
 	fun test_cmd_catalog_stats is test do
 		var cmd = new CmdCatalogStats(test_model, test_catalog)
 		var res = cmd.init_command

--- a/src/doc/commands/tests/test_commands_graph.nit
+++ b/src/doc/commands/tests/test_commands_graph.nit
@@ -22,28 +22,28 @@ class TestCommandsGraph
 	test
 
 	fun test_cmd_uml is test do
-		var cmd = new CmdUML(test_model, test_main, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdUML(test_model, test_main, mentity_name = "test_prog::Character")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.uml != null
 	end
 
 	fun test_cmd_uml_bad_format is test do
-		var cmd = new CmdUML(test_model, test_main, test_filter, mentity_name = "test_prog::Character", format = "foo")
+		var cmd = new CmdUML(test_model, test_main, mentity_name = "test_prog::Character", format = "foo")
 		var res = cmd.init_command
 		assert res isa ErrorBadGraphFormat
 		assert cmd.uml == null
 	end
 
 	fun test_cmd_uml_not_found is test do
-		var cmd = new CmdUML(test_model, test_main, test_filter, mentity_name = "strength_bonus")
+		var cmd = new CmdUML(test_model, test_main, mentity_name = "strength_bonus")
 		var res = cmd.init_command
 		assert res isa WarningNoUML
 		assert cmd.uml == null
 	end
 
 	fun test_cmd_inh_graph is test do
-		var cmd = new CmdInheritanceGraph(test_model, test_main, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdInheritanceGraph(test_model, test_main, mentity_name = "test_prog::Character")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.graph != null

--- a/src/doc/commands/tests/test_commands_http.nit
+++ b/src/doc/commands/tests/test_commands_http.nit
@@ -38,7 +38,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_entity is test do
 		var req = new_request("/test_prog::Character")
-		var cmd = new CmdEntity(test_model, test_filter)
+		var cmd = new CmdEntity(test_model)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.mentity.as(not null).full_name == "test_prog::Character"
@@ -46,7 +46,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_entity_not_found is test do
 		var req = new_request("/Characterzzz")
-		var cmd = new CmdEntity(test_model, test_filter)
+		var cmd = new CmdEntity(test_model)
 		var res = cmd.http_init(req)
 		assert res isa ErrorMEntityNotFound
 		assert res.suggestions.first.full_name == "test_prog::Character"
@@ -54,7 +54,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_entity_conflict is test do
 		var req = new_request("/+")
-		var cmd = new CmdEntity(test_model, test_filter)
+		var cmd = new CmdEntity(test_model)
 		var res = cmd.http_init(req)
 		assert res isa ErrorMEntityConflict
 		assert res.conflicts.length == 2
@@ -64,7 +64,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_comment is test do
 		var req = new_request("/test_prog::Character")
-		var cmd = new CmdComment(test_model, test_filter)
+		var cmd = new CmdComment(test_model)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.mdoc != null
@@ -72,7 +72,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_comment_no_mdoc is test do
 		var req = new_request("/test_prog::Character?fallback=false")
-		var cmd = new CmdComment(test_model, test_filter)
+		var cmd = new CmdComment(test_model)
 		var res = cmd.http_init(req)
 		assert res isa WarningNoMDoc
 	end
@@ -119,7 +119,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_parents is test do
 		var req = new_request("/test_prog::Warrior")
-		var cmd = new CmdParents(test_model, test_main, test_filter)
+		var cmd = new CmdParents(test_model, test_main)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 1
@@ -127,7 +127,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_ancestors is test do
 		var req = new_request("/test_prog::Warrior")
-		var cmd = new CmdAncestors(test_model, test_main, test_filter)
+		var cmd = new CmdAncestors(test_model, test_main)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 2
@@ -135,7 +135,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_ancestorsi_without_parents is test do
 		var req = new_request("/test_prog::Warrior?parents=false")
-		var cmd = new CmdAncestors(test_model, test_main, test_filter)
+		var cmd = new CmdAncestors(test_model, test_main)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 1
@@ -143,7 +143,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_children is test do
 		var req = new_request("/test_prog::Career")
-		var cmd = new CmdChildren(test_model, test_main, test_filter)
+		var cmd = new CmdChildren(test_model, test_main)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 3
@@ -151,7 +151,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_descendants is test do
 		var req = new_request("/test_prog::Career?children=false")
-		var cmd = new CmdDescendants(test_model, test_main, test_filter)
+		var cmd = new CmdDescendants(test_model, test_main)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 0
@@ -161,7 +161,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_search is test do
 		var req = new_request("/?q=Carer&l=1")
-		var cmd = new CmdSearch(test_model, test_filter)
+		var cmd = new CmdSearch(test_model)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).first.full_name == "test_prog::Career"
@@ -170,7 +170,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_search_no_query is test do
 		var req = new_request("/")
-		var cmd = new CmdSearch(test_model, test_filter)
+		var cmd = new CmdSearch(test_model)
 		var res = cmd.http_init(req)
 		assert res isa ErrorNoQuery
 	end
@@ -179,7 +179,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_features is test do
 		var req = new_request("/test_prog::Character?l=10")
-		var cmd = new CmdFeatures(test_model, test_filter)
+		var cmd = new CmdFeatures(test_model)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 10
@@ -187,7 +187,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_features_no_features is test do
 		var req = new_request("/test_prog$Career$strength_bonus?l=10")
-		var cmd = new CmdFeatures(test_model, test_filter)
+		var cmd = new CmdFeatures(test_model)
 		var res = cmd.http_init(req)
 		assert res isa WarningNoFeatures
 	end
@@ -196,7 +196,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_lin is test do
 		var req = new_request("/init?l=10")
-		var cmd = new CmdLinearization(test_model, test_main, test_filter)
+		var cmd = new CmdLinearization(test_model, test_main)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 10
@@ -204,7 +204,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_lin_no_lin is test do
 		var req = new_request("/test_prog?l=10")
-		var cmd = new CmdLinearization(test_model, test_main, test_filter)
+		var cmd = new CmdLinearization(test_model, test_main)
 		var res = cmd.http_init(req)
 		assert res isa WarningNoLinearization
 	end
@@ -213,7 +213,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_code is test do
 		var req = new_request("/test_prog::Career")
-		var cmd = new CmdEntityCode(test_model, test_builder, test_filter)
+		var cmd = new CmdEntityCode(test_model, test_builder)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.node isa AStdClassdef
@@ -222,7 +222,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_code_format is test do
 		var req = new_request("/test_prog::Career?format=html")
-		var cmd = new CmdEntityCode(test_model, test_builder, test_filter)
+		var cmd = new CmdEntityCode(test_model, test_builder)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.node isa AStdClassdef
@@ -231,7 +231,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_code_no_code is test do
 		var req = new_request("/test_prog")
-		var cmd = new CmdEntityCode(test_model, test_builder, test_filter)
+		var cmd = new CmdEntityCode(test_model, test_builder)
 		var res = cmd.http_init(req)
 		assert res isa WarningNoCode
 	end
@@ -240,7 +240,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_results is test do
 		var req = new_request("/?kind=modules&l=2")
-		var cmd = new CmdModelEntities(test_model, test_filter, kind = "modules")
+		var cmd = new CmdModelEntities(test_model, kind = "modules")
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 2
@@ -248,7 +248,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_results_random is test do
 		var req = new_request("/?kind=packages&l=1")
-		var cmd = new CmdRandomEntities(test_model, test_filter, kind = "packages")
+		var cmd = new CmdRandomEntities(test_model, kind = "packages")
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 1
@@ -258,7 +258,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_uml is test do
 		var req = new_request("/test_prog::Character?format=svg")
-		var cmd = new CmdUML(test_model, test_main, test_filter)
+		var cmd = new CmdUML(test_model, test_main)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.uml != null
@@ -267,7 +267,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_uml_not_found is test do
 		var req = new_request("/strength_bonus")
-		var cmd = new CmdUML(test_model, test_main, test_filter)
+		var cmd = new CmdUML(test_model, test_main)
 		var res = cmd.http_init(req)
 		assert res isa WarningNoUML
 		assert cmd.format == "dot"
@@ -276,7 +276,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_inh_graph is test do
 		var req = new_request("/test_prog::Character?pdepth=1&cdepth=1")
-		var cmd = new CmdInheritanceGraph(test_model, test_main, test_filter)
+		var cmd = new CmdInheritanceGraph(test_model, test_main)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.graph != null
@@ -288,7 +288,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_catalog_search is test do
 		var req = new_request("/?q=testprog&l=1")
-		var cmd = new CmdCatalogSearch(test_model, test_catalog, test_filter)
+		var cmd = new CmdCatalogSearch(test_model, test_catalog)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).first.full_name == "test_prog"
@@ -298,7 +298,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_catalog_tag is test do
 		var req = new_request("/test", "/:tid")
-		var cmd = new CmdCatalogTag(test_model, test_catalog, test_filter)
+		var cmd = new CmdCatalogTag(test_model, test_catalog)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.tag == "test"
@@ -307,7 +307,7 @@ class TestCommandsHttp
 
 	fun test_cmd_http_catalog_person is test do
 		var req = new_request("/Alexandre%20Terrasa", "/:pid")
-		var cmd = new CmdCatalogPerson(test_model, test_catalog, test_filter)
+		var cmd = new CmdCatalogPerson(test_model, test_catalog)
 		var res = cmd.http_init(req)
 		assert res isa CmdSuccess
 		assert cmd.person.as(not null).name == "Alexandre Terrasa"

--- a/src/doc/commands/tests/test_commands_http.nit
+++ b/src/doc/commands/tests/test_commands_http.nit
@@ -157,6 +157,14 @@ class TestCommandsHttp
 		assert cmd.results.as(not null).length == 0
 	end
 
+	fun test_cmd_http_ancestors_with_filter_match is test do
+		var req = new_request("/test_prog::Warrior?match=Object")
+		var cmd = new CmdAncestors(test_model, test_main)
+		var res = cmd.http_init(req)
+		assert res isa CmdSuccess
+		assert cmd.results.as(not null).length == 1
+	end
+
 	# CmdSearch
 
 	fun test_cmd_http_search is test do
@@ -190,6 +198,14 @@ class TestCommandsHttp
 		var cmd = new CmdFeatures(test_model)
 		var res = cmd.http_init(req)
 		assert res isa WarningNoFeatures
+	end
+
+	fun test_cmd_http_features_with_filter_inherited is test do
+		var req = new_request("/test_prog::TestGame?inherited=TestGame")
+		var cmd = new CmdFeatures(test_model)
+		var res = cmd.http_init(req)
+		assert res isa CmdSuccess
+		assert cmd.results.as(not null).length == 3
 	end
 
 	# CmdLinearization

--- a/src/doc/commands/tests/test_commands_json.nit
+++ b/src/doc/commands/tests/test_commands_json.nit
@@ -30,13 +30,13 @@ class TestCommandsJson
 	# CmdEntity
 
 	fun test_cmd_entity is test do
-		var cmd = new CmdEntity(test_model, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdEntity(test_model, mentity_name = "test_prog::Character")
 		cmd.init_command
 		print_json cmd.to_json
 	end
 
 	fun test_cmd_comment is test do
-		var cmd = new CmdComment(test_model, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdComment(test_model, mentity_name = "test_prog::Character")
 		cmd.init_command
 		print_json cmd.to_json
 	end
@@ -50,25 +50,25 @@ class TestCommandsJson
 	# CmdInheritance
 
 	fun test_cmd_parents is test do
-		var cmd = new CmdParents(test_model, test_main, test_filter, mentity_name = "test_prog::Warrior")
+		var cmd = new CmdParents(test_model, test_main, mentity_name = "test_prog::Warrior")
 		cmd.init_command
 		print_json cmd.to_json
 	end
 
 	fun test_cmd_ancestors is test do
-		var cmd = new CmdAncestors(test_model, test_main, test_filter, mentity_name = "test_prog::Warrior", parents = false)
+		var cmd = new CmdAncestors(test_model, test_main, mentity_name = "test_prog::Warrior", parents = false)
 		cmd.init_command
 		print_json cmd.to_json
 	end
 
 	fun test_cmd_children is test do
-		var cmd = new CmdChildren(test_model, test_main, test_filter, mentity_name = "test_prog::Career")
+		var cmd = new CmdChildren(test_model, test_main, mentity_name = "test_prog::Career")
 		cmd.init_command
 		print_json cmd.to_json
 	end
 
 	fun test_cmd_descendants is test do
-		var cmd = new CmdDescendants(test_model, test_main, test_filter, mentity_name = "test_prog::Career")
+		var cmd = new CmdDescendants(test_model, test_main, mentity_name = "test_prog::Career")
 		cmd.init_command
 		print_json cmd.to_json
 	end
@@ -76,7 +76,7 @@ class TestCommandsJson
 	# CmdSearch
 
 	fun test_cmd_search is test do
-		var cmd = new CmdSearch(test_model, test_filter, query = "Carer", limit = 10)
+		var cmd = new CmdSearch(test_model, query = "Carer", limit = 10)
 		cmd.init_command
 		print_json cmd.to_json
 	end
@@ -84,7 +84,7 @@ class TestCommandsJson
 	# CmdFeatures
 
 	fun test_cmd_features is test do
-		var cmd = new CmdFeatures(test_model, test_filter, mentity_name = "test_prog::Career")
+		var cmd = new CmdFeatures(test_model, mentity_name = "test_prog::Career")
 		cmd.init_command
 		print_json cmd.to_json
 	end
@@ -92,7 +92,7 @@ class TestCommandsJson
 	# CmdLinearization
 
 	fun test_cmd_lin is test do
-		var cmd = new CmdLinearization(test_model, test_main, test_filter, mentity_name = "init")
+		var cmd = new CmdLinearization(test_model, test_main, mentity_name = "init")
 		cmd.init_command
 		print_json cmd.to_json
 	end
@@ -100,7 +100,7 @@ class TestCommandsJson
 	# CmdModel
 
 	fun test_cmd_mentities is test do
-		var cmd = new CmdModelEntities(test_model, test_filter, kind = "modules")
+		var cmd = new CmdModelEntities(test_model, kind = "modules")
 		cmd.init_command
 		print_json cmd.to_json
 	end
@@ -108,25 +108,25 @@ class TestCommandsJson
 	# CmdUsage
 
 	fun test_cmd_new is test do
-		var cmd = new CmdNew(test_model, test_builder, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdNew(test_model, test_builder, mentity_name = "test_prog::Character")
 		cmd.init_command
 		print_json cmd.to_json
 	end
 
 	fun test_cmd_call is test do
-		var cmd = new CmdCall(test_model, test_builder, test_filter, mentity_name = "strength_bonus")
+		var cmd = new CmdCall(test_model, test_builder, mentity_name = "strength_bonus")
 		cmd.init_command
 		print_json cmd.to_json
 	end
 
 	fun test_cmd_return is test do
-		var cmd = new CmdReturn(test_model, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdReturn(test_model, mentity_name = "test_prog::Character")
 		cmd.init_command
 		print_json cmd.to_json
 	end
 
 	fun test_cmd_param is test do
-		var cmd = new CmdParam(test_model, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdParam(test_model, mentity_name = "test_prog::Character")
 		cmd.init_command
 		print_json cmd.to_json
 	end

--- a/src/doc/commands/tests/test_commands_json.sav/test_cmd_mentities.res
+++ b/src/doc/commands/tests/test_commands_json.sav/test_cmd_mentities.res
@@ -128,6 +128,18 @@
 		"html_synopsis": "<span class=\"synopsys nitdoc\">A worlg RPG abstraction.</span>",
 		"modifiers": ["module"]
 	}, {
+		"name": "test_game",
+		"namespace": [{
+			"name": "test_prog",
+			"synopsis": "Test program for model tools."
+		}, "::", {
+			"name": "test_game"
+		}],
+		"class_name": "MModule",
+		"full_name": "test_prog::test_game",
+		"visibility": "public",
+		"modifiers": ["module"]
+	}, {
 		"name": "test_prog",
 		"synopsis": "A test program with a fake model to check model tools.",
 		"namespace": [{

--- a/src/doc/commands/tests/test_commands_model.nit
+++ b/src/doc/commands/tests/test_commands_model.nit
@@ -130,6 +130,29 @@ class TestCommandsModel
 		assert cmd.results.as(not null).length == 3
 	end
 
+	fun test_cmd_children_without_filter is test do
+		var cmd = new CmdDescendants(test_model, test_main, mentity_name = "test_prog::Game")
+		var res = cmd.init_command
+		assert res isa CmdSuccess
+		assert cmd.results.as(not null).length == 2
+	end
+
+	fun test_cmd_children_with_filter_example is test do
+		var filter = new ModelFilter(accept_example = false)
+		var cmd = new CmdDescendants(test_model, test_main, filter, mentity_name = "test_prog::Game")
+		var res = cmd.init_command
+		assert res isa CmdSuccess
+		assert cmd.results.as(not null).length == 1
+	end
+
+	fun test_cmd_children_with_filter_match is test do
+		var filter = new ModelFilter(accept_full_name = "MyGame")
+		var cmd = new CmdDescendants(test_model, test_main, filter, mentity_name = "test_prog::Game")
+		var res = cmd.init_command
+		assert res isa CmdSuccess
+		assert cmd.results.as(not null).length == 1
+	end
+
 	fun test_cmd_descendants is test do
 		var cmd = new CmdDescendants(test_model, test_main, mentity_name = "test_prog::Career", children = false)
 		var res = cmd.init_command
@@ -159,6 +182,39 @@ class TestCommandsModel
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 10
+	end
+
+	fun test_cmd_features_with_filter_attribute is test do
+		var filter = new ModelFilter(accept_attribute = false)
+		var cmd = new CmdFeatures(test_model, filter, mentity_name = "test_prog::Career")
+		var res = cmd.init_command
+		assert res isa CmdSuccess
+		assert cmd.results.as(not null).length == 7
+	end
+
+	fun test_cmd_features_with_filter_public is test do
+		var filter = new ModelFilter(min_visibility = public_visibility)
+		var cmd = new CmdFeatures(test_model, filter, mentity_name = "test_prog::Career")
+		var res = cmd.init_command
+		assert res isa CmdSuccess
+		assert cmd.results.as(not null).length == 4
+	end
+
+	fun test_cmd_features_with_filter_match is test do
+		var filter = new ModelFilter(accept_full_name = "endurance")
+		var cmd = new CmdFeatures(test_model, filter, mentity_name = "test_prog::Career")
+		var res = cmd.init_command
+		assert res isa CmdSuccess
+		assert cmd.results.as(not null).length == 3
+	end
+
+	fun test_cmd_features_with_filter_inh is test do
+		var context = test_model.mentity_by_full_name("test_prog::TestGame").as(not null)
+		var filter = new ModelFilter(accept_inherited = context)
+		var cmd = new CmdFeatures(test_model, filter, mentity_name = "test_prog::TestGame")
+		var res = cmd.init_command
+		assert res isa CmdSuccess
+		assert cmd.results.as(not null).length == 3
 	end
 
 	fun test_cmd_features_no_features is test do
@@ -203,7 +259,16 @@ class TestCommandsModel
 		var cmd = new CmdModelEntities(test_model, kind = "modules")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
-		assert cmd.results.as(not null).length == 10
+		assert cmd.results.as(not null).length == 11
+	end
+
+	fun test_cmd_results_with_filter is test do
+		var filter = new ModelFilter(accept_test = false, accept_example = false)
+		var cmd = new CmdModelEntities(test_model, filter, kind = "modules")
+		var res = cmd.init_command
+		assert res isa CmdSuccess
+		print cmd.results.as(not null)
+		assert cmd.results.as(not null).length == 9
 	end
 
 	fun test_cmd_results_random is test do

--- a/src/doc/commands/tests/test_commands_model.nit
+++ b/src/doc/commands/tests/test_commands_model.nit
@@ -24,28 +24,28 @@ class TestCommandsModel
 	# CmdEntity
 
 	fun test_cmd_entity is test do
-		var cmd = new CmdEntity(test_model, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdEntity(test_model, mentity_name = "test_prog::Character")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.mentity.as(not null).full_name == "test_prog::Character"
 	end
 
 	fun test_cmd_entity_not_found is test do
-		var cmd = new CmdEntity(test_model, test_filter, mentity_name = "test_prog::Characterzz")
+		var cmd = new CmdEntity(test_model, mentity_name = "test_prog::Characterzz")
 		var res = cmd.init_command
 		assert res isa ErrorMEntityNotFound
 		assert res.suggestions.first.full_name == "test_prog::Character"
 	end
 
 	fun test_cmd_entity_conflict is test do
-		var cmd = new CmdEntity(test_model, test_filter, mentity_name = "+")
+		var cmd = new CmdEntity(test_model, mentity_name = "+")
 		var res = cmd.init_command
 		assert res isa ErrorMEntityConflict
 		assert res.conflicts.length == 2
 	end
 
 	fun test_cmd_entity_no_name is test do
-		var cmd = new CmdEntity(test_model, test_filter)
+		var cmd = new CmdEntity(test_model)
 		var res = cmd.init_command
 		assert res isa ErrorMEntityNoName
 	end
@@ -53,14 +53,14 @@ class TestCommandsModel
 	# CmdComment
 
 	fun test_cmd_comment is test do
-		var cmd = new CmdComment(test_model, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdComment(test_model, mentity_name = "test_prog::Character")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.mdoc != null
 	end
 
 	fun test_cmd_comment_no_mdoc is test do
-		var cmd = new CmdComment(test_model, test_filter, mentity_name = "test_prog::Character", fallback = false)
+		var cmd = new CmdComment(test_model, mentity_name = "test_prog::Character", fallback = false)
 		var res = cmd.init_command
 		assert res isa WarningNoMDoc
 	end
@@ -68,7 +68,7 @@ class TestCommandsModel
 	# CmdLink
 
 	fun test_cmd_link is test do
-		var cmd = new CmdEntityLink(test_model, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdEntityLink(test_model, mentity_name = "test_prog::Character")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.text == "Character"
@@ -76,7 +76,7 @@ class TestCommandsModel
 	end
 
 	fun test_cmd_link_with_text is test do
-		var cmd = new CmdEntityLink(test_model, test_filter, mentity_name = "test_prog::Character", text = "foo")
+		var cmd = new CmdEntityLink(test_model, mentity_name = "test_prog::Character", text = "foo")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.text == "foo"
@@ -84,7 +84,7 @@ class TestCommandsModel
 	end
 
 	fun test_cmd_link_with_title is test do
-		var cmd = new CmdEntityLink(test_model, test_filter, mentity_name = "test_prog::Character", title = "bar")
+		var cmd = new CmdEntityLink(test_model, mentity_name = "test_prog::Character", title = "bar")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.text == "Character"
@@ -92,7 +92,7 @@ class TestCommandsModel
 	end
 
 	fun test_cmd_link_with_text_and_title is test do
-		var cmd = new CmdEntityLink(test_model, test_filter, mentity_name = "test_prog::Character",
+		var cmd = new CmdEntityLink(test_model, mentity_name = "test_prog::Character",
 			text = "foo", title = "bar")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
@@ -103,35 +103,35 @@ class TestCommandsModel
 	# CmdInheritance
 
 	fun test_cmd_parents is test do
-		var cmd = new CmdParents(test_model, test_main, test_filter, mentity_name = "test_prog::Warrior")
+		var cmd = new CmdParents(test_model, test_main, mentity_name = "test_prog::Warrior")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 1
 	end
 
 	fun test_cmd_ancestors is test do
-		var cmd = new CmdAncestors(test_model, test_main, test_filter, mentity_name = "test_prog::Warrior")
+		var cmd = new CmdAncestors(test_model, test_main, mentity_name = "test_prog::Warrior")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 2
 	end
 
 	fun test_cmd_ancestors_without_parents is test do
-		var cmd = new CmdAncestors(test_model, test_main, test_filter, mentity_name = "test_prog::Warrior", parents = false)
+		var cmd = new CmdAncestors(test_model, test_main, mentity_name = "test_prog::Warrior", parents = false)
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 1
 	end
 
 	fun test_cmd_children is test do
-		var cmd = new CmdChildren(test_model, test_main, test_filter, mentity_name = "test_prog::Career")
+		var cmd = new CmdChildren(test_model, test_main, mentity_name = "test_prog::Career")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 3
 	end
 
 	fun test_cmd_descendants is test do
-		var cmd = new CmdDescendants(test_model, test_main, test_filter, mentity_name = "test_prog::Career", children = false)
+		var cmd = new CmdDescendants(test_model, test_main, mentity_name = "test_prog::Career", children = false)
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 0
@@ -140,14 +140,14 @@ class TestCommandsModel
 	# CmdSearch
 
 	fun test_cmd_search is test do
-		var cmd = new CmdSearch(test_model, test_filter, query = "Carer")
+		var cmd = new CmdSearch(test_model, query = "Carer")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).first.full_name == "test_prog::Career"
 	end
 
 	fun test_cmd_search_no_query is test do
-		var cmd = new CmdSearch(test_model, test_filter)
+		var cmd = new CmdSearch(test_model)
 		var res = cmd.init_command
 		assert res isa ErrorNoQuery
 	end
@@ -155,14 +155,14 @@ class TestCommandsModel
 	# CmdFeatures
 
 	fun test_cmd_features is test do
-		var cmd = new CmdFeatures(test_model, test_filter, mentity_name = "test_prog::Career")
+		var cmd = new CmdFeatures(test_model, mentity_name = "test_prog::Career")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 10
 	end
 
 	fun test_cmd_features_no_features is test do
-		var cmd = new CmdFeatures(test_model, test_filter, mentity_name = "test_prog$Career$strength_bonus")
+		var cmd = new CmdFeatures(test_model, mentity_name = "test_prog$Career$strength_bonus")
 		var res = cmd.init_command
 		assert res isa WarningNoFeatures
 	end
@@ -170,14 +170,14 @@ class TestCommandsModel
 	# CmdLinearization
 
 	fun test_cmd_lin is test do
-		var cmd = new CmdLinearization(test_model, test_main, test_filter, mentity_name = "init")
+		var cmd = new CmdLinearization(test_model, test_main, mentity_name = "init")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 10
 	end
 
 	fun test_cmd_lin_no_lin is test do
-		var cmd = new CmdLinearization(test_model, test_main, test_filter, mentity_name = "test_prog")
+		var cmd = new CmdLinearization(test_model, test_main, mentity_name = "test_prog")
 		var res = cmd.init_command
 		assert res isa WarningNoLinearization
 	end
@@ -185,14 +185,14 @@ class TestCommandsModel
 	# CmdCode
 
 	fun test_cmd_code is test do
-		var cmd = new CmdEntityCode(test_model, test_builder, test_filter, mentity_name = "test_prog::Career")
+		var cmd = new CmdEntityCode(test_model, test_builder, mentity_name = "test_prog::Career")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.node isa AStdClassdef
 	end
 
 	fun test_cmd_code_no_code is test do
-		var cmd = new CmdEntityCode(test_model, test_builder, test_filter, mentity_name = "test_prog")
+		var cmd = new CmdEntityCode(test_model, test_builder, mentity_name = "test_prog")
 		var res = cmd.init_command
 		assert res isa WarningNoCode
 	end
@@ -200,14 +200,14 @@ class TestCommandsModel
 	# CmdModel
 
 	fun test_cmd_results is test do
-		var cmd = new CmdModelEntities(test_model, test_filter, kind = "modules")
+		var cmd = new CmdModelEntities(test_model, kind = "modules")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 10
 	end
 
 	fun test_cmd_results_random is test do
-		var cmd = new CmdRandomEntities(test_model, test_filter, kind = "packages")
+		var cmd = new CmdRandomEntities(test_model, kind = "packages")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results.as(not null).length == 2

--- a/src/doc/commands/tests/test_commands_parser.nit
+++ b/src/doc/commands/tests/test_commands_parser.nit
@@ -160,7 +160,7 @@ class TestCommandsParser
 
 	fun test_cmd_parser_ancestors_without_parents is test do
 		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
-		var cmd = parser.parse("ancestors: test_prog::Warrior | parents: false")
+		var cmd = parser.parse("ancestors: test_prog::Warrior | no-parents")
 		assert cmd isa CmdAncestors
 		assert parser.error == null
 		assert cmd.results.as(not null).length == 1
@@ -184,7 +184,7 @@ class TestCommandsParser
 
 	fun test_cmd_parser_descendants_without_children is test do
 		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
-		var cmd = parser.parse("descendants: Object | children: false")
+		var cmd = parser.parse("descendants: Object | no-children: true")
 		assert cmd isa CmdDescendants
 		assert parser.error == null
 		assert cmd.results.as(not null).length == 9

--- a/src/doc/commands/tests/test_commands_parser.nit
+++ b/src/doc/commands/tests/test_commands_parser.nit
@@ -25,7 +25,7 @@ class TestCommandsParser
 	# CmdEntity
 
 	fun test_cmd_parser_comment is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("doc: test_prog::Character")
 		assert cmd isa CmdComment
 		assert parser.error == null
@@ -193,7 +193,7 @@ class TestCommandsParser
 	# CmdSearch
 
 	fun test_cmd_parser_search is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("search: Caracter")
 		assert cmd isa CmdSearch
 		assert parser.error == null
@@ -201,7 +201,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_search_limit is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("search: Caracter | limit: 2")
 		assert cmd isa CmdSearch
 		assert parser.error == null
@@ -211,7 +211,7 @@ class TestCommandsParser
 	# CmdFeatures
 
 	fun test_cmd_parser_features is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("defs: test_prog::Character")
 		assert cmd isa CmdFeatures
 		assert parser.error == null
@@ -219,7 +219,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_features_limit is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("defs: test_prog::Character | limit: 2")
 		assert cmd isa CmdFeatures
 		assert parser.error == null
@@ -229,7 +229,7 @@ class TestCommandsParser
 	# CmdLinearization
 
 	fun test_cmd_parser_lin is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("lin: test_prog::Character")
 		assert cmd isa CmdLinearization
 		assert parser.error == null
@@ -237,7 +237,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_lin_limit is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("lin: test_prog::Character | limit: 2")
 		assert cmd isa CmdLinearization
 		assert parser.error == null
@@ -247,7 +247,7 @@ class TestCommandsParser
 	# CmdCode
 
 	fun test_cmd_parser_code is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("code: test_prog::Character")
 		assert cmd isa CmdEntityCode
 		assert parser.error == null
@@ -257,7 +257,7 @@ class TestCommandsParser
 	# CmdModel
 
 	fun test_cmd_parser_mentities is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("list: modules")
 		assert cmd isa CmdModelEntities
 		assert parser.error == null
@@ -265,7 +265,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_results_mentities is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("random: modules")
 		assert cmd isa CmdRandomEntities
 		assert parser.error == null
@@ -275,7 +275,7 @@ class TestCommandsParser
 	# CmdGraph
 
 	fun test_cmd_parser_uml is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("uml: test_prog::Career")
 		assert cmd isa CmdUML
 		assert parser.error == null
@@ -283,7 +283,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_inh_graph is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("graph: test_prog::Career")
 		assert cmd isa CmdInheritanceGraph
 		assert parser.error == null
@@ -291,7 +291,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_inh_graph_opts is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("graph: test_prog::Career | cdepth: 2, pdepth: 5")
 		assert cmd isa CmdInheritanceGraph
 		assert parser.error == null
@@ -303,7 +303,7 @@ class TestCommandsParser
 	# CmdUsage
 
 	fun test_cmd_parser_new is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("new: test_prog::Career")
 		assert cmd isa CmdNew
 		assert parser.error == null
@@ -311,7 +311,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_call is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("call: strength_bonus")
 		assert cmd isa CmdCall
 		assert parser.error == null
@@ -319,7 +319,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_return is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("return: test_prog::Career")
 		assert cmd isa CmdReturn
 		assert parser.error == null
@@ -327,7 +327,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_param is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("param: test_prog::Career")
 		assert cmd isa CmdParam
 		assert parser.error == null
@@ -337,7 +337,7 @@ class TestCommandsParser
 	# CmdCatalog
 
 	fun test_parser_catalog_search is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("search: Caracter")
 		assert cmd isa CmdSearch
 		assert parser.error == null
@@ -345,7 +345,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_catalog_packages is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("catalog:")
 		assert cmd isa CmdCatalogPackages
 		assert parser.error == null
@@ -353,7 +353,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_catalog_stats is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("stats:")
 		assert cmd isa CmdCatalogStats
 		assert parser.error == null
@@ -361,7 +361,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_catalog_tags is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("tags:")
 		assert cmd isa CmdCatalogTags
 		assert parser.error == null
@@ -369,7 +369,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_catalog_tag is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("tag: test")
 		assert cmd isa CmdCatalogTag
 		assert parser.error == null
@@ -378,7 +378,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_catalog_person is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("person: Alexandre Terrasa")
 		assert cmd isa CmdCatalogPerson
 		assert parser.error == null
@@ -386,7 +386,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_catalog_contributing is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("contrib: Alexandre Terrasa")
 		assert cmd isa CmdCatalogContributing
 		assert parser.error == null
@@ -395,7 +395,7 @@ class TestCommandsParser
 	end
 
 	fun test_cmd_parser_catalog_maintaining is test do
-		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog, test_filter)
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
 		var cmd = parser.parse("maintain: Alexandre Terrasa")
 		assert cmd isa CmdCatalogMaintaining
 		assert parser.error == null

--- a/src/doc/commands/tests/test_commands_parser.nit
+++ b/src/doc/commands/tests/test_commands_parser.nit
@@ -190,6 +190,14 @@ class TestCommandsParser
 		assert cmd.results.as(not null).length == 9
 	end
 
+	fun test_cmd_parser_ancestors_with_filter_match is test do
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
+		var cmd = parser.parse("ancestors: test_prog::Warrior | match: Object")
+		assert cmd isa CmdAncestors
+		assert parser.error == null
+		assert cmd.results.as(not null).length == 1
+	end
+
 	# CmdSearch
 
 	fun test_cmd_parser_search is test do
@@ -224,6 +232,14 @@ class TestCommandsParser
 		assert cmd isa CmdFeatures
 		assert parser.error == null
 		assert cmd.results.as(not null).length == 2
+	end
+
+	fun test_cmd_parser_with_filter_inherited is test do
+		var parser = new CommandParser(test_model, test_main, test_builder, test_catalog)
+		var cmd = parser.parse("defs: test_prog::TestGame | inherited: TestGame")
+		assert cmd isa CmdFeatures
+		assert parser.error == null
+		assert cmd.results.as(not null).length == 3
 	end
 
 	# CmdLinearization

--- a/src/doc/commands/tests/test_commands_usage.nit
+++ b/src/doc/commands/tests/test_commands_usage.nit
@@ -22,40 +22,40 @@ class TestCommandsUsage
 	test
 
 	fun test_cmd_new is test do
-		var cmd = new CmdNew(test_model, test_builder, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdNew(test_model, test_builder, mentity_name = "test_prog::Character")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results != null
 	end
 
 	fun test_cmd_new_not_class is test do
-		var cmd = new CmdNew(test_model, test_builder, test_filter, mentity_name = "strength_bonus")
+		var cmd = new CmdNew(test_model, test_builder, mentity_name = "strength_bonus")
 		var res = cmd.init_command
 		assert res isa ErrorNotClass
 	end
 
 	fun test_cmd_call is test do
-		var cmd = new CmdCall(test_model, test_builder, test_filter, mentity_name = "strength_bonus")
+		var cmd = new CmdCall(test_model, test_builder, mentity_name = "strength_bonus")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results != null
 	end
 
 	fun test_cmd_call_not_prop is test do
-		var cmd = new CmdCall(test_model, test_builder, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdCall(test_model, test_builder, mentity_name = "test_prog::Character")
 		var res = cmd.init_command
 		assert res isa ErrorNotProperty
 	end
 
 	fun test_cmd_return is test do
-		var cmd = new CmdReturn(test_model, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdReturn(test_model, mentity_name = "test_prog::Character")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results != null
 	end
 
 	fun test_cmd_param is test do
-		var cmd = new CmdParam(test_model, test_filter, mentity_name = "test_prog::Character")
+		var cmd = new CmdParam(test_model, mentity_name = "test_prog::Character")
 		var res = cmd.init_command
 		assert res isa CmdSuccess
 		assert cmd.results != null

--- a/src/doc/term/term.nit
+++ b/src/doc/term/term.nit
@@ -26,7 +26,7 @@ redef class CommandParser
 		# Translate links to doc commands
 		if cmd isa CmdEntityLink then
 			cmd = new CmdComment(model, mentity_name = query)
-			var opts = new HashMap[String, String]
+			var opts = new CmdOptions
 			var status = cmd.parser_init(query, opts)
 			if not status isa CmdSuccess then error = status
 		end

--- a/src/doc/term/term.nit
+++ b/src/doc/term/term.nit
@@ -25,7 +25,7 @@ redef class CommandParser
 
 		# Translate links to doc commands
 		if cmd isa CmdEntityLink then
-			cmd = new CmdComment(model, filter, mentity_name = query)
+			cmd = new CmdComment(model, mentity_name = query)
 			var opts = new HashMap[String, String]
 			var status = cmd.parser_init(query, opts)
 			if not status isa CmdSuccess then error = status

--- a/src/doc/term/tests/test_term.nit
+++ b/src/doc/term/tests/test_term.nit
@@ -71,12 +71,12 @@ class TestTerm
 
 	fun test_ancestors is test do
 		var parser = new CommandParser(test_model, test_main, test_builder)
-		parser.execute("ancestors: Warrior | parents: true", true)
+		parser.execute("ancestors: Warrior | no-parents: false", true)
 	end
 
 	fun test_ancestors_without_parents is test do
 		var parser = new CommandParser(test_model, test_main, test_builder)
-		parser.execute("ancestors: Warrior | parents: false", true)
+		parser.execute("ancestors: Warrior | no-parents", true)
 	end
 
 	fun test_parents is test do
@@ -96,7 +96,7 @@ class TestTerm
 
 	fun test_descendants_without_children is test do
 		var parser = new CommandParser(test_model, test_main, test_builder)
-		parser.execute("descendants: Career | children: false", true)
+		parser.execute("descendants: Career | no-children", true)
 	end
 
 	# CmdLin

--- a/src/model/model_collect.nit
+++ b/src/model/model_collect.nit
@@ -649,32 +649,46 @@ redef class MClass
 		return mclassdefs
 	end
 
+	# Collect all ancestors of `self`
+	redef fun collect_ancestors(mainmodule, filter) do
+		var res = new HashSet[MENTITY]
+		if not mainmodule.flatten_mclass_hierarchy.has(self) then return res
+		for mclass in in_hierarchy(mainmodule).greaters do
+			if mclass == self then continue
+			if filter == null or filter.accept_mentity(mclass) then res.add mclass
+		end
+		return res
+	end
+
 	# Collect all direct parents of `self`
-	#
-	# This method uses a flattened hierarchy containing all the mclassdefs.
 	redef fun collect_parents(mainmodule, filter) do
 		var res = new HashSet[MENTITY]
 		if not mainmodule.flatten_mclass_hierarchy.has(self) then return res
 		for mclass in in_hierarchy(mainmodule).direct_greaters do
-			if mclass == self or (filter != null and not filter.accept_mentity(mclass)) then
-				continue
-			end
-			res.add mclass
+			if mclass == self then continue
+			if filter == null or filter.accept_mentity(mclass) then res.add mclass
 		end
 		return res
 	end
 
 	# Collect all direct children of `self`
-	#
-	# This method uses a flattened hierarchy containing all the mclassdefs.
 	redef fun collect_children(mainmodule, filter) do
 		var res = new HashSet[MENTITY]
 		if not mainmodule.flatten_mclass_hierarchy.has(self) then return res
 		for mclass in in_hierarchy(mainmodule).direct_smallers do
-			if mclass == self or (filter != null and not filter.accept_mentity(mclass)) then
-				continue
-			end
-			res.add mclass
+			if mclass == self then continue
+			if filter == null or filter.accept_mentity(mclass) then res.add mclass
+		end
+		return res
+	end
+
+	# Collect all descendants of `self`
+	redef fun collect_descendants(mainmodule, filter) do
+		var res = new HashSet[MENTITY]
+		if not mainmodule.flatten_mclass_hierarchy.has(self) then return res
+		for mclass in in_hierarchy(mainmodule).smallers do
+			if mclass == self then continue
+			if filter == null or filter.accept_mentity(mclass) then res.add mclass
 		end
 		return res
 	end

--- a/src/model/model_filters.nit
+++ b/src/model/model_filters.nit
@@ -41,6 +41,22 @@ import parse_annotations
 # ~~~
 class ModelFilter
 
+	# Initialize `self` by copying the options from another `filter`
+	init from(filter: ModelFilter) do
+		init(
+			min_visibility = filter.min_visibility,
+			accept_fictive = filter.accept_fictive,
+			accept_test = filter.accept_test,
+			accept_redef = filter.accept_redef,
+			accept_extern = filter.accept_extern,
+			accept_example = filter.accept_example,
+			accept_attribute = filter.accept_attribute,
+			accept_empty_doc = filter.accept_empty_doc,
+			accept_inherited = filter.accept_inherited,
+			accept_full_name = filter.accept_full_name
+		)
+	end
+
 	# Accept `mentity` based on all the options from `self`?
 	#
 	# If one of the filter returns `false` then the `mentity` is not accepted.

--- a/src/model/model_filters.nit
+++ b/src/model/model_filters.nit
@@ -184,7 +184,7 @@ class ModelFilter
 	# Accept examples?
 	#
 	# Default is `true`.
-	var accept_example = true is optional
+	var accept_example = true is optional, writable
 
 	# Accept only entities that are not example related
 	fun accept_mentity_example(mentity: MEntity): Bool do
@@ -193,7 +193,7 @@ class ModelFilter
 	end
 
 	# If set, accept only entities local to `accept_inherited`
-	var accept_inherited: nullable MEntity = null is optional
+	var accept_inherited: nullable MEntity = null is optional, writable
 
 	# Accept only entities local to `accept_inherited`
 	#


### PR DESCRIPTION
This PR allows the DocCommands to use ModelFilter.

With this, one can setup the filter used by a command from:
* The commands programmatic Nit interface
   ~~~nit
   var filter = new ModelFilter(accept_test = false)
   var cmd = new CmdParents(model, main, filter, mentity_name = "MyEntity")
   ~~~
* The string interface through the CommandParser
   ~~~raw
   [[parents: MyEntity | no-test]]
   ~~~
* The HTTP interface
   ~~~raw
   /children/MyEntity?no-test=true
   ~~~