### PR TITLE
ci: nitlang/nit-ci docker image runs in UTF8

### DIFF
--- a/misc/docker/ci/Dockerfile
+++ b/misc/docker/ci/Dockerfile
@@ -108,3 +108,6 @@ RUN pip3 install junit2html
 
 #  Prepare to install npm (npm is not packaged for debian:stretch)
 RUN npm install pug-cli -g
+
+# Some tools, like gradle, need an explitit UTF8 environement
+ENV LANG C.UTF-8


### PR DESCRIPTION
Or else gradle fails with an exception