### PR TITLE
Contract: Change mpropdef driving

### DIFF
--- a/src/frontend/check_annotation.nit
+++ b/src/frontend/check_annotation.nit
@@ -112,8 +112,8 @@ after
 after_all
 example
 
-expects
-ensures
+expect
+ensure
 no_contract
 """
 

--- a/tests/contracts.nit
+++ b/tests/contracts.nit
@@ -18,8 +18,8 @@
 class MyClass
 	fun foo(x: Int)
 	is
-		expects(x == 1)
-		ensures(x > 0)
+		expect(x == 1)
+		ensure(x > 0)
 	do
 		x = 0
 	end
@@ -28,8 +28,8 @@ end
 class MyClass2
 	fun foo(bool: Bool)
 	is
-		expects(not bool)
-		ensures(not bool)
+		expect(not bool)
+		ensure(not bool)
 	do
 		if bool then print "Error"
 	end

--- a/tests/contracts_abstract.nit
+++ b/tests/contracts_abstract.nit
@@ -15,15 +15,15 @@
 # Verification if it's possible to define a contract in different context (abstract class, interface and class) and it's possible to inherit it.
 
 class MyClass
-	fun foo(x: Int, y: Float)is abstract, expects(x != 10)
+	fun foo(x: Int, y: Float)is abstract, expect(x != 10)
 end
 
 abstract class AbstractClass
-	fun bar(x: Int, y: Float)is abstract, expects(x >= 1), ensures(y == 10.0)
+	fun bar(x: Int, y: Float)is abstract, expect(x >= 1), ensure(y == 10.0)
 end
 
 interface Interface
-	fun baz(x: Int, y: Float)is abstract, ensures(y <= 10.0, y == 42.0)
+	fun baz(x: Int, y: Float)is abstract, ensure(y <= 10.0, y == 42.0)
 end
 
 

--- a/tests/contracts_add.nit
+++ b/tests/contracts_add.nit
@@ -18,14 +18,14 @@
 class MyClass
 	fun foo(x: Int)
 	is
-		expects(x == 1)
+		expect(x == 1)
 	do
 		x=1
 	end
 
 	fun bar(x: Float): Bool
 	is
-		ensures(result)
+		ensure(result)
 	do
 		return true
 	end
@@ -36,14 +36,14 @@ class MyClass2
 
 	redef fun foo(x: Int)
 	is
-		ensures(x == 0)
+		ensure(x == 0)
 	do
 		x=0
 	end
 
 	redef fun bar(x: Float)
 	is
-		expects(x == 1)
+		expect(x == 1)
 	do
 		return true
 	end

--- a/tests/contracts_attributs.nit
+++ b/tests/contracts_attributs.nit
@@ -20,8 +20,8 @@ class MyClass
 
 	fun foo(x: Int)
 	is
-		expects(bar == 10)
-		ensures(x > 0)
+		expect(bar == 10)
+		ensure(x > 0)
 	do
 		if bar != 10 then print "Error"
 	end
@@ -38,8 +38,8 @@ class MyClass2
 
 	fun foo(bool: Bool)
 	is
-		expects(not self.baz)
-		ensures(my_class.bar == 11)
+		expect(not self.baz)
+		ensure(my_class.bar == 11)
 	do
 		if baz then print "Error"
 		my_class.bar = 11

--- a/tests/contracts_constructor.nit
+++ b/tests/contracts_constructor.nit
@@ -17,7 +17,7 @@
 class MyClass
 	init construct(test: Int)
 	is
-		expects(test > 10)
+		expect(test > 10)
 	do
 
 	end

--- a/tests/contracts_ensures.nit
+++ b/tests/contracts_ensures.nit
@@ -17,7 +17,7 @@
 class MyClass
 	fun foo(x: Int)
 	is
-		ensures(x > 0)
+		ensure(x > 0)
 	do
 
 	end
@@ -26,7 +26,7 @@ end
 class MyClass2
 	fun foo(bool: Bool)
 	is
-		ensures(not bool)
+		ensure(not bool)
 	do
 
 	end

--- a/tests/contracts_ensures_1.nit
+++ b/tests/contracts_ensures_1.nit
@@ -17,7 +17,7 @@
 class MyClass
 	fun foo(x: Int)
 	is
-		ensures(x > 0)
+		ensure(x > 0)
 	do
 		print "Good"
 	end

--- a/tests/contracts_ensures_2.nit
+++ b/tests/contracts_ensures_2.nit
@@ -17,7 +17,7 @@
 class MyClass
 	fun foo(x: Int, y: Float)
 	is
-		ensures(x > 0)
+		ensure(x > 0)
 	do
 		print "Good"
 	end
@@ -28,7 +28,7 @@ class SubClass
 
 	redef fun foo(x: Int, y: Float)
 	is
-		ensures(y == 1.2)
+		ensure(y == 1.2)
 	do
 		print "Good"
 	end

--- a/tests/contracts_ensures_3.nit
+++ b/tests/contracts_ensures_3.nit
@@ -17,7 +17,7 @@
 class MyClass
 	fun foo(x: Int): Int
 	is
-		ensures(result > 0)
+		ensure(result > 0)
 	do
 		return x
 	end

--- a/tests/contracts_ensures_4.nit
+++ b/tests/contracts_ensures_4.nit
@@ -17,7 +17,7 @@
 class MyClass
 	fun foo(x: Int): Bool
 	is
-		ensures(x > 0, result)
+		ensure(x > 0, result)
 	do
 		return true
 	end
@@ -28,7 +28,7 @@ class MySubClass
 
 	redef fun foo(x: Int)
 	is
-		ensures(not result)
+		ensure(not result)
 	do
 		return super
 	end

--- a/tests/contracts_ensures_sequence.nit
+++ b/tests/contracts_ensures_sequence.nit
@@ -15,7 +15,7 @@
 class MyClass
 	fun foo(x: Int, y: Float)
 	is
-		ensures(x > 2)
+		ensure(x > 2)
 	do
 
 	end
@@ -26,7 +26,7 @@ class MySubClass
 
 	redef fun foo(x: Int, y: Float)
 	is
-		ensures(y > 1.0)
+		ensure(y > 1.0)
 	do
 
 	end

--- a/tests/contracts_error.nit
+++ b/tests/contracts_error.nit
@@ -20,8 +20,8 @@ class MyClass
 
 	fun foo(x: Int)
 	is
-		expects(bar_no_return)
-		ensures(assert x == 1)
+		expect(bar_no_return)
+		ensure(assert x == 1)
 	do
 		x = 0
 	end

--- a/tests/contracts_expects.nit
+++ b/tests/contracts_expects.nit
@@ -17,7 +17,7 @@
 class MyClass
 	fun foo(x: Int)
 	is
-		expects(x > 0)
+		expect(x > 0)
 	do
 		if x <= 0 then print "FAIL"
 	end
@@ -26,7 +26,7 @@ end
 class MyClass2
 	fun foo(bool: Bool)
 	is
-		expects(not bool)
+		expect(not bool)
 	do
 		if bool then print "FAIL"
 	end

--- a/tests/contracts_expects_1.nit
+++ b/tests/contracts_expects_1.nit
@@ -17,7 +17,7 @@
 class MyClass
 	fun foo(x: Int)
 	is
-		expects(x > 0)
+		expect(x > 0)
 	do
 		if x <= 0 then print "FAIL"
 	end

--- a/tests/contracts_expects_2.nit
+++ b/tests/contracts_expects_2.nit
@@ -17,7 +17,7 @@
 class MyClass
 	fun foo(x: Int)
 	is
-		expects(x > 0)
+		expect(x > 0)
 	do
 		if x <= 0 then print "FAIL"
 	end
@@ -28,7 +28,7 @@ class SubClass
 
 	redef fun foo(x: Int)
 	is
-		expects(x == 0)
+		expect(x == 0)
 	do
 		if x < 0 then print "FAIL"
 	end

--- a/tests/contracts_expects_3.nit
+++ b/tests/contracts_expects_3.nit
@@ -26,7 +26,7 @@ class SubClass
 
 	redef fun foo(x: Int)
 	is
-		expects(x == 0)
+		expect(x == 0)
 	do
 		if x != 0 then print "Good"
 	end

--- a/tests/contracts_generic_type.nit
+++ b/tests/contracts_generic_type.nit
@@ -18,7 +18,7 @@ class MyGenericClass[E]
 
 	fun foo(x: E)
 	is
-		expects(x == 1)
+		expect(x == 1)
 	do
 		if x != 1 then print "Error x != 1"
 	end
@@ -30,7 +30,7 @@ class MyGenericClass2[E]
 
 	fun add_all(x: Array[Object])
 	is
-		expects(x.length != 0)
+		expect(x.length != 0)
 	do
 		real.add_all x
 	end

--- a/tests/contracts_inheritance.nit
+++ b/tests/contracts_inheritance.nit
@@ -29,7 +29,7 @@ class MyArrayInt
 
 	redef fun toto(e)
 	is
-		ensures(e == 12)
+		ensure(e == 12)
 	do
 		print "toto MyArrayInt"
 		super e
@@ -41,7 +41,7 @@ class MyArrayInt2
 
 	redef fun toto(e)
 	is
-		ensures(e == 11)
+		ensure(e == 11)
 	do
 		print "toto MyArrayInt2"
 		super e

--- a/tests/contracts_same_contract.nit
+++ b/tests/contracts_same_contract.nit
@@ -18,8 +18,8 @@ class MyClass
 
 	fun foo(x: Int)
 	is
-		expects(x == 10)
-		expects(x >= 10)
+		expect(x == 10)
+		expect(x >= 10)
 	do
 		x = 0
 	end

--- a/tests/contracts_static.nit
+++ b/tests/contracts_static.nit
@@ -1,0 +1,38 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test the resolution of contract when the static mpropdef does not have contract and the dynamic has one
+
+class MyClass
+	fun foo(x: Int)
+	do
+		x = 0
+	end
+end
+
+class MySubClass
+	super MyClass
+
+	redef fun foo(x)
+	is
+		ensure(x > 10)
+	do
+		if x < 10 then print "Error"
+	end
+end
+
+var first = new MyClass
+first.foo(1) # No contract on the mpropdef
+var second: MyClass = new MySubClass
+second.foo(2) #Fail

--- a/tests/contracts_virtual_type.nit
+++ b/tests/contracts_virtual_type.nit
@@ -20,7 +20,7 @@ class MyClass
 
 	fun foo(x: VIRTUAL)
 	is
-		expects(x == 1)
+		expect(x == 1)
 	do
 
 	end

--- a/tests/sav/contracts.res
+++ b/tests/sav/contracts.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expects' failed (contracts.nit:31)
+Runtime error: Assert 'expect' failed (contracts.nit:31)

--- a/tests/sav/contracts_abstract.res
+++ b/tests/sav/contracts_abstract.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensures' failed (contracts_abstract.nit:26)
+Runtime error: Assert 'ensure' failed (contracts_abstract.nit:26)

--- a/tests/sav/contracts_add.res
+++ b/tests/sav/contracts_add.res
@@ -1,2 +1,2 @@
-contracts_add.nit:46,3--17: Useless contract: No contract defined at the introduction of the method
-Runtime error: Assert 'ensures' failed (contracts_add.nit:39)
+contracts_add.nit:46,3--16: Useless contract: No contract defined at the introduction of the method
+Runtime error: Assert 'ensure' failed (contracts_add.nit:39)

--- a/tests/sav/contracts_constructor.res
+++ b/tests/sav/contracts_constructor.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expects' failed (contracts_constructor.nit:20)
+Runtime error: Assert 'expect' failed (contracts_constructor.nit:20)

--- a/tests/sav/contracts_ensures.res
+++ b/tests/sav/contracts_ensures.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensures' failed (contracts_ensures.nit:29)
+Runtime error: Assert 'ensure' failed (contracts_ensures.nit:29)

--- a/tests/sav/contracts_ensures_1.res
+++ b/tests/sav/contracts_ensures_1.res
@@ -1,3 +1,3 @@
-Runtime error: Assert 'ensures' failed (contracts_ensures_1.nit:20)
+Runtime error: Assert 'ensure' failed (contracts_ensures_1.nit:20)
 Good
 Fail

--- a/tests/sav/contracts_ensures_2.res
+++ b/tests/sav/contracts_ensures_2.res
@@ -1,4 +1,4 @@
-Runtime error: Assert 'ensures' failed (contracts_ensures_2.nit:31)
+Runtime error: Assert 'ensure' failed (contracts_ensures_2.nit:31)
 Good
 Good
 Good

--- a/tests/sav/contracts_ensures_3.res
+++ b/tests/sav/contracts_ensures_3.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensures' failed (contracts_ensures_3.nit:20)
+Runtime error: Assert 'ensure' failed (contracts_ensures_3.nit:20)

--- a/tests/sav/contracts_ensures_4.res
+++ b/tests/sav/contracts_ensures_4.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensures' failed (contracts_ensures_4.nit:31)
+Runtime error: Assert 'ensure' failed (contracts_ensures_4.nit:31)

--- a/tests/sav/contracts_ensures_5.res
+++ b/tests/sav/contracts_ensures_5.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensures' failed (contracts_ensures_5.nit:29)
+Runtime error: Assert 'ensure' failed (contracts_ensures_5.nit:29)

--- a/tests/sav/contracts_ensures_sequence.res
+++ b/tests/sav/contracts_ensures_sequence.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensures' failed (contracts_ensures_sequence.nit:18)
+Runtime error: Assert 'ensure' failed (contracts_ensures_sequence.nit:18)

--- a/tests/sav/contracts_error.res
+++ b/tests/sav/contracts_error.res
@@ -1,2 +1,2 @@
-contracts_error.nit:23,11--23: Error: expected an expression.
-contracts_error.nit:24,11--23: Error: expected an expression.
+contracts_error.nit:23,10--22: Error: expected an expression.
+contracts_error.nit:24,10--22: Error: expected an expression.

--- a/tests/sav/contracts_expects_1.res
+++ b/tests/sav/contracts_expects_1.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expects' failed (contracts_expects_1.nit:20)
+Runtime error: Assert 'expect' failed (contracts_expects_1.nit:20)

--- a/tests/sav/contracts_expects_3.res
+++ b/tests/sav/contracts_expects_3.res
@@ -1,3 +1,3 @@
-contracts_expects_3.nit:29,3--17: Useless contract: No contract defined at the introduction of the method
+contracts_expects_3.nit:29,3--16: Useless contract: No contract defined at the introduction of the method
 Good
 Good

--- a/tests/sav/contracts_generic_type.res
+++ b/tests/sav/contracts_generic_type.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expects' failed (contracts_generic_type.nit:33)
+Runtime error: Assert 'expect' failed (contracts_generic_type.nit:33)

--- a/tests/sav/contracts_inheritance.res
+++ b/tests/sav/contracts_inheritance.res
@@ -1,5 +1,5 @@
 contracts_inheritance.nit:58,6--9: Warning: conflicting property definitions for property `toto` in `MySubArray`: contracts_inheritance$MyArrayInt$toto contracts_inheritance$MyArrayInt2$toto
-Runtime error: Assert 'ensures' failed (contracts_inheritance.nit:32)
+Runtime error: Assert 'ensure' failed (contracts_inheritance.nit:32)
 toto MyArrayInt2
 toto MyArrayInt
 toto ArrayInt

--- a/tests/sav/contracts_same_contract.res
+++ b/tests/sav/contracts_same_contract.res
@@ -1,1 +1,1 @@
-contracts_same_contract.nit:22,3--18: The method already has a defined `expects` contract at line 21
+contracts_same_contract.nit:22,3--17: The method already has a defined `expect` contract at line 21

--- a/tests/sav/contracts_static.res
+++ b/tests/sav/contracts_static.res
@@ -1,0 +1,2 @@
+Runtime error: Assert 'ensure' failed (contracts_static.nit:29)
+Error

--- a/tests/sav/contracts_virtual_type.res
+++ b/tests/sav/contracts_virtual_type.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expects' failed (contracts_virtual_type.nit:23)
+Runtime error: Assert 'expect' failed (contracts_virtual_type.nit:23)


### PR DESCRIPTION
This pr change the driving strategy to resolve the problem when the static type has no contract and the dynamic has one.

Note: now when a mpropdef has a contract after the introduction a facet is added in the intro class. Indeed, as there is no way to know the dynamic type we are going to meet, we must always direct to the facet of contract even if it only redirects to the method and executes no contract.

I change at the same time the syntax of the keywords `ensures` by `ensure` and `expects` by `expect`. The doc will arrive in the next pr.