### PR TITLE
fix nitcc assert failure and nitcc continuous integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,7 +88,7 @@ nitunit_some:
   dependencies:
     - build_tools
   script:
-    - git diff --name-only origin/master..HEAD -- "*.nit" "*.res" "README.*" | grep -v "^tests/" > list0.txt || true
+    - git diff --name-only origin/master..HEAD -- "*.nit" "*.res" "README.*" | grep -v "^tests/\|contrib/" > list0.txt || true
     - xargs nitls -pP < list0.txt > list.txt
     - test -s list.txt || exit 0
     - xargs nitunit < list.txt

--- a/contrib/nitcc/src/autom.nit
+++ b/contrib/nitcc/src/autom.nit
@@ -358,10 +358,14 @@ class Automaton
 			if not goods.has(s) then bads.add(s)
 		end
 
-		# Remove their transitions
+		# Remove their transitions and tags
 		for s in bads do
 			for t in s.ins.to_a do t.delete
 			for t in s.outs.to_a do t.delete
+			if tags.has_key(s) then
+				for t in tags[s] do retrotags[t].remove(s)
+				tags.keys.remove(s)
+			end
 		end
 
 		# Keep only the good stuff

--- a/contrib/nitcc/tests/t
+++ b/contrib/nitcc/tests/t
@@ -54,21 +54,26 @@ differ() {
                         echo "[***no sav***] cp 'out/$r' sav/"
                         test $verbose = true && { cat "out/$r" ; echo ; }
 			echo >>"$tap" "not ok $tapcount - $name # TODO no sav"
+			return 1
                 else
                         echo "[0K]"
 			echo >>"$tap" "ok $tapcount - $name"
+			return 0
                 fi
         elif diff "sav/$r" "out/$r" >/dev/null
         then
                 echo "[OK]"
 		echo >>"$tap" "ok $tapcount - $name"
+		return 0
         else
                 echo "[******failed******] diff -u {sav,out}/$r"
                 test $verbose = true && { diff -u "sav/$r" "out/$r" ; echo ; }
 		echo >>"$tap" "not ok $tapcount - $name"
+		return 1
         fi
 }
 
+err=0
 for f in "$@"
 do
         for a in "$f" `./alterner.pl $f`
@@ -107,7 +112,7 @@ do
 
 		grep -i "error" "out/$bn.nitcc.log" > "out/$res"
 		name="$a"
-                differ $res
+                differ $res || err=1
 
                 if test \! -z $cla
                 then
@@ -129,7 +134,7 @@ do
 
 				cp "$langname.ast.out" "out/$resi"
 				name="$a $i"
-                                differ "$resi"
+                                differ "$resi" || err=1
                         done
                 fi
         done
@@ -137,3 +142,4 @@ done
 
 echo >>"$tap" "1..$tapcount"
 #prove --formatter=TAP::Formatter::JUnit /bin/cat :: tap.output > tap.xml
+exit "$err"


### PR DESCRIPTION
Since #2573, some nitcc tests failed on a self-check (because the trim function did not correctly remove tags on trimmed nodes).

The bug was benign and easily fixable, but the subversion of the expectation was that the script kind of forgot about correctly reporting the error (an error message was printed but a success error code was returned). So the whole CI job was a success as failed tests where unreported.

Reported-by: Florian Deljarry <deljarry.florian@gmail.com>