### PR TITLE
curl: fix concurrent requests and intro shortcut services for scripts

### DIFF
--- a/lib/curl/curl.nit
+++ b/lib/curl/curl.nit
@@ -540,7 +540,10 @@ end
 class CurlResponseFailed
 	super CurlResponse
 
+	# Curl error code
 	var error_code: Int
+
+	# Curl error message
 	var error_msg: String
 
 	redef fun to_s do return "{error_msg} ({error_code})"
@@ -568,23 +571,27 @@ end
 class CurlResponseSuccess
 	super CurlResponseSuccessIntern
 
-	var body_str = ""
+	# Server HTTP response code
 	var status_code = 0
 
-	# Receive body from request due to body callback registering
-	redef fun body_callback(line) do
-		self.body_str = "{self.body_str}{line}"
-	end
+	# Response body as a `String`
+	var body_str = ""
+
+	# Accept part of the response body
+	redef fun body_callback(line) do self.body_str += line
 end
 
 # Success Response Class of a downloaded File
 class CurlFileResponseSuccess
 	super CurlResponseSuccessIntern
 
+	# Server HTTP response code
 	var status_code = 0
+
 	var speed_download = 0.0
 	var size_download = 0.0
 	var total_time = 0.0
+
 	private var file: nullable FileWriter = null
 
 	# Receive bytes stream from request due to stream callback registering
@@ -621,7 +628,7 @@ class HeaderMap
 	# Get `self` as a single string for HTTP POST
 	#
 	# Require: `curl.is_ok`
-	fun to_url_encoded(curl: Curl): String
+	private fun to_url_encoded(curl: Curl): String
 	do
 		assert curl.is_ok
 

--- a/lib/curl/curl.nit
+++ b/lib/curl/curl.nit
@@ -16,7 +16,9 @@
 
 # Data transfer powered by the native curl library
 #
-# Download or upload over HTTP with `CurlHTTPRequest` and send emails with `CurlMail`.
+# Download or upload data over HTTP with `CurlHTTPRequest` and send emails
+# with `CurlMail`. Scripts can use the easier (but limited) services on `Text`,
+# `http_get` and `http_download`, provided by `curl::extra`.
 module curl
 
 import native_curl

--- a/lib/curl/extra.nit
+++ b/lib/curl/extra.nit
@@ -1,0 +1,89 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shortcut services for scripts: `http_get` and `http_download`
+module extra
+
+import curl
+
+redef class Text
+
+	# Execute a simple HTTP GET request to the URL `self`
+	#
+	# Set `accept_status_code` to the expected response HTTP code, defaults to 200.
+	# If a different status code is received, the return code is printed to stderr.
+	#
+	# Returns the response body on success and `null` on error. Prints the error
+	# message to stderr.
+	#
+	# For more control, set HTTP request headers, keep the response status code
+	# and much more, use `CurlHTTPRequest`.
+	#
+	# ~~~nitish
+	# assert "http://example.com/".http_get != null
+	# ~~~
+	fun http_get(accept_status_code: nullable Int): nullable String
+	do
+		var req = new CurlHTTPRequest(self.to_s)
+		var resp = req.execute
+		req.close
+
+		if resp isa CurlResponseSuccess then
+			if resp.status_code == (accept_status_code or else 200) then
+				return resp.body_str
+			else
+				print_error "HTTP request failed: server returned {resp.status_code}"
+			end
+		else if resp isa CurlResponseFailed then
+			print_error "HTTP request failed: {resp.error_msg}"
+		else abort
+		return null
+	end
+
+	# Download the file at URL `self` to `output_path` with a simple HTTP request
+	#
+	# If not set, `output_path` defaults to `self.basename`.
+	#
+	# Set `accept_status_code` to the expected response HTTP code, defaults to 200.
+	# If a different status code is received, the return code is printed to stderr.
+	#
+	# Returns the path to the downloaded file on success and `null` on errors.
+	# Prints the error message to stderr.
+	#
+	# For more control, set HTTP request headers, keep the response status code
+	# and much more, use `CurlHTTPRequest`.
+	#
+	# ~~~nitish
+	# assert "http://example.com/".http_download("index.html") == "example.com"
+	# ~~~
+	fun http_download(output_path: nullable Text, accept_status_code: nullable Int): nullable String
+	do
+		var path = (output_path or else self.basename).to_s
+
+		var req = new CurlHTTPRequest(self.to_s)
+		var resp = req.download_to_file(path)
+		req.close
+
+		if resp isa CurlFileResponseSuccess then
+			if resp.status_code == (accept_status_code or else 200) then
+				return path
+			else
+				print_error "HTTP request failed: server returned {resp.status_code}"
+			end
+		else if resp isa CurlResponseFailed then
+			print_error "HTTP request failed: {resp.error_msg}"
+		else abort
+		return null
+	end
+end

--- a/lib/neo4j/neo4j.nit
+++ b/lib/neo4j/neo4j.nit
@@ -111,8 +111,6 @@ class Neo4jClient
 	# REST service to send cypher requests
 	private var cypher_url: String
 
-	private var curl = new Curl
-
 	init(base_url: String) do
 		self.base_url = base_url
 		var root = service_root

--- a/lib/popcorn/pop_auth.nit
+++ b/lib/popcorn/pop_auth.nit
@@ -197,9 +197,6 @@ class GithubOAuthCallBack
 			return
 		end
 
-		# FIXME reinit curl before next request to avoid weird 404
-		curl = new Curl
-
 		# Load github user
 		var gh_api = new GithubAPI(access_token)
 		var user = gh_api.load_auth_user

--- a/tests/test_curl.nit
+++ b/tests/test_curl.nit
@@ -15,15 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import curl
+intrude import curl
 
 class CallbackManager
   super CurlCallbacks
 
-  redef fun body_callback(line: String) do end
+  redef fun body_callback(line) do end
 end
 
-fun error_manager(err: CURLCode) do if not err.is_ok then print err
+private fun error_manager(err: CURLCode) do if not err.is_ok then print err
 
 var url = "http://example.org/"
 
@@ -210,4 +210,4 @@ var hashMapRefined = new HeaderMap
 hashMapRefined["hello"] = "toto"
 hashMapRefined["hello"] = "tata"
 hashMapRefined["allo"] = "foo"
-print hashMapRefined.to_url_encoded(sys.curl)
+print hashMapRefined.to_url_encoded(new Curl)


### PR DESCRIPTION
This PR brings 2 main changes:

* The handle to a Curl request is now kept by the `CurlRequest` instances, instead of being shared by all requests. This makes it possible to execute concurrent HTTP requests.

* Intro two new services on `Text` to execute simple HTTP requests. While these new services are useful to simple scripts, if more control is needed you should still use `CurlHTTPRequest`.

  `Text::http_get` makes a GET request and returns the response body.

  `Text::http_download` makes a GET request and saves the response body to a file.