### PR TITLE
gitlab-ci: add android

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -254,6 +254,21 @@ test_contribs:
     - test ! -s status.txt # no lines, no errors
   allow_failure: true
 
+test_contribs_android:
+  stage: more_test
+  dependencies:
+    - build_tools
+  script:
+    - misc/jenkins/check_contrib.sh android
+    - grep 'error message' *.xml > status.txt || true
+    - mkdir -p apk
+    - find . -name '*.apk' -exec cp {} apk/ ";"
+    - test ! -s status.txt # no lines, no errors
+  artifacts:
+    paths:
+      - "apk"
+    when: always
+
 build_oot:
   stage: more_test
   dependencies:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,8 @@ image: nitlang/nit-ci
 cache:
   paths:
     - .ccache
+    - .gradle/caches
+    - .gradle/wrapper
   key: "$CI_JOB_NAME"
 
 stages:
@@ -14,16 +16,19 @@ stages:
 before_script:
   - date
   - export CCACHE_DIR=$PWD/.ccache
+  - export GRADLE_USER_HOME=$PWD/.gradle
   - export PATH=$PWD/bin:$PATH
   - pwd
   - ccache -s
   - ccache -M 500M
+  - du -sh .gradle || true
   - type -a nitc nitdoc || true # is there some nit tools?
   - "> status.txt"
 
 after_script:
   - export CCACHE_DIR=$PWD/.ccache
   - ccache -s
+  - du -sh .gradle || true
   - git status --ignored
   - date
   - tail status.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,7 +81,7 @@ nitunit_some:
   dependencies:
     - build_tools
   script:
-    - git diff --name-only origin/master..HEAD -- "*.nit" "*.res" "README.*" | grep -v "^tests/" > list0.txt
+    - git diff --name-only origin/master..HEAD -- "*.nit" "*.res" "README.*" | grep -v "^tests/" > list0.txt || true
     - xargs nitls -pP < list0.txt > list.txt
     - xargs nitunit < list.txt
   artifacts:
@@ -98,7 +98,7 @@ nitpick_full:
     - build_tools
   script:
     - nitls lib src examples contrib
-    - nitls -Pp lib src examples | grep -v -f tests/gitlab_ci.skip > list.txt # filter what is skipped by tests.sh
+    - nitls -Pp lib src examples | grep -v -f tests/gitlab_ci.skip > list.txt || true # filter what is skipped by tests.sh
     - xargs nitpick < list.txt
 
 basic_android:
@@ -210,7 +210,7 @@ nitunit_lib:
   dependencies:
     - build_tools
   script:
-    - nitls -Pp lib | grep -v -f tests/gitlab_ci.skip > list.txt # filter what is skipped by tests.sh
+    - nitls -Pp lib | grep -v -f tests/gitlab_ci.skip > list.txt || true # filter what is skipped by tests.sh
     - xargs nitunit -v < list.txt| tee log.txt
     - grep -e KO log.txt > status.txt || true
     - tail -3 log.txt >> status.txt
@@ -227,7 +227,7 @@ nitunit_src:
   dependencies:
     - build_tools
   script:
-    - nitls -Pp src examples | grep -v -f tests/gitlab_ci.skip > list.txt # filter what is skipped by tests.sh
+    - nitls -Pp src examples | grep -v -f tests/gitlab_ci.skip > list.txt || true # filter what is skipped by tests.sh
     - xargs nitunit -v < list.txt| tee log.txt
     - grep -e KO log.txt > status.txt || true
     - tail -3 log.txt >> status.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,6 +101,16 @@ nitpick_full:
     - nitls -Pp lib src examples | grep -v -f tests/gitlab_ci.skip > list.txt # filter what is skipped by tests.sh
     - xargs nitpick < list.txt
 
+basic_android:
+  stage: test
+  dependencies:
+    - build_tools
+  script:
+    - make -C contrib/asteronits android
+  artifacts:
+    paths:
+      - contrib/asteronits/bin/*.apk
+
 # TEST FULL #########################################################
 
 test_full_nitcs:

--- a/lib/android/README.md
+++ b/lib/android/README.md
@@ -23,33 +23,33 @@ it may be possible to support other platforms with some tweaks.
 		You will probably need to tweak it to you system or update the download URL
 		to the latest SDK tools from https://developer.android.com/studio/index.html#command-tools
 
-		~~~
-		# Fetch and extract SDK tools
-		mkdir -p ~/Android/Sdk
-		cd ~/Android/Sdk
-		wget https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip
-		unzip sdk-tools-linux-3859397.zip
+	~~~raw
+	# Fetch and extract SDK tools
+	mkdir -p ~/Android/Sdk
+	cd ~/Android/Sdk
+	wget https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip
+	unzip sdk-tools-linux-3859397.zip
 
-		# Update tools
-		tools/bin/sdkmanager --update
+	# Update tools
+	tools/bin/sdkmanager --update
 
-		# Accept the licenses
-		tools/bin/sdkmanager --licenses
+	# Accept the licenses
+	tools/bin/sdkmanager --licenses
 
-		# Install the basic build tools
-		tools/bin/sdkmanager "build-tools;27.0.0" ndk-bundle
-		~~~
+	# Install the basic build tools
+	tools/bin/sdkmanager "build-tools;27.0.0" ndk-bundle
+	~~~
 
 3.	Set the environment variable ANDROID_HOME to the SDK installation directory, usually `~/Android/Sdk/`.
 	Use the following command to setup the variable for bash.
 
-	~~~
+	~~~raw
 	echo "export ANDROID_HOME=~/Android/Sdk/" >> ~/.bashrc
 	~~~
 
 4.	Install Java 8 JDK, on Debian/Ubuntu systems you can use the following command:
 
-	~~~
+	~~~raw
 	sudo apt install openjdk-8-jdk
 	~~~
 
@@ -71,7 +71,7 @@ and `android_manifest_activity`.
 
     Example usage to specify an extra permission:
 
-    ~~~
+    ~~~raw
     android_manifest """<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>"""
     ~~~
 
@@ -143,7 +143,7 @@ as they change between versions of the Java SDK. You should instead use a
 command similar to the following, replacing `KEYSTORE_PATH` and `KEY_ALIAS`
 with the desired values.
 
-    ~~~
+    ~~~raw
     keytool -genkey -keystore KEYSTORE_PATH -alias KEY_ALIAS -sigalg MD5withRSA -keyalg RSA -keysize 1024 -validity 10000
     ~~~
 
@@ -154,7 +154,7 @@ optionally `TSA_SERVER`. These settings can be set in a startup script such as
     You can use the following commands by replacing the right-hand values
 to your own configuration.
 
-    ~~~
+    ~~~raw
     export KEYSTORE=keystore_path
     export KEY_ALIAS=key_alias
     export TSA_SERVER=timestamp_authority_server_url # Optional

--- a/misc/docker/ci/Dockerfile
+++ b/misc/docker/ci/Dockerfile
@@ -71,11 +71,37 @@ RUN dpkg --add-architecture i386 \
 	&& apt-get install -y nodejs \
 	&& rm -rf /var/lib/apt/lists/*
 
+# Install OpenGL validator
+RUN git clone https://github.com/KhronosGroup/glslang.git --depth=1 \
+	&& mkdir -p glslang/build \
+	&& cd glslang/build \
+	&& cmake .. \
+	&& make \
+	&& make install
+
+# Install android sdk/ndk
+RUN mkdir -p /opt \
+	&& cd /opt \
+	# Android SDK
+	&& curl https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip -o android-sdk-linux.zip \
+	&& unzip -q android-sdk-linux.zip -d android-sdk-linux \
+	# Download a specific ndk version because old versions are not available trough sdkmanager
+	&& curl https://dl.google.com/android/repository/android-ndk-r17c-linux-x86_64.zip -o android-ndk-linux.zip \
+	&& unzip -q android-ndk-linux.zip \
+	&& mv android-ndk-r17c android-sdk-linux/ndk-bundle \
+	&& rm android-sdk-linux.zip android-ndk-linux.zip
+RUN cd /opt \
+	&& yes | android-sdk-linux/tools/bin/sdkmanager "build-tools;27.0.0" "cmake;3.6.4111459" platform-tools tools  --verbose\
+	&& yes | android-sdk-linux/tools/bin/sdkmanager --licenses --verbose
+# TODO: predownload bwdgc and gradle?
+
 # Setup environment variables
+ENV ANDROID_HOME=/opt/android-sdk-linux/
 ENV JAVA_HOME=/usr/lib/jvm/default-java/
 ENV JNI_LIB_PATH=$JAVA_HOME/jre/lib/amd64/server/
 ENV LD_LIBRARY_PATH=$JAVA_HOME/jre/lib/amd64/server/
 
+# Used by CI to render junit files to html
 RUN pip3 install junit2html
 
 #  Prepare to install npm (npm is not packaged for debian:stretch)

--- a/misc/docker/ci/Dockerfile
+++ b/misc/docker/ci/Dockerfile
@@ -56,6 +56,7 @@ RUN dpkg --add-architecture i386 \
 		file \
 		gnupg \
 		gnuplot-nox \
+		imagemagick \
 		inkscape \
 		libopenmpi-dev \
 		time \

--- a/share/android-bdwgc/setup.sh
+++ b/share/android-bdwgc/setup.sh
@@ -25,4 +25,4 @@ git clone --depth=1 -b android https://github.com/xymus/bdwgc.git || exit 1
 # Setup libatomic_ops too
 cd bdwgc || exit 1
 git submodule init || exit 1
-git submodule update --depth=1 || exit 1
+git submodule update || exit 1

--- a/tests/gitlab_ci.skip
+++ b/tests/gitlab_ci.skip
@@ -1,4 +1,3 @@
-android
 emscripten
 java
 glsl
@@ -7,7 +6,5 @@ mpi
 neo
 objc
 postgres
-action_nitro
-asteronits
 nitrpg
 wiringPi


### PR DESCRIPTION
Add android test and build to gitlab-ci. This also fixes some issues.

Note: the version of the android tools are not the most recent. Trying to update the android toolchain to a more modern one should be done in another PR.

Prof of concept: https://gitlab.com/nit/nit-ci/-/jobs/164255403/artifacts/browse/apk/