### PR TITLE
tests/base_autocast: workaround a gcc bug

### DIFF
--- a/tests/base_autocast.nit
+++ b/tests/base_autocast.nit
@@ -17,9 +17,13 @@ import kernel
 class G[E]
 	type V: nullable Object
 
-	fun foo
+	fun foo1
 	do
 		bar(1)
+	end
+
+	fun foo2
+	do
 		baz(2)
 	end
 
@@ -36,6 +40,9 @@ class I
 	redef type V: Char
 end
 
-(new G[Object]).foo
-#alt1#(new H).foo
-#alt2#(new I).foo
+(new G[Object]).foo1
+(new G[Object]).foo2
+#alt1#(new H).foo1
+#alt1#(new H).foo2
+#alt2#(new I).foo1
+#alt2#(new I).foo2

--- a/tests/sav/base_autocast_alt2.res
+++ b/tests/sav/base_autocast_alt2.res
@@ -1,4 +1,4 @@
-Runtime error: Cast failed. Expected `V`, got `Int` (alt/base_autocast_alt2.nit:23)
+Runtime error: Cast failed. Expected `V`, got `Int` (alt/base_autocast_alt2.nit:27)
 1
 2
 1


### PR DESCRIPTION
Versions of gcc between bellow 6.4.1 and 7.3.1 failed to compile
correctly the generated C.
So this changes the Nit, so the C can be compiled with buggy gcc versions.

Cf https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85244 for details