### PR TITLE
Update basic requirements and document them

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ after_script:
   - export CCACHE_DIR=$PWD/.ccache
   - ccache -s
   - du -sh .gradle || true
-  - git status --ignored
+  - git status --ignored || true
   - date
   - tail status.txt
 
@@ -289,6 +289,22 @@ build_oot:
     # Errors are somewhat expected
 
 # MISC ##############################################################
+
+check_requirments:
+  stage: more_test
+  image: debian:buster
+  before_script:
+    - date # cancel the default `before_script`, an empty list does nothing
+  script: # from the README
+    - apt-get update && apt-get install --yes --no-install-recommends build-essential ccache libgc-dev libunwind-dev pkg-config
+    - make
+    - bin/nitc examples/hello_world.nit
+    - ./hello_world
+    - . misc/nit_env.sh install
+    - nitc examples/hello_world.nit
+    - ./hello_world
+    - apt-get update && apt-get install --yes --no-install-recommends graphviz libcurl4-openssl-dev libevent-dev libmongoc-dev
+    - make more
 
 bootstrap_full:
   stage: more_test

--- a/README.md
+++ b/README.md
@@ -19,20 +19,19 @@ Requirements:
  * pkg-config	http://www.freedesktop.org/wiki/Software/pkg-config/
  * ccache	http://ccache.samba.org/	to improve recompilation
  * libgc-dev	http://hboehm.info/gc/
- * graphviz	http://www.graphviz.org/	to enable graphs with the nitdoc tool
  * libunwind	http://nongnu.org/libunwind
 
 Those are available in most Linux distributions
 
-    $ sudo apt-get install build-essential ccache libgc-dev graphviz libunwind-dev pkg-config
+    $ sudo apt-get install build-essential ccache libgc-dev libunwind-dev pkg-config
 
 and on OS X using brew
 
-    $ brew install ccache bdw-gc graphviz libunwind-headers pkgconfig
+    $ brew install ccache bdw-gc libunwind-headers pkgconfig
 
 or with MacPorts
 
-    $ sudo port install ccache boehmgc graphviz libunwind-headers pkgconfig
+    $ sudo port install ccache boehmgc libunwind-headers pkgconfig
 
 Important files and directories:
 
@@ -64,6 +63,20 @@ You can source `misc/nit_env.sh` to setup your environment like PATH, MANPATH an
 To have your environment automatically configured at login, just source it with `install` as argument.
 
     $ . misc/nit_env.sh install
+
+
+More tools:
+
+Additional tools can also be compiled but require more dependencies.
+
+ * graphviz	http://www.graphviz.org/	to enable graphs with the nitdoc tool
+ * libcurl      https://curl.haxx.se/libcurl/   for the nit package manager nitpm
+ * libevent	https://libevent.org/           for the nit documentation server nitweb
+ * libmongoc    http://mongoc.org/              also for nitweb
+
+    $ sudo apt-get install graphviz libcurl4-openssl-dev libevent-dev libmongoc-dev
+    $ make more
+
 
 Contributing:
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,10 +16,10 @@
 
 NITCOPT=--semi-global
 OLDNITCOPT=--semi-global
-OBJS=nitc nitpick nit nitls nitunit nitpm nitx nitlight nitserial nitrestful nitpackage
+OBJS=nitc nitpick nit nitls nitunit nitx nitlight nitserial nitrestful nitpackage
 SRCS=$(patsubst %,%.nit,$(OBJS))
 BINS=$(patsubst %,../bin/%,$(OBJS))
-MOREOBJS=nitdoc nitweb nitcatalog nitmetrics nitpretty nitweb
+MOREOBJS=nitdoc nitweb nitcatalog nitmetrics nitpretty nitweb nitpm
 MORESRCS=$(patsubst %,%.nit,$(MOREOBJS))
 MOREBINS=$(patsubst %,../bin/%,$(MOREOBJS))
 DEPS=$(wildcard *.nit */*.nit) parser/parser.nit


### PR DESCRIPTION
Since #2615 we broke the initial build according to the documentation since nitpm (picnit) requires libcurl.

To minimize the number of doc to update I just moved `nitpm` to the "more" set of tools and documented their requirements.
I also added a CI job to avoid future failures (note: I'm not sure how to adapt it on other docker-less platforms).