### PR TITLE
Introduce `test_frontend`

### DIFF
--- a/src/doc/commands/tests/test_commands.nit
+++ b/src/doc/commands/tests/test_commands.nit
@@ -16,50 +16,9 @@
 module test_commands
 
 import commands_base
-import frontend
-import frontend::parse_examples
+import test_frontend
 
 # Nitunit test suite specific to commands
 class TestCommands
-
-	# The path to the testunit being executed
-	#
-	# Used to retrieve the path to sources to compile.
-	var test_path: String = "NIT_TESTING_PATH".environ.dirname is lazy
-
-	# Test program to compile
-	#
-	# Default is `$NIT_DIR/tests/test_prog`.
-	var test_src: String = test_path / "../../../../tests/test_prog" is lazy
-
-	# Model used for tests
-	var test_model: Model is noinit
-
-	# ModelBuilder used for tests
-	var test_builder: ModelBuilder is noinit
-
-	# Mainmodule used for tests
-	var test_main: MModule is noinit
-
-	# Initialize test variables
-	#
-	# Must be called before test execution.
-	# FIXME should be before_all
-	fun build_test_env is before do
-		var toolcontext = new ToolContext
-
-		# build model
-		var model = new Model
-		var modelbuilder = new ModelBuilder(model, toolcontext)
-		var mmodules = modelbuilder.parse_full([test_src])
-
-		# process
-		modelbuilder.run_phases
-		toolcontext.run_global_phases(mmodules)
-		var mainmodule = toolcontext.make_main_module(mmodules)
-
-		test_main = mainmodule
-		test_model = model
-		test_builder = modelbuilder
-	end
+	super TestModel
 end

--- a/src/doc/templates/tests/test_json_model.nit
+++ b/src/doc/templates/tests/test_json_model.nit
@@ -15,46 +15,30 @@
 module test_json_model is test
 
 import json_model
-import frontend
+import test_frontend
 
 class TestModelSerialization
+	super TestModel
 	test
-
-	var suite_path: String = "NIT_TESTING_PATH".environ
-	var lib_path: String = "{suite_path.dirname}/../../../../tests/test_prog"
-
-	var mainmodule: MModule is noinit
-
-	private var model: Model do
-		var toolcontext = new ToolContext
-		var model = new Model
-		var mbuilder = new ModelBuilder(model, toolcontext)
-		var mmodules = mbuilder.parse_full([lib_path])
-		if mmodules.is_empty then return model
-		mbuilder.run_phases
-		toolcontext.run_global_phases(mmodules)
-		mainmodule = mmodules.first
-		return model
-	end
 
 	fun test_refs_to_full_json is test do
 		var mentities = new Array[MEntity]
-		mentities.add model.mpackages.first
-		mentities.add model.mmodules.first
-		mentities.add model.mclasses.first
+		mentities.add test_model.mpackages.first
+		mentities.add test_model.mmodules.first
+		mentities.add test_model.mclasses.first
 		for mentity in mentities do
 			print ((new MEntityRef(mentity)).serialize_to_json(pretty = true, plain = true))
 		end
 	end
 
 	fun test_packages_to_full_json is test do
-		for mentity in model.mpackages do
+		for mentity in test_model.mpackages do
 			print mentity.serialize_to_json(pretty = true, plain = true)
 		end
 	end
 
 	fun test_groups_to_full_json is test do
-		for mpackage in model.mpackages do
+		for mpackage in test_model.mpackages do
 			for mentity in mpackage.mgroups do
 				print mentity.serialize_to_json(pretty = true, plain = true)
 			end
@@ -62,19 +46,19 @@ class TestModelSerialization
 	end
 
 	fun test_modules_to_full_json is test do
-		for mentity in model.mmodules do
+		for mentity in test_model.mmodules do
 			print mentity.serialize_to_json(pretty = true, plain = true)
 		end
 	end
 
 	fun test_classes_to_full_json is test do
-		for mentity in model.mclasses do
+		for mentity in test_model.mclasses do
 			print mentity.serialize_to_json(pretty = true, plain = true)
 		end
 	end
 
 	fun test_classdefs_to_full_json is test do
-		for mclass in model.mclasses do
+		for mclass in test_model.mclasses do
 			for mentity in mclass.mclassdefs do
 				print mentity.serialize_to_json(pretty = true, plain = true)
 			end
@@ -82,13 +66,13 @@ class TestModelSerialization
 	end
 
 	fun test_props_to_full_json is test do
-		for mentity in model.mproperties do
+		for mentity in test_model.mproperties do
 			print mentity.serialize_to_json(pretty = true, plain = true)
 		end
 	end
 
 	fun test_propdefs_to_full_json is test do
-		for mprop in model.mproperties do
+		for mprop in test_model.mproperties do
 			for mentity in mprop.mpropdefs do
 				print mentity.serialize_to_json(pretty = true, plain = true)
 			end

--- a/src/doc/templates/tests/test_json_model.sav/test_modules_to_full_json.res
+++ b/src/doc/templates/tests/test_json_model.sav/test_modules_to_full_json.res
@@ -174,3 +174,13 @@
 	"visibility": "public",
 	"modifiers": ["module"]
 }
+{
+	"name": "test_prog-m",
+	"namespace": [{
+		"name": "test_prog-m"
+	}],
+	"class_name": "MModule",
+	"full_name": "test_prog-m",
+	"visibility": "public",
+	"modifiers": ["module"]
+}

--- a/src/frontend/test_frontend.nit
+++ b/src/frontend/test_frontend.nit
@@ -1,0 +1,76 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Testing Model with `nitunit`
+#
+# This module introduce useful tools if you want to test Model with nitunit.
+# It provides an abstract test suite `TestModel` that can load a `Model` from
+# Nit files.
+#
+# See `TestModel::test_src`.
+module test_frontend is test
+
+import frontend
+import frontend::parse_examples
+
+# An abstract NitUnit that loads a `Model` from Nit files.
+#
+# To define a custom test using `TestModel`:
+#
+# ~~~
+# class MyTest
+#	super TestModel
+#	test
+#
+#	redef var test_src = "path/to/files"
+#
+#	fun my_test is test do
+#		assert test_model.mmodules.length == 10
+#	end
+# end
+# ~~~
+abstract class TestModel
+
+	# Path this unit test is executed in
+	var test_path: String = "NIT_TESTING_PATH".environ.dirname is lazy
+
+	# Test program to compile
+	#
+	# Change this source in your test suite.
+	# Default is `$NIT_DIR/tests/test_prog`.
+	#
+	# You can use either a file or a directory.
+	var test_src: String = "NIT_DIR".environ / "tests/test_prog" is lazy
+
+	# ToolContext used for the ModelBuilder
+	var test_context = new ToolContext
+
+	# Model used for tests
+	var test_model = new Model
+
+	# ModelBuilder used for tests
+	var test_builder = new ModelBuilder(test_model, test_context)
+
+	# Mainmodule used for tests
+	var test_main: MModule is noinit
+
+	# Build the test environment
+	fun build_test_env is before do
+		var mmodules = test_builder.parse_full([test_src])
+		test_builder.run_phases
+		test_context.run_global_phases(mmodules)
+		var mainmodule = test_context.make_main_module(mmodules)
+		test_main = mainmodule
+	end
+end

--- a/src/indexing/tests/test_code_index.nit
+++ b/src/indexing/tests/test_code_index.nit
@@ -15,37 +15,21 @@
 module test_code_index is test
 
 import code_index
-import frontend
+import test_frontend
 
 class TestCodeIndex
+	super TestModel
 	test
 
 	# CodeIndex used in tests
-	var test_index: CodeIndex is noinit
+	var test_index = new CodeIndex(test_context)
 
-	# Initialize test variables
-	#
-	# Must be called before test execution.
-	# FIXME should be before_all
-	fun build_test_env is before do
-		var test_path = "NIT_TESTING_PATH".environ.dirname
-		var test_src = test_path / "../../../tests/test_prog"
-
-		# build model
-		var toolcontext = new ToolContext
-		var model = new Model
-		var modelbuilder = new ModelBuilder(model, toolcontext)
-		var mmodules = modelbuilder.parse_full([test_src])
-		modelbuilder.run_phases
-		toolcontext.run_global_phases(mmodules)
-
-		# create index
-		var index = new CodeIndex(toolcontext)
-		for mmodule in mmodules do
-			index.index_mentity(mmodule)
+	redef fun build_test_env do
+		super
+		for mmodule in test_model.mmodules do
+			test_index.index_mentity(mmodule)
 		end
-		test_index = index
-		modelbuilder.paths.add test_src
+		test_builder.paths.add test_src
 	end
 
 	fun test_find1 is test do


### PR DESCRIPTION
Sometimes we need to test things related to a model and it's not easy to do this with NitUnit since creating
a model by hand is tedious.

With the `TestModel` abstract suite it's easier:

```nit
module my_test is test

import test_frontend

class MyTest
   super TestModel
   test
   
   redef var test_src = "path/to/files"

   fun my_test is test do
       assert test_model.mmodules.length == 1
   end
end
```