### PR TITLE
fix ci nitunit some

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,7 @@ before_script:
   - git config --add github.oauthtoken "$GITHUB_OAUTHTOKEN" # needed for github api rate limit
   - pwd
   - ccache -s
+  - ccache -z
   - ccache -M 500M
   - du -sh .gradle || true
   - type -a nitc nitdoc || true # is there some nit tools?

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,6 +90,7 @@ nitunit_some:
   script:
     - git diff --name-only origin/master..HEAD -- "*.nit" "*.res" "README.*" | grep -v "^tests/" > list0.txt || true
     - xargs nitls -pP < list0.txt > list.txt
+    - test -s list.txt || exit 0
     - xargs nitunit < list.txt
     - junit2html nitunit.xml
   artifacts:


### PR DESCRIPTION
When there is no change in watched nit files, the job `nitunit_some` failed.