### PR TITLE
nitunit the manual

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -333,6 +333,20 @@ bench_fast:
       - benchmarks/*.gnu
     when: always
 
+nitunit_manual:
+  stage: more_test
+  dependencies:
+    - build_tools
+  script:
+    - nitunit doc/manual/*.nit
+    - junit2html nitunit.xml
+  artifacts:
+    paths:
+      - nitunit.xml*
+    when: always
+    reports:
+      junit:
+        - nitunit.xml
 
 # MORE TOOLS ########################################################
 

--- a/doc/manual/attribute.md
+++ b/doc/manual/attribute.md
@@ -16,7 +16,7 @@ end
 
 Note that from an API point of view, there is no way to distinguish the read access of an attribute with a normal method neither to distinguish a write access of an attribute with a setter. Therefore, the read access of an attribute is called a getter while the write access is called a setter.
 
-~~~
+~~~nitish
 var x = foo.bar # Is bar an attribute or a method?
 foo.bar = y # Is bar an attribute or a setter?
 # In fact, we do not need to know.
@@ -28,12 +28,12 @@ By default, a getter is public and a setter is private. The visibility of getter
 additional `writable` keyword.
 
 ~~~
-class Foo
-    var pub_pri: X
-    protected var pro_pri: X
-    var pub_pub: X is writable
-    private var pri_pro: X is protected writable
-    var pub_pri2: X is private writable # the default
+class Foo2
+    var pub_pri: Int
+    protected var pro_pri: Int
+    var pub_pub: Int is writable
+    private var pri_pro: Int is protected writable
+    var pub_pri2: Int is private writable # the default
 end
 ~~~
 
@@ -43,17 +43,17 @@ Getters and setters of attributes behave like genuine methods that can be inheri
 a redefinition while `redef writable` declares that the setter is a redefinition.
 
 ~~~
-interface Foo
+interface Foo3
     fun derp: Int is abstract
     fun derp=(o: Int) is abstract
 end
-class Bar
-    super Foo
-    redef var derp: Int redef writable
+class Bar3
+    super Foo3
+    redef var derp is redef writable
 end
-class Baz
-    super Bar
-    redef fun derp do ...
-    redef fun derp=(o) do ...
+class Baz3
+    super Bar3
+    redef fun derp do return 1
+    redef fun derp=(o) do end
 end
 ~~~

--- a/doc/manual/constructor.md
+++ b/doc/manual/constructor.md
@@ -166,8 +166,8 @@ class MultiProduct
 end
 var mp = new MultiProduct("ABC", "Bla bla", 15.96, 1, 3)
 assert mp.id == "ABC"
-assert mp.price == 159.6
-assert mp.total_price == 175.4
+assert mp.price.is_approx(159.6, 0.001)
+assert mp.total_price.is_approx(175.4, 0.001)
 assert mp.z == 13
 ~~~
 
@@ -197,11 +197,11 @@ class Point
 	redef fun to_s do return "({x},{y})"
 end
 var p1 = new Point(1.0, 2.0)
-assert p1.to_s ==  "(1,2)"
+assert p1.to_s ==  "(1.0,2.0)"
 var p2 = new Point.origin
-assert p2.to_s ==  "(0,0)"
+assert p2.to_s ==  "(0.0,0.0)"
 var p3 = new Point.polar(1.0, 2.0)
-assert p3.to_s ==  "(-0.4161,0.9092)"
+assert p3.to_s ==  "(-0.416,0.909)"
 ~~~
 
 

--- a/doc/manual/constructor.md
+++ b/doc/manual/constructor.md
@@ -27,6 +27,11 @@ assert p.id == "ABC"
 In subclasses, additional attributes are automatically collected.
 
 ~~~
+class Product
+	var id: String
+	var description: String
+	var price: Float
+end
 class Book
 	super Product
 	var author: String
@@ -44,6 +49,11 @@ It is used to perform additional systematic tasks.
 Because the `init` is run at the end of the initialization sequence, initialized attributes are usable in the body.
 
 ~~~
+class Product
+	var id: String
+	var description: String
+	var price: Float
+end
 class OverpricedProduct
 	super Product
 	init
@@ -52,7 +62,7 @@ class OverpricedProduct
 	end
 end
 var op = new OverpricedProduct("ABC", "Bla bla", 15.95)
-assert op.price == 159.50
+assert op.price.is_approx(159.50, 0.001)
 ~~~
 
 
@@ -65,6 +75,11 @@ There is three cases for an attributes to not be collected in the `new`.
 * Attributes introduced in refinement of classes
 
 ~~~
+class Product
+	var id: String
+	var description: String
+	var price: Float
+end
 class TaxedProduct
 	super Product
 	var tax_rate = 9.90
@@ -75,7 +90,7 @@ class TaxedProduct
 	end
 end
 var tp = new TaxedProduct("ABC", "Bla bla", 15.95)
-assert tp.total_price == 17.52905
+assert tp.total_price.is_approx(17.52905, 0.00001)
 ~~~
 
 Note: The orchestration here is important. In order, the following is executed:
@@ -95,6 +110,11 @@ In fact, by default, the setter of an attribute is used as a initializer.
 `autoinit` is used to register a method as a setter.
 
 ~~~
+class Product
+	var id: String
+	var description: String
+	var price: Float
+end
 class FooProduct
 	super Product
 	fun set_xy(x, y: Int) is autoinit do z = x * 10 + y
@@ -113,6 +133,32 @@ In most case, there is no reason that an argument of a `new` construction is not
 As explained above, one of the main advantage of these constructors is their compatibility with multiple inheritance.
 
 ~~~
+class Product
+	var id: String
+	var description: String
+	var price: Float
+end
+class OverpricedProduct
+	super Product
+	init
+	do
+		price = price * 10.0
+	end
+end
+class TaxedProduct
+	super Product
+	var tax_rate = 9.90
+	var total_price: Float is noinit
+	init
+	do
+		total_price = price * (1.0 + tax_rate/100.0)
+	end
+end
+class FooProduct
+	super Product
+	fun set_xy(x, y: Int) is autoinit do z = x * 10 + y
+	var z: Int is noinit
+end
 class MultiProduct
 	super OverpricedProduct
 	super TaxedProduct

--- a/doc/manual/method.md
+++ b/doc/manual/method.md
@@ -2,8 +2,8 @@
 
 `fun` declares methods. Methods must have a name, may have parameters, and may have a return type. Parameters are typed; however, a single type can be used for multiple parameters.
 
-~~~
-fun foo(x, y: Int, s: String): Bool ...
+~~~nitish
+fun foo(x, y: Int, s: String): Bool # ...
 ~~~
 
 `do` declares the body of methods. Alike control structures, a one-liner version is available.
@@ -38,7 +38,7 @@ print a.length # no () for length, no () for print
 
 However, this last facility requires that the first argument does not start with a parenthesis or a bracket.
 
-~~~
+~~~nitish
 foo (x).bar # will be interpreted as (foo(x)).bar
 foo [x].bar # will be interpreted as (foo[x]).bar
 ~~~
@@ -140,7 +140,7 @@ Operators and setters are methods that require a special syntax for their defini
 
 <!-- -->
 
-~~~
+~~~nitish
 class Foo
     fun +(a: Bar): Baz do ...
     fun -: Baz do ...
@@ -162,7 +162,7 @@ a[b] = c # The bracket setter '[]='
 
 `+=` and `-=` are combinations of the assignment (`=`) and a binary operator. These feature are extended to setters where a single `+=` is in fact three method calls: a function call, the operator call, then a setter call.
 
-~~~
+~~~nitish
 a += c # equiv. a = a + c
 a[b] += c # equiv. a[b] = a[b] + c
 a.foo += c # equiv. a.foo = a.foo + c

--- a/doc/manual/module.md
+++ b/doc/manual/module.md
@@ -31,7 +31,7 @@ intrude importers), there is still no restriction.
 
 Visibility of attributes is more specific and is detailed in its own section.
 
-~~~
+~~~nitish
 module m1
 class Foo
     fun pub do ...
@@ -55,7 +55,7 @@ y.pri2
 
 <!-- -->
 
-~~~
+~~~nitish
 module m2
 import m1
 class Baz

--- a/doc/manual/structure.md
+++ b/doc/manual/structure.md
@@ -23,14 +23,16 @@ Note that the control flow is determined only from the position, the
 order and the nesting of the control structures. The real value of the
 expressions used has no effect on the control flow analyses.
 
-~~~
+~~~nitish
 if true then
     return
 else
     return
 end
 print 1 # Compile error: unreachable statement
+~~~
 
+~~~
 if true then
     return
 end
@@ -40,18 +42,24 @@ print 1 # OK, but never executed
 ## if
 
 ~~~
-if exp then stm
-if exp then stm else stm
+var exp = true
+# ...
+if exp then print 1
+if exp then print 2 else print 2
 if exp then
-    stms
+    print 1
+    print 2
 end
 
 if exp then
-    stms
+    print 1
+    print 2
 else if exp then
-    stms
+    print 10
+    print 20
 else
-    stms
+    print 100
+    print 200
 end
 ~~~
 
@@ -60,17 +68,21 @@ syntactically complete thus the newline terminate the whole `if`
 structure; then an error is signaled since a statement cannot begin with
 `else`.
 
-~~~
-if exp then stm # OK: complete 'if' structure
-else stm # Syntax error: unexpected 'else'
+~~~nitish
+if exp then print 1 # OK: complete 'if' structure
+else print 2 # Syntax error: unexpected 'else'
 ~~~
 
 ## while
 
 ~~~
-while exp do stm
-while exp do
-    stms
+var x = 0
+while x < 10 do x += 1
+print x # outputs 10
+
+while x < 20 do
+    print x # outputs 10 11 ... 19
+    x += 1
 end
 ~~~
 
@@ -79,9 +91,9 @@ end
 `for` declares an automatic variable used to iterates on `Collection` (`Array` and `Range` are both `Collection`).
 
 ~~~
-for x in [1..5] do print x # outputs 1 2 3 4 5
-for x in [1, 4, 6] do
-    print x # outputs 1 4 6
+for i in [1..5] do print i # outputs 1 2 3 4 5
+for i in [1, 4, 6] do
+    print i # outputs 1 4 6
 end
 ~~~
 
@@ -90,8 +102,8 @@ end
 Step can also be used to specify the size of each increment at the end of a for cycle.
 
 ~~~
-for x in [9 .. 4].step(-1) do print x # outputs 9 8 7 6 5 4
-for x in [9 .. 4[.step(-2) do print x # outputs 9 7 5
+for i in [9 .. 4].step(-1) do print i # outputs 9 8 7 6 5 4
+for i in [9 .. 4[.step(-2) do print i # outputs 9 7 5
 ~~~
 
 ## loop
@@ -100,9 +112,9 @@ Infinite loops are mainly used with breaks. They are useful to implement *until*
 
 ~~~
 loop
-    stms
+    print 1
     if exp then break
-    stms
+    print 2
 end
 ~~~
 
@@ -114,10 +126,10 @@ Single `do` are used to create scope for variables or to be attached with labele
 
 ~~~
 do
-    var x = 5
-    print x
+    var j = 5
+    print j
 end
-# x is not defined here
+# j is not defined here
 ~~~
 
 ## break, continue and label
@@ -127,9 +139,10 @@ Unlabeled `break` exits the current `for`, `while`, `loop`, Unlabeled `continue`
 `label` can be used with `break` or `continue` to act on a specific control structure (not necessary the current one). The corresponding `label` must be defined after the `end` keyword of the designated control structure.
 
 ~~~
-for i in [0..width[ do
-    for j in [0..height[ do
-        if foo(i, j) then break label outer_loop
+for i in [0..10[ do
+    for j in [0..10[ do
+        if i + j > 15 then break label outer_loop
+	print "{i},{j}"
         # The 'break' breaks the 'for i' loop
     end
 end label outer_loop
@@ -139,9 +152,9 @@ end label outer_loop
 
 ~~~
 do
-    stmts
-    if expr then break label block
-    stmts
+    print 1 # printed
+    if exp then break label block
+    print 2 # not printed because exp is true
 end label block
 ~~~
 
@@ -154,9 +167,9 @@ end label block
 `assert` verifies that a given Boolean expression is true, or else it aborts. An optional label can be precised, it will be displayed on the error message. An optional `else` can also be added and will be executed before the abort.
 
 ~~~
-assert bla: whatever else
-    # "bla" is the label
-    # "whatever" is the expression to verify
+assert bla: exp else
+    # `bla` is the label
+    # `exp` is the expression to verify
     print "Fatal error in module blablabla."
     print "Please contact the customer service."
 end

--- a/doc/manual/variable.md
+++ b/doc/manual/variable.md
@@ -6,16 +6,23 @@ control structure. Two variables with the same name cannot coexist: no nesting n
 Variables are bound to values. A variable cannot be used unless it has a value in all control flow paths (à la Java).
 
 ~~~
-var x
-var y
-if whatever then
-    x = 5
-    y = 6
+var exp = 10
+# ...
+var a
+if exp > 0 then
+    a = 5
 else
-    x = 7
+    a = 7
 end
-print x # OK
-print y # Compile error: y is possibly not initialized
+print a # OK
+~~~
+
+~~~nitish
+var b
+if exp > 0 then
+    b = 6
+end
+print b # Compile error: y is possibly not initialized
 ~~~
 
 ## Adaptive Typing
@@ -24,52 +31,61 @@ Nit features adaptive typing, which means that the static type of a variable can
 `or else`, `==`, `!=`, and `isa`).
 
 ~~~
-var x # a variable
-x = 5
+var c # a variable
+c = 5
 # static type is Int
-print x + 1 # outputs 6
-x = [6, 7]
+print c + 1 # outputs 6
+c = [6, 7]
 # static type is Array[Int]
-print x[0] # outputs "6"
+print c[0] # outputs "6"
+~~~
 
-var x
-if whatever then
-    x = 5
+~~~
+# ...
+var d
+if exp > 0 then
+    d = 5
 else
-    x = 6
+    d = 6
 end
 # Static type is Int
+print d + 1
 ~~~
 
 ## Variable Upper Bound
 
 An optional type information can be added to a variable declaration. This type is used as an upper bound of the type of the variable. When a initial value is given in a variable declaration without a specific type information, the static type of the initial value is used as an upper bound. If no type and no initial value are given, the upper bound is set to `nullable Object`.
 
+~~~nitish
+var e: Int # Upper bound is Int
+e = "Hello" # Compile error: expected Int
+
+var f = 5 # Upper bound is Int
+f = "Hello" # Compile error: expected Int
 ~~~
-var x: Int # Upper bound is Int
-x = "Hello" # Compile error: expected Int
-var y: Object # Upper bound is Object
-y = 5 # OK since Int specializes Object
-var z = 5 # Upper bound is Int
-z = "Hello" # Compile error: expected Int
-var t: Object = 5 # Upper bound is Object
-t = "Hello" # OK
+
+~~~
+var g: Object # Upper bound is Object
+g = 5 # OK since Int specializes Object
+
+var h: Object = 5 # Upper bound is Object
+h = "Hello" # OK
 ~~~
 
 The adaptive typing flow is straightforward, therefore loops (`for`, `while`, `loop`) have a special requirement: on entry, the upper bound is set to the current static type; on exit, the upper bound is reset to its previous value.
 
-~~~
-var x: Object = ...
+~~~nitish
+var l: Object
 # static type is Object, upper bound is Object
-x = 5
+l = 5
 # static type is Int, bound remains Object
-while x > 0 do
+while l > 0 do
     # static type remains Int, bound sets to Int
-    x -= 1 # OK
-    x = "Hello" # Compile error: expected Int
+    l -= 1 # OK
+    l = "Hello" # Compile error: expected Int
 end
 # static type is Int, bound reset to Object
-x = "Hello" # OK
+l = "Hello" # OK
 ~~~
 
 ## Type Checks
@@ -77,18 +93,24 @@ x = "Hello" # OK
 `isa` tests if an object is an instance of a given type. If the expression used in an `isa` is a variable, then its static type is automatically adapted, therefore avoiding the need of a specific cast.
 
 ~~~
-var x: Object = whatever
-if x isa Int then
-    # static type of x is Int
-    print x * 10 # OK
+var m: Object = 5
+# ...
+if m isa Int then
+    # static type of m is Int
+    print m * 10 # OK
 end
 ~~~
 
 Remember that adaptive typing follows the control flow, including the Boolean operators.
 
 ~~~
-var a: Array[Object] = ...
-for i in a do
+var n = new Array[Object]
+n.add(1)
+n.add(true)
+n.add("one")
+n.add(11)
+
+for i in n do
     # the static type of i is Object
     if not i isa Int then continue
     # now the static type of i is Int
@@ -100,22 +122,23 @@ An interesting example:
 
 ~~~
 var max = 0
-for i in whatever do
+for i in n do
     if i isa Int and i > max then max = i
     # the > is valid since, in the right part
     # of the "and", the static type of i is Int
 end
+print max # outputs 11
 ~~~
 
 Note that type adaptation occurs only in an `isa` if the target type is more specific that the current type.
 
 ~~~
-var a: Collection[Int] = ...
-if a isa Comparable then
+var col: Collection[Int] = [1, 2, 3]
+if col isa Comparable then
     # the static type is still Collection[Int]
     # even if the dynamic type of a is a subclass
     # of both Collection[Int] and Comparable
-    ...
+    # ...
 end
 ~~~
 
@@ -126,55 +149,65 @@ end
 `nullable` annotates types that can accept `null` or an expression of a compatible nullable static type.
 
 ~~~
-var x: nullable Int
-var y: Int
-x = 1 # OK
-y = 1 # OK
-x = null # OK
-y = null # Compile error
-x = y # OK
-y = x # Compile error
+var o: nullable Int
+var p: Int
+o = 1 # OK
+p = 1 # OK
+o = null # OK
+o = p # OK
+~~~
+
+~~~nitish
+p = null # Compile error
+p = o # Compile error
 ~~~
 
 Adaptive typing works well with nullable types.
 
 ~~~
-var x
-if whatever then
-    x = 5
+var q
+if exp > 0 then
+    q = 5
 else
-    x = null
+    q = null
 end
-# The static type of x is nullable Int
+# The static type of q is nullable Int
 ~~~
 
 Moreover, like the `isa` keyword, the `==` and `!=` operators can adapt the static type of a variable when compared to `null`.
 
 ~~~
-var x: nullable Int = whatever
-if x != null then
-    # The static type of x is Int (without nullable)
-    print x + 6
+var r: nullable Int = 10
+# ...
+if r != null then
+    # The static type of r is Int (without nullable)
+    print r + 6
 end
-# The static type of x is nullable Int
+# The static type of r is nullable Int
 ~~~
 
 And another example:
 
 ~~~
-var x: nullable Int = whatever
+var s: nullable Int = 10
+# ...
 loop
-    if x == null then continue
-    # The static type of x is Int
+    if s == null then break
+    # The static type of s is Int
+    print s + 1
+
+    s = null
+    # The static type of s is null
 end
 ~~~
 
 `or else` can be used to compose a nullable expression with any other expression. The value of `x or else y` is `x` if `x` is not `null` and is `y` if `x` is null. The static type of `x or else y` is the combination of the type of `y` and the not null version of the type of `x`.
 
 ~~~
-var i: nullable Int = ...
-var j = i or else 0
-# the static type of j is Int (without nullable)
+var t: nullable Int = 10
+# ...
+var u = t or else 0
+# the static type of u is Int (without nullable)
 ~~~
 
 Note that nullable types require a special management for [[attributes|attribute]] and [[constructors|constructor]].
@@ -184,17 +217,20 @@ Note that nullable types require a special management for [[attributes|attribute
 `as` casts an expression to a type. The expression is either casted successfully or there is an `abort`.
 
 ~~~
-var x: Object = 5 # static type of x is Object
-print x.as(Int) * 10 # outputs 50
-print x.as(String) # aborts: cast failed
+var v: Object = 5 # static type of v is Object
+print v.as(Int) * 10 # outputs 50
+~~~
+
+~~~nitish
+print v.as(String) # aborts: cast failed
 ~~~
 
 Note that `as` does not change the object nor does perform conversion.
 
 ~~~
-var x: Object = 5 # static type of x is Object
-print x.as(Int) + 10 # outputs "15"
-print x.to_s + "10" # outputs "510"
+var w: Object = 5 # static type of w is Object
+print w.as(Int) + 10 # outputs "15"
+print w.to_s + "10" # outputs "510"
 ~~~
 
 Because of type adaptation, `as` is rarely used on variables. `isa` (sometime coupled with `assert`) is preferred.
@@ -209,11 +245,11 @@ print x * 10 # outputs 50
 `as(not null)` can be used to cast an expression typed by a nullable type to its non nullable version. This form keeps the programmer from writing explicit static types.
 
 ~~~
-var x: nullable Int = 5 # static type of x is nullable Int
-print x.as(not null) * 10 # cast, outputs 50
-print x.as(Int) * 10 # same cast, outputs 50
-assert x != null # same cast, but type of x is now Int
-print x * 10 # outputs 50
+var y: nullable Int = 5 # static type of y is nullable Int
+print y.as(not null) * 10 # cast, outputs 50
+print y.as(Int) * 10 # same cast, outputs 50
+assert y != null # same cast, but type of y is now Int
+print y * 10 # outputs 50
 ~~~
 
 ## Static Type Combination Rule
@@ -229,14 +265,17 @@ Adaptive typing, literal arrays, and `or else` need to determine a static type b
 <!-- -->
 
 ~~~
-var d: Discrete = ...
+var dis: Discrete = 'a'
 # Note: Int < Discrete < Object
-var x
-if whatever then x = 1 else x = d
+var z
+if exp > 0 then z = 1 else z = dis
 # static type is Discrete
-if whatever then x = 1 else x = "1"
+if exp < 0 then z = 1 else z = "1"
 # static type is nullable Object (upper bound)
-var a1 = [1, d] # a1 is a Array[Discrete]
+var a1 = [1, dis] # a1 is a Array[Discrete]
+~~~
+
+~~~nitish
 var a2 = [1, "1"] # Compile error:
         # incompatible types Int and String
 ~~~


### PR DESCRIPTION
Since the manual is now back in the repository, just use niunit to check the example.

Some examples needed to be updated

* renaming things to avoid conflicts
* using real expression and statements (and not placeholders)
* add `nitish` for example with explicit static or dynamic errors