### PR TITLE
lib/core: handling of plus (+) sign when using to_i with Text objects

### DIFF
--- a/lib/core/text/abstract_text.nit
+++ b/lib/core/text/abstract_text.nit
@@ -253,6 +253,7 @@ abstract class Text
 	# assert "0x64".to_i       == 100
 	# assert "0b1100_0011".to_i== 195
 	# assert "--12".to_i       == 12
+	# assert "+45".to_i        == 45
 	# ~~~
 	#
 	# REQUIRE: `self`.`is_int`

--- a/lib/core/text/fixed_ints_text.nit
+++ b/lib/core/text/fixed_ints_text.nit
@@ -208,6 +208,8 @@ redef class Text
 	#
 	#     assert "123".is_int
 	#     assert "0b1011".is_int
+	#     assert "-34".is_int
+	#     assert "+45".is_int
 	#     assert not "0x_".is_int
 	#     assert not "0xGE".is_int
 	#     assert not "".is_int
@@ -218,7 +220,7 @@ redef class Text
 		var s = remove_all('_')
 		var pos = 0
 		var len = s.length
-		while pos < len and s[pos] == '-' do
+		while pos < len and (s[pos] == '-' or s[pos] == '+') do
 			pos += 1
 		end
 		s = s.substring_from(pos)
@@ -238,9 +240,15 @@ redef class Text
 		var val = 0
 		var neg = false
 		var pos = 0
-		while s[pos] == '-' do
-			neg = not neg
-			pos += 1
+		loop
+			if s[pos] == '-' then
+				neg = not neg
+				pos += 1
+			else if s[pos] == '+' then
+				pos += 1
+			else
+				break
+			end
 		end
 		s = s.substring_from(pos)
 		if s.length >= 2 then


### PR DESCRIPTION
While doing the Advent of Code 2018 in Nit, I encountered a file with numbers prefaced with a plus (+) sign. The to_i of Text wasn't able to handle that kind of input so I added it.

The PR add handling of prefacing + signs with the current - sign implementation. Also added the same logic to is_int so that assert can work. Added new tests in the documentation to show normal usage.

Signed-off-by: Hugo Leblanc <dullin@hololink.org>