### PR TITLE
Follow the INI specification

### DIFF
--- a/contrib/nitiwiki/src/wiki_base.nit
+++ b/contrib/nitiwiki/src/wiki_base.nit
@@ -612,7 +612,13 @@ end
 #
 # This class provides services that ensure static typing when accessing the `config.ini` file.
 class WikiConfig
-	super ConfigTree
+	super IniFile
+	autoinit ini_file
+
+	# Path to this file
+	var ini_file: String
+
+	init do load_file(ini_file)
 
 	# Returns the config value at `key` or return `default` if no key was found.
 	protected fun value_or_default(key: String, default: String): String do
@@ -779,8 +785,8 @@ class WikiConfig
 	var sidebar_blocks: Array[String] is lazy do
 		var res = new Array[String]
 		if not has_key("wiki.sidebar.blocks") then return res
-		for val in at("wiki.sidebar.blocks").as(not null).values do
-			res.add val
+		for val in section("wiki.sidebar.blocks").as(not null).values do
+			res.add val.as(not null)
 		end
 		return res
 	end
@@ -834,7 +840,13 @@ end
 # Each section can provide its own config file to customize
 # appearance or behavior.
 class SectionConfig
-	super ConfigTree
+	super IniFile
+	autoinit ini_file
+
+	# Path to this file
+	var ini_file: String
+
+	init do load_file(ini_file)
 
 	# Returns the config value at `key` or `null` if no key was found.
 	private fun value_or_null(key: String): nullable String do

--- a/lib/config/config.nit
+++ b/lib/config/config.nit
@@ -299,7 +299,7 @@ class IniConfig
 	super Config
 
 	# Config tree used to store config options
-	var ini: ConfigTree is noinit
+	var ini: IniFile is noinit
 
 	# Path to app config file
 	var opt_config = new OptionString("Path to config file", "--config")
@@ -311,7 +311,7 @@ class IniConfig
 
 	redef fun parse_options(args) do
 		super
-		ini = new ConfigTree(config_file)
+		ini = new IniFile.from_file(config_file)
 	end
 
 	# Default config file path

--- a/lib/github/loader.nit
+++ b/lib/github/loader.nit
@@ -104,12 +104,18 @@ class LoaderConfig
 
 	# Github tokens used to access data.
 	var tokens: Array[String] is lazy do
-		var arr = opt_tokens.value
-		if arr.is_empty then
-			var iarr = ini.at("tokens")
-			if iarr != null then arr = iarr.values.to_a
+		var opt_tokens = self.opt_tokens.value
+		if opt_tokens.not_empty then return opt_tokens
+
+		var res = new Array[String]
+		var ini_tokens = ini.section("tokens")
+		if ini_tokens == null then return res
+
+		for token in ini_tokens.values do
+			if token == null then continue
+			res.add token
 		end
-		return arr or else new Array[String]
+		return res
 	end
 
 	# Github tokens wallet

--- a/lib/ini/README.md
+++ b/lib/ini/README.md
@@ -1,0 +1,316 @@
+# `ini` - Read and write INI configuration files
+
+[INI files](https://en.wikipedia.org/wiki/INI_file) are simple text files with
+a basic structure composed of sections, properties and values used to store
+configuration parameters.
+
+Here's an example from the `package.ini` of this package:
+
+~~~
+import ini
+
+var package_ini = """
+[package]
+name=ini
+desc=Read and write INI configuration files.
+[upstream]
+git=https://github.com/nitlang/nit.git
+git.directory=lib/ini/
+"""
+~~~
+
+## Basic usage
+
+`IniFile` is used to parse INI strings and access their content:
+
+~~~
+var ini = new IniFile.from_string(package_ini)
+assert ini["package.name"] == "ini"
+assert ini["upstream.git.directory"] == "lib/ini/"
+assert ini["unknown.unknown"] == null
+~~~
+
+`IniFile` can also load INI configuration from a file:
+
+~~~
+package_ini.write_to_file("my_package.ini")
+
+ini = new IniFile.from_file("my_package.ini")
+assert ini["package.name"] == "ini"
+assert ini["upstream.git.directory"] == "lib/ini/"
+
+"my_package.ini".to_path.delete
+~~~
+
+INI content can be added or edited through the `IniFile` API then written to
+a stream or a file.
+
+~~~
+ini["package.name"] = "new name"
+ini["upstream.git.directory"] = "/dev/null"
+ini["section.key"] = "value"
+
+var stream = new StringWriter
+ini.write_to(stream)
+
+assert stream.to_s == """
+[package]
+name=new name
+desc=Read and write INI configuration files.
+[upstream]
+git=https://github.com/nitlang/nit.git
+git.directory=/dev/null
+[section]
+key=value
+"""
+~~~
+
+## INI content
+
+### Properties
+
+Properties are the basic element of the INI format.
+Every property correspond to a *key* associated to a *value* thanks to the equal (`=`) sign.
+
+~~~
+ini = new IniFile.from_string("""
+key1=value1
+key2=value2
+""")
+assert ini["key1"] == "value1"
+assert ini["key2"] == "value2"
+assert ini.length == 2
+~~~
+
+Accessing an unknown property returns `null`:
+
+~~~
+assert ini["unknown"] == null
+~~~
+
+Properties can be iterated over:
+
+~~~
+var i = 1
+for key, value in ini do
+	assert key == "key{i}"
+	assert value == "value{i}"
+	i += 1
+end
+~~~
+
+Property keys cannot contain the character `=`.
+Values can contain any character.
+Spaces are trimmed.
+
+~~~
+ini = new IniFile.from_string("""
+prop=erty1=value1
+ property2 =  value2
+property3=value3 ; with semicolon
+""")
+assert ini[";property1"] == null
+assert ini["prop=erty1"] == null
+assert ini["prop"] == "erty1=value1"
+assert ini["property2"] == "value2"
+assert ini[" property2 "] == "value2"
+assert ini["property3"] == "value3 ; with semicolon"
+~~~
+
+Both keys and values are case sensitive.
+
+~~~
+ini = new IniFile.from_string("""
+Property1=value1
+property2=Value2
+""")
+assert ini["property1"] == null
+assert ini["Property1"] == "value1"
+assert ini["property2"] != "value2"
+assert ini["property2"] == "Value2"
+~~~
+
+### Sections
+
+Properties may be grouped into arbitrary sections.
+The section name appears on a line by itself between square brackets (`[` and `]`).
+
+All keys after the section declaration are associated with that section.
+The is no explicit "end of section" delimiter; sections end at the next section
+declaration or the end of the file.
+Sections cannot be nested.
+
+~~~
+var content = """
+key1=value1
+key2=value2
+[section1]
+key1=value3
+key2=value4
+[section2]
+key1=value5
+"""
+
+ini = new IniFile.from_string(content)
+assert ini["key1"] == "value1"
+assert ini["unknown"] == null
+assert ini["section1.key1"] == "value3"
+assert ini["section1.unknown"] == null
+assert ini["section2.key1"] == "value5"
+~~~
+
+Sections can be iterated over:
+
+~~~
+i = 1
+for section in ini.sections do
+	assert section.name == "section{i}"
+	assert section["key1"].has_prefix("value")
+	i += 1
+end
+~~~
+
+When iterating over a file properties, only properties at root are returned.
+`flatten` can be used to iterate over all properties including the one from
+sections.
+
+~~~
+assert ini.join(", ", ": ") == "key1: value1, key2: value2"
+assert ini.flatten.join(", ", ": ") ==
+	"key1: value1, key2: value2, section1.key1: value3, section1.key2: value4, section2.key1: value5"
+
+i = 0
+for key, value in ini do
+	i += 1
+	assert key == "key{i}" and value == "value{i}"
+end
+assert i == 2
+
+~~~
+
+Sections name may contain any character including brackets (`[` and `]`).
+Spaces are trimmed.
+
+~~~
+ini = new IniFile.from_string("""
+[[section1]]
+key=value1
+[ section 2 ]
+key=value2
+[section1.section3]
+key=value3
+""")
+assert ini.sections.length == 3
+assert ini["[section1].key"] == "value1"
+assert ini["section 2.key"] == "value2"
+assert ini["section1.section3.key"] == "value3"
+assert ini.sections.last.name == "section1.section3"
+~~~
+
+The dot `.` notation is used to create new sections with `[]=`.
+Unknown sections will be created on the fly.
+
+~~~
+ini = new IniFile
+ini["key"] = "value1"
+ini["section1.key"] = "value2"
+ini["section2.key"] = "value3"
+
+stream = new StringWriter
+ini.write_to(stream)
+assert stream.to_s == """
+key=value1
+[section1]
+key=value2
+[section2]
+key=value3
+"""
+~~~
+
+Sections can also be created manually:
+
+~~~
+ini = new IniFile
+ini["key"] = "value1"
+
+var section = new IniSection("section1")
+section["key"] = "value2"
+ini.sections.add section
+
+stream = new StringWriter
+ini.write_to(stream)
+assert stream.to_s == """
+key=value1
+[section1]
+key=value2
+"""
+~~~
+
+### Comments
+
+Comments are indicated by semicolon (`;`) or a number sign (`#`) at the begining
+of the line. Commented lines are ignored as well as empty lines.
+
+~~~
+ini = new IniFile.from_string("""
+; This is a comment.
+; property1=value1
+
+# This is another comment.
+# property2=value2
+""")
+assert ini.is_empty
+~~~
+
+### Unicode support
+
+INI files support Unicode:
+
+~~~
+ini = new IniFile.from_string("""
+property❤=héhé
+""")
+assert ini["property❤"] == "héhé"
+~~~
+
+## Error handling
+
+By default `IniFile` does not stop when it cannot parse a line in a string (loaded
+by `from_string` or `load_string`) or a file (loaded by `from_file` or `load_file`).
+
+~~~
+ini = new IniFile.from_string("""
+key1=value1
+key2
+key3=value3
+""")
+
+assert ini.length == 2
+assert ini["key1"] == "value1"
+assert ini["key2"] == null
+assert ini["key3"] == "value3"
+~~~
+
+
+This behaviour can be modified by setting `stop_on_first_error` to `true`.
+
+~~~
+ini = new IniFile.from_string("""
+key1=value1
+key2
+key3=value3
+""", stop_on_first_error = true)
+
+assert ini.length == 1
+assert ini["key1"] == "value1"
+assert ini["key2"] == null
+assert ini["key3"] == null
+~~~
+
+Wathever the value set for `stop_on_first_error`, errors can be checked thanks
+to the `errors` array:
+
+~~~
+assert ini.errors.length == 1
+assert ini.errors.first.message == "Unexpected string `key2` at line 2."
+~~~

--- a/lib/ini/package.ini
+++ b/lib/ini/package.ini
@@ -3,7 +3,7 @@ name=ini
 tags=format,lib
 maintainer=Alexandre Terrasa <alexandre@moz-code.org>
 license=Apache-2.0
-desc=Handle ini config files
+desc=Read and write INI configuration files
 [upstream]
 browse=https://github.com/nitlang/nit/tree/master/lib/ini/
 git=https://github.com/nitlang/nit.git

--- a/src/doc/commands/commands_ini.nit
+++ b/src/doc/commands/commands_ini.nit
@@ -21,7 +21,7 @@ abstract class CmdIni
 	super CmdEntity
 
 	# Ini file
-	var ini: nullable ConfigTree = null
+	var ini: nullable IniFile = null
 
 	redef fun init_command do
 		var res = super

--- a/src/loader.nit
+++ b/src/loader.nit
@@ -477,7 +477,7 @@ redef class ModelBuilder
 			# Attach homonymous `ini` file to the package
 			var inipath = path.dirname / "{pn}.ini"
 			if inipath.file_exists then
-				var ini = new ConfigTree(inipath)
+				var ini = new IniFile.from_file(inipath)
 				mpackage.ini = ini
 			end
 		end
@@ -543,7 +543,7 @@ redef class ModelBuilder
 		var parent = null
 		var inipath = dirpath / "package.ini"
 		if inipath.file_exists then
-			ini = new ConfigTree(inipath)
+			ini = new IniFile.from_file(inipath)
 		end
 
 		if ini == null then
@@ -1178,7 +1178,7 @@ redef class MPackage
 	# The `ini` file is given as is and might contain invalid or missing information.
 	#
 	# Some packages, like stand-alone packages or virtual packages have no `ini` file associated.
-	var ini: nullable ConfigTree = null
+	var ini: nullable IniFile = null
 
 	# Array of relative source paths excluded according to the `source.exclude` key of the `ini`
 	var excludes: nullable Array[String] is lazy do

--- a/src/nitpackage.nit
+++ b/src/nitpackage.nit
@@ -253,14 +253,14 @@ redef class MPackage
 		var ini_path = ini_path
 		if ini_path == null then return
 
-		var ini = new ConfigTree(ini_path)
+		var ini = new IniFile.from_file(ini_path)
 
-		ini.check_key(toolcontext, self, "package.name", name)
-		ini.check_key(toolcontext, self, "package.desc")
-		ini.check_key(toolcontext, self, "package.tags")
+		ini.check_key(ini_path, toolcontext, self, "package.name", name)
+		ini.check_key(ini_path, toolcontext, self, "package.desc")
+		ini.check_key(ini_path, toolcontext, self, "package.tags")
 
 		# FIXME since `git reflog --follow` seems bugged
-		ini.check_key(toolcontext, self, "package.maintainer")
+		ini.check_key(ini_path, toolcontext, self, "package.maintainer")
 		# var maint = mpackage.maintainer
 		# if maint != null then
 			# ini.check_key(toolcontext, self, "package.maintainer", maint)
@@ -272,24 +272,24 @@ redef class MPackage
 			# ini.check_key(toolcontext, self, "package.more_contributors", contribs.join(", "))
 		# end
 
-		ini.check_key(toolcontext, self, "package.license", license)
-		ini.check_key(toolcontext, self, "upstream.browse", browse_url)
-		ini.check_key(toolcontext, self, "upstream.git", git_url)
-		ini.check_key(toolcontext, self, "upstream.git.directory", git_dir)
-		ini.check_key(toolcontext, self, "upstream.homepage", homepage_url)
-		ini.check_key(toolcontext, self, "upstream.issues", issues_url)
+		ini.check_key(ini_path, toolcontext, self, "package.license", license)
+		ini.check_key(ini_path, toolcontext, self, "upstream.browse", browse_url)
+		ini.check_key(ini_path, toolcontext, self, "upstream.git", git_url)
+		ini.check_key(ini_path, toolcontext, self, "upstream.git.directory", git_dir)
+		ini.check_key(ini_path, toolcontext, self, "upstream.homepage", homepage_url)
+		ini.check_key(ini_path, toolcontext, self, "upstream.issues", issues_url)
 
-		for key in ini.to_map.keys do
+		for key in ini.flatten.keys do
 			if not allowed_ini_keys.has(key) then
 				toolcontext.warning(location, "unknown-ini-key",
-					"Warning: ignoring unknown `{key}` key in `{ini.ini_file}`")
+					"Warning: ignoring unknown `{key}` key in `{ini_path}`")
 			end
 		end
 	end
 
 	private fun gen_ini: String do
 		var ini_path = self.ini_path.as(not null)
-		var ini = new ConfigTree(ini_path)
+		var ini = new IniFile.from_file(ini_path)
 
 		ini.update_value("package.name", name)
 		ini.update_value("package.desc", "")
@@ -304,7 +304,7 @@ redef class MPackage
 		ini.update_value("upstream.homepage", homepage_url)
 		ini.update_value("upstream.issues", issues_url)
 
-		ini.save
+		ini.write_to_file(ini_path)
 		return ini_path
 	end
 
@@ -528,8 +528,8 @@ redef class MModule
 	end
 end
 
-redef class ConfigTree
-	private fun check_key(toolcontext: ToolContext, mpackage: MPackage, key: String, value: nullable String) do
+redef class IniFile
+	private fun check_key(ini_file: String, toolcontext: ToolContext, mpackage: MPackage, key: String, value: nullable String) do
 		if not has_key(key) then
 			toolcontext.warning(mpackage.location, "missing-ini-key",
 				"Warning: missing `{key}` key in `{ini_file}`")

--- a/src/nitpm.nit
+++ b/src/nitpm.nit
@@ -78,7 +78,7 @@ class CommandInstall
 				exit 1
 			end
 
-			var ini = new ConfigTree(ini_path)
+			var ini = new IniFile.from_file(ini_path)
 			var import_line = ini["package.import"]
 			if import_line == null then
 				print_error "The local `package.ini` declares no external dependencies."
@@ -135,7 +135,7 @@ class CommandInstall
 				print ini_path.to_path.read_all
 			end
 
-			var ini = new ConfigTree(ini_path)
+			var ini = new IniFile.from_file(ini_path)
 			var git_repo = ini["upstream.git"]
 			if git_repo == null then
 				print_error "Package description invalid, or it does not declare a Git repository"
@@ -195,7 +195,7 @@ class CommandInstall
 		end
 
 		# Recursive install
-		var ini = new ConfigTree(target_dir/"package.ini")
+		var ini = new IniFile.from_file(target_dir/"package.ini")
 		var import_line = ini["package.import"]
 		if import_line != null then
 			install_packages import_line
@@ -320,7 +320,7 @@ class CommandList
 		for file in files do
 			var ini_path = nitpm_lib_dir / file / "package.ini"
 			if verbose then print "- Reading ini file at {ini_path}"
-			var ini = new ConfigTree(ini_path)
+			var ini = new IniFile.from_file(ini_path)
 			var tags = ini["package.tags"]
 
 			name_to_desc[file] = tags


### PR DESCRIPTION
This version follows more closely the INI specification (https://en.wikipedia.org/wiki/INI_file) and adds some improvements to the API.

Spec changes:
* Allow `#` and `;` for comments
* No more sections nesting as by the spec (which actually change nothing see below)

API changes:
* Renaming `ConfigTree` -> `IniFile` (as it's no more a "tree")
* No more coupling with a file path, use utility methods `load_string`, `load_file`, `write_to`  instead
* Ability to iterate keys, values, sections and section content
* Ability to create `IniSection` by hand
* `IniFile` and `IniSection` implements `Map[String, nullable String]`

The biggest change is that sub-sections are now flattened.

Before, with the following ini:

~~~ini
[section1]
key1=value1
[section1.section2]
key2=value2
~~~

You would get this hierarchy:

~~~
section1
  |   key1=value1
  `- section2
      `-  key2=value2
~~~

Now you get:

~~~
section1
  `- key1=value1
section1.section2
  `-  key2=value2
~~~

Two independent (unnested) sections, one called `section1` and the other called `section1.section2`.
This actually change nothing if the client was using the `[]` operator with the `.` notation as:

~~~
ini["section1.section2.key2"] # still returns `value2`
~~~

Documentation and specification from the README:

# `ini` - Read and write INI configuration files

[INI files](https://en.wikipedia.org/wiki/INI_file) are simple text files with
a basic structure composed of sections, properties and values used to store
configuration parameters.

Here's an example from the `package.ini` of this package:

~~~nit
import ini

var package_ini = """
[package]
name=ini
desc=Read and write INI configuration files.
[upstream]
git=https://github.com/nitlang/nit.git
git.directory=lib/ini/
"""
~~~

## Basic usage

`IniFile` is used to parse INI strings and access their content:

~~~nit
var ini = new IniFile.from_string(package_ini)
assert ini["package.name"] == "ini"
assert ini["upstream.git.directory"] == "lib/ini/"
assert ini["unknown.unknown"] == null
~~~

`IniFile` can also load INI configuration from a file:

~~~nit
package_ini.write_to_file("my_package.ini")

ini = new IniFile.from_file("my_package.ini")
assert ini["package.name"] == "ini"
assert ini["upstream.git.directory"] == "lib/ini/"

"my_package.ini".to_path.delete
~~~

INI content can be added or edited through the `IniFile` API then written to
a stream or a file.

~~~nit
ini["package.name"] = "new name"
ini["upstream.git.directory"] = "/dev/null"
ini["section.key"] = "value"

var stream = new StringWriter
ini.write_to(stream)

assert stream.to_s == """
[package]
name=new name
desc=Read and write INI configuration files.
[upstream]
git=https://github.com/nitlang/nit.git
git.directory=/dev/null
[section]
key=value
"""
~~~

## INI content

### Properties

Properties are the basic element of the INI format.
Every property correspond to a *key* associated to a *value* thanks to the equal (`=`) sign.

~~~nit
ini = new IniFile.from_string("""
key1=value1
key2=value2
""")
assert ini["key1"] == "value1"
assert ini["key2"] == "value2"
assert ini.length == 2
~~~

Accessing an unknown property returns `null`:

~~~nit
assert ini["unknown"] == null
~~~

Properties can be iterated over:

~~~nit
var i = 1
for key, value in ini do
	assert key == "key{i}"
	assert value == "value{i}"
	i += 1
end
~~~

Property keys cannot contain the character `=`.
Values can contain any character.
Spaces are trimmed.

~~~nit
ini = new IniFile.from_string("""
prop=erty1=value1
 property2 =  value2
property3=value3 ; with semicolon
""")
assert ini[";property1"] == null
assert ini["prop=erty1"] == null
assert ini["prop"] == "erty1=value1"
assert ini["property2"] == "value2"
assert ini[" property2 "] == "value2"
assert ini["property3"] == "value3 ; with semicolon"
~~~

Both keys and values are case sensitive.

~~~nit
ini = new IniFile.from_string("""
Property1=value1
property2=Value2
""")
assert ini["property1"] == null
assert ini["Property1"] == "value1"
assert ini["property2"] != "value2"
assert ini["property2"] == "Value2"
~~~

### Sections

Properties may be grouped into arbitrary sections.
The section name appears on a line by itself between square brackets (`[` and `]`).

All keys after the section declaration are associated with that section.
The is no explicit "end of section" delimiter; sections end at the next section
declaration or the end of the file.
Sections cannot be nested.

~~~nit
var content = """
key1=value1
key2=value2
[section1]
key1=value3
key2=value4
[section2]
key1=value5
"""

ini = new IniFile.from_string(content)
assert ini["key1"] == "value1"
assert ini["unknown"] == null
assert ini["section1.key1"] == "value3"
assert ini["section1.unknown"] == null
assert ini["section2.key1"] == "value5"
~~~

Sections can be iterated over:

~~~nit
i = 1
for section in ini.sections do
	assert section.name == "section{i}"
	assert section["key1"].has_prefix("value")
	i += 1
end
~~~

When iterating over a file properties, only properties at root are returned.
`flatten` can be used to iterate over all properties including the one from
sections.

~~~nit
assert ini.join(", ", ": ") == "key1: value1, key2: value2"
assert ini.flatten.join(", ", ": ") ==
	"key1: value1, key2: value2, section1.key1: value3, section1.key2: value4, section2.key1: value5"

i = 0
for key, value in ini do
	i += 1
	assert key == "key{i}" and value == "value{i}"
end
assert i == 2

~~~

Sections name may contain any character including brackets (`[` and `]`).
Spaces are trimmed.

~~~nit
ini = new IniFile.from_string("""
[[section1]]
key=value1
[ section 2 ]
key=value2
[section1.section3]
key=value3
""")
assert ini.sections.length == 3
assert ini["[section1].key"] == "value1"
assert ini["section 2.key"] == "value2"
assert ini["section1.section3.key"] == "value3"
assert ini.sections.last.name == "section1.section3"
~~~

The dot `.` notation is used to create new sections with `[]=`.
Unknown sections will be created on the fly.

~~~nit
ini = new IniFile
ini["key"] = "value1"
ini["section1.key"] = "value2"
ini["section2.key"] = "value3"

stream = new StringWriter
ini.write_to(stream)
assert stream.to_s == """
key=value1
[section1]
key=value2
[section2]
key=value3
"""
~~~

Sections can also be created manually:

~~~nit
ini = new IniFile
ini["key"] = "value1"

var section = new IniSection("section1")
section["key"] = "value2"
ini.sections.add section

stream = new StringWriter
ini.write_to(stream)
assert stream.to_s == """
key=value1
[section1]
key=value2
"""
~~~

### Comments

Comments are indicated by semicolon (`;`) or a number sign (`#`) at the begining
of the line. Commented lines are ignored as well as empty lines.

~~~nit
ini = new IniFile.from_string("""
; This is a comment.
; property1=value1

# This is another comment.
# property2=value2
""")
assert ini.is_empty
~~~

### Unicode support

INI files support Unicode:

~~~nit
ini = new IniFile.from_string("""
property❤=héhé
""")
assert ini["property❤"] == "héhé"
~~~