### PR TITLE
CI: macOS jobs for Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,6 +124,7 @@ test_full_nitcs: &test_full_nitcs
   dependencies:
     - build_tools
   script:
+    - share/android-bdwgc/setup.sh
     - cd tests
     - ./testfull.sh | tee log.txt
     - grep -v '=>' log.txt > ../status.txt || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ sanity_checks:
     - misc/jenkins/checksignedoffby.sh | tee -a status.txt
     - misc/jenkins/checklicense.sh | tee -a status.txt
 
-build_tools:
+build_tools: &build_tools
   stage: build
   script:
     - make 2>> status.txt
@@ -65,7 +65,7 @@ build_tools:
       - src/nitc_0
     when: always
 
-test_some:
+test_some: &test_some
   stage: test
   dependencies:
     - build_tools
@@ -119,7 +119,7 @@ basic_android:
 
 # TEST FULL #########################################################
 
-test_full_nitcs:
+test_full_nitcs: &test_full_nitcs
   stage: more_test
   dependencies:
     - build_tools
@@ -356,11 +356,21 @@ build_catalog:
     paths:
       - catalog.out
 
-.test_macos:
-  script:
-    - uname
-    - pwd
-    - ls /
-  stage: build
+build_tools_macos:
+  <<: *build_tools
   tags:
     - macos
+
+test_some_macos:
+  <<: *test_some
+  tags:
+    - macos
+  dependencies:
+    - build_tools_macos
+
+test_full_nitcs_macos:
+  <<: *test_full_nitcs
+  tags:
+    - macos
+  dependencies:
+    - build_tools_macos

--- a/misc/jenkins/check_manpages.sh
+++ b/misc/jenkins/check_manpages.sh
@@ -59,7 +59,7 @@ for bin in bin/nit*; do
 		fi
 
 		# Test what is expected
-		if ! diff -q <(sed 's/\s*(.*)//' check_manpages-from_help.out) <(sed  's/\s*(.*)//' check_manpages-from_man.out) > /dev/null; then
+		if ! diff -q <(sed -E 's/\s*(.*)//' check_manpages-from_help.out) <(sed -E 's/\s*(.*)//' check_manpages-from_man.out) > /dev/null; then
 			echo "$opt: mismatch documentation in the manpage $man. Here the word diff:"
 			echo ""
 			wdiff check_manpages-from_help.out check_manpages-from_man.out | colordiff

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -37,9 +37,13 @@ if ! locale -a 2>/dev/null | grep -q C.UTF-8; then
 fi
 export LC_ALL="$locale_candidate"
 
+# Darwin / macOS
 if uname | grep Darwin 1>/dev/null 2>&1; then
 	export LANG=en_US.UTF-8
 	export LC_ALL=en_US.UTF-8
+
+	# Fix for errors on some libevent/nitcorn clients
+	export EVENT_NOKQUEUE=1
 fi
 
 export NIT_TESTING=true


### PR DESCRIPTION
Add 3 CI jobs for macOS, equivalent to `build_tools`, `test_some` and `test_full_nitcs`. They are executed by a shell executor on a macOS host, Nit Gitlab repos should have a such a runner with the tag `macos`. The new jobs are similar enough to the GNU/Linux versions that they can share the same script.

This PR also fixes 3 problems with macOS portability:

* Workaround for the error with kqueue on libevent and nitcorn clients.

* Set `sed -E` explicitly in `check_manpages.sh` for portability with macOS.

* Download bdwgc in the CI docker image, to prevent `test_full_nitcs_macos` to fail on `hello_ios` because it downloads bdwgc at compilation and prints to the test output. This will require regenerating the official Docker image.
