### PR TITLE
Adding a Windows build test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -441,3 +441,16 @@ bench_old:
     - benchmarks/bench_old.sh
   allow_failure: true # time is unreliable. manual check required
   services: []
+
+build_tools_windows:
+  stage: build
+  before_script:
+    - date
+  after_script:
+    - date
+  tags:
+    - windows
+  script:
+    - $project_dir = "$CI_PROJECT_DIR" -replace "\\", "\\\"
+    - $converted_project_dir = $(c:\msys64\usr\bin\bash -l -c "cygpath -u $project_dir")
+    - c:\msys64\usr\bin\env MSYSTEM=MINGW64 c:\msys64\usr\bin\bash -l -c "cd $converted_project_dir; make"


### PR DESCRIPTION
In parallel, a new Gitlab Runner tagged "windows" was added. This new test only builds the project.