### PR TITLE
model: Add `mpackage` importation hierarchy

### DIFF
--- a/src/catalog/catalog.nit
+++ b/src/catalog/catalog.nit
@@ -266,7 +266,7 @@ class Catalog
 	var contrib2proj = new MultiHashMap[Person, MPackage]
 
 	# Dependency between packages
-	var deps = new POSet[MPackage]
+	fun deps: HashDigraph[MPackage] do return modelbuilder.model.mpackage_importation_graph
 
 	# Number of modules by package
 	var mmodules = new Counter[MPackage]
@@ -382,11 +382,11 @@ class Catalog
 			cat2proj[cat].add mpackage
 			score += tags.length.score
 		end
-		if deps.has(mpackage) then
-			score += deps[mpackage].greaters.length.score
-			score += deps[mpackage].direct_greaters.length.score
-			score += deps[mpackage].smallers.length.score
-			score += deps[mpackage].direct_smallers.length.score
+		if deps.has_vertex(mpackage) then
+			score += deps.predecessors(mpackage).length.score
+			score += deps.get_all_predecessors(mpackage).length.score
+			score += deps.successors(mpackage).length.score
+			score += deps.get_all_successors(mpackage).length.score
 		end
 
 		var contributors = mpackage.metadata.contributors

--- a/src/doc/commands/tests/test_commands_catalog.nit
+++ b/src/doc/commands/tests/test_commands_catalog.nit
@@ -30,15 +30,6 @@ class TestCommandsCatalog
 			var g = p.root
 			assert g != null
 			test_builder.scan_group(g)
-
-			catalog.deps.add_node(p)
-			for gg in p.mgroups do for m in gg.mmodules do
-				for im in m.in_importation.direct_greaters do
-					var ip = im.mpackage
-					if ip == null or ip == p then continue
-					test_catalog.deps.add_edge(p, ip)
-				end
-			end
 		end
 		# Build the catalog
 		for mpackage in test_model.mpackages do

--- a/src/doc/static/static_structure.nit
+++ b/src/doc/static/static_structure.nit
@@ -232,8 +232,8 @@ redef class PageMPackage
 		super
 		main_tab.metadata.cards.add new CardMetadata(mentity, mentity.metadata,
 			doc.catalog.mpackages_stats[mentity],
-			doc.catalog.deps[mentity].direct_greaters.to_a,
-			doc.catalog.deps[mentity].direct_smallers.to_a)
+			doc.catalog.deps.successors(mentity).to_a,
+			doc.catalog.deps.predecessors(mentity).to_a)
 	end
 end
 

--- a/src/model/mmodule.nit
+++ b/src/model/mmodule.nit
@@ -185,12 +185,19 @@ class MModule
 		self.in_importation = model.mmodule_importation_hierarchy.add_node(self)
 	end
 
-	# Register the imported modules (ie "import some_module")
+	# Register the imported modules (ie "import some_module") and packages importation graph
+	# In the same time it register the imported package
 	# The visibility must be set with `set_visibility_for`.
 	fun set_imported_mmodules(imported_mmodules: Array[MModule])
 	do
 		for m in imported_mmodules do
 			self.model.mmodule_importation_hierarchy.add_edge(self, m)
+			var actual_mpackage = self.mpackage
+			var imported_mpackage = m.mpackage
+			if actual_mpackage != null and imported_mpackage != null then
+				# Register the imported package
+				self.model.mpackage_importation_graph.add_arc(actual_mpackage, imported_mpackage)
+			end
 		end
 	end
 

--- a/src/model/mpackage.nit
+++ b/src/model/mpackage.nit
@@ -19,6 +19,7 @@ import model_base
 private import more_collections
 import poset
 import mdoc
+import graph::digraph
 
 # A Nit package, that encompass a product
 class MPackage
@@ -47,6 +48,8 @@ class MPackage
 	init
 	do
 		model.mpackages.add(self)
+		# Add `self` to the importation graph
+		model.mpackage_importation_graph.add_vertex(self)
 		model.mpackage_by_name.add_one(name, self)
 	end
 
@@ -177,6 +180,11 @@ class MGroup
 end
 
 redef class Model
+
+	# Full package importation graph
+	# Each package is in relation with itself
+	var mpackage_importation_graph = new HashDigraph[MPackage]
+
 	# packages of the model
 	var mpackages = new Array[MPackage]
 

--- a/src/nitdoc.nit
+++ b/src/nitdoc.nit
@@ -233,15 +233,6 @@ redef class Catalog
 			var g = p.root
 			assert g != null
 			modelbuilder.scan_group(g)
-
-			deps.add_node(p)
-			for gg in p.mgroups do for m in gg.mmodules do
-				for im in m.in_importation.direct_greaters do
-					var ip = im.mpackage
-					if ip == null or ip == p then continue
-					deps.add_edge(p, ip)
-				end
-			end
 		end
 		# Build the catalog
 		for mpackage in mpackages do

--- a/src/nitweb.nit
+++ b/src/nitweb.nit
@@ -115,15 +115,6 @@ private class NitwebPhase
 			var g = p.root
 			assert g != null
 			modelbuilder.scan_group(g)
-
-			catalog.deps.add_node(p)
-			for gg in p.mgroups do for m in gg.mmodules do
-				for im in m.in_importation.direct_greaters do
-					var ip = im.mpackage
-					if ip == null or ip == p then continue
-					catalog.deps.add_edge(p, ip)
-				end
-			end
 		end
 		# Build the catalog
 		for mpackage in mpackages do

--- a/src/nitx.nit
+++ b/src/nitx.nit
@@ -121,20 +121,11 @@ end
 redef class Catalog
 	# Build the catalog for Nitx
 	private fun build_catalog(model: Model, filter: nullable ModelFilter) do
-		# Compute the poset
+		# Scan all modules of collected packages
 		for p in model.collect_mpackages(filter) do
 			var g = p.root
 			assert g != null
 			modelbuilder.scan_group(g)
-
-			deps.add_node(p)
-			for gg in p.mgroups do for m in gg.mmodules do
-				for im in m.in_importation.direct_greaters do
-					var ip = im.mpackage
-					if ip == null or ip == p then continue
-					deps.add_edge(p, ip)
-				end
-			end
 		end
 		# Build the catalog
 		for mpackage in model.collect_mpackages(filter) do


### PR DESCRIPTION
Added a `mpackage_importation_hierarchy` graph to keep the hierarchy of packages. The packages relations are defined when the `set_imported_mmodules` is called. 

This pr is related to the programming by contract. The objective is to determine when the use of a contract is necessary in a given context.

Note in this graph all the packages are in relation with themself.

example for all nitc package hierarchy :

![](https://sendeyo.com/up/d/514e168e33)

This pr has a dependency with the #2784 
