### PR TITLE
Java FFI: use class NitObject for references to Nit objects from Java

### DIFF
--- a/contrib/benitlux/src/client/android.nit
+++ b/contrib/benitlux/src/client/android.nit
@@ -52,7 +52,7 @@ redef class App
 
 		android.content.IntentFilter filter = new android.content.IntentFilter();
 		filter.addAction(android.net.wifi.WifiManager.SCAN_RESULTS_AVAILABLE_ACTION);
-		final int final_self = self;
+		final nit.app.NitObject final_self = self;
 		App_incr_ref(final_self);
 
 		context.registerReceiver(
@@ -197,7 +197,7 @@ redef class BeerView
 		final String final_title = title;
 		final boolean final_loggedin = loggedin;
 
-		final int final_self = self;
+		final nit.app.NitObject final_self = self;
 		BeerView_incr_ref(self); // Nit GC
 
 		view.setOnTouchListener(new android.view.View.OnTouchListener() {

--- a/lib/android/NitActivity.java
+++ b/lib/android/NitActivity.java
@@ -25,7 +25,7 @@ import android.view.KeyEvent;
 public class NitActivity extends Activity {
 
 	// Nit activity associated to `this`
-	protected int nitActivity = 0;
+	protected long nitActivity = 0;
 
 	/*
 	 * Calls to Nit or to the C framework
@@ -38,21 +38,21 @@ public class NitActivity extends Activity {
 	/*
 	 * Callbacks to Nit through C
 	 */
-	protected native int nitRegisterActivity();
-	protected native void nitOnCreate(int activity, Bundle savedInstanceState);
-	protected native void nitOnStart(int activity);
-	protected native void nitOnRestart(int activity);
-	protected native void nitOnResume(int activity);
-	protected native void nitOnPause(int activity);
-	protected native void nitOnStop(int activity);
-	protected native void nitOnDestroy(int activity);
-	protected native void nitOnSaveInstanceState(int activity, Bundle savedInstanceState);
-	protected native void nitOnRestoreInstanceState(int activity, Bundle savedInstanceState);
-	protected native boolean nitOnBackPressed(int activity);
-	protected native boolean nitOnKeyDown(int activity, int keyCode, KeyEvent event);
-	protected native boolean nitOnKeyLongPress(int activity, int keyCode, KeyEvent event);
-	protected native boolean nitOnKeyMultiple(int activity, int keyCode, int count, KeyEvent event);
-	protected native boolean nitOnKeyUp(int activity, int keyCode, KeyEvent event);
+	protected native long nitRegisterActivity();
+	protected native void nitOnCreate(long activity, Bundle savedInstanceState);
+	protected native void nitOnStart(long activity);
+	protected native void nitOnRestart(long activity);
+	protected native void nitOnResume(long activity);
+	protected native void nitOnPause(long activity);
+	protected native void nitOnStop(long activity);
+	protected native void nitOnDestroy(long activity);
+	protected native void nitOnSaveInstanceState(long activity, Bundle savedInstanceState);
+	protected native void nitOnRestoreInstanceState(long activity, Bundle savedInstanceState);
+	protected native boolean nitOnBackPressed(long activity);
+	protected native boolean nitOnKeyDown(long activity, int keyCode, KeyEvent event);
+	protected native boolean nitOnKeyLongPress(long activity, int keyCode, KeyEvent event);
+	protected native boolean nitOnKeyMultiple(long activity, int keyCode, int count, KeyEvent event);
+	protected native boolean nitOnKeyUp(long activity, int keyCode, KeyEvent event);
 
 	/*
 	 * Implementation of OS callbacks

--- a/lib/android/activities.nit
+++ b/lib/android/activities.nit
@@ -43,7 +43,7 @@ extern class NativeActivity in "Java" `{ android.app.Activity `}
 
 	# Execute `task.main` on the UI thread when possible
 	fun run_on_ui_thread(task: Task) import Task.main in "Java" `{
-		final int final_task = task;
+		final nit.app.NitObject final_task = task;
 		Runnable runnable = new Runnable() {
 			@Override
 			public void run() {

--- a/lib/android/assets_and_resources.nit
+++ b/lib/android/assets_and_resources.nit
@@ -52,7 +52,7 @@ private extern class NativeAssetManager in "Java" `{ android.content.res.AssetMa
 
 	# Get the locales that this assets manager contains data for
 	fun get_locales: Array[JavaString] import Array[JavaString], Array[JavaString].add in "Java" `{
-		int arr = new_Array_of_JavaString();
+		nit.app.NitObject arr = new_Array_of_JavaString();
 		for (String s : self.getLocales()) {
 			Array_of_JavaString_add(arr, s);
 		}
@@ -61,7 +61,7 @@ private extern class NativeAssetManager in "Java" `{ android.content.res.AssetMa
 
 	# String Array of all the assets at the given path
 	fun list(path: JavaString): Array[JavaString] import Array[JavaString], Array[JavaString].add  in "Java" `{
-		int arr = new_Array_of_JavaString();
+		nit.app.NitObject arr = new_Array_of_JavaString();
 		try {
 			for (String s : self.list(path)) {
 				Array_of_JavaString_add(arr, s);

--- a/lib/android/bundle/bundle.nit
+++ b/lib/android/bundle/bundle.nit
@@ -29,6 +29,7 @@ in "Java" `{
 	import android.app.Activity;
 	import java.util.ArrayList;
 	import java.util.Set;
+	import nit.app.NitObject;
 `}
 
 extern class NativeBundle in "Java" `{ android.os.Bundle `}
@@ -44,10 +45,10 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get(key: JavaString): JavaObject in "Java" `{ return self.get(key); `}
 	fun remove(key: JavaString) in "Java" `{ self.remove(key); `}
 	fun put_all(bundle: NativeBundle) in "Java" `{ self.putAll(bundle); `}
-	fun key_set: HashSet[JavaString] import HashSet[JavaString], 
-	  HashSet[JavaString].add in "Java" `{ 
+	fun key_set: HashSet[JavaString] import HashSet[JavaString],
+	  HashSet[JavaString].add in "Java" `{
 		Set<String> java_set = self.keySet();
-		int nit_hashset = new_HashSet_of_JavaString();
+		NitObject nit_hashset = new_HashSet_of_JavaString();
 
 		for (String element: java_set)
 			HashSet_of_JavaString_add(nit_hashset, element);
@@ -257,7 +258,7 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get_integer_array_list(key: JavaString): Array[Int]
 		import Array[Int], Array[Int].add in "Java" `{
 		ArrayList<Integer> java_array = self.getIntegerArrayList(key);
-		int nit_array = new_Array_of_Int();
+		NitObject nit_array = new_Array_of_Int();
 
 		if (java_array == null) return nit_array;
 
@@ -269,7 +270,7 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get_string_array_list(key: JavaString): Array[String]
 		import StringCopyArray, StringCopyArray.add, StringCopyArray.collection in "Java" `{
 		ArrayList<String> java_array = self.getStringArrayList(key);
-		int nit_array = new_StringCopyArray();
+		NitObject nit_array = new_StringCopyArray();
 
 		if (java_array == null) return nit_array;
 
@@ -281,7 +282,7 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get_char_sequence_array_list(key: JavaString): Array[String]
 		import StringCopyArray, StringCopyArray.add, StringCopyArray.collection in "Java" `{
 		ArrayList<CharSequence> java_array = self.getCharSequenceArrayList(key);
-		int nit_array = new_StringCopyArray();
+		NitObject nit_array = new_StringCopyArray();
 
 		if (java_array == null) return nit_array;
 
@@ -293,7 +294,7 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get_boolean_array(key: JavaString): Array[Bool]
 		import Array[Bool], Array[Bool].add in "Java" `{
 		boolean[] java_array = self.getBooleanArray(key);
-		int nit_array = new_Array_of_Bool();
+		NitObject nit_array = new_Array_of_Bool();
 
 		if (java_array == null) return nit_array;
 
@@ -305,7 +306,7 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get_byte_array(key: JavaString): Array[Int]
 		import Array[Int], Array[Int].add in "Java" `{
 		byte[] java_array = self.getByteArray(key);
-		int nit_array = new_Array_of_Int();
+		NitObject nit_array = new_Array_of_Int();
 
 		if (java_array == null) return nit_array;
 
@@ -317,7 +318,7 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get_short_array(key: JavaString): Array[Int]
 		import Array[Int], Array[Int].add in "Java" `{
 		short[] java_array = self.getShortArray(key);
-		int nit_array = new_Array_of_Int();
+		NitObject nit_array = new_Array_of_Int();
 
 		if (java_array == null) return nit_array;
 
@@ -330,7 +331,7 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get_char_array(key: JavaString): Array[Char]
 		import Array[Char], Array[Char].add in "Java" `{
 		char[] java_array = self.getCharArray(key);
-		int nit_array = new_Array_of_Char();
+		NitObject nit_array = new_Array_of_Char();
 
 		if (java_array == null) return nit_array;
 
@@ -342,7 +343,7 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get_int_array(key: JavaString): Array[Int]
 		import Array[Int], Array[Int].add in "Java" `{
 		int[] java_array = self.getIntArray(key);
-		int nit_array = new_Array_of_Int();
+		NitObject nit_array = new_Array_of_Int();
 
 		if (java_array == null) return nit_array;
 
@@ -355,7 +356,7 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get_long_array(key: JavaString): Array[Int]
 		import Array[Int], Array[Int].add in "Java" `{
 		long[] java_array = self.getLongArray(key);
-		int nit_array = new_Array_of_Int();
+		NitObject nit_array = new_Array_of_Int();
 
 		if (java_array == null) return nit_array;
 
@@ -367,7 +368,7 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get_float_array(key: JavaString): Array[Float]
 		import Array[Float], Array[Float].add in "Java" `{
 		float[] java_array = self.getFloatArray(key);
-		int nit_array = new_Array_of_Float();
+		NitObject nit_array = new_Array_of_Float();
 
 		if (java_array == null) return nit_array;
 
@@ -379,7 +380,7 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get_double_array(key: JavaString): Array[Float]
 		import Array[Float], Array[Float].add in "Java" `{
 		double[] java_array = self.getDoubleArray(key);
-		int nit_array = new_Array_of_Float();
+		NitObject nit_array = new_Array_of_Float();
 
 		if (java_array == null) return nit_array;
 
@@ -391,7 +392,7 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get_string_array(key: JavaString): Array[String]
 		import StringCopyArray, StringCopyArray.add, StringCopyArray.collection in "Java" `{
 		String[] java_array = self.getStringArray(key);
-		int nit_array = new_StringCopyArray();
+		NitObject nit_array = new_StringCopyArray();
 
 		if (java_array == null) return nit_array;
 
@@ -403,7 +404,7 @@ extern class NativeBundle in "Java" `{ android.os.Bundle `}
 	fun get_char_sequence_array(key: JavaString): Array[String]
 		import StringCopyArray, StringCopyArray.add, StringCopyArray.collection in "Java" `{
 		CharSequence[] java_array = self.getCharSequenceArray(key);
-		int nit_array = new_StringCopyArray();
+		NitObject nit_array = new_StringCopyArray();
 
 		if (java_array == null) return nit_array;
 

--- a/lib/android/intent/intent_api10.nit
+++ b/lib/android/intent/intent_api10.nit
@@ -29,6 +29,7 @@ in "Java" `{
 	import android.graphics.Rect;
 	import java.util.Set;
 	import java.util.ArrayList;
+	import nit.app.NitObject;
 `}
 
 extern class NativeIntent in "Java" `{ android.content.Intent `}
@@ -45,7 +46,7 @@ extern class NativeIntent in "Java" `{ android.content.Intent `}
 	fun boolean_array_extra(name: JavaString): Array[Bool] import Array[Bool],
 	  Array[Bool].push in "Java" `{
 		boolean[] java_array = self.getBooleanArrayExtra(name);
-		int nit_array = new_Array_of_Bool();
+		NitObject nit_array = new_Array_of_Bool();
 
 		for(int i=0; i < java_array.length; ++i)
 			Array_of_Bool_push(nit_array, java_array[i]);
@@ -58,7 +59,7 @@ extern class NativeIntent in "Java" `{ android.content.Intent `}
 	fun byte_array_extra(name: JavaString): Array[Int] import Array[Int],
 	  Array[Int].add in "Java" `{
 		byte[] java_array = self.getByteArrayExtra(name);
-		int nit_array = new_Array_of_Int();
+		NitObject nit_array = new_Array_of_Int();
 
 		for (int i=0; i < java_array.length; ++i)
 			Array_of_Int_add(nit_array, java_array[i]);
@@ -72,7 +73,7 @@ extern class NativeIntent in "Java" `{ android.content.Intent `}
 	fun char_array_extra(name: JavaString): Array[Char] import Array[Char],
 	  Array[Char].add in "Java" `{
 		char[] java_array = self.getCharArrayExtra(name);
-		int nit_array = new_Array_of_Char();
+		NitObject nit_array = new_Array_of_Char();
 
 		for (int i = 0; i < java_array.length; ++i)
 			Array_of_Char_add(nit_array, java_array[i]);
@@ -86,7 +87,7 @@ extern class NativeIntent in "Java" `{ android.content.Intent `}
 	fun char_sequence_array_extra(name: JavaString): Array[String]
 	  import StringCopyArray, StringCopyArray.add, StringCopyArray.collection in "Java" `{
 		CharSequence[] java_array = self.getCharSequenceArrayExtra(name);
-		int nit_array = new_StringCopyArray();
+		NitObject nit_array = new_StringCopyArray();
 
 		for (int i = 0; i < java_array.length; ++i)
 			StringCopyArray_add(nit_array, (String) java_array[i]);
@@ -96,7 +97,7 @@ extern class NativeIntent in "Java" `{ android.content.Intent `}
 	fun char_sequence_array_list_extra(name: JavaString): Array[String]
 	  import StringCopyArray, StringCopyArray.add, StringCopyArray.collection in "Java" `{
 		ArrayList<CharSequence> java_array = self.getCharSequenceArrayListExtra(name);
-		int nit_array = new_StringCopyArray();
+		NitObject nit_array = new_StringCopyArray();
 
 		if (java_array == null) return nit_array;
 
@@ -111,7 +112,7 @@ extern class NativeIntent in "Java" `{ android.content.Intent `}
 	fun categories: HashSet[String] import StringCopyHashSet,
 	  StringCopyHashSet.add, StringCopyHashSet.collection  in "Java" `{
 		Set<String> java_set = self.getCategories();
-		int nit_hashset = new_StringCopyHashSet();
+		NitObject nit_hashset = new_StringCopyHashSet();
 
 		if (java_set == null) return nit_hashset;
 
@@ -125,7 +126,7 @@ extern class NativeIntent in "Java" `{ android.content.Intent `}
 	fun double_array_extra(name: JavaString): Array[Float] import Array[Float],
 	  Array[Float].push in "Java" `{
 		double[] java_array = self.getDoubleArrayExtra(name);
-		int nit_array = new_Array_of_Float();
+		NitObject nit_array = new_Array_of_Float();
 
 		for(int i=0; i < java_array.length; ++i)
 			Array_of_Float_push(nit_array, java_array[i]);
@@ -139,7 +140,7 @@ extern class NativeIntent in "Java" `{ android.content.Intent `}
 	fun float_array_extra(name: JavaString): Array[Float] import Array[Float],
 	  Array[Float].push in "Java" `{
 		float[] java_array = self.getFloatArrayExtra(name);
-		int nit_array = new_Array_of_Float();
+		NitObject nit_array = new_Array_of_Float();
 
 		for(int i=0; i < java_array.length; ++i)
 			Array_of_Float_push(nit_array, java_array[i]);
@@ -152,7 +153,7 @@ extern class NativeIntent in "Java" `{ android.content.Intent `}
 	fun int_array_extra(name: JavaString): Array[Int] import Array[Int],
 	  Array[Int].push in "Java" `{
 		int[] java_array = self.getIntArrayExtra(name);
-		int nit_array = new_Array_of_Int();
+		NitObject nit_array = new_Array_of_Int();
 
 		for(int i=0; i < java_array.length; ++i)
 			Array_of_Int_push(nit_array, java_array[i]);
@@ -165,7 +166,7 @@ extern class NativeIntent in "Java" `{ android.content.Intent `}
 	fun long_array_extra(name: JavaString): Array[Int] import Array[Int],
 	  Array[Int].push in "Java" `{
 		long[] java_array = self.getLongArrayExtra(name);
-		int nit_array = new_Array_of_Int();
+		NitObject nit_array = new_Array_of_Int();
 
 		for(int i=0; i < java_array.length; ++i)
 			Array_of_Int_push(nit_array, (int) java_array[i]);
@@ -180,7 +181,7 @@ extern class NativeIntent in "Java" `{ android.content.Intent `}
 	fun short_array_extra(name: JavaString): Array[Int] import Array[Int],
 	  Array[Int].push in "Java" `{
 		short[] java_array = self.getShortArrayExtra(name);
-		int nit_array = new_Array_of_Int();
+		NitObject nit_array = new_Array_of_Int();
 
 		for(int i=0; i < java_array.length; ++i)
 			Array_of_Int_push(nit_array, (int) java_array[i]);
@@ -193,7 +194,7 @@ extern class NativeIntent in "Java" `{ android.content.Intent `}
 	fun string_array_extra(name: JavaString): Array[String]
 	  import StringCopyArray, StringCopyArray.add, StringCopyArray.collection in "Java" `{
 		String[] java_array = self.getStringArrayExtra(name);
-		int nit_array = new_StringCopyArray();
+		NitObject nit_array = new_StringCopyArray();
 
 		for(int i=0; i < java_array.length; ++i)
 			StringCopyArray_add(nit_array, java_array[i]);
@@ -203,7 +204,7 @@ extern class NativeIntent in "Java" `{ android.content.Intent `}
 	fun string_array_list_extra(name: JavaString): Array[String]
 	  import StringCopyArray, StringCopyArray.add, StringCopyArray.collection in "Java" `{
 		ArrayList<String> java_array = self.getStringArrayListExtra(name);
-		int nit_array = new_StringCopyArray();
+		NitObject nit_array = new_StringCopyArray();
 
 		for (String element: java_array)
 			StringCopyArray_add(nit_array, element);

--- a/lib/android/nit_activity.nit
+++ b/lib/android/nit_activity.nit
@@ -36,7 +36,7 @@
 # the Java virtual machine. For this reason, the main _must_ execute quickly,
 # on the main UI thread at least.
 module nit_activity is
-	extra_java_files "NitActivity.java"
+	extra_java_files "nit.app.NitActivity"
 	android_activity "nit.app.NitActivity"
 end
 

--- a/lib/android/nit_activity.nit
+++ b/lib/android/nit_activity.nit
@@ -74,94 +74,94 @@ in "C body" `{
 	 * Implementations of NitActivity.java native methods
 	 */
 
-	JNIEXPORT jint JNICALL Java_nit_app_NitActivity_nitRegisterActivity
+	JNIEXPORT jlong JNICALL Java_nit_app_NitActivity_nitRegisterActivity
 	  (JNIEnv *env, jobject java_activity)
 	{
 		Activity nit_activity = App_register_activity(global_app, java_activity);
 		Activity_incr_ref(nit_activity);
-		return (jint)(void*)nit_activity;
+		return (jlong)(void*)nit_activity;
 	}
 
 	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnCreate
-	  (JNIEnv *env, jobject java_activity, jint nit_activity, jobject saved_state)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity, jobject saved_state)
 	{
 		Activity_on_create((Activity)nit_activity, saved_state);
 	}
 
 	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnStart
-	  (JNIEnv *env, jobject java_activity, jint nit_activity)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity)
 	{
 		Activity_on_start((Activity)nit_activity);
 	}
 
 	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnRestart
-	  (JNIEnv *env, jobject java_activity, jint nit_activity)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity)
 	{
 		Activity_on_restart((Activity)nit_activity);
 	}
 
 	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnResume
-	  (JNIEnv *env, jobject java_activity, jint nit_activity)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity)
 	{
 		Activity_on_resume((Activity)nit_activity);
 	}
 
 	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnPause
-	  (JNIEnv *env, jobject java_activity, jint nit_activity)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity)
 	{
 		Activity_on_pause((Activity)nit_activity);
 	}
 
 	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnStop
-	  (JNIEnv *env, jobject java_activity, jint nit_activity)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity)
 	{
 		Activity_on_stop((Activity)nit_activity);
 	}
 
 	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnDestroy
-	  (JNIEnv *env, jobject java_activity, jint nit_activity)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity)
 	{
 		Activity_on_destroy((Activity)nit_activity);
 	}
 
 	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnSaveInstanceState
-	  (JNIEnv *env, jobject java_activity, jint nit_activity, jobject saved_state)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity, jobject saved_state)
 	{
 		Activity_on_save_instance_state((Activity)nit_activity, saved_state);
 	}
 
 	JNIEXPORT void JNICALL Java_nit_app_NitActivity_nitOnRestoreInstanceState
-	  (JNIEnv *env, jobject java_activity, jint nit_activity, jobject saved_state)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity, jobject saved_state)
 	{
 		Activity_on_restore_instance_state((Activity)nit_activity, saved_state);
 	}
 
 	JNIEXPORT jboolean JNICALL Java_nit_app_NitActivity_nitOnBackPressed
-	  (JNIEnv *env, jobject java_activity, jint nit_activity)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity)
 	{
 		return (jboolean)Activity_on_back_pressed((Activity)nit_activity);
 	}
 
 	JNIEXPORT jboolean JNICALL Java_nit_app_NitActivity_nitOnKeyDown
-	  (JNIEnv *env, jobject java_activity, jint nit_activity, jint keyCode, jobject event)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity, jint keyCode, jobject event)
 	{
 		return (jboolean)Activity_on_key_down((Activity)nit_activity, keyCode, event);
 	}
 
 	JNIEXPORT jboolean JNICALL Java_nit_app_NitActivity_nitOnKeyLongPress
-	  (JNIEnv *env, jobject java_activity, jint nit_activity, jint keyCode, jobject event)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity, jint keyCode, jobject event)
 	{
 		return (jboolean)Activity_on_key_long_press((Activity)nit_activity, keyCode, event);
 	}
 
 	JNIEXPORT jboolean JNICALL Java_nit_app_NitActivity_nitOnKeyMultiple
-	  (JNIEnv *env, jobject java_activity, jint nit_activity, jint keyCode, jint count, jobject event)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity, jint keyCode, jint count, jobject event)
 	{
 		return (jboolean)Activity_on_key_multiple((Activity)nit_activity, keyCode, count, event);
 	}
 
 	JNIEXPORT jboolean JNICALL Java_nit_app_NitActivity_nitOnKeyUp
-	  (JNIEnv *env, jobject java_activity, jint nit_activity, jint keyCode, jobject event)
+	  (JNIEnv *env, jobject java_activity, jlong nit_activity, jint keyCode, jobject event)
 	{
 		return (jboolean)Activity_on_key_up((Activity)nit_activity, keyCode, event);
 	}

--- a/lib/android/service/NitService.java
+++ b/lib/android/service/NitService.java
@@ -22,7 +22,7 @@ import android.os.IBinder;
 // Service implemented in Nit
 public class NitService extends Service {
 
-	protected int nitService = 0;
+	protected long nitService = 0;
 
 	static {
 		System.loadLibrary("nit_app");
@@ -51,8 +51,8 @@ public class NitService extends Service {
 		return null;
 	}
 
-	protected native int nitNewService();
-	protected native int nitOnStartCommand(int nitService, Intent intent, int flags, int id);
-	protected native void nitOnCreate(int nitService);
-	protected native void nitOnDestroy(int nitService);
+	protected native long nitNewService();
+	protected native int nitOnStartCommand(long nitService, Intent intent, int flags, int id);
+	protected native void nitOnCreate(long nitService);
+	protected native void nitOnDestroy(long nitService);
 }

--- a/lib/android/service/at_boot.nit
+++ b/lib/android/service/at_boot.nit
@@ -14,7 +14,7 @@
 
 # Import this module to launch `Service` at device boot
 module at_boot is
-	extra_java_files "NitBroadcastReceiver.java"
+	extra_java_files "nit.app.NitBroadcastReceiver"
 	android_manifest """
 <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 """

--- a/lib/android/service/service.nit
+++ b/lib/android/service/service.nit
@@ -24,7 +24,7 @@ in "C" `{
 	// Nit's App running instance, declared in `nit_activity`
 	extern App global_app;
 
-	JNIEXPORT jint JNICALL Java_nit_app_NitService_nitNewService
+	JNIEXPORT jlong JNICALL Java_nit_app_NitService_nitNewService
 		(JNIEnv *env, jobject java_service)
 	{
 		// Pin a ref to the Java service in the Java GC
@@ -39,23 +39,23 @@ in "C" `{
 
 		Service_incr_ref(nit_service);
 
-		return (jint)(void*)nit_service;
+		return (jlong)(void*)nit_service;
 	}
 
 	JNIEXPORT jint JNICALL Java_nit_app_NitService_nitOnStartCommand
-		(JNIEnv *env, jobject java_service, jint nit_service, jobject intent, jint flags, jint id)
+		(JNIEnv *env, jobject java_service, jlong nit_service, jobject intent, jint flags, jint id)
 	{
 		return Service_on_start_command((Service)nit_service, intent, flags, id);
 	}
 
 	JNIEXPORT void JNICALL Java_nit_app_NitService_nitOnCreate
-		(JNIEnv *env, jobject java_service, jint nit_service)
+		(JNIEnv *env, jobject java_service, jlong nit_service)
 	{
 		Service_on_create((Service)nit_service);
 	}
 
 	JNIEXPORT void JNICALL Java_nit_app_NitService_nitOnDestroy
-		(JNIEnv *env, jobject java_service, jint nit_service)
+		(JNIEnv *env, jobject java_service, jlong nit_service)
 	{
 		Service_on_destroy((Service)nit_service);
 

--- a/lib/android/service/service.nit
+++ b/lib/android/service/service.nit
@@ -14,7 +14,7 @@
 
 # Android service support for _app.nit_ centered around the class `Service`
 module service is
-	extra_java_files "NitService.java"
+	extra_java_files "nit.app.NitService"
 	android_manifest_application """<service android:name="nit.app.NitService"></service>"""
 end
 

--- a/lib/android/shared_preferences/shared_preferences_api10.nit
+++ b/lib/android/shared_preferences/shared_preferences_api10.nit
@@ -38,7 +38,7 @@ extern class NativeSharedPreferences in "Java" `{ android.content.SharedPreferen
 	fun get_all: HashMap[JavaString, JavaObject] import HashMap[JavaString, JavaObject],
 		HashMap[JavaString, JavaObject].[]= in "Java" `{
 		Map<String, ?> java_map = null;
-		int nit_hashmap = new_HashMap_of_JavaString_JavaObject();
+		nit.app.NitObject nit_hashmap = new_HashMap_of_JavaString_JavaObject();
 		try {
 			java_map = self.getAll();
 		} catch (NullPointerException e) {

--- a/lib/android/shared_preferences/shared_preferences_api11.nit
+++ b/lib/android/shared_preferences/shared_preferences_api11.nit
@@ -32,7 +32,7 @@ redef extern class NativeSharedPreferences
 		HashSet[JavaString].add in "Java" `{
 		Set<String> def_value = new HashSet<String>();
 		Set<String> java_set = self.getStringSet(key, def_value);
-		int nit_hashset = new_HashSet_of_JavaString();
+		nit.app.NitObject nit_hashset = new_HashSet_of_JavaString();
 
 		for (String element: java_set)
 			HashSet_of_JavaString_add(nit_hashset, element);
@@ -47,7 +47,7 @@ redef extern class NativeSharedPreferencesEditor
 		import HashSet[JavaString], HashSet[JavaString].iterator, Iterator[JavaString].is_ok,
 		Iterator[JavaString].item, Iterator[JavaString].next in "Java" `{
 		Set<String> java_set = new HashSet<String>();
-		int itr = HashSet_of_JavaString_iterator(value);
+		nit.app.NitObject itr = HashSet_of_JavaString_iterator(value);
 
 		while (Iterator_of_JavaString_is_ok(itr)) {
 			java_set.add(Iterator_of_JavaString_item(itr));

--- a/lib/android/ui/ui.nit
+++ b/lib/android/ui/ui.nit
@@ -207,7 +207,7 @@ end
 redef class Android_widget_ArrayAdapter
 	private new (context: NativeContext, res: Int, sender: ListLayout)
 	import ListLayout.create_view in "Java" `{
-		final int final_sender_object = sender;
+		final nit.app.NitObject final_sender_object = sender;
 		ListLayout_incr_ref(sender);
 
 		return new android.widget.ArrayAdapter(context, (int)res) {
@@ -276,7 +276,7 @@ redef class CheckBox
 
 	private fun set_callback_on_toggle(view: NATIVE)
 	import on_toggle in "Java" `{
-		final int final_sender_object = self;
+		final nit.app.NitObject final_sender_object = self;
 		CheckBox_incr_ref(final_sender_object);
 
 		view.setOnCheckedChangeListener(
@@ -328,7 +328,7 @@ end
 redef class NativeButton
 	private new (context: NativeActivity, sender_object: Button)
 	import Button.on_click in "Java" `{
-		final int final_sender_object = sender_object;
+		final nit.app.NitObject final_sender_object = sender_object;
 		Button_incr_ref(final_sender_object);
 
 		return new android.widget.Button(context) {
@@ -349,7 +349,7 @@ end
 redef class Android_app_Fragment
 	private new (nit_window: Window)
 	import Window.on_create_fragment in "Java" `{
-		final int final_nit_window = nit_window;
+		final nit.app.NitObject final_nit_window = nit_window;
 		Window_incr_ref(nit_window);
 
 		return new android.app.Fragment(){

--- a/lib/java/NitObject.java
+++ b/lib/java/NitObject.java
@@ -1,0 +1,27 @@
+/* This file is part of NIT ( http://www.nitlanguage.org ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nit.app;
+
+// General class for all references to Nit objects from Java in the FFI
+public class NitObject {
+
+	// Address to the object in Nit memory
+	private long pointer;
+
+	protected NitObject(long pointer) {
+		this.pointer = pointer;
+	}
+}

--- a/lib/java/ffi_support.nit
+++ b/lib/java/ffi_support.nit
@@ -21,6 +21,7 @@ module ffi_support is
 	cflags "-I $(JAVA_HOME)/include/ -I $(JAVA_HOME)/include/linux/"
 	ldflags "-L $(JNI_LIB_PATH) -ljvm"
 	new_annotation extra_java_files
+	extra_java_files "nit.app.NitObject"
 end
 
 import jvm

--- a/src/c_tools.nit
+++ b/src/c_tools.nit
@@ -105,7 +105,8 @@ end
 
 # An extern file to compile
 class ExternFile
-	# The filename of the file
+
+	# Filename relative to the nit-compile folder
 	var filename: String
 
 	# The name of the target in the Makefile

--- a/src/c_tools.nit
+++ b/src/c_tools.nit
@@ -119,6 +119,7 @@ class ExternFile
 
 	fun compiles_to_o_file: Bool do return false
 
+	# Is `self` a Java file to include in the JAR archive?
 	fun add_to_jar: Bool do return false
 
 	# Additional libraries needed for the compilation

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -465,6 +465,13 @@ ifneq ($(findstring MINGW64,$(uname_S)),)
 	CFLAGS += -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
 endif
 
+# Add the compilation dir to the Java CLASSPATH
+ifeq ($(CLASSPATH),)
+	CLASSPATH := .
+else
+	CLASSPATH := $(CLASSPATH):.
+endif
+
 """
 
 		makefile.write("all: {outpath}\n")

--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -528,8 +528,7 @@ endif
 		var java_files = new Array[ExternFile]
 		for f in compiler.extern_bodies do
 			var o = f.makefile_rule_name
-			var ff = f.filename.basename
-			makefile.write("{o}: {ff}\n")
+			makefile.write("{o}: {f.filename}\n")
 			makefile.write("\t{f.makefile_rule_content}\n\n")
 			dep_rules.add(f.makefile_rule_name)
 
@@ -712,7 +711,7 @@ abstract class AbstractCompiler
 		stream.write("const char* get_nit_name(register const char* procname, register unsigned int len);\n")
 		stream.close
 
-		extern_bodies.add(new ExternCFile("{compile_dir}/c_functions_hash.c", ""))
+		extern_bodies.add(new ExternCFile("c_functions_hash.c", ""))
 	end
 
 	# Compile C headers

--- a/src/compiler/compiler_ffi/light.nit
+++ b/src/compiler/compiler_ffi/light.nit
@@ -29,7 +29,7 @@ redef class MModule
 		return v.compiler.modelbuilder.mmodule2node(self)
 	end
 
-	redef fun finalize_ffi(compiler: AbstractCompiler)
+	redef fun finalize_ffi(compiler)
 	do
 		if not uses_ffi then return
 

--- a/src/compiler/compiler_ffi/light.nit
+++ b/src/compiler/compiler_ffi/light.nit
@@ -53,7 +53,7 @@ extern void nitni_global_ref_decr(void*);
 		nitni_ccu.write_as_nitni(self, v.compiler.toolchain.compile_dir)
 
 		for file in nitni_ccu.files do
-			var f = new ExternCFile(file, cflags)
+			var f = new ExternCFile(file.basename, cflags)
 			f.pkgconfigs.add_all pkgconfigs
 			v.compiler.extern_bodies.add(f)
 		end

--- a/src/ffi/cpp.nit
+++ b/src/ffi/cpp.nit
@@ -171,7 +171,7 @@ class CPPCompilationUnit
 
 		files.add("{compdir}/{c_file}")
 
-		return new ExternCppFile("{compdir}/{c_file}", mmodule)
+		return new ExternCppFile(c_file, mmodule)
 	end
 end
 
@@ -180,8 +180,8 @@ class ExternCppFile
 
 	var mmodule: MModule
 
-	redef fun makefile_rule_name do return "{filename.basename}.o"
-	redef fun makefile_rule_content do return "$(CXX) $(CFLAGS) {mmodule.cppflags[""].join(" ")} -c {filename.basename} -o {filename.basename}.o"
+	redef fun makefile_rule_name do return "{filename}.o"
+	redef fun makefile_rule_content do return "$(CXX) $(CFLAGS) {mmodule.cppflags[""].join(" ")} -c {filename} -o {filename}.o"
 	redef fun compiles_to_o_file do return true
 end
 

--- a/src/ffi/java.nit
+++ b/src/ffi/java.nit
@@ -367,8 +367,11 @@ end
 class JavaFile
 	super ExternFile
 
-	redef fun makefile_rule_name do return "{filename.basename(".java")}.class"
-	redef fun makefile_rule_content do return "javac {filename.basename} -d ."
+	# Full Java class name: package and class
+	fun full_name: String do return filename.basename(".java")
+
+	redef fun makefile_rule_name do return full_name.replace(".", "/") + ".class"
+	redef fun makefile_rule_content do return "javac {filename} -d ."
 	redef fun add_to_jar do return true
 end
 

--- a/src/ffi/java.nit
+++ b/src/ffi/java.nit
@@ -165,6 +165,9 @@ class JavaLanguage
 
 	redef fun compile_to_files(mmodule, compdir)
 	do
+		var ffi_ccu = ffi_ccu
+		assert ffi_ccu != null
+
 		# Make sure we have a .java file
 		mmodule.ensure_java_files
 
@@ -172,7 +175,7 @@ class JavaLanguage
 		mmodule.insert_compiler_options
 
 		# Enable linking C callbacks to java native methods
-		mmodule.ensure_linking_callback_methods(ffi_ccu.as(not null))
+		mmodule.ensure_linking_callback_methods(ffi_ccu)
 
 		# Java implementation code
 		var java_file = mmodule.java_file
@@ -343,7 +346,7 @@ class JavaClassTemplate
 	fun write_to_files(compdir: String): ExternFile
 	do
 		var filename = "{java_class_name}.java"
-		var filepath = "{compdir}/{filename}"
+		var filepath = compdir/filename
 
 		write_to_file filepath
 

--- a/src/ffi/java.nit
+++ b/src/ffi/java.nit
@@ -105,7 +105,7 @@ class JavaLanguage
 			jni_signature_alt = mclass_type.jni_signature_alt
 			return_type = mclass_type
 		else
-			params.add "self"
+			params.add to_java_call_context.cast_to(mclass_type, "self")
 			if signature.return_mtype != null then
 				var ret_mtype = signature.return_mtype
 				ret_mtype = ret_mtype.resolve_for(mclass_type, mclass_type, mmodule, true)
@@ -176,6 +176,64 @@ class JavaLanguage
 
 		# Enable linking C callbacks to java native methods
 		mmodule.ensure_linking_callback_methods(ffi_ccu)
+
+		# Function to build instances to the Java class NitObject
+		var callbacks = mmodule.callbacks_used_from_java.callbacks
+		if callbacks.not_empty then
+			var cf = new CFunction("jobject nit_ffi_with_java_new_nit_object(JNIEnv *env, void *data)")
+			cf.exprs.add """
+	// retrieve the current JVM
+	Sys sys = Pointer_sys(NULL);
+
+	jclass java_class = Sys_load_jclass(sys, "nit/app/NitObject");
+	if (java_class == NULL) {
+		PRINT_ERROR("Nit FFI with Java error: failed to load class NitObject.\\n");
+		(*env)->ExceptionDescribe(env);
+		exit(1);
+	}
+
+	jmethodID java_init = (*env)->GetMethodID(env, java_class, "<init>", "(J)V");
+	if (java_init == NULL) {
+		PRINT_ERROR("Nit FFI with Java error: NitObject constructor not found.\\n");
+		(*env)->ExceptionDescribe(env);
+		exit(1);
+	}
+
+	jobject nit_object = (*env)->NewObject(env, java_class, java_init, (jlong)data);
+	if (nit_object == NULL) {
+		PRINT_ERROR("Nit FFI with Java error: NitObject construction failed.\\n");
+		(*env)->ExceptionDescribe(env);
+		exit(1);
+	}
+
+	return nit_object;
+	"""
+			ffi_ccu.add_local_function cf
+
+			# Function to extract the pointer held by instances of the Java class NitObject
+			cf = new CFunction("void *nit_ffi_with_java_nit_object_data(JNIEnv *env, jobject nit_object)")
+			cf.exprs.add """
+	Sys sys = Pointer_sys(NULL);
+	jclass java_class = Sys_load_jclass(sys, "nit/app/NitObject");
+	if (java_class == NULL) {
+		PRINT_ERROR("Nit FFI with Java error: failed to load class NitObject.\\n");
+		(*env)->ExceptionDescribe(env);
+		exit(1);
+	}
+
+	jfieldID java_field = (*env)->GetFieldID(env, java_class, "pointer", "J");
+	if (java_field == NULL) {
+		PRINT_ERROR("Nit FFI with Java error: NitObject field not found.\\n");
+		(*env)->ExceptionDescribe(env);
+		exit(1);
+	}
+
+	jlong data = (*env)->GetLongField(env, nit_object, java_field);
+
+	return (void*)data;
+	"""
+			ffi_ccu.add_local_function cf
+		end
 
 		# Java implementation code
 		var java_file = mmodule.java_file
@@ -386,8 +444,24 @@ end
 private class ToJavaCallContext
 	super CallContext
 
-	redef fun cast_to(mtype, name) do return "({mtype.jni_type})({name})"
-	redef fun cast_from(mtype, name) do return "({mtype.cname})({name})"
+	redef fun cast_to(mtype, name)
+	do
+		if mtype.java_is_nit_object then
+			return "nit_ffi_with_java_new_nit_object(nit_ffi_jni_env, {name})"
+		else
+			return "({mtype.jni_type})({name})"
+		end
+	end
+
+	redef fun cast_from(mtype, name)
+	do
+		if mtype.java_is_nit_object then
+			return "({mtype.cname})nit_ffi_with_java_nit_object_data(nit_ffi_jni_env, {name})"
+		else
+			return "({mtype.cname})({name})"
+		end
+	end
+
 	redef fun name_mtype(mtype) do return mtype.jni_type
 end
 
@@ -395,8 +469,24 @@ end
 private class FromJavaCallContext
 	super CallContext
 
-	redef fun cast_to(mtype, name) do return "({mtype.cname})({name})"
-	redef fun cast_from(mtype, name) do return "({mtype.jni_type})({name})"
+	redef fun cast_to(mtype, name)
+	do
+		if mtype.java_is_nit_object then
+			return "({mtype.cname})nit_ffi_with_java_nit_object_data(nit_ffi_jni_env, {name})"
+		else
+			return "({mtype.cname})({name})"
+		end
+	end
+
+	redef fun cast_from(mtype, name)
+	do
+		if mtype.java_is_nit_object then
+			return "nit_ffi_with_java_new_nit_object(nit_ffi_jni_env, {name})"
+		else
+			return "({mtype.jni_type})({name})"
+		end
+	end
+
 	redef fun name_mtype(mtype) do return mtype.jni_type
 end
 
@@ -458,21 +548,23 @@ redef class MType
 	#
 	# * Primitives common to both languages use their Java primitive type
 	# * Nit extern Java classes are represented by their full Java type
-	# * Other Nit objects are represented by `int` in Java. It holds the
-	#	pointer to the underlying C structure.
-	#	TODO create static Java types to store and hide the pointer
-	private fun java_type: String do return "int"
+	# * Other Nit objects are represented by `NitObject` in Java, a class
+	#   encapsulating the pointer to the underlying C structure.
+	private fun java_type: String do return "nit.app.NitObject"
+
+	# Is this type opaque in Java? As so it is represented by `nit.app.NitObject`.
+	private fun java_is_nit_object: Bool do return true
 
 	# JNI type name (in C)
 	#
 	# So this is a C type, usually defined in `jni.h`
-	private fun jni_type: String do return "long"
+	private fun jni_type: String do return "jobject"
 
 	# JNI short type name (for signatures)
 	#
 	# Is used by `MMethod::build_jni_format` to pass a Java method signature
 	# to the JNI function `GetStaticMetodId`.
-	private fun jni_format: String do return "I"
+	private fun jni_format: String do return "Lnit/app/NitObject;"
 
 	# Type name appearing within JNI function names.
 	#
@@ -482,20 +574,22 @@ redef class MType
 
 	redef fun compile_callback_to_java(mmodule, mainmodule, ccu)
 	do
+		if self isa MClassType and mclass.ftype isa ForeignJavaType then return
+
 		var java_file = mmodule.java_file
-		if java_file == null then return
+		if java_file == null or mmodule.callbacks_used_from_java.callbacks.is_empty then return
 
 		for variation in ["incr", "decr"] do
 			var friendly_name = "{mangled_cname}_{variation}_ref"
 
 			# C
-			var csignature = "void {mmodule.impl_java_class_name}_{friendly_name}(JNIEnv *env, jclass clazz, jint object)"
+			var csignature = "void {mmodule.impl_java_class_name}_{friendly_name}(JNIEnv *nit_ffi_jni_env, jclass clazz, jobject object)"
 			var cf = new CFunction("JNIEXPORT {csignature}")
-			cf.exprs.add "\tnitni_global_ref_{variation}((void*)(long)object);"
+			cf.exprs.add "\tnitni_global_ref_{variation}(nit_ffi_with_java_nit_object_data(nit_ffi_jni_env, object));"
 			ccu.add_non_static_local_function cf
 
 			# Java
-			java_file.class_content.add "private native static void {friendly_name}(int object);\n"
+			java_file.class_content.add "private native static void {friendly_name}(nit.app.NitObject object);\n"
 		end
 	end
 
@@ -504,7 +598,7 @@ redef class MType
 		var arr = new Array[String]
 		for variation in ["incr", "decr"] do
 			var friendly_name = "{mangled_cname}_{variation}_ref"
-			var jni_format = "(I)V"
+			var jni_format = "(Lnit/app/NitObject;)V"
 			var cname = "{from_mmodule.impl_java_class_name}_{friendly_name}"
 			arr.add """{"{{{friendly_name}}}", "{{{jni_format}}}", {{{cname}}}}"""
 		end
@@ -530,6 +624,16 @@ redef class MClassType
 		if mclass.name == "Int32" then return "int"
 		if mclass.name == "UInt32" then return "int"
 		return super
+	end
+
+	redef fun java_is_nit_object
+	do
+		var ftype = mclass.ftype
+		if ftype isa ForeignJavaType then return false
+
+		var java_primitives = once new HashSet[String].from(
+			["Bool", "Char", "Int", "Float", "Byte", "Int8", "Int16", "UInt16", "Int32", "UInt32"])
+		return not java_primitives.has(mclass.name)
 	end
 
 	redef fun jni_type
@@ -631,6 +735,22 @@ redef class MClassType
 		if mclass.name == "UInt32" then return "Int"
 		return super
 	end
+
+	redef fun compile_callback_to_java(mmodule, mainmodule, ccu)
+	do
+		# Don't generate functions for reference counters on extern classes
+		if mclass.ftype != null then return
+
+		super
+	end
+
+	redef fun jni_methods_declaration(from_mmodule)
+	do
+		# Don't generate functions for reference counters on extern classes
+		if mclass.ftype != null then return new Array[String]
+
+		return super
+	end
 end
 
 redef class MMethod
@@ -696,8 +816,7 @@ redef class MMethod
 
 		var cparams = new List[String]
 
-		# This is different
-		cparams.add "JNIEnv *env"
+		cparams.add "JNIEnv *nit_ffi_jni_env"
 		cparams.add "jclass clazz"
 
 		if not self.is_init then

--- a/src/ffi/light_ffi.nit
+++ b/src/ffi/light_ffi.nit
@@ -57,7 +57,7 @@ redef class MModule
 
 		ffi_ccu.write_as_impl(self, compdir)
 		for filename in ffi_ccu.files do
-			var f = new ExternCFile(filename, cflags)
+			var f = new ExternCFile(filename.basename, cflags)
 			f.pkgconfigs.add_all pkgconfigs
 			ffi_files.add(f)
 		end

--- a/src/ffi/objc.nit
+++ b/src/ffi/objc.nit
@@ -156,7 +156,7 @@ private class ObjCCompilationUnit
 
 		mmodule.ldflags.add_one("", "-lobjc")
 
-		return new ExternObjCFile(compdir/c_file, mmodule)
+		return new ExternObjCFile(c_file, mmodule)
 	end
 end
 
@@ -169,7 +169,7 @@ class ExternObjCFile
 
 	redef fun makefile_rule_name do return "{filename.basename(".m")}_m.o"
 	redef fun makefile_rule_content do
-		return "clang $(CFLAGS) -c {filename.basename} -o {makefile_rule_name}"
+		return "clang $(CFLAGS) -c {filename} -o {makefile_rule_name}"
 	end
 	redef fun compiles_to_o_file do return true
 end

--- a/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
+++ b/src/interpreter/dynamic_loading_ffi/on_demand_compiler.nit
@@ -404,7 +404,7 @@ redef class ExternCFile
 		var cflags = mmodule.cflags[""].join(" ") + " " + pkg_cflags
 		var obj = compile_dir / filename.basename(".c") + ".o"
 
-		var cmd = "{v.c_compiler} -Wall -c -fPIC -I {compile_dir} -g -o {obj} {filename} {cflags}"
+		var cmd = "{v.c_compiler} -Wall -c -fPIC -I {compile_dir} -g -o {obj} {compile_dir / filename} {cflags}"
 		if sys.system(cmd) != 0 then
 			 v.fatal "FFI Error: Failed to compile C code using `{cmd}`"
 			 return false

--- a/src/platform/android.nit
+++ b/src/platform/android.nit
@@ -419,8 +419,10 @@ target_link_libraries(nit_app gc-lib
 		for mmodule in compiler.mainmodule.in_importation.greaters do
 			var extra_java_files = mmodule.extra_java_files
 			if extra_java_files != null then for file in extra_java_files do
-				var path = file.filename
-				path.file_copy_to(java_dir/path.basename)
+				var path = file.src_path
+				var dir = file.filename.dirname
+				(java_dir/dir).mkdir
+				path.file_copy_to(java_dir/file.filename)
 			end
 		end
 

--- a/tests/gitlab_ci.skip
+++ b/tests/gitlab_ci.skip
@@ -1,5 +1,4 @@
 emscripten
-java
 glsl
 mpi
 objc

--- a/tests/test_ffi_java_annot_files.nit
+++ b/tests/test_ffi_java_annot_files.nit
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 module test_ffi_java_annot_files is
-	extra_java_files("test_ffi_java_annot_files_a.java")
+	extra_java_files("test_ffi_java_annot_files_a")
 end
 
 import java


### PR DESCRIPTION
This PR improves the type safety of the Java FFI and fixes a bug with pointers to Nit objects at the same time.

* The main change is the introduction of the Java class `NitObject` used as a general type for Nit objects referenced from Java code. It replaces the use of a simple `int` holding the pointer value, which was the source of the Java FFI bug.

* Change internal pointers to Nit object to use the Java primitive types `long` instead of `int`, addressing to the same pointer bug. Only low-level services should still use `long` this way, in this case it is the support for Android that relies mostly on the FFI with C.

* Change the annotation `extra_java_files` to accept the full name of Java classes (package + class) instead of the path to the Java source file. The compile still looks for the file in the same directory as the Nit module.

* Clear up the documentation of the class `ExternFile` for `filename` to be relative to the compilation folder. This required updating previous usages.