### PR TITLE
Contracts: Add invariant contract

### DIFF
--- a/share/man/nitc.md
+++ b/share/man/nitc.md
@@ -546,7 +546,13 @@ By default the contracts can be defined as "semi-global". I.E. All contracts (en
 Option used to disable the contracts(ensures, expects) usage.
 
 ### `--full-contract`
-Option used to enables contracts (ensures, expects) on all classes. Warning this is an expensive option at runtime.
+Enable contracts (ensures, expects) on all classes. Warning this is an expensive option at runtime.
+
+### `--in-out-invariant`
+Enable invariants checking on enter and exit (by default invariants are only checked at exit).
+
+### `--no-self-contract`
+Disable contracts checking for methods called on `self`.
 
 # ENVIRONMENT VARIABLES
 

--- a/src/contracts.nit
+++ b/src/contracts.nit
@@ -18,10 +18,11 @@
 # FIXME Split the module in three parts: extension of the modele, building phase and the "re-driving"
 module contracts
 
-import astbuilder
+intrude import astbuilder
 import parse_annotations
 import phase
 import semantize
+import mclassdef_collect
 intrude import modelize_property
 intrude import scope
 intrude import typing
@@ -57,7 +58,7 @@ redef class AModule
 	#	the case the callsite is replaced by another callsite to the contract method.
 	fun do_contracts(toolcontext: ToolContext) do
 		#
-		var contract_visitor = new ContractsVisitor(toolcontext, toolcontext.modelbuilder.identified_modules.first, self, new ASTBuilder(mmodule.as(not null)))
+		var contract_visitor = new ContractsVisitor(toolcontext, new ASTBuilder(mmodule.as(not null)), toolcontext.modelbuilder.identified_modules.first, self)
 		contract_visitor.enter_visit(self)
 		#
 		var callsite_visitor = new CallSiteVisitor(toolcontext)
@@ -71,6 +72,8 @@ private class ContractsVisitor
 
 	var toolcontext: ToolContext
 
+	var ast_builder: ASTBuilder
+
 	# The main module
 	# It's strore to define if the contract need to be build depending on the selected policy `--no-contract` `--full-contract` or default
 	var mainmodule: MModule
@@ -78,7 +81,11 @@ private class ContractsVisitor
 	# Actual visited module
 	var visited_module: AModule
 
-	var ast_builder: ASTBuilder
+	# Actual visited class
+	var visited_class: nullable AClassdef
+
+	# Actual visited class
+	var visited_method: nullable AMethPropdef
 
 	# The `ASignature` of the actual build contract
 	var n_signature: ASignature is noinit
@@ -92,21 +99,21 @@ private class ContractsVisitor
 	# Is the contrat is an introduction or not?
 	var is_intro_contract: Bool is noinit
 
-	# Actual visited class
-	var visited_class: nullable AClassdef
+	# Keep the invariant property to avoid searching at each invariant
+	var global_invariant: nullable MInvariant = null
 
-	# is `no_contract` annotation was found
-	var find_no_contract = false
+	# Keep the set in_contract attribute to avoid searching at each contrat
+	var in_contract_attribute: nullable MAttribute = null
 
 	redef fun visit(node)
 	do
-		node.create_contracts(self)
+		node.check_contracts(self)
 		node.visit_all(self)
 	end
 
 	# Method use to define the signature part of the method `ASignature` and `MSignature`
 	# The given `mcontract` provided `adapt_nsignature` and `adapt_msignature` to copy and adapt the given signature (`nsignature` and `msignature`)
-	fun define_signature(mcontract: MContract, nsignature: nullable ASignature, msignature: nullable MSignature)
+	fun define_contract_signature(mcontract: MContract, nsignature: nullable ASignature, msignature: nullable MSignature)
 	do
 		if nsignature != null and msignature != null then nsignature.ret_type = msignature.return_mtype
 		self.n_signature = mcontract.adapt_nsignature(nsignature)
@@ -114,18 +121,18 @@ private class ContractsVisitor
 	end
 
 	# Define the new contract take in consideration that an old contract exist or not
-	private fun build_contract(n_annotation: AAnnotation, mcontract: MContract, mclassdef: MClassDef): MMethodDef
+	private fun build_contract(n_annotations: Array[AAnnotation], mcontract: MContract, mclassdef: MClassDef): MMethodDef
 	do
-		self.current_location = n_annotation.location
 		# Retrieving the expression provided in the annotation
-		var n_condition = n_annotation.construct_condition(self)
+		var n_conditions = new Array[AExpr]
+		for n_annotation in n_annotations do n_conditions.add n_annotation.construct_condition(self)
 		var m_contractdef: AMethPropdef
 		if is_intro_contract then
 			# Create new contract method
-			m_contractdef = mcontract.create_intro_contract(self, n_condition, mclassdef)
+			m_contractdef = mcontract.create_intro_contract(self, n_conditions, mclassdef)
 		else
 			# Create a redef of contract to take in consideration the new condition
-			m_contractdef = mcontract.create_subcontract(self, n_condition, mclassdef)
+			m_contractdef = mcontract.create_subcontract(self, n_conditions, mclassdef)
 		end
 		var contract_propdef = m_contractdef.mpropdef
 		# The contract has a null mpropdef, this should never happen
@@ -162,6 +169,134 @@ private class ContractsVisitor
 		return toolcontext.opt_full_contract.value or mainmodule.mpackage == actual_mmodule.mpackage
 	end
 
+	# Verification if the construction of the contract is necessary.
+	# Two cases are checked for `invariant`:
+	#
+	# - Is the `--full-contract` option it's use?
+	# - Is the method is in the main package
+	#
+	fun check_usage_invariants(actual_mmodule: MModule): Bool
+	do
+		return toolcontext.opt_full_contract.value or mainmodule.mpackage == actual_mmodule.mpackage
+	end
+
+	# Inject the invariant method (`_invariant_`) verification in the Object class
+	# By default the method is empty.
+	# Note it is not abstract because the implementation of this method makes a super call to resolve multiple inheritance problem
+	private fun inject_invariant_in_object
+	do
+		# Get the object class from the modelbuilder
+		var object_class = toolcontext.modelbuilder.get_mclass_by_name(visited_module, mainmodule, "Object")
+		# If the global_invariant already know just return
+		if global_invariant != null then return
+		# Try to get a global invariant if it's already defined in a previously visited module.
+		var invariant_property = toolcontext.modelbuilder.try_get_mproperty_by_name(visited_module, object_class.intro, "_invariant_")
+		if invariant_property != null then
+			global_invariant = invariant_property.as(MInvariant)
+			return
+		end
+		# Create a new invariant method
+		var m_invariant = new MInvariant(object_class.intro, "_invariant_", object_class.intro.location, public_visibility)
+		self.define_contract_signature(m_invariant, null, null)
+		m_invariant.create_empty_contract(self, object_class.intro)
+		global_invariant = m_invariant
+	end
+
+	# Return the invariant property (`Minvariant`)
+	# If the `_invariant_` does not exist it's injected this with `inject_invariant_in_object`
+	private fun get_global_invariant: MInvariant
+	do
+		if self.global_invariant == null then inject_invariant_in_object
+		return global_invariant.as(not null)
+	end
+
+	# Inject the incontract attribut (`_in_contract_`) in the Sys class
+	# This attribute allows to check if the contract need to be executed
+	private fun inject_incontract_in_sys
+	do
+		# Get the sys class from the modelbuilder
+		var sys_class = toolcontext.modelbuilder.get_mclass_by_name(visited_module, mainmodule, "Sys")
+		# If the global_invariant already know just return
+		if in_contract_attribute != null then return
+		# Try to get a global in_contract if it's already defined in a previously visited module.
+		var in_contract_property = toolcontext.modelbuilder.try_get_mproperty_by_name(visited_module, sys_class.intro, "__in_contract_")
+		if in_contract_property != null then
+			self.in_contract_attribute = in_contract_property.as(MAttribute)
+			return
+		end
+		# Create a new invariant method
+		var m_in_contract = new MAttribute(sys_class.intro, "__in_contract_", sys_class.intro.location, public_visibility)
+		var m_in_contract_propdef = new MAttributeDef(sys_class.intro, m_in_contract, sys_class.intro.location)
+
+		var bool_false = new AFalseExpr.make(mainmodule.bool_type)
+
+		m_in_contract_propdef.static_mtype = mainmodule.bool_type
+		var n_attribute = ast_builder.make_attribute("_in_contract_", mainmodule.bool_type, null, bool_false, null, m_in_contract_propdef)
+		toolcontext.modelbuilder.mpropdef2npropdef[m_in_contract_propdef] = n_attribute
+
+		var n_sys = toolcontext.modelbuilder.mclassdef2node(sys_class.intro)
+
+		n_sys.n_propdefs.unsafe_add_all([n_attribute])
+
+		n_attribute.location = sys_class.intro.location
+		n_attribute.validate
+
+		n_attribute.build_get_set(toolcontext.modelbuilder, sys_class.intro)
+
+		in_contract_attribute = m_in_contract
+	end
+
+	# Return the in_contract attribut of sys (`_in_contract_`)
+	# If the attribute `_in_contract_` does not exist it's injected this with `inject_incontract_in_sys`
+	private fun get_incontract: MAttribute
+	do
+		if self.in_contract_attribute == null then inject_incontract_in_sys
+		return in_contract_attribute.as(not null)
+	end
+
+	# Return an AIfExpr with the contract encapsulated by an if to check if it's already in a contract verification.
+	#
+	# exemple
+	# ~~~nitish
+	# class A
+	# 	fun bar([...]) is except([...])
+	#
+	# 	fun _contract_bar([...])
+	#	do
+	#		if self.sys._in_contract_ then
+	#			self.sys._in_contract_ = true
+	#			_bar_expect([...])
+	#			self.sys._in_contract_ = false
+	#		end
+	#		bar([...])
+	#	end
+	#
+	# 	fun _bar_expect([...])
+	# end
+	# ~~~~
+	#
+	private fun encapsulated_contract_call(visited_method: AMethPropdef, call_to_contracts: Array[ACallExpr]): AIfExpr
+	do
+		var n_self = new ASelfExpr
+
+		var sys_property = toolcontext.modelbuilder.model.get_mproperties_by_name("sys").first.as(MMethod)
+		var callsite_sys = ast_builder.create_callsite(toolcontext.modelbuilder, visited_method, sys_property, true)
+
+		var incontract_attribute = get_incontract
+
+		var callsite_get_incontract = ast_builder.create_callsite(toolcontext.modelbuilder, visited_method, incontract_attribute.getter.as(MMethod), false)
+		var callsite_set_incontract = ast_builder.create_callsite(toolcontext.modelbuilder, visited_method, incontract_attribute.setter.as(MMethod), false)
+
+		var n_condition = ast_builder.make_not(ast_builder.make_call(ast_builder.make_call(new ASelfExpr, callsite_sys, null), callsite_get_incontract, null))
+
+		var n_if = ast_builder.make_if(n_condition, null)
+
+		n_if.n_then.as(ABlockExpr).add(ast_builder.make_call(ast_builder.make_call(new ASelfExpr, callsite_sys, null), callsite_set_incontract, [new ATrueExpr.make(mainmodule.bool_type)]))
+		n_if.n_then.as(ABlockExpr).add_all(call_to_contracts)
+		n_if.n_then.as(ABlockExpr).add(ast_builder.make_call(ast_builder.make_call(new ASelfExpr, callsite_sys, null), callsite_set_incontract, [new AFalseExpr.make(mainmodule.bool_type)]))
+
+		return n_if
+	end
 end
 
 # This visitor checks the `callsite` to see if the target `mpropdef` has a contract.
@@ -181,25 +316,37 @@ private class CallSiteVisitor
 
 	# Check if the callsite calls a method with a contract.
 	# If it's the case the callsite is replaced by another callsite to the contract method.
-	private fun drive_method_contract(callsite: CallSite): CallSite
+	private fun drive_callsite_contract(callsite: CallSite, mclass: nullable MClass): CallSite
 	do
-		if callsite.mproperty.mcontract_facet != null then
-			var contract_facet = callsite.mproperty.mcontract_facet
-			var visited_mpropdef = visited_method.mpropdef
-			assert contract_facet != null and visited_mpropdef != null
+		var contract_facet = callsite.mproperty.mcontract_facet
+		var invariant_facet = callsite.mproperty.minvariant_facet
+		var visited_mpropdef = visited_method.mpropdef
 
-			var type_visitor = new TypeVisitor(toolcontext.modelbuilder, visited_mpropdef)
-			var drived_callsite = type_visitor.build_callsite_by_property(visited_method, callsite.recv, contract_facet, callsite.recv_is_self)
-			# This never happen this check is here for debug
-			assert drived_callsite != null
-			return drived_callsite
+		if contract_facet == null or visited_mpropdef == null then return callsite
+		if visited_mpropdef isa MContract or visited_mpropdef isa MFacet then return callsite
+		if mclass != null and invariant_facet != null and not mclass.check_invariant then return callsite
+
+		# Do not drive contract in self if it's necessary `--no-self-contract`
+		if toolcontext.opt_no_self_contract.value and visited_mpropdef.mclassdef.mclass == contract_facet.intro_mclassdef.mclass then return callsite
+
+		var facet: MFacet
+		# Check to drive the callsite on the right facet
+		if visited_mpropdef.mclassdef.mclass != contract_facet.intro_mclassdef.mclass and invariant_facet != null then
+			facet = invariant_facet
+		else
+			facet = contract_facet
 		end
-		return callsite
+
+		var type_visitor = new TypeVisitor(toolcontext.modelbuilder, visited_mpropdef)
+		var drived_callsite = type_visitor.build_callsite_by_property(visited_method, callsite.recv, facet, callsite.recv_is_self)
+		# This never happen this check is here for debug
+		assert drived_callsite != null
+		return drived_callsite
 	end
 end
 
 redef class ANode
-	private fun create_contracts(v: ContractsVisitor) do end
+	private fun check_contracts(v: ContractsVisitor) do end
 	private fun check_callsite(v: CallSiteVisitor) do end
 end
 
@@ -214,6 +361,7 @@ redef class AAnnotation
 		var n_condition = n_args.first
 		n_args.remove_at(0)
 		for n_arg in n_args do n_condition = v.ast_builder.make_and(n_condition, n_arg)
+		n_condition.location = self.location
 		return n_condition
 	end
 end
@@ -229,13 +377,13 @@ abstract class MContract
 	fun contract_name: String is abstract
 
 	# Method use to diplay warning when the contract is not present at the introduction
-	private fun no_intro_contract(v: ContractsVisitor, a: AAnnotation)do end
+	private fun no_intro_contract(v: ContractsVisitor, a: Array[AAnnotation])do end
 
 	# Creating specific inheritance block contract
-	private fun create_nblock(v: ContractsVisitor, n_condition: AExpr, args: Array[AExpr]): ABlockExpr is abstract
+	private fun create_nblock(v: ContractsVisitor, n_conditions: Array[AExpr], args: Array[AExpr]): ABlockExpr is abstract
 
 	# Method to adapt the `n_mpropdef.n_block` to the contract
-	private fun adapt_block_to_contract(v: ContractsVisitor, n_mpropdef: AMethPropdef) is abstract
+	private fun adapt_method_to_contract(v: ContractsVisitor, n_mpropdef: AMethPropdef, called_method: MMethod) is abstract
 
 	# Adapt the msignature specifically for the contract method
 	private fun adapt_specific_msignature(m_signature: MSignature): MSignature do return m_signature.adapt_to_condition
@@ -260,45 +408,51 @@ abstract class MContract
 	end
 
 	# Create a new empty contract
-	private fun create_empty_contract(v: ContractsVisitor, mclassdef: MClassDef, msignature: nullable MSignature, n_signature: ASignature)
+	private fun create_empty_contract(v: ContractsVisitor, mclassdef: MClassDef)
 	do
-		var n_contract_def = intro_mclassdef.mclass.create_empty_method(v, self, mclassdef, msignature, n_signature)
+		var n_contract_def = intro_mclassdef.mclass.create_empty_method(v, self, mclassdef, v.m_signature, v.n_signature.clone)
 		n_contract_def.do_all(v.toolcontext)
 	end
 
 	# Create the initial contract (intro)
 	# All contracts have the same implementation for the introduction.
 	#
+	# exemple
+	# ~~~nitish
 	# fun contrat([...])
 	# do
 	#	assert contract_condition
 	# end
+	# ~~~
 	#
-	private fun create_intro_contract(v: ContractsVisitor, n_condition: nullable AExpr, mclassdef: MClassDef): AMethPropdef
+	private fun create_intro_contract(v: ContractsVisitor, n_conditions: Array[AExpr], mclassdef: MClassDef): AMethPropdef
 	do
 		var n_block = v.ast_builder.make_block
-		if n_condition != null then
+		for n_condition in n_conditions do
 			# Create a new tid to set the name of the assert for more explicit error
-			var tid = new TId.init_tk(self.location)
-			tid.text = "{self.contract_name}"
-			n_block.add v.ast_builder.make_assert(tid, n_condition, null)
+			var tid = new TId.init_tk(n_condition.location)
+			tid.text = "{n_condition.location.text}"
+			var n_assert = v.ast_builder.make_assert(tid, n_condition, null)
+			# Define the assert location to reference the annoation
+			n_assert.location = n_condition.location
+			n_block.add n_assert
 		end
 		return make_contract(v, n_block, mclassdef)
 	end
 
 	# Create a contract with old (super) and the new conditions
-	private fun create_subcontract(v: ContractsVisitor, ncondition: nullable AExpr, mclassdef: MClassDef): AMethPropdef
+	private fun create_subcontract(v: ContractsVisitor, n_conditions: Array[AExpr], mclassdef: MClassDef): AMethPropdef
 	do
 		var args = v.n_signature.make_parameter_read(v.ast_builder)
 		var n_block = v.ast_builder.make_block
-		if ncondition != null then n_block = self.create_nblock(v, ncondition, args)
+		n_block = self.create_nblock(v, n_conditions, args)
 		return make_contract(v, n_block, mclassdef)
 	end
 
 	# Build a method with a specific block `n_block` in a specified `mclassdef`
 	private fun make_contract(v: ContractsVisitor, n_block: AExpr, mclassdef: MClassDef): AMethPropdef
 	do
-		var n_contractdef = intro_mclassdef.mclass.create_empty_method(v, self, mclassdef, v.m_signature, v.n_signature)
+		var n_contractdef = intro_mclassdef.mclass.create_empty_method(v, self, mclassdef, v.m_signature, v.n_signature.clone)
 		n_contractdef.n_block = n_block
 		# Define the location of the new method for corresponding of the annotation location
 		n_contractdef.location = v.current_location
@@ -333,30 +487,34 @@ class MExpect
 	# 	redef fun bar is expect(contract_condition)
 	# 	redef fun _bar_expect([...])
 	# 	do
-	# 		if not (contract_condition) then super
+	# 		if (contract_condition) then return
+	#		super
 	# 	end
 	# end
 	# ~~~~
 	#
-	redef fun no_intro_contract(v: ContractsVisitor, a: AAnnotation)
+	redef fun no_intro_contract(v: ContractsVisitor, a: Array[AAnnotation])
 	do
-		v.toolcontext.warning(a.location,"","Useless contract: No contract defined at the introduction of the method")
+		v.toolcontext.warning(a.first.location,"useless_contract","Useless contract: No contract defined at the introduction of the method")
 	end
 
-	redef fun create_nblock(v: ContractsVisitor, n_condition: AExpr, args: Array[AExpr]): ABlockExpr
+	redef fun create_nblock(v: ContractsVisitor, n_conditions: Array[AExpr], args: Array[AExpr]): ABlockExpr
 	do
-		# Creating the if expression with the new condition
-		var if_block = v.ast_builder.make_if(n_condition, n_condition.mtype)
-		# Creating and adding return expr to the then case
-		if_block.n_then = v.ast_builder.make_return(null)
-		# Creating the super call to the contract and adding this to else case
-		if_block.n_else = v.ast_builder.make_super_call(args,null)
 		var n_block = v.ast_builder.make_block
-		n_block.add if_block
+		for n_condition in n_conditions do
+			# Creating the if expression with the new condition
+			var if_block = v.ast_builder.make_if(n_condition, n_condition.mtype)
+			# Creating and adding return expr to the then case
+			if_block.n_then = v.ast_builder.make_return(null)
+			if_block.location = n_condition.location
+			n_block.add if_block
+		end
+		# Creating the super call if all `if` has no returned
+		n_block.add v.ast_builder.make_super_call(args,null)
 		return n_block
 	end
 
-	redef fun adapt_block_to_contract(v: ContractsVisitor, n_mpropdef: AMethPropdef)
+	redef fun adapt_method_to_contract(v: ContractsVisitor, n_mpropdef: AMethPropdef, called_method: MMethod)
 	do
 		var callsite = v.ast_builder.create_callsite(v.toolcontext.modelbuilder, n_mpropdef, self, true)
 		var n_self = new ASelfExpr
@@ -365,7 +523,7 @@ class MExpect
 		# Creation of the new instruction block with the call to expect condition
 		var actual_expr = n_mpropdef.n_block
 		var new_block = new ABlockExpr
-		new_block.n_expr.push n_callexpect
+		new_block.n_expr.push v.encapsulated_contract_call(n_mpropdef, [n_callexpect])
 		if actual_expr isa ABlockExpr then
 			new_block.n_expr.add_all(actual_expr.n_expr)
 		else if actual_expr != null then
@@ -379,19 +537,22 @@ end
 abstract class BottomMContract
 	super MContract
 
-	redef fun create_nblock(v: ContractsVisitor, n_condition: AExpr, args: Array[AExpr]): ABlockExpr
+	redef fun create_nblock(v: ContractsVisitor, n_conditions: Array[AExpr], args: Array[AExpr]): ABlockExpr
 	do
-		var tid = new TId.init_tk(v.current_location)
-		tid.text = "{contract_name}"
-		# Creating the assert expression with the new condition
-		var assert_block = v.ast_builder.make_assert(tid,n_condition,null)
-		# Creating the super call to the contract
-		var super_call = v.ast_builder.make_super_call(args,null)
 		# Define contract block
 		var n_block = v.ast_builder.make_block
+		# Creating the super call to the contract
+		var super_call = v.ast_builder.make_super_call(args,null)
 		# Adding the expressions to the block
 		n_block.add super_call
-		n_block.add assert_block
+		for n_condition in n_conditions do
+			var tid = new TId.init_tk(n_condition.location)
+			tid.text = "{n_condition.location.text}"
+			# Creating the assert expression with the new condition
+			var n_assert = v.ast_builder.make_assert(tid,n_condition,null)
+			n_assert.location = n_condition.location
+			n_block.add n_assert
+		end
 		return n_block
 	end
 
@@ -453,21 +614,18 @@ class MEnsure
 		return n_signature.adapt_to_ensurecondition
 	end
 
-	redef fun adapt_block_to_contract(v: ContractsVisitor, n_mpropdef: AMethPropdef)
+	redef fun adapt_method_to_contract(v: ContractsVisitor, n_mpropdef: AMethPropdef, called_method: MMethod)
 	do
 		var callsite = v.ast_builder.create_callsite(v.toolcontext.modelbuilder, n_mpropdef, self, true)
 		var n_self = new ASelfExpr
 		# argument to call the contract method
 		var args = n_mpropdef.n_signature.make_parameter_read(v.ast_builder)
-		# Inject the variable result
-		# The cast is always safe because the online adapted method is the contract facet
-
 		var actual_block = n_mpropdef.n_block
 		# never happen. If it's the case the problem is in the contract facet building
 		assert actual_block isa ABlockExpr
-
 		var ret_type = n_mpropdef.mpropdef.mproperty.intro.msignature.return_mtype
 		if ret_type != null then
+			# Inject the variable result
 			var result_var = inject_result(v, n_mpropdef, ret_type)
 			# Expr to read the result variable
 			var read_result = v.ast_builder.make_var_read(result_var, ret_type)
@@ -475,28 +633,116 @@ class MEnsure
 			# Adding the read return to argument
 			args.add(read_result)
 			var n_callcontract = v.ast_builder.make_call(n_self,callsite,args)
-			actual_block.add_all([n_callcontract,return_expr])
+			actual_block.add_all([v.encapsulated_contract_call(n_mpropdef, [n_callcontract]), return_expr])
 		else
 			# build the call to the contract method
 			var n_callcontract = v.ast_builder.make_call(n_self,callsite,args)
-			actual_block.add n_callcontract
+			actual_block.add v.encapsulated_contract_call(n_mpropdef, [n_callcontract])
 		end
 	end
 end
 
+# A invariant contract representation
+# This method check if the Object is in a valid state.
+class MInvariant
+	super BottomMContract
+
+	redef fun no_intro_contract(v: ContractsVisitor, a: Array[AAnnotation])
+	do
+		v.toolcontext.warning(a.first.location,"useless_contract","Useless contract: No contract defined at the introduction of the method")
+	end
+
+	# Define the name of the contract
+	redef fun contract_name: String do return "invariant"
+
+	redef fun adapt_method_to_contract(v: ContractsVisitor, n_mpropdef: AMethPropdef, called_method: MMethod)
+	do
+		var callsite = v.ast_builder.create_callsite(v.toolcontext.modelbuilder, n_mpropdef, self, true)
+		var n_self = new ASelfExpr
+		# build the call to the contract method
+		var n_call = v.ast_builder.make_call(n_self, callsite, null)
+		var actual_block = n_mpropdef.n_block
+		# never happen. If it's the case the problem is in the contract facet building
+		assert actual_block isa ABlockExpr
+
+		var new_block = v.ast_builder.make_block
+
+		if v.toolcontext.opt_in_out_invariant.value and not called_method.is_init then new_block.add n_call
+
+		new_block.n_expr.add_all(actual_block.n_expr)
+
+		n_mpropdef.n_block = new_block
+
+		var ret_type = n_mpropdef.mpropdef.mproperty.intro.msignature.return_mtype
+		if ret_type != null then
+			# Inject the variable result (the injection of the result is necessary even if the invariants cannot take `result` as an argument)
+			# In this case the result variable is here to keep the return value of the original method.
+			# exemple
+			# ~~~nitish
+			# class A
+			# 	fun bar([...]): Bool is invariant([...])
+			#
+			# 	fun _contract_bar([...])
+			#	do
+			#		var result = bar([...])
+			#		# Check if the invariant check call is necessary and execute it.
+			#		[...]
+			#		return result
+			#	end
+			#
+			# 	fun _bar_expect([...])
+			# end
+			# ~~~~
+			var result_var = inject_result(v, n_mpropdef, ret_type)
+			var return_expr = new_block.n_expr.pop
+			new_block.add_all([n_call, return_expr])
+		else
+			new_block.add(n_call)
+		end
+	end
+end
+
+# A facet contract representation
+# This class is created to keep the information of which method is a contract facet
+class MFacet
+	super MMethod
+end
+
 redef class MClass
 
+	# The invariant contract method
+	# This method check all invariants class
+	var minvariant: nullable MInvariant = null
+
+
+	# Build invariant if is not exist and return it
+	private fun build_invariant(v: ContractsVisitor): MInvariant
+	do
+		var m_invariant = self.minvariant
+		if m_invariant != null then return m_invariant
+		# get a invariant property from the `ContractsVisitor`
+		m_invariant = v.get_global_invariant
+		self.minvariant = m_invariant
+		return m_invariant
+	end
+
+	# Check if the MClass has no invariant contract
+	private fun check_invariant: Bool
+	do
+		return self.minvariant != null
+	end
+
 	# This method create an abstract method representation with this MMethodDef an this AMethoddef
-	private fun create_abstract_method(v: ContractsVisitor, mproperty: MMethod, mclassdef: MClassDef, msignature: nullable MSignature, n_signature: ASignature): AMethPropdef
+	private fun create_abstract_method(v: ContractsVisitor, mproperty: MMethod, mclassdef: MClassDef, msignature: MSignature, n_signature: ASignature): AMethPropdef
 	do
 		# new methoddef definition
 		var m_def = new MMethodDef(mclassdef, mproperty, v.current_location)
 		# set the signature
-		if msignature != null then m_def.msignature = msignature.clone
+		m_def.msignature = msignature.clone
 		# set the abstract flag
 		m_def.is_abstract = true
 		# Build the new node method
-		var n_def = v.ast_builder.make_method(null,null,m_def,n_signature,null,null,null,null)
+		var n_def = v.ast_builder.make_method(null,null,m_def, n_signature)
 		# Define the location of the new method for corresponding of the actual method
 		n_def.location = v.current_location
 		# Association new npropdef to mpropdef
@@ -505,8 +751,8 @@ redef class MClass
 	end
 
 	# Create method with an empty block
-	# the `mproperty` i.e the global property definition. The mclassdef to set where the method is declared and it's model `msignature` and ast `n_signature` signature
-	private fun create_empty_method(v: ContractsVisitor, mproperty: MMethod, mclassdef: MClassDef, msignature: nullable MSignature, n_signature: ASignature): AMethPropdef
+	# the `mproperty` i.e the global property definition. The mclassdef to set where the method is declared and it's model `msignature`
+	private fun create_empty_method(v: ContractsVisitor, mproperty: MMethod, mclassdef: MClassDef, msignature: MSignature, n_signature: ASignature): AMethPropdef
 	do
 		var n_def = create_abstract_method(v, mproperty, mclassdef, msignature, n_signature)
 		n_def.mpropdef.is_abstract = false
@@ -520,7 +766,12 @@ redef class MMethod
 	# The contract facet of the method
 	# it's representing the method with contract
 	# This method call the contract and the method
-	var mcontract_facet: nullable MMethod = null
+	var mcontract_facet: nullable MFacet = null
+
+	# The contract facet of the method wit invariant
+	# it's representing the method with contract
+	# This method call the mcontract_facet
+	var minvariant_facet: nullable MFacet = null
 
 	# The expected contract method
 	var mexpect: nullable MExpect = null
@@ -528,104 +779,160 @@ redef class MMethod
 	# The ensure contract method
 	var mensure: nullable MEnsure = null
 
-	# Check if the MMethod has no ensure contract
-	# if this is the case returns false and built it
-	# else return true
-	private fun check_exist_ensure: Bool
+	# Build ensure if is not exist and return it
+	private fun build_ensure: MEnsure
 	do
-		if self.mensure != null then return true
+		var m_mensure = self.mensure
 		# build a new `MEnsure` contract
-		self.mensure = new MEnsure(intro_mclassdef, "_ensure_{name}", intro_mclassdef.location, public_visibility)
-		return false
+		if m_mensure == null then m_mensure = new MEnsure(intro_mclassdef, "_ensure_{name}", intro_mclassdef.location, public_visibility)
+		self.mensure = m_mensure
+		return m_mensure
+	end
+
+	# Check if the MMethod has no ensure contract
+	private fun check_ensure: Bool
+	do
+		return self.mensure != null
+	end
+
+	# Build expect if is not exist and return it
+	private fun build_expect: MExpect
+	do
+		var m_mexpect = self.mexpect
+		# build a new `MExpect` contract
+		if m_mexpect == null then m_mexpect = new MExpect(intro_mclassdef, "_expect_{name}", intro_mclassdef.location, public_visibility)
+		self.mexpect = m_mexpect
+		return m_mexpect
 	end
 
 	# Check if the MMethod has no expect contract
-	# if this is the case returns false and built it
-	# else return true
-	private fun check_exist_expect: Bool
+	private fun check_expect: Bool
 	do
-		if self.mexpect != null then return true
-		# build a new `MExpect` contract
-		self.mexpect = new MExpect(intro_mclassdef, "_expect_{name}", intro_mclassdef.location, public_visibility)
-		return false
+		return self.mexpect != null
+	end
+
+	# If the method has no contract facet she create it
+	private fun build_contract_facet: MFacet
+	do
+		var m_mcontract_facet = self.mcontract_facet
+		# build a new `MFacet` contract
+		if m_mcontract_facet == null then m_mcontract_facet = new MFacet(intro_mclassdef, "_contract_{name}", intro_mclassdef.location, public_visibility)
+		self.mcontract_facet = m_mcontract_facet
+		return m_mcontract_facet
 	end
 
 	# Check if the MMethod has an contract facet
-	# If the method has no contract facet she create it
-	private fun check_exist_contract_facet(mpropdef : MMethodDef): Bool
+	private fun check_contract_facet: Bool
 	do
-		if self.mcontract_facet != null then return true
-		# build a new `MMethod` contract
-		self.mcontract_facet = new MMethod(intro_mclassdef, "_contract_{name}", intro_mclassdef.location, public_visibility)
-		return false
+		return self.mcontract_facet != null
 	end
-end
 
-redef class MMethodDef
-
-	# Verification of the contract facet
-	# Check if a contract facet already exists to use it again or if it is necessary to create it.
-	private fun check_contract_facet(v: ContractsVisitor, n_signature: ASignature, classdef: MClassDef, mcontract: MContract, exist_contract: Bool)
+	# Build invariant_facet if is not exist and return it
+	private fun build_invariant_facet: MFacet
 	do
-		var exist_contract_facet = mproperty.check_exist_contract_facet(self)
+		var m_minvariant_facet = self.minvariant_facet
+		# build a new `MFacet` contract
+		if m_minvariant_facet == null then m_minvariant_facet = new MFacet(intro_mclassdef, "_contract_inv_{name}", intro_mclassdef.location, public_visibility)
+		self.minvariant_facet = m_minvariant_facet
+		return m_minvariant_facet
+	end
+
+	# Check if the MMethod has an invariant facet
+	private fun check_invariant_facet: Bool
+	do
+		return self.minvariant_facet != null
+	end
+
+	# Define contract facet for MMethod in the given mclassdef.
+	# If a contract is given adapt the contract facet.
+	private fun define_contract_facet(v: ContractsVisitor, msignature: MSignature, n_signature: ASignature, classdef: MClassDef, exist_contract: Bool, mcontract: nullable MContract)
+	do
+		var exist_contract_facet = check_contract_facet
+		# Do nothing the contract and the contract facet already exist
 		if exist_contract_facet and exist_contract then return
 
-		var contract_facet: AMethPropdef
+		var intro_classdef = intro_mclassdef
+
+		var contract_facet = build_contract_facet
+
+		var n_contract_facet: AMethPropdef
 		if not exist_contract_facet then
 			# If has no contract facet in intro just create it
-			if classdef != mproperty.intro_mclassdef then create_contract_facet(v, mproperty.intro_mclassdef, n_signature)
-			# If has no contract facet just create it
-			contract_facet = create_contract_facet(v, classdef, n_signature)
+			if classdef != intro_mclassdef then
+				create_facet(v, intro_mclassdef, msignature, n_signature.clone, contract_facet, self)
+			end
+			n_contract_facet = create_facet(v, classdef, msignature, n_signature, contract_facet, self)
 		else
 			# Check if the contract facet already exist in this context (in this classdef)
-			if classdef.mpropdefs_by_property.has_key(mproperty.mcontract_facet) then
-				# get the define
-				contract_facet = v.toolcontext.modelbuilder.mpropdef2node(classdef.mpropdefs_by_property[mproperty.mcontract_facet]).as(AMethPropdef)
+			if classdef.mpropdefs_by_property.has_key(contract_facet) then
+				# get the definition
+				n_contract_facet = v.toolcontext.modelbuilder.mpropdef2node(classdef.mpropdefs_by_property[contract_facet]).as(AMethPropdef)
 			else
 				# create a new contract facet definition
-				contract_facet = create_contract_facet(v, classdef, n_signature)
+				n_contract_facet = create_facet(v, classdef, msignature, n_signature, contract_facet, self)
 				var block = v.ast_builder.make_block
 				# super call to the contract facet
-				var n_super_call = v.ast_builder.make_super_call(n_signature.make_parameter_read(v.ast_builder), null)
+				var args = v.n_signature.make_parameter_read(v.ast_builder)
+				var n_super_call = v.ast_builder.make_super_call(args)
 				# verification for add a return or not
-				if contract_facet.mpropdef.msignature.return_mtype != null then
+				if msignature.return_mtype != null then
 					block.add(v.ast_builder.make_return(n_super_call))
 				else
 					block.add(n_super_call)
 				end
-				contract_facet.n_block = block
+				n_contract_facet.n_block = block
 			end
 		end
-		contract_facet.adapt_block_to_contract(v, mcontract, contract_facet)
-		contract_facet.location = v.current_location
-		contract_facet.do_all(v.toolcontext)
+		if mcontract != null then mcontract.adapt_method_to_contract(v, n_contract_facet, self)
+
+		n_contract_facet.location = v.current_location
+		n_contract_facet.do_all(v.toolcontext)
 	end
 
-	# Method to create a contract facet of the method
-	private fun create_contract_facet(v: ContractsVisitor, classdef: MClassDef, n_signature: ASignature): AMethPropdef
+	# Define invariant facet for the MMethod in the given mclassdef.
+	# This method also define the contract facet.
+	private fun define_invariant_facet(v: ContractsVisitor, msignature: MSignature, n_signature: ASignature, classdef: MClassDef, exist_contract: Bool, mcontract: MContract)
 	do
-		var contract_facet = mproperty.mcontract_facet
-		assert contract_facet != null
-		# Defines the contract phase is an init or not
-		# it is necessary to use the contracts on constructor
-		contract_facet.is_init = self.mproperty.is_init
+		# Make a contract facet if it's not exist
+		define_contract_facet(v, msignature, n_signature.clone, classdef, false)
+		# Do nothing the invariant facet already exist
+		if check_invariant_facet then return
+		# Make invariant mproperty facet
+		var invariant_facet = build_invariant_facet
 
-		# check if the method has an `msignature` to copy it.
-		var m_signature: nullable MSignature = null
-		if mproperty.intro.msignature != null then m_signature = mproperty.intro.msignature.clone
+		# Check if the MMethod has a invariant facet in the intro_mclassdef
+		if classdef != intro_mclassdef then
+			create_facet(v, intro_mclassdef, msignature, n_signature.clone, invariant_facet, self.mcontract_facet.as(not null))
+		end
 
-		var n_contractdef = classdef.mclass.create_empty_method(v, contract_facet, classdef, m_signature, n_signature)
+		# Create an ast definition for the invariant facet
+		var n_invariant_facet = create_facet(v, classdef, msignature, n_signature, invariant_facet, self.mcontract_facet.as(not null))
+		mcontract.adapt_method_to_contract(v, n_invariant_facet, self)
+		n_invariant_facet.location = v.current_location
+		n_invariant_facet.do_all(v.toolcontext)
+	end
+
+	# Method to create a facet of the method
+	private fun create_facet(v: ContractsVisitor, classdef: MClassDef, msignature: MSignature, n_signature: ASignature, facet: MFacet, called: MMethod): AMethPropdef
+	do
+		# Defines the contract facet is an init or not
+		# it is necessary to use the contracts with constructor
+		facet.is_init = is_init
+		var n_contractdef = classdef.mclass.create_empty_method(v, facet, classdef, msignature, n_signature)
 		# FIXME set the location because the callsite creation need the node location
 		n_contractdef.location = v.current_location
 		n_contractdef.validate
 
 		var block = v.ast_builder.make_block
 		var n_self = new ASelfExpr
-		var args = n_contractdef.n_signature.make_parameter_read(v.ast_builder)
-		var callsite = v.ast_builder.create_callsite(v.toolcontext.modelbuilder, n_contractdef, mproperty, true)
+
+		var args: Array[AVarExpr]
+		args = n_signature.make_parameter_read(v.ast_builder)
+
+		var callsite = v.ast_builder.create_callsite(v.toolcontext.modelbuilder, n_contractdef, called, true)
 		var n_call = v.ast_builder.make_call(n_self, callsite, args)
 
-		if m_signature.return_mtype == null then
+		if msignature.return_mtype == null then
 			block.add(n_call)
 		else
 			block.add(v.ast_builder.make_return(n_call))
@@ -635,53 +942,229 @@ redef class MMethodDef
 		n_contractdef.do_all(v.toolcontext)
 		return n_contractdef
 	end
+end
+
+redef class MMethodDef
 
 	# Entry point to build contract (define the contract facet and define the contract method verification)
-	private fun construct_contract(v: ContractsVisitor, n_signature: ASignature, n_annotation: AAnnotation, mcontract: MContract, exist_contract: Bool)
+	private fun construct_contract(v: ContractsVisitor, n_signature: ASignature, n_annotations: Array[AAnnotation], mcontract: MContract, exist_contract: Bool)
 	do
-		if check_same_contract(v, n_annotation, mcontract) then return
-		if not exist_contract and not is_intro then no_intro_contract(v, n_signature, mcontract, n_annotation)
-		v.define_signature(mcontract, n_signature, mproperty.intro.msignature)
-
-		var conditiondef = v.build_contract(n_annotation, mcontract, mclassdef)
-		check_contract_facet(v, n_signature.clone, mclassdef, mcontract, exist_contract)
-		has_contract = true
+		v.define_contract_signature(mcontract, n_signature, mproperty.intro.msignature)
+		if not exist_contract and not is_intro then no_intro_contract(v, mcontract, n_annotations)
+		var conditiondef = v.build_contract(n_annotations, mcontract, mclassdef)
+		mproperty.define_contract_facet(v, mproperty.intro.msignature.as(not null), n_signature.clone, mclassdef, exist_contract, mcontract)
 	end
 
 	# Create a contract on the introduction classdef of the property.
 	# Display an warning message if necessary
-	private fun no_intro_contract(v: ContractsVisitor, n_signature: ASignature, mcontract: MContract, n_annotation: AAnnotation)
+	private fun no_intro_contract(v: ContractsVisitor, mcontract: MContract, n_annotations: Array[AAnnotation])
 	do
-		mcontract.create_empty_contract(v, mcontract.intro_mclassdef, mcontract.adapt_msignature(self.mproperty.intro.msignature), mcontract.adapt_nsignature(n_signature))
-		mcontract.no_intro_contract(v, n_annotation)
-		mproperty.intro.has_contract = true
+		mcontract.create_empty_contract(v, mcontract.intro_mclassdef)
+		mcontract.no_intro_contract(v, n_annotations)
 	end
 
-	# Is the contract already defined in the context
-	#
-	# Exemple :
-	# fun foo is expect([...]), expect([...])
-	#
-	# Here `check_same_contract` display an error when the second expect is processed
-	private fun check_same_contract(v: ContractsVisitor, n_annotation: AAnnotation ,mcontract: MContract): Bool
+	# Apply the `no_contract` annotation to the contract
+	# Display a warning if the annotation is not needed
+	private fun no_contract_apply(v: ContractsVisitor, n_signature: ASignature)
 	do
-		if self.mclassdef.mpropdefs_by_property.has_key(mcontract) then
-			v.toolcontext.error(n_annotation.location, "The method already has a defined `{mcontract.contract_name}` contract at line {self.mclassdef.mpropdefs_by_property[mcontract].location.line_start}")
-			return true
+		var mensure = mproperty.mensure
+		var mexpect = mproperty.mexpect
+		if mensure == null and mexpect == null then
+			v.toolcontext.warning(location, "useless_nocontract", "Useless `no_contract`, no contract was declared for `{name}`. Remove the `no_contract`")
 		end
-		return false
+		if mensure != null then
+			# Add an empty ensure method to replace the actual definition
+			mclassdef.mclass.create_empty_method(v, mensure, mclassdef, mensure.intro.msignature.as(not null), n_signature.adapt_to_ensurecondition)
+		end
+		if mexpect != null then
+			# Add an empty expect method to replace the actual definition
+			mclassdef.mclass.create_empty_method(v, mexpect, mclassdef, mexpect.intro.msignature.as(not null), n_signature.adapt_to_condition)
+		end
 	end
 end
 
-redef class MPropDef
-	# flag to indicate is the `MPropDef` has a contract
-	var has_contract = false
+redef class MClassDef
+	# check if the class inherits an invariant contract
+	private fun check_inherited_invariant: Bool
+	do
+		var super_classes = self.in_hierarchy.direct_greaters
+		for super_class in super_classes do
+			if super_class.mclass.check_invariant then return true
+		end
+		return false
+	end
 end
 
 redef class APropdef
 	redef fun check_callsite(v)
 	do
 		v.visited_method = self
+	end
+end
+
+redef class AClassdef
+
+	# Entry point to create a contract (verification of inheritance, or new contract)
+	redef fun check_contracts(v)
+	do
+		v.ast_builder.check_mmodule(mclassdef.mmodule)
+		v.current_location = location
+		v.visited_class = self
+		# It's always false to solve the problem of multiple inheritance an empty invariant method is systematically added in object.
+		v.is_intro_contract = false
+		check_redef(v)
+		check_annotation(v)
+	end
+
+	# Verification of the annotation to know if it is a contract annotation.
+	# If this is the case, we built the appropriate contract.
+	private fun check_annotation(v: ContractsVisitor)
+	do
+		var annotation_invariants = get_annotations("invariant")
+		var annotation_no_contract = get_annotations("no_contract")
+
+		if not annotation_invariants.is_empty and not annotation_no_contract.is_empty then
+			v.toolcontext.error(location, "The new contract definition is not correct when using `no_contract`. Remove the `invariant` definition or the` no_contract`")
+			return
+		end
+
+		if not annotation_no_contract.is_empty then
+			var minvariant = mclass.minvariant
+			if minvariant == null then
+				v.toolcontext.warning(location, "useless_nocontract", "Useless `no_contract`, no invariant was declared for `{mclass.name}`. Remove the `no_contract`")
+			else
+				# Add an empty invariant method to replace the actual definition
+				mclass.create_empty_method(v, minvariant, mclassdef.as(not null), minvariant.intro.msignature.as(not null), new ASignature)
+			end
+		end
+
+		if not annotation_invariants.is_empty then
+			# Check if the contract is necessary
+			if not v.check_usage_invariants(mclassdef.mmodule) then return
+
+			var minvariant = mclass.build_invariant(v)
+			v.define_contract_signature(minvariant, null, null)
+			v.build_contract(annotation_invariants, minvariant, mclassdef.as(not null))
+			add_invariant_in_super_def(v)
+		end
+	end
+
+	# Verification if the class has an inherited contract to apply it.
+	private fun check_redef(v: ContractsVisitor)
+	do
+		var is_inherited_contract = mclassdef.check_inherited_invariant
+		# Check if the method has an attached contract (Inherited)
+		if is_inherited_contract then mclass.minvariant = v.global_invariant
+	end
+
+	# Create all contract facet for each inherited property definition of the class
+	# Redefine properties will be processed later
+	private fun add_invariant_in_super_def(v: ContractsVisitor)
+	do
+		var mpropertys = mclassdef.collect_all_methods(v.mainmodule, new ModelFilter)
+		for mproperty in mpropertys do
+			if not mproperty isa MFacet and not mproperty isa MContract and mproperty.minvariant_facet == null then
+				# check if the actual definition have this property definition. if it's the case do nothing the visit of the method will do the job
+				if mclassdef.mpropdefs_by_property.has_key(mproperty) then continue
+				var intro_propdef = mproperty.intro
+				if intro_propdef.is_intern then continue
+				# Get the n_intro to use the signature as a contract facet signature
+				var n_intro = v.toolcontext.modelbuilder.mpropdef2node(intro_propdef)
+				if n_intro isa AMethPropdef then
+					var nsignature = n_intro.n_signature or else new ASignature
+					# Define the contract facet (add contract facet in the actual mclass definition and in intro if intro mclassdef != actual mclassdef)
+					mproperty.define_invariant_facet(v, intro_propdef.msignature.as(not null).clone, nsignature.clone, mclassdef.as(not null), false, mclass.minvariant.as(not null))
+				end
+			end
+		end
+	end
+end
+
+redef class AAttrPropdef
+
+	# Entry point to create all contracts.
+	redef fun check_contracts(v)
+	do
+		v.ast_builder.check_mmodule(v.visited_module.mmodule.as(not null))
+		v.current_location = self.location
+		check_annotation(v)
+		check_invariant(v)
+	end
+
+	# Verification of the annotation to know if it is a contract annotation.
+	# If this is the case, we built the appropriate contract.
+	private fun check_annotation(v: ContractsVisitor)
+	do
+		var annotation_expect = get_annotations("expect")
+		var annotation_ensure = get_annotations("ensure")
+		var annotation_no_contract = get_annotations("no_contract")
+
+		if (not annotation_expect.is_empty or not annotation_ensure.is_empty) and not annotation_no_contract.is_empty then
+			v.toolcontext.error(location, "The new contract definition is not correct when using `no_contract`. Remove the contract definition or the` no_contract`")
+			return
+		end
+
+		if mwritepropdef == null and (not annotation_expect.is_empty or not annotation_ensure.is_empty) then
+			# The contract is not applicable on no writable attribute
+			v.toolcontext.error(location, "Not applicable contract on not writable attribute")
+			return
+		end
+
+		if mwritepropdef != null and not annotation_no_contract.is_empty then
+			mwritepropdef.no_contract_apply(v, new ASignature.make_from_msignature(mwritepropdef.msignature.as(not null)))
+			return
+		end
+
+		if not annotation_expect.is_empty then
+			if not v.check_usage_expect(mwritepropdef.mclassdef.mmodule) then return
+
+			v.is_intro_contract = mwritepropdef.is_intro
+			var exist_set_contract = mwritepropdef.mproperty.check_expect
+			mwritepropdef.construct_contract(v, new ASignature.make_from_msignature(mwritepropdef.msignature.as(not null)), annotation_expect, mwritepropdef.mproperty.build_expect, exist_set_contract)
+		end
+
+		if not annotation_ensure.is_empty then
+			if not v.check_usage_ensure(mwritepropdef.mclassdef.mmodule) then return
+
+			v.is_intro_contract = mwritepropdef.is_intro
+			var exist_set_contract = mwritepropdef.mproperty.check_ensure
+			mwritepropdef.construct_contract(v, new ASignature.make_from_msignature(mwritepropdef.msignature.as(not null)), annotation_ensure, mwritepropdef.mproperty.build_ensure, exist_set_contract)
+		end
+	end
+
+	# Check if the class has an invariant.
+	private fun check_invariant(v: ContractsVisitor)
+	do
+		var propdef = mreadpropdef or else mwritepropdef
+
+		if propdef != null and propdef.mclassdef.mclass.check_invariant then
+			var minvariant = propdef.mclassdef.mclass.minvariant
+			assert minvariant != null
+			if mreadpropdef != null then mreadpropdef.mproperty.define_invariant_facet(v, mreadpropdef.msignature.as(not null), new ASignature, propdef.mclassdef, false, minvariant)
+			if mwritepropdef != null then mwritepropdef.mproperty.define_invariant_facet(v, mwritepropdef.msignature.as(not null), new ASignature.make_from_msignature(mwritepropdef.msignature.as(not null)), propdef.mclassdef, false, minvariant)
+		end
+	end
+
+	# Create a ASignature for the set method of the attribut
+	private fun create_set_nsignature: ASignature
+	do
+		var param_list = new Array[AParam]
+		var n_id = new TId.init_tk(self.location)
+		var new_param = new AParam.init_aparam(n_id,null,null,null)
+		new_param.variable = new Variable(mpropdef.name)
+		new_param.variable.declared_type = self.mtype
+		param_list.add new_param
+		var n_signature = new ASignature.init_asignature(null, param_list, null, null)
+		n_signature.location = self.location
+		return n_signature
+	end
+
+	private fun build_get_set(modelbuilder: ModelBuilder, mclassdef: MClassDef)
+	do
+		build_read_property(modelbuilder, mclassdef)
+		build_write_property(modelbuilder, mclassdef, true)
+		build_read_signature
+		build_write_signature
 	end
 end
 
@@ -695,66 +1178,62 @@ redef class AMethPropdef
 		# FIXME: The `do_` usage it is maybe to much (verification...). Solution: Cut the `do_` methods into simpler parts
 		self.do_scope(toolcontext)
 		self.do_flow(toolcontext)
-		self.do_typing(toolcontext.modelbuilder)
+		self.do_typing(toolcontext.modelbuilder, true)
 	end
 
 	# Entry point to create a contract (verification of inheritance, or new contract).
-	redef fun create_contracts(v)
+	redef fun check_contracts(v)
 	do
 		v.ast_builder.check_mmodule(mpropdef.mclassdef.mmodule)
-
 		v.current_location = self.location
 		v.is_intro_contract = mpropdef.is_intro
-
-		if n_annotations != null then
-			for n_annotation in n_annotations.n_items do
-				check_annotation(v,n_annotation)
-			end
-		end
-
-		if not mpropdef.is_intro and not v.find_no_contract then
-			self.check_redef(v)
-		end
-
-		# reset the flag
-		v.find_no_contract = false
+		v.visited_method = self
+		check_annotation(v)
+		check_invariant(v)
 	end
 
 	# Verification of the annotation to know if it is a contract annotation.
 	# If this is the case, we built the appropriate contract.
-	private fun check_annotation(v: ContractsVisitor, n_annotation: AAnnotation)
+	private fun check_annotation(v: ContractsVisitor)
 	do
-		if n_annotation.name == "expect" then
+		var annotation_expect = get_annotations("expect")
+		var annotation_ensure = get_annotations("ensure")
+		var annotation_no_contract = get_annotations("no_contract")
+
+		if (not annotation_expect.is_empty or not annotation_ensure.is_empty) and not annotation_no_contract.is_empty then
+			v.toolcontext.error(location, "The new contract definition is not correct when using `no_contract`. Remove the contract definition or the `no_contract`")
+			return
+		end
+
+		var nsignature = n_signature or else new ASignature
+
+		if not annotation_no_contract.is_empty then
+			mpropdef.no_contract_apply(v, n_signature.as(not null))
+			return
+		end
+
+		if not annotation_expect.is_empty then
 			if not v.check_usage_expect(mpropdef.mclassdef.mmodule) then return
-			var exist_contract = mpropdef.mproperty.check_exist_expect
-			mpropdef.construct_contract(v, self.n_signature.as(not null), n_annotation, mpropdef.mproperty.mexpect.as(not null), exist_contract)
-		else if n_annotation.name == "ensure" then
+			var exist_contract = mpropdef.mproperty.check_expect
+			mpropdef.construct_contract(v, nsignature.clone, annotation_expect, mpropdef.mproperty.build_expect, exist_contract)
+		end
+
+		if not annotation_ensure.is_empty then
 			if not v.check_usage_ensure(mpropdef.mclassdef.mmodule) then return
-			var exist_contract = mpropdef.mproperty.check_exist_ensure
-			mpropdef.construct_contract(v, self.n_signature.as(not null), n_annotation, mpropdef.mproperty.mensure.as(not null), exist_contract)
-		else if n_annotation.name == "no_contract" then
-			# no_contract found set the flag to true
-			v.find_no_contract = true
+			var exist_contract = mpropdef.mproperty.check_ensure
+			mpropdef.construct_contract(v, nsignature.clone, annotation_ensure, mpropdef.mproperty.build_ensure, exist_contract)
 		end
 	end
 
-	# Verification if the method have an inherited contract to apply it.
-	private fun check_redef(v: ContractsVisitor)
+	# Check if the class has an invariant.
+	private fun check_invariant(v: ContractsVisitor)
 	do
-		# Check if the method has an attached contract
-		if not mpropdef.has_contract then
-			if mpropdef.mproperty.intro.has_contract then
-				mpropdef.has_contract = true
-			end
+		if mpropdef != null and mpropdef.mclassdef.mclass.check_invariant then
+			var minvariant = mpropdef.mclassdef.mclass.minvariant
+			assert minvariant != null
+			var nsignature = n_signature or else new ASignature
+			mpropdef.mproperty.define_invariant_facet(v, mpropdef.msignature.as(not null), nsignature.clone, mpropdef.mclassdef, false, minvariant)
 		end
-	end
-
-	# Adapt the block to use the contracts
-	private fun adapt_block_to_contract(v: ContractsVisitor, contract: MContract, n_mpropdef: AMethPropdef)
-	do
-		contract.adapt_block_to_contract(v, n_mpropdef)
-		mpropdef.has_contract = true
-		n_mpropdef.do_all(v.toolcontext)
 	end
 end
 
@@ -828,7 +1307,7 @@ redef class ASendExpr
 	do
 		var actual_callsite = callsite
 		if actual_callsite != null then
-			callsite = v.drive_method_contract(actual_callsite)
+			callsite = v.drive_callsite_contract(actual_callsite)
 		end
 	end
 end
@@ -838,7 +1317,7 @@ redef class ANewExpr
 	do
 		var actual_callsite = callsite
 		if actual_callsite != null then
-			callsite = v.drive_method_contract(actual_callsite)
+			callsite = v.drive_callsite_contract(actual_callsite, recvtype.mclass)
 		end
 	end
 end

--- a/src/frontend/check_annotation.nit
+++ b/src/frontend/check_annotation.nit
@@ -114,6 +114,7 @@ example
 
 expect
 ensure
+invariant
 no_contract
 """
 

--- a/src/model/model_contract.nit
+++ b/src/model/model_contract.nit
@@ -1,0 +1,185 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The abstract concept of a contract in the model
+module model_contract
+import model
+import scope
+
+# The root of all contracts
+abstract class MContract
+	super MMethod
+end
+
+# An expect (precondition) contract representation
+class MExpect
+	super MContract
+end
+
+# The root of all contracts where the call is after the execution of the original method (`invariant` and `ensure`).
+abstract class BottomMContract
+	super MContract
+end
+
+# A ensure (postcondition) representation
+class MEnsure
+	super BottomMContract
+
+	# Old MClass, this class contains the set of old attributes used in the contract
+	var old_mclass: nullable MOldClass = null
+
+	# Check if self has an old mclass
+	private fun check_old_mclass: Bool
+	do
+		return self.old_mclass != null
+	end
+
+	# Build old_mclass if it does not exist already and return it
+	private fun build_old_mclass: MOldClass
+	do
+		var m_old_mclass = self.old_mclass
+		# build a new `MClass` to keep the old value
+		if m_old_mclass == null then m_old_mclass = new MOldClass(intro_mclassdef.mmodule, "old_{self.c_name}", intro_mclassdef.location, new Array[String], concrete_kind, public_visibility)
+		self.old_mclass = m_old_mclass
+		return m_old_mclass
+	end
+end
+
+# An invariant contract representation
+class MInvariant
+	super BottomMContract
+end
+
+# A facet contract representation
+# This class is created to keep the information of which method is a contract facet
+class MFacet
+	super MMethod
+end
+
+redef class MMethod
+
+	# The contract facet of the method
+	# is representing the method with a contract
+	# This method calls the contract and the method
+	var mcontract_facet: nullable MFacet = null
+
+	# The contract facet of the method with an invariant
+	# is representing the method with a contract
+	# This method calls the `mcontract_facet`
+	var minvariant_facet: nullable MFacet = null
+
+	# The expected contract method
+	var mexpect: nullable MExpect = null
+
+	# The ensure contract method
+	var mensure: nullable MEnsure = null
+
+	# Build ensure if is not exist and return it
+	private fun build_ensure: MEnsure
+	do
+		var m_mensure = self.mensure
+		# build a new `MEnsure` contract
+		if m_mensure == null then m_mensure = new MEnsure(intro_mclassdef, "_ensure_{name}", intro_mclassdef.location, public_visibility)
+		self.mensure = m_mensure
+		return m_mensure
+	end
+
+	# Check if the MMethod has no ensure contract
+	private fun check_ensure: Bool
+	do
+		return self.mensure != null
+	end
+
+	# Build expect if is not exist and return it
+	private fun build_expect: MExpect
+	do
+		var m_mexpect = self.mexpect
+		# build a new `MExpect` contract
+		if m_mexpect == null then m_mexpect = new MExpect(intro_mclassdef, "_expect_{name}", intro_mclassdef.location, public_visibility)
+		self.mexpect = m_mexpect
+		return m_mexpect
+	end
+
+	# Check if the MMethod has no expect contract
+	private fun check_expect: Bool
+	do
+		return self.mexpect != null
+	end
+
+	# Build contract facet if is not exist and return it
+	private fun build_contract_facet: MFacet
+	do
+		var m_mcontract_facet = self.mcontract_facet
+		# build a new `MFacet` contract
+		if m_mcontract_facet == null then m_mcontract_facet = new MFacet(intro_mclassdef, "_contract_{name}", intro_mclassdef.location, public_visibility)
+		self.mcontract_facet = m_mcontract_facet
+		return m_mcontract_facet
+	end
+
+	# Check if the MMethod has an contract facet
+	private fun check_contract_facet: Bool
+	do
+		return self.mcontract_facet != null
+	end
+
+	# Build invariant_facet if is not exist and return it
+	private fun build_invariant_facet: MFacet
+	do
+		var m_minvariant_facet = self.minvariant_facet
+		# build a new `MFacet` contract
+		if m_minvariant_facet == null then m_minvariant_facet = new MFacet(intro_mclassdef, "_contract_inv_{name}", intro_mclassdef.location, public_visibility)
+		self.minvariant_facet = m_minvariant_facet
+		return m_minvariant_facet
+	end
+
+	# Check if the MMethod has an invariant facet
+	private fun check_invariant_facet: Bool
+	do
+		return self.minvariant_facet != null
+	end
+end
+
+redef class MClass
+	# The invariant contract method
+	# This method checks all invariants
+	var minvariant: nullable MInvariant = null
+
+	# Check if the MClass has no invariant contract
+	private fun has_invariant: Bool do return self.minvariant != null
+end
+
+# Representation of `old` class to store an old context
+class MOldClass
+	super MClass
+
+	# Property to init all old attributes.
+	var init_old_property: nullable MMethod
+
+	# The old variable.
+	var old_variable = new Variable("old")
+end
+
+class MOldInit
+	super MMethod
+end
+
+redef class MModule
+	fun get_mclassdef(mclass: MClass): nullable MClassDef
+	do
+		for mclassdef in mclassdefs do
+			if mclassdef.mclass == mclass then return mclassdef
+		end
+		return null
+	end
+end

--- a/src/modelbuilder_base.nit
+++ b/src/modelbuilder_base.nit
@@ -60,7 +60,7 @@ class ModelBuilder
 	# If no such a class exists, then null is returned.
 	# If more than one class exists, then an error on `anode` is displayed and null is returned.
 	# FIXME: add a way to handle class name conflict
-	fun try_get_mclass_by_name(anode: ANode, mmodule: MModule, name: String): nullable MClass
+	fun try_get_mclass_by_name(anode: nullable ANode, mmodule: MModule, name: String): nullable MClass
 	do
 		var classes = model.get_mclasses_by_name(name)
 		if classes == null then
@@ -112,7 +112,7 @@ class ModelBuilder
 	end
 
 	# Like `try_get_mclass_by_name` but display an error message when the class is not found
-	fun get_mclass_by_name(node: ANode, mmodule: MModule, name: String): nullable MClass
+	fun get_mclass_by_name(node: nullable ANode, mmodule: MModule, name: String): nullable MClass
 	do
 		var mclass = try_get_mclass_by_name(node, mmodule, name)
 		if mclass == null then
@@ -127,7 +127,7 @@ class ModelBuilder
 	# If no such a property exists, then null is returned.
 	# If more than one property exists, then an error on `anode` is displayed and null is returned.
 	# FIXME: add a way to handle property name conflict
-	fun try_get_mproperty_by_name2(anode: ANode, mmodule: MModule, mtype: MType, name: String): nullable MProperty
+	fun try_get_mproperty_by_name2(anode: nullable ANode, mmodule: MModule, mtype: MType, name: String): nullable MProperty
 	do
 		var props = self.model.get_mproperties_by_name(name)
 		if props == null then
@@ -209,7 +209,7 @@ class ModelBuilder
 
 
 	# Alias for try_get_mproperty_by_name2(anode, mclassdef.mmodule, mclassdef.mtype, name)
-	fun try_get_mproperty_by_name(anode: ANode, mclassdef: MClassDef, name: String): nullable MProperty
+	fun try_get_mproperty_by_name(anode: nullable ANode, mclassdef: MClassDef, name: String): nullable MProperty
 	do
 		return try_get_mproperty_by_name2(anode, mclassdef.mmodule, mclassdef.bound_mtype, name)
 	end

--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -53,6 +53,17 @@ redef class ModelBuilder
 		mpropdef2npropdef[mpropdef] = npropdef
 	end
 
+	# Associate a `nclassdef` with its `mclassdef`
+	#
+	# Be careful, this method is unsafe, no checking is done when it's used.
+	# The safe way to add mclass it's to use the `build_property`
+	#
+	# See `mclassdef2nclassdef`
+	fun unsafe_add_mclassdef2nclassdef(mclassdef: MClassDef, nclassdef: AClassdef)
+	do
+		mclassdef2nclassdef[mclassdef] = nclassdef
+	end
+
 	# Retrieve the associated AST node of a mpropertydef.
 	# This method is used to associate model entity with syntactic entities.
 	#

--- a/src/nitbuilder.nit
+++ b/src/nitbuilder.nit
@@ -1,0 +1,275 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Instantiation and transformation of language entities in AST and model. NitBuilder know how to associate a model and ast representation.
+module nitbuilder
+
+import modelbuilder
+intrude import astbuilder
+intrude import modelize_property
+intrude import scope
+intrude import typing
+
+# Provides the construction of model entities and their associated ast.
+class NitBuilder
+
+	# The toolcontext instance
+	var toolcontext: ToolContext
+
+	# Instance of the AST constructor
+	var ast_builder: ASTBuilder
+
+	# Try to get MMethod property if exist in the given mclassdef. return new MMethod if not exist.
+	private fun get_mmethod(name: String, mclassdef: MClassDef, visibility: nullable MVisibility): MMethod do
+		if visibility == null then visibility = public_visibility
+		var mproperty = toolcontext.modelbuilder.try_get_mproperty_by_name(null, mclassdef, name).as(nullable MMethod)
+		if mproperty == null then mproperty = new MMethod(mclassdef, name, mclassdef.location, visibility)
+		return mproperty
+	end
+
+	# Creation of a new method (AST and model representation) with the given name.
+	# See `create_method_from_property` for more information.
+	fun create_method_from_name(name: String, mclassdef: MClassDef, msignature: nullable MSignature, visibility: nullable MVisibility): AMethPropdef do
+		var mproperty = get_mmethod(name, mclassdef, visibility)
+		return create_method_from_property(mproperty, mclassdef, msignature)
+	end
+
+	# Same as `create_method_from_name` except the returned AMethPropdef is abstract.
+	# See `create_abstract_method_from_property` for more information.
+	fun create_abstract_method_from_name(name: String, mclassdef: MClassDef, msignature: nullable MSignature, visibility: nullable MVisibility): AMethPropdef do
+		var mproperty = get_mmethod(name, mclassdef, visibility)
+		return create_abstract_method_from_property(mproperty, mclassdef, msignature)
+	end
+
+	# Creation of a new method (AST and model representation) with the given MMethod.
+	# See `create_abstract_method_from_property` for more information.
+	# Take care, the AMethPropdef returned has an empty body (potential error if the signature given has a return type).
+	fun create_method_from_property(mproperty: MMethod,  mclassdef: MClassDef, msignature: nullable MSignature): AMethPropdef do
+		var n_def = create_abstract_method_from_property(mproperty, mclassdef, msignature)
+		n_def.mpropdef.is_abstract = false
+		n_def.n_block = ast_builder.make_block
+		return n_def
+	end
+
+	# Creation of a new abstract method (AST and model representation) with the given MMethod
+	fun create_abstract_method_from_property(mproperty: MMethod,  mclassdef: MClassDef, msignature: nullable MSignature): AMethPropdef do
+		# new methoddef definition
+		var m_def = new MMethodDef(mclassdef, mproperty, mclassdef.location)
+		if msignature == null then msignature = new MSignature(new Array[MParameter])
+		# set the signature
+		m_def.msignature = msignature
+		# set the abstract flag
+		m_def.is_abstract = true
+		# Build ast representation of the method
+		var n_def = m_def.create_ast_representation(ast_builder)
+		# Association new npropdef to mpropdef
+		toolcontext.modelbuilder.unsafe_add_mpropdef2npropdef(m_def,n_def)
+		return n_def
+	end
+
+	# Creation of a new attribute (AST and model representation) with the given name.
+	# See `create_attribute_from_property` for more information.
+	fun create_attribute_from_name(name: String, mclassdef: MClassDef, mtype: MType, visibility: nullable MVisibility, is_writable: nullable Bool, default_value: nullable AExpr): AAttrPropdef do
+		if visibility == null then visibility = public_visibility
+		# Try to get the attribut.
+		var mattribute = toolcontext.modelbuilder.try_get_mproperty_by_name(null, mclassdef, name)
+		if mattribute == null then mattribute = new MAttribute(mclassdef, name, mclassdef.location, visibility)
+		return create_attribute_from_property(mattribute.as(MAttribute), mclassdef, mtype, is_writable, default_value)
+	end
+
+	# Creation of a new attribute (AST and model representation) with the given MAttribute.
+	# See `create_attribute_from_propdef` for more information.
+	fun create_attribute_from_property(mattribute: MAttribute, mclassdef: MClassDef, mtype: MType, is_writable: nullable Bool, default_value: nullable AExpr): AAttrPropdef do
+		var attribut_def = new MAttributeDef(mclassdef, mattribute, mclassdef.location)
+		attribut_def.static_mtype = mtype
+		return create_attribute_from_propdef(attribut_def, is_writable, default_value)
+	end
+
+	# Creation of a new attribute (AST representation) with the given MAttributeDef.
+	# See `create_attribute_from_propdef` for more information.
+	fun create_attribute_from_propdef(mattribut_def: MAttributeDef, is_writable: nullable Bool, default_value: nullable AExpr): AAttrPropdef
+	is
+		expect(toolcontext.modelbuilder.mclassdef2node(mattribut_def.mclassdef) != null)
+	do
+		var n_attribute = mattribut_def.create_ast_representation(ast_builder)
+		n_attribute.n_expr = default_value
+		if default_value != null then n_attribute.has_value = true
+
+		var nclass = toolcontext.modelbuilder.mclassdef2node(mattribut_def.mclassdef)
+
+		n_attribute.location = mattribut_def.location
+		n_attribute.validate
+
+		nclass.n_propdefs.unsafe_add_all([n_attribute])
+		nclass.validate
+
+		n_attribute.build_read_property(toolcontext.modelbuilder, mattribut_def.mclassdef)
+		n_attribute.build_read_signature
+
+		if is_writable == null or is_writable then
+			n_attribute.build_write_property(toolcontext.modelbuilder, mattribut_def.mclassdef, true)
+			n_attribute.build_write_signature
+		end
+
+		toolcontext.modelbuilder.mpropdef2npropdef[mattribut_def] = n_attribute
+		return n_attribute
+	end
+
+	# Creation of a new class (AST and model representation) with the given name.
+	# See `create_class_from_mclass` for more information.
+	fun create_class_from_name(name: String, super_type: Array[MClassType], mmodule: MModule, visibility: nullable MVisibility): AStdClassdef do
+		if visibility == null then visibility = public_visibility
+		var mclass = toolcontext.modelbuilder.try_get_mclass_by_name(null, mmodule, name)
+		if mclass == null then mclass = new MClass(mmodule, name, mmodule.location, new Array[String], concrete_kind, visibility)
+		return create_class_from_mclass(mclass, super_type, mmodule)
+	end
+
+	# Creation of a new class (AST and model representation) with the given MClass.
+	# This method creates a new concrete class definition `MClassDef`, and adds it to the class hierarchy.
+	# See `create_class_from_mclassdef` for more information.
+	fun create_class_from_mclass(mclass: MClass, super_type: Array[MClassType], mmodule: MModule): AStdClassdef do
+		var mclassdef = new MClassDef(mmodule, mclass.mclass_type, mmodule.location)
+		mclassdef.set_supertypes(super_type)
+		mclassdef.add_in_hierarchy
+
+		return create_class_from_mclassdef(mclassdef, mmodule)
+	end
+
+	# Creation of a new class (AST representation) with the given MClassDef.
+	# Note all the properties of our MClassDef will also generate an AST representation.
+	# Make an error if the attribute already has already representation in the modelbuilder.
+	fun create_class_from_mclassdef(mclassdef: MClassDef, mmodule: MModule): AStdClassdef do
+		var n_classdef = mclassdef.create_ast_representation
+		n_classdef.location = mclassdef.location
+		n_classdef.validate
+
+		for n_propdef in n_classdef.n_propdefs do
+			var mpropdef = n_propdef.mpropdef
+			assert mpropdef != null
+
+			var p_npropdef = toolcontext.modelbuilder.mpropdef2node(mpropdef)
+			if  p_npropdef != null then toolcontext.modelbuilder.error(null, "The property `{mpropdef.name}` already has a representation in the AST.")
+			toolcontext.modelbuilder.unsafe_add_mpropdef2npropdef(mpropdef, n_propdef)
+		end
+
+		toolcontext.modelbuilder.process_default_constructors(n_classdef)
+
+		toolcontext.modelbuilder.unsafe_add_mclassdef2nclassdef(mclassdef, n_classdef)
+		return n_classdef
+	end
+
+	# Build a callsite to call the `mproperty` in the current method `caller`.
+	# `is_self_call` indicate if the called method is a property of `self`
+	#
+	# This method provides a safe entry point to create a callsite. See `build_callsite_by_property` in TypeVisitor.
+	fun create_callsite(caller: APropdef, mproperty: MMethod, is_self_call: Bool): CallSite
+	do
+		var type_visitor = new TypeVisitor(toolcontext.modelbuilder, caller.mpropdef.as(not null))
+		var callsite = type_visitor.build_callsite_by_property(caller, mproperty.intro_mclassdef.bound_mtype, mproperty, is_self_call)
+		assert callsite != null
+		return callsite
+	end
+end
+
+redef class MEntity
+	# Return a ast representation of self model entity.
+	fun create_ast_representation(astbuilder: nullable ASTBuilder): ANode is abstract
+end
+
+redef class MPropDef
+	redef fun create_ast_representation(astbuilder: nullable ASTBuilder): APropdef is abstract
+end
+
+redef class MClassDef
+	redef fun create_ast_representation(astbuilder: nullable ASTBuilder): AStdClassdef do
+		if astbuilder == null then astbuilder = new ASTBuilder(mmodule)
+		var n_propdefs = new Array[APropdef]
+		for mpropdef in self.mpropdefs do
+			n_propdefs.add(mpropdef.create_ast_representation(astbuilder))
+		end
+		var n_formaldefs = new Array[AFormaldef]
+		return astbuilder.make_class(self, visibility.create_ast_representation(astbuilder), n_formaldefs, null, n_propdefs, null)
+	end
+end
+
+redef class MAttributeDef
+	redef fun create_ast_representation(astbuilder: nullable ASTBuilder): AAttrPropdef do
+		if astbuilder == null then astbuilder = new ASTBuilder(mclassdef.mmodule)
+		var ntype = null
+		if self.static_mtype != null then ntype = static_mtype.create_ast_representation(astbuilder)
+		return astbuilder.make_attribute("_" + self.name, ntype, self.visibility.create_ast_representation(astbuilder), null, null, self, null, null)
+	end
+end
+
+redef class MMethodDef
+	redef fun create_ast_representation(astbuilder: nullable ASTBuilder): AMethPropdef do
+		if astbuilder == null then astbuilder = new ASTBuilder(mclassdef.mmodule)
+		var tk_redef = null
+		if self.mproperty.intro != self then tk_redef = new TKwredef
+		var n_signature = new ASignature
+		if self.msignature != null then n_signature = self.msignature.create_ast_representation(astbuilder)
+		return astbuilder.make_method(visibility.create_ast_representation(astbuilder) , tk_redef, self, n_signature)
+	end
+end
+
+redef class MVisibility
+	fun create_ast_representation(astbuilder: nullable ASTBuilder): AVisibility do
+		if self.to_s == "public" then
+			return new APublicVisibility
+		else if self.to_s == "private" then
+			return new APrivateVisibility
+		else if self.to_s == "protected" then
+			return new AProtectedVisibility
+		else
+			return new AIntrudeVisibility
+		end
+	end
+end
+
+redef class MSignature
+	redef fun create_ast_representation(astbuilder: nullable ASTBuilder): ASignature do
+		var nparams = new Array[AParam]
+		for mparam in mparameters do nparams.add(mparam.create_ast_representation(astbuilder))
+		var return_type = null
+		if self.return_mtype != null then return_type = self.return_mtype.create_ast_representation(astbuilder)
+		return new ASignature.init_asignature(null, nparams, null, return_type)
+	end
+end
+
+redef class MParameter
+	redef fun create_ast_representation(astbuilder: nullable ASTBuilder): AParam do
+		var variable = new Variable(self.name)
+		variable.declared_type = self.mtype
+		return new AParam.make(variable, self.mtype.create_ast_representation(astbuilder))
+	end
+end
+
+redef class MType
+	redef fun create_ast_representation(astbuilder: nullable ASTBuilder): AType do
+		return new AType.make(self)
+	end
+end
+
+redef class AMethPropdef
+	# Execute all method verification scope flow and typing.
+	# It also execute an ast validation to define all parents and all locations
+	fun do_all(toolcontext: ToolContext)
+	do
+		self.validate
+		# FIXME: The `do_` usage it is maybe to much (verification...). Solution: Cut the `do_` methods into simpler parts
+		self.do_scope(toolcontext)
+		self.do_flow(toolcontext)
+		self.do_typing(toolcontext.modelbuilder, true)
+	end
+end

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -49,7 +49,7 @@ private class TypeVisitor
 	var mpropdef: MPropDef
 
 	# Are warnings disabled ?
-	# By default the value is false to enable all warnings for typing.
+	# By default the value is false to enable all warning for typing.
 	var disable_warning = false is optional, writable
 
 	var selfvariable = new Variable("self")
@@ -897,7 +897,7 @@ redef class AMethPropdef
 		var mpropdef = self.mpropdef
 		if mpropdef == null then return # skip error
 
-		# Define if the warning are disabled
+		# Define if warnings are disabled
 		var warning = disable_warning
 		if warning == null then warning = false
 
@@ -968,7 +968,7 @@ redef class AAttrPropdef
 		var mpropdef = self.mreadpropdef
 		if mpropdef == null or mpropdef.msignature == null then return # skip error
 
-		# Define if the warning are disabled
+		# Define if warnings are disabled
 		var warning = disable_warning
 		if warning == null then warning = false
 
@@ -2031,6 +2031,15 @@ redef class ASendExpr
 		else
 			self.is_typed = true
 		end
+	end
+
+	# The entry point of typing analysis of ASendExpr.
+	fun do_typing(modelbuilder: ModelBuilder, visited_mpropdef: MPropDef)
+	do
+		var v = new TypeVisitor(modelbuilder, visited_mpropdef)
+		v.visit_stmt(self)
+		var post_visitor = new PostTypingVisitor(v)
+		post_visitor.enter_visit(self)
 	end
 
 	# The name of the property

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -48,6 +48,10 @@ private class TypeVisitor
 	# The analyzed property
 	var mpropdef: MPropDef
 
+	# Are warnings disabled ?
+	# By default the value is false to enable all warnings for typing.
+	var disable_warning = false is optional, writable
+
 	var selfvariable = new Variable("self")
 
 	# Is `self` use restricted?
@@ -74,6 +78,12 @@ private class TypeVisitor
 		if mprop isa MMethod and mprop.is_new then
 			is_toplevel_context = true
 		end
+	end
+
+	# Helper function to display a warning on a node in function of `disable_warning` value.
+	fun display_warning(node: ANode, tag: String, message: String)
+	do
+		if not disable_warning then self.modelbuilder.warning(node, tag, message)
 	end
 
 	fun anchor_to(mtype: MType): MType
@@ -191,9 +201,9 @@ private class TypeVisitor
 		if sup == null then return null # Forward error
 
 		if sup == sub then
-			self.modelbuilder.warning(node, "useless-type-test", "Warning: expression is already a `{sup}`.")
+			display_warning(node, "useless-type-test", "Warning: expression is already a `{sup}`.")
 		else if self.is_subtype(sub, sup) then
-			self.modelbuilder.warning(node, "useless-type-test", "Warning: expression is already a `{sup}` since it is a `{sub}`.")
+			display_warning(node, "useless-type-test", "Warning: expression is already a `{sup}` since it is a `{sub}`.")
 		end
 		return sup
 	end
@@ -216,16 +226,16 @@ private class TypeVisitor
 	fun check_can_be_null(anode: ANode, mtype: MType): Bool
 	do
 		if mtype isa MNullType then
-			modelbuilder.warning(anode, "useless-null-test", "Warning: expression is always `null`.")
+			if not disable_warning then modelbuilder.warning(anode, "useless-null-test", "Warning: expression is always `null`.")
 			return true
 		end
 		if can_be_null(mtype) then return true
 
 		if mtype isa MFormalType then
 			var res = anchor_to(mtype)
-			modelbuilder.warning(anode, "useless-null-test", "Warning: expression is not null, since it is a `{mtype}: {res}`.")
+			display_warning(anode, "useless-null-test", "Warning: expression is not null, since it is a `{mtype}: {res}`.")
 		else
-			modelbuilder.warning(anode, "useless-null-test", "Warning: expression is not null, since it is a `{mtype}`.")
+			display_warning(anode, "useless-null-test", "Warning: expression is not null, since it is a `{mtype}`.")
 		end
 		return false
 	end
@@ -371,9 +381,9 @@ private class TypeVisitor
 		if info != null and self.mpropdef.mproperty.deprecation == null then
 			var mdoc = info.mdoc
 			if mdoc != null then
-				self.modelbuilder.warning(node, "deprecated-method", "Deprecation Warning: method `{mproperty.name}` is deprecated: {mdoc.content.first}")
+				display_warning(node, "deprecated-method", "Deprecation Warning: method `{mproperty.name}` is deprecated: {mdoc.content.first}")
 			else
-				self.modelbuilder.warning(node, "deprecated-method", "Deprecation Warning: method `{mproperty.name}` is deprecated.")
+				display_warning(node, "deprecated-method", "Deprecation Warning: method `{mproperty.name}` is deprecated.")
 			end
 		end
 
@@ -386,7 +396,7 @@ private class TypeVisitor
 		else if propdefs.length == 1 then
 			mpropdef = propdefs.first
 		else
-			self.modelbuilder.warning(node, "property-conflict", "Warning: conflicting property definitions for property `{mproperty.name}` in `{unsafe_type}`: {propdefs.join(" ")}")
+			display_warning(node, "property-conflict", "Warning: conflicting property definitions for property `{mproperty.name}` in `{unsafe_type}`: {propdefs.join(" ")}")
 			mpropdef = mproperty.intro
 		end
 
@@ -873,7 +883,7 @@ end
 
 redef class APropdef
 	# The entry point of the whole typing analysis
-	fun do_typing(modelbuilder: ModelBuilder)
+	fun do_typing(modelbuilder: ModelBuilder, disable_warning: nullable Bool)
 	do
 	end
 
@@ -882,12 +892,16 @@ redef class APropdef
 end
 
 redef class AMethPropdef
-	redef fun do_typing(modelbuilder: ModelBuilder)
+	redef fun do_typing(modelbuilder: ModelBuilder, disable_warning: nullable Bool)
 	do
 		var mpropdef = self.mpropdef
 		if mpropdef == null then return # skip error
 
-		var v = new TypeVisitor(modelbuilder, mpropdef)
+		# Define if the warning are disabled
+		var warning = disable_warning
+		if warning == null then warning = false
+
+		var v = new TypeVisitor(modelbuilder, mpropdef, disable_warning = warning)
 		self.selfvariable = v.selfvariable
 
 		var mmethoddef = self.mpropdef.as(not null)
@@ -947,14 +961,18 @@ redef class ANode
 end
 
 redef class AAttrPropdef
-	redef fun do_typing(modelbuilder: ModelBuilder)
+	redef fun do_typing(modelbuilder: ModelBuilder, disable_warning: nullable Bool)
 	do
 		if not has_value then return
 
 		var mpropdef = self.mreadpropdef
 		if mpropdef == null or mpropdef.msignature == null then return # skip error
 
-		var v = new TypeVisitor(modelbuilder, mpropdef)
+		# Define if the warning are disabled
+		var warning = disable_warning
+		if warning == null then warning = false
+
+		var v = new TypeVisitor(modelbuilder, mpropdef, disable_warning = warning)
 		self.selfvariable = v.selfvariable
 
 		var nexpr = self.n_expr

--- a/src/toolcontext.nit
+++ b/src/toolcontext.nit
@@ -411,12 +411,18 @@ class ToolContext
 	# Option --full-contract
 	var opt_full_contract = new OptionBool("Enable all contracts usage", "--full-contract")
 
+	# Option --in-out-invariant
+	var opt_in_out_invariant = new OptionBool("Enable the verification of invariant contracts in enter and exit", "--in-out-invariant")
+
+	# Option --self-contract
+	var opt_no_self_contract = new OptionBool("Disable the verification of contracts in self", "--no-self-contract")
+
 	# Verbose level
 	var verbose_level: Int = 0
 
 	init
 	do
-		option_context.add_option(opt_warn, opt_warning, opt_quiet, opt_stop_on_first_error, opt_keep_going, opt_no_color, opt_log, opt_log_dir, opt_nit_dir, opt_help, opt_version, opt_set_dummy_tool, opt_verbose, opt_bash_completion, opt_stub_man, opt_no_contract, opt_full_contract)
+		option_context.add_option(opt_warn, opt_warning, opt_quiet, opt_stop_on_first_error, opt_keep_going, opt_no_color, opt_log, opt_log_dir, opt_nit_dir, opt_help, opt_version, opt_set_dummy_tool, opt_verbose, opt_bash_completion, opt_stub_man, opt_no_contract, opt_full_contract, opt_in_out_invariant, opt_no_self_contract)
 
 		# Hide some internal options
 		opt_stub_man.hidden = true

--- a/tests/contract_invariant_defaultinit.nit
+++ b/tests/contract_invariant_defaultinit.nit
@@ -1,0 +1,27 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+	invariant(i > 0)
+
+	var i: Int
+
+	init
+	do
+
+	end
+
+end
+
+var a = new A(0)

--- a/tests/contract_old_1.nit
+++ b/tests/contract_old_1.nit
@@ -1,0 +1,40 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+	var i: Int
+
+	fun add_one
+	is
+		ensure(old(i) + 1 == i)
+	do
+		i = i + 1
+	end
+end
+
+class B
+	var i: Int
+
+	fun add_one
+	is
+		ensure(old(i) + 1 == i)
+	do
+		i = i
+	end
+end
+
+var a = new A(0)
+a.add_one
+var b = new B(0)
+b.add_one

--- a/tests/contract_old_add_redef.nit
+++ b/tests/contract_old_add_redef.nit
@@ -1,0 +1,41 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+	var i: Int
+
+	fun add_one
+	is
+		ensure(self.i > 0)
+	do
+		i = i + 1
+	end
+end
+
+class B
+	super A
+
+	redef fun add_one
+	is
+		ensure(old(i) + 1 == i)
+	do
+		super
+	end
+end
+
+var a = new A(0)
+a.add_one
+
+var b = new B(0)
+b.add_one

--- a/tests/contract_old_already_declared.nit
+++ b/tests/contract_old_already_declared.nit
@@ -1,0 +1,41 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+	var i: Int
+
+	fun foo
+	is
+		ensure(old(i) < i)
+	do
+		i = i + 10
+	end
+end
+
+class B
+	super A
+
+	redef fun foo
+	is
+		ensure(old(i) + 10 < i)
+	do
+		super
+		i = i + 10
+	end
+end
+
+var a = new A(0)
+a.foo
+var b = new B(0)
+b.foo

--- a/tests/contract_old_default_init.nit
+++ b/tests/contract_old_default_init.nit
@@ -1,0 +1,26 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+	var i: Int
+
+	init
+	is
+		ensure(old(i) + 1 == i)
+	do
+		i = i + 1
+	end
+end
+
+var a = new A(10)

--- a/tests/contract_old_no_expression.nit
+++ b/tests/contract_old_no_expression.nit
@@ -1,0 +1,29 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+	var i: Int
+
+	fun bar do print "Test"
+
+	fun foo
+	is
+		ensure(old(bar))
+	do
+		i = i + 10
+	end
+end
+
+var a = new A(0)
+a.foo

--- a/tests/contract_old_redef.nit
+++ b/tests/contract_old_redef.nit
@@ -1,0 +1,44 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+	var i: Int
+
+	fun add_one
+	is
+		ensure(old(i) + 1 == i)
+	do
+		i = i + 1
+	end
+end
+
+class B
+	super A
+
+	var new_int: Int
+
+	redef fun add_one
+	is
+		ensure(old(new_int) + 1 == new_int)
+	do
+		new_int = new_int
+	end
+
+end
+
+var a = new A(0)
+a.add_one
+
+var b = new B(0, 0)
+b.add_one

--- a/tests/contract_old_same_name.nit
+++ b/tests/contract_old_same_name.nit
@@ -1,0 +1,41 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+	var i: Int
+
+	fun add_one
+	is
+		ensure(old(i) + 1 == i)
+	do
+		i = i + 1
+	end
+end
+
+class B
+	var i: Int
+
+	fun add_one
+	is
+		ensure(old(i) + 1 == i)
+	do
+		i = i + 1
+	end
+end
+
+var a = new A(0)
+a.add_one
+
+var b = new B(0)
+b.add_one

--- a/tests/contract_old_same_property.nit
+++ b/tests/contract_old_same_property.nit
@@ -1,0 +1,42 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+	var i: Int
+
+	fun add_one
+	is
+		ensure(old(i) + 1 == i)
+	do
+		i = i + 1
+	end
+end
+
+class B
+	var i: Int
+
+	var a: A
+
+	fun add_one
+	is
+		ensure(old(i) + 1 == i)
+		ensure(old(a.i) + 1 == a.i)
+	do
+		i = i + 1
+		a.add_one
+	end
+end
+
+var b = new B(0, new A(0))
+b.add_one

--- a/tests/contract_old_unknown.nit
+++ b/tests/contract_old_unknown.nit
@@ -1,0 +1,27 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+	var i: Int
+
+	fun foo
+	is
+		ensure(old(z) == 10)
+	do
+		i = i + 10
+	end
+end
+
+var a = new A(0)
+a.foo

--- a/tests/contract_old_with_expect.nit
+++ b/tests/contract_old_with_expect.nit
@@ -1,0 +1,28 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+	var i: Int
+
+	fun add_one
+	is
+		expect(i > 0)
+		ensure(old(i) + 1 == i)
+	do
+		i = i + 1
+	end
+end
+
+var a = new A(0)
+a.add_one

--- a/tests/contract_stack.nit
+++ b/tests/contract_stack.nit
@@ -1,0 +1,51 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Stack[T]
+	var data = new Array[T]
+
+	var top = -1
+
+	var max_size: Int
+
+	init defaultinit(size: Int)
+	is
+		expect(size > 0)
+	do
+		self.max_size = size
+	end
+
+	fun push(object: T)
+	is
+		expect(top < (max_size - 1))
+		ensure(top == old(top) + 1)
+		ensure(data[top] == object)
+	do
+		top += 1
+		data[top] = object
+	end
+
+	fun pop
+	is
+		expect(top > -1)
+		ensure(top == old(top) - 1)
+	do
+		data.pop
+		top -= 1
+	end
+end
+
+var stack = new Stack[Int](10)
+stack.push(10)
+stack.pop

--- a/tests/contracts_attribut_ensure.nit
+++ b/tests/contracts_attribut_ensure.nit
@@ -1,0 +1,27 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test the creation and usage of simple contracts on attributes.
+
+class MyClass
+
+	var bar: Int is ensure(self.bar != 10)
+
+	var baz: Float is ensure(self.baz != 10.0)
+
+end
+
+var first = new MyClass(1, 1.0)
+first.baz = 11.0
+first.bar = 10 # Fail bar != 10

--- a/tests/contracts_attribut_expect.nit
+++ b/tests/contracts_attribut_expect.nit
@@ -1,0 +1,28 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test the creation and usage of simple contracts on attributes.
+
+class MyClass
+
+	var bar: Int is expect(self.bar != 10)
+
+	var baz: Float is expect(self.baz != 10.0)
+
+end
+
+var first = new MyClass(1, 1.0)
+first.baz = 11.0
+first.bar = 10 # First is ok because the check is before the set
+first.bar = 10 # Fail bar != 10

--- a/tests/contracts_attribut_readonly.nit
+++ b/tests/contracts_attribut_readonly.nit
@@ -1,0 +1,25 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test contracts on readonly attributes (an error should be displayed)
+
+class MyClass
+
+	var bar = 10 is readonly, ensure(self.bar != 10)
+
+	var baz: Float is ensure(self.baz != 10.0)
+
+end
+
+var first = new MyClass(1.0)

--- a/tests/contracts_invariant_1.nit
+++ b/tests/contracts_invariant_1.nit
@@ -1,0 +1,29 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test the creation and usage of simple invariant contract.
+
+class Test
+	invariant(bar >= 10)
+
+	var bar: Int
+
+	fun set_bar(x: Int) do
+		print x
+		bar = x
+	end
+end
+
+var test = new Test(10)
+test.set_bar(9)# Fail broke the invariant

--- a/tests/contracts_invariant_attr.nit
+++ b/tests/contracts_invariant_attr.nit
@@ -1,0 +1,29 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test the creation and usage of simple invariant contract with attribute.
+
+class Test
+	invariant(bar >= 10)
+
+	var bar: Int
+
+	fun set_bar(x: Int) do
+		print x
+		bar = x
+	end
+end
+
+var test = new Test(10)
+test.bar = 9 # Fail broke the invariant

--- a/tests/contracts_invariant_diamond.nit
+++ b/tests/contracts_invariant_diamond.nit
@@ -1,0 +1,42 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+	invariant(bar >= 10)
+
+	var bar: Int
+end
+
+class B
+	invariant(bar > 10)
+	super A
+
+	fun set_bar(x: Int) do
+		print x
+		bar = x
+	end
+end
+
+class C
+	invariant(bar > 12)
+	super A
+end
+
+class D
+	super B
+	super C
+end
+
+var test = new D(13)
+test.set_bar(11)

--- a/tests/contracts_invariant_in_redef.nit
+++ b/tests/contracts_invariant_in_redef.nit
@@ -1,0 +1,23 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import contracts_abstract
+
+# Test if the invariant contract is added to old method definitions.
+
+redef class MySubClass
+	invariant(false)
+end
+
+var test = new MySubClass
+test.foo(11, 2.5)

--- a/tests/contracts_invariant_inheritance.nit
+++ b/tests/contracts_invariant_inheritance.nit
@@ -1,0 +1,34 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test the creation and usage of invariant contracts with inheritance.
+
+class A
+	invariant(bar >= 10)
+
+	var bar: Int
+end
+
+class B
+	super A
+
+	fun set_bar(x: Int) do
+		print x
+		bar = x
+	end
+end
+
+var test = new B(10)
+test.set_bar(11) # OK
+test.set_bar(2) # Fail broke invariant bar >= 10

--- a/tests/contracts_invariant_inheritance_multi.nit
+++ b/tests/contracts_invariant_inheritance_multi.nit
@@ -1,0 +1,47 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+module contracts_invariant_inheritance_multi
+
+# Test the creation and usage of invariant contracts with multiple inheritance.
+
+class A
+	invariant(bar >= 10)
+
+	var bar: Int
+end
+
+class B
+	invariant(baz <= 2.0)
+
+	var baz: Float
+end
+
+class C
+	super A
+	super B
+
+	autoinit bar=, baz=
+
+	fun set_bar_baz(x: Int, y: Float)
+	do
+		print x
+		bar = x
+		print y
+		baz = y
+	end
+end
+
+var test = new C(10, 2.0)
+test.set_bar_baz(16, 1.5)# Ok
+test.set_bar_baz(1, 3.8)# Fail

--- a/tests/contracts_invariant_inheritance_multi_2.nit
+++ b/tests/contracts_invariant_inheritance_multi_2.nit
@@ -1,0 +1,35 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import contracts_invariant_inheritance_multi
+
+# Test import a class with invariant and add a new one by new inheritance
+
+class E
+	invariant(bazz)
+
+	var bazz = true
+end
+
+redef class C
+	super E
+
+	redef fun set_bar_baz(x: Int, y: Float) do
+		super
+		self.bazz = false
+		print bazz
+	end
+end
+
+var test = new C(10, 2.0)
+test.set_bar_baz(10, 2.0)# The method broke the E invariant with the set bazz = false

--- a/tests/contracts_no_contract_attribut.nit
+++ b/tests/contracts_no_contract_attribut.nit
@@ -1,0 +1,44 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verification if it's possible to define a simple ensure contract on attribut and remove it by inheritence.
+
+class A
+	var i: Int is ensure(i > 10)
+end
+
+class B
+	super A
+	redef fun i=(i)
+	is
+		no_contract
+	do
+		super
+	end
+end
+
+class C
+	super B
+	redef fun i=(i)
+	is
+		ensure(i < 10)
+	do
+		super
+	end
+end
+
+var a = new A(20)
+var b = new B(5)
+var c = new C(5)
+c.i = 20

--- a/tests/contracts_no_contract_class.nit
+++ b/tests/contracts_no_contract_class.nit
@@ -1,0 +1,42 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verification if it's possible to define a simple invariant contract and remove it by inheritence.
+
+class A
+	invariant(i > 10)
+
+	var i: Int
+
+	fun foo do end
+end
+
+class B
+	super A
+	no_contract
+end
+
+class C
+	super B
+	invariant(i < 10)
+end
+
+var a = new A(11)
+a.foo
+var b = new B(9)
+b.foo
+var c = new C(6)
+c.foo
+var c2 = new C(10)
+c2.foo

--- a/tests/contracts_no_contract_method.nit
+++ b/tests/contracts_no_contract_method.nit
@@ -1,0 +1,40 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verification if it's possible to define a simple expect contract and remove it by inheritence.
+
+class A
+	fun foo(i: Int)
+	is
+		expect(i > 10)
+	do
+		print "Foo of A"
+	end
+end
+
+class B
+	super A
+
+	redef fun foo(i: Int)
+	is
+		no_contract
+	do
+		print "Foo of B"
+	end
+end
+
+var a = new A
+a.foo(20)
+var b = new B
+b.foo(5)

--- a/tests/contracts_strength_ensure.nit
+++ b/tests/contracts_strength_ensure.nit
@@ -1,0 +1,45 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test the weakening of an ensure contract
+
+class MyClass
+
+	fun foo(x: Int): Int
+	is
+		ensure(x > 0)
+	do
+		print "Execution of `MyClass.foo` and return x equal {x}"
+		return x
+	end
+end
+
+class MySubClass
+	super MyClass
+
+	redef fun foo(x: Int)
+	is
+		ensure(x > 1)
+	do
+		print "Execution of `MySubClass.foo` and return x equal {x}"
+		return x
+	end
+end
+
+var first = new MyClass
+first.foo(1)
+var second = new MySubClass
+second.foo(2)
+second.foo(3)
+second.foo(1)

--- a/tests/contracts_weake_expect.nit
+++ b/tests/contracts_weake_expect.nit
@@ -1,0 +1,43 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test the weakening of an expect contract
+
+class MyClass
+
+	fun foo(x: Int)
+	is
+		expect(x == 1)
+	do
+		print "Execution of `MyClass.foo` with x equal {x}"
+	end
+end
+
+class MySubClass
+	super MyClass
+
+	redef fun foo(x: Int)
+	is
+		expect(x == 2)
+	do
+		print "Execution of `MySubClass.foo` with x equal {x}"
+	end
+end
+
+var first = new MyClass
+first.foo(1)
+var second = new MySubClass
+second.foo(1)
+second.foo(2)
+second.foo(3)

--- a/tests/sav/contract_invariant_defaultinit.res
+++ b/tests/sav/contract_invariant_defaultinit.res
@@ -1,0 +1,1 @@
+Runtime error: Assert 'invariant(i > 0)' failed (contract_invariant_defaultinit.nit:16)

--- a/tests/sav/contract_old_1.res
+++ b/tests/sav/contract_old_1.res
@@ -1,0 +1,1 @@
+Runtime error: Assert 'ensure(old(i) + 1 == i)' failed (contract_old_1.nit:31)

--- a/tests/sav/contract_old_add_redef.res
+++ b/tests/sav/contract_old_add_redef.res
@@ -1,0 +1,1 @@
+contract_old_add_redef.nit:29,2--34,4: The `old` is not declared at the introduction

--- a/tests/sav/contract_old_default_init.res
+++ b/tests/sav/contract_old_default_init.res
@@ -1,0 +1,1 @@
+contract_old_default_init.nit:18,2--23,4: The `old` cannot be used with a constructor

--- a/tests/sav/contract_old_no_expression.res
+++ b/tests/sav/contract_old_no_expression.res
@@ -1,0 +1,2 @@
+contract_old_no_expression.nit:22,14--16: Error: expected an expression to be store in `old` context.
+contract_old_no_expression.nit:22,3--18: Error: expected an expression.

--- a/tests/sav/contract_old_redef.res
+++ b/tests/sav/contract_old_redef.res
@@ -1,0 +1,1 @@
+Runtime error: Assert 'ensure(old(i) + 1 == i)' failed (contract_old_redef.nit:20)

--- a/tests/sav/contract_old_unknown.res
+++ b/tests/sav/contract_old_unknown.res
@@ -1,0 +1,1 @@
+contract_old_unknown.nit:20,14: Error: method or variable `z` unknown in `A`.

--- a/tests/sav/contract_old_with_expect.res
+++ b/tests/sav/contract_old_with_expect.res
@@ -1,0 +1,1 @@
+Runtime error: Assert 'expect(i > 0)' failed (contract_old_with_expect.nit:20)

--- a/tests/sav/contracts.res
+++ b/tests/sav/contracts.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expect' failed (contracts.nit:31)
+Runtime error: Assert 'expect(not bool)' failed (contracts.nit:31)

--- a/tests/sav/contracts_abstract.res
+++ b/tests/sav/contracts_abstract.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensure' failed (contracts_abstract.nit:26)
+Runtime error: Assert 'ensure(y <= 10.0, y == 42.0)' failed (contracts_abstract.nit:26)

--- a/tests/sav/contracts_add.res
+++ b/tests/sav/contracts_add.res
@@ -1,2 +1,2 @@
 contracts_add.nit:46,3--16: Useless contract: No contract defined at the introduction of the method
-Runtime error: Assert 'ensure' failed (contracts_add.nit:39)
+Runtime error: Assert 'ensure(x == 0)' failed (contracts_add.nit:39)

--- a/tests/sav/contracts_attribut_ensure.res
+++ b/tests/sav/contracts_attribut_ensure.res
@@ -1,0 +1,1 @@
+Runtime error: Assert 'ensure(self.bar != 10)' failed (contracts_attribut_ensure.nit:19)

--- a/tests/sav/contracts_attribut_expect.res
+++ b/tests/sav/contracts_attribut_expect.res
@@ -1,0 +1,1 @@
+Runtime error: Assert 'expect(self.bar != 10)' failed (contracts_attribut_expect.nit:19)

--- a/tests/sav/contracts_attribut_readonly.res
+++ b/tests/sav/contracts_attribut_readonly.res
@@ -1,0 +1,1 @@
+contracts_attribut_readonly.nit:19,2--49: Not applicable contract on not writable attribute

--- a/tests/sav/contracts_constructor.res
+++ b/tests/sav/contracts_constructor.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expect' failed (contracts_constructor.nit:20)
+Runtime error: Assert 'expect(test > 10)' failed (contracts_constructor.nit:20)

--- a/tests/sav/contracts_ensures.res
+++ b/tests/sav/contracts_ensures.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensure' failed (contracts_ensures.nit:29)
+Runtime error: Assert 'ensure(not bool)' failed (contracts_ensures.nit:29)

--- a/tests/sav/contracts_ensures_1.res
+++ b/tests/sav/contracts_ensures_1.res
@@ -1,3 +1,3 @@
-Runtime error: Assert 'ensure' failed (contracts_ensures_1.nit:20)
+Runtime error: Assert 'ensure(x > 0)' failed (contracts_ensures_1.nit:20)
 Good
 Fail

--- a/tests/sav/contracts_ensures_2.res
+++ b/tests/sav/contracts_ensures_2.res
@@ -1,4 +1,4 @@
-Runtime error: Assert 'ensure' failed (contracts_ensures_2.nit:31)
+Runtime error: Assert 'ensure(y == 1.2)' failed (contracts_ensures_2.nit:31)
 Good
 Good
 Good

--- a/tests/sav/contracts_ensures_3.res
+++ b/tests/sav/contracts_ensures_3.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensure' failed (contracts_ensures_3.nit:20)
+Runtime error: Assert 'ensure(result > 0)' failed (contracts_ensures_3.nit:20)

--- a/tests/sav/contracts_ensures_4.res
+++ b/tests/sav/contracts_ensures_4.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensure' failed (contracts_ensures_4.nit:31)
+Runtime error: Assert 'ensure(not result)' failed (contracts_ensures_4.nit:31)

--- a/tests/sav/contracts_ensures_sequence.res
+++ b/tests/sav/contracts_ensures_sequence.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensure' failed (contracts_ensures_sequence.nit:18)
+Runtime error: Assert 'ensure(x > 2)' failed (contracts_ensures_sequence.nit:18)

--- a/tests/sav/contracts_error.res
+++ b/tests/sav/contracts_error.res
@@ -1,2 +1,2 @@
-contracts_error.nit:23,10--22: Error: expected an expression.
-contracts_error.nit:24,10--22: Error: expected an expression.
+contracts_error.nit:23,3--23: Error: expected an expression.
+contracts_error.nit:24,3--23: Error: expected an expression.

--- a/tests/sav/contracts_expects_1.res
+++ b/tests/sav/contracts_expects_1.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expect' failed (contracts_expects_1.nit:20)
+Runtime error: Assert 'expect(x > 0)' failed (contracts_expects_1.nit:20)

--- a/tests/sav/contracts_generic_type.res
+++ b/tests/sav/contracts_generic_type.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expect' failed (contracts_generic_type.nit:33)
+Runtime error: Assert 'expect(x.length != 0)' failed (contracts_generic_type.nit:33)

--- a/tests/sav/contracts_inheritance.res
+++ b/tests/sav/contracts_inheritance.res
@@ -1,5 +1,5 @@
 contracts_inheritance.nit:58,6--9: Warning: conflicting property definitions for property `toto` in `MySubArray`: contracts_inheritance$MyArrayInt$toto contracts_inheritance$MyArrayInt2$toto
-Runtime error: Assert 'ensure' failed (contracts_inheritance.nit:32)
+Runtime error: Assert 'ensure(e == 12)' failed (contracts_inheritance.nit:32)
 toto MyArrayInt2
 toto MyArrayInt
 toto ArrayInt

--- a/tests/sav/contracts_invariant_1.res
+++ b/tests/sav/contracts_invariant_1.res
@@ -1,0 +1,2 @@
+Runtime error: Assert 'invariant(bar >= 10)' failed (contracts_invariant_1.nit:18)
+9

--- a/tests/sav/contracts_invariant_attr.res
+++ b/tests/sav/contracts_invariant_attr.res
@@ -1,0 +1,1 @@
+Runtime error: Assert 'invariant(bar >= 10)' failed (contracts_invariant_attr.nit:18)

--- a/tests/sav/contracts_invariant_diamond.res
+++ b/tests/sav/contracts_invariant_diamond.res
@@ -1,0 +1,2 @@
+Runtime error: Assert 'invariant(bar > 12)' failed (contracts_invariant_diamond.nit:32)
+11

--- a/tests/sav/contracts_invariant_in_redef.res
+++ b/tests/sav/contracts_invariant_in_redef.res
@@ -1,0 +1,1 @@
+Runtime error: Assert 'invariant(false)' failed (contracts_invariant_in_redef.nit:19)

--- a/tests/sav/contracts_invariant_inheritance.res
+++ b/tests/sav/contracts_invariant_inheritance.res
@@ -1,0 +1,3 @@
+Runtime error: Assert 'invariant(bar >= 10)' failed (contracts_invariant_inheritance.nit:18)
+11
+2

--- a/tests/sav/contracts_invariant_inheritance_multi.res
+++ b/tests/sav/contracts_invariant_inheritance_multi.res
@@ -2,3 +2,4 @@ Runtime error: Assert 'invariant(bar >= 10)' failed (contracts_invariant_inherit
 16
 1.5
 1
+3.8

--- a/tests/sav/contracts_invariant_inheritance_multi.res
+++ b/tests/sav/contracts_invariant_inheritance_multi.res
@@ -1,0 +1,4 @@
+Runtime error: Assert 'invariant(bar >= 10)' failed (contracts_invariant_inheritance_multi.nit:19)
+16
+1.5
+1

--- a/tests/sav/contracts_invariant_inheritance_multi_2.res
+++ b/tests/sav/contracts_invariant_inheritance_multi_2.res
@@ -1,3 +1,4 @@
 Runtime error: Assert 'invariant(bazz)' failed (contracts_invariant_inheritance_multi_2.nit:19)
 10
 2.0
+false

--- a/tests/sav/contracts_invariant_inheritance_multi_2.res
+++ b/tests/sav/contracts_invariant_inheritance_multi_2.res
@@ -1,0 +1,3 @@
+Runtime error: Assert 'invariant(bazz)' failed (contracts_invariant_inheritance_multi_2.nit:19)
+10
+2.0

--- a/tests/sav/contracts_no_contract_attribut.res
+++ b/tests/sav/contracts_no_contract_attribut.res
@@ -1,0 +1,1 @@
+Runtime error: Assert 'ensure(i < 10)' failed (contracts_no_contract_attribut.nit:35)

--- a/tests/sav/contracts_no_contract_class.res
+++ b/tests/sav/contracts_no_contract_class.res
@@ -1,0 +1,1 @@
+Runtime error: Assert 'invariant(i < 10)' failed (contracts_no_contract_class.nit:32)

--- a/tests/sav/contracts_no_contract_method.res
+++ b/tests/sav/contracts_no_contract_method.res
@@ -1,0 +1,2 @@
+Foo of A
+Foo of B

--- a/tests/sav/contracts_same_contract.res
+++ b/tests/sav/contracts_same_contract.res
@@ -1,1 +1,0 @@
-contracts_same_contract.nit:22,3--17: The method already has a defined `expect` contract at line 21

--- a/tests/sav/contracts_static.res
+++ b/tests/sav/contracts_static.res
@@ -1,2 +1,2 @@
-Runtime error: Assert 'ensure' failed (contracts_static.nit:29)
+Runtime error: Assert 'ensure(x > 10)' failed (contracts_static.nit:29)
 Error

--- a/tests/sav/contracts_strength_ensure.res
+++ b/tests/sav/contracts_strength_ensure.res
@@ -1,0 +1,5 @@
+Runtime error: Assert 'ensure(x > 1)' failed (contracts_strength_ensure.nit:33)
+Execution of `MyClass.foo` and return x equal 1
+Execution of `MySubClass.foo` and return x equal 2
+Execution of `MySubClass.foo` and return x equal 3
+Execution of `MySubClass.foo` and return x equal 1

--- a/tests/sav/contracts_virtual_type.res
+++ b/tests/sav/contracts_virtual_type.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expect' failed (contracts_virtual_type.nit:23)
+Runtime error: Assert 'expect(x == 1)' failed (contracts_virtual_type.nit:23)

--- a/tests/sav/contracts_weake_expect.res
+++ b/tests/sav/contracts_weake_expect.res
@@ -1,0 +1,4 @@
+Runtime error: Assert 'expect(x == 1)' failed (contracts_weake_expect.nit:21)
+Execution of `MyClass.foo` with x equal 1
+Execution of `MySubClass.foo` with x equal 1
+Execution of `MySubClass.foo` with x equal 2

--- a/tests/sav/syntax_annotations3.res
+++ b/tests/sav/syntax_annotations3.res
@@ -1,4 +1,4 @@
-syntax_annotations3.nit:16,2--20: Warning: unknown annotation `invariant`.
+syntax_annotations3.nit:16,12--16: Error: method or variable `solde` unknown in `Account`.
 syntax_annotations3.nit:19,3--12: Warning: unknown annotation `pre`.
 syntax_annotations3.nit:20,3--22: Warning: unknown annotation `post`.
 syntax_annotations3.nit:28,3--7: Warning: unknown annotation `inter`.

--- a/tests/sav/test_toolcontext_args1.res
+++ b/tests/sav/test_toolcontext_args1.res
@@ -5,7 +5,7 @@ _DUMMY_TOOL()
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	opts="--warn --warning --quiet --stop-on-first-error --keep-going --no-color --log --log-dir --nit-dir --help --version --set-dummy-tool --verbose --bash-completion --stub-man --no-contract --full-contract --option-a --option-b"
+	opts="--warn --warning --quiet --stop-on-first-error --keep-going --no-color --log --log-dir --nit-dir --help --version --set-dummy-tool --verbose --bash-completion --stub-man --no-contract --full-contract --in-out-invariant --no-self-contract --option-a --option-b"
 	if [[ ${cur} == -* ]] ; then
 		COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
 		return 0

--- a/tests/sav/test_toolcontext_args2.res
+++ b/tests/sav/test_toolcontext_args2.res
@@ -14,6 +14,8 @@ Test for ToolContext, try --bash-completion.
   -v, --verbose           Additional messages from the tool
   --no-contract           Disable the contracts usage
   --full-contract         Enable all contracts usage
+  --in-out-invariant      Enable the verification of invariant contracts in enter and exit
+  --no-self-contract      Disable the verification of contracts in self
   -a, --option-a          option a, do nothing
   -b, --option-b          option b, do nothing
   -c                      option c, do nothing


### PR DESCRIPTION

This pr adds a two major feature in the contracts, the addition of invariants as well as the care of the old in the ensure.

# Annotations

To define a new class contract you need to use the `invariant` annotation. The principle is the same as the other contract `expects` and `ensures` all expressions returning a boolean (comparison...) can be used as a condition.

# Invariant generation process 

## Building contract phase

A phase is executed to check all classes and methods. This check is done to know if:

- The class is annotated (redefined or not)

When a contract is detected the code is extended to add the verification features. One method is created. This method is the contract invariant verification.

Note: When a class has an invariant, all methods (redef, inherited, intro) have now two contract face to check this. One for the invariant verification and one for a potential `ensures` or `expect` verification. This split was made to avoid the invariant verification on self.

### Exemple

```nit
class MyClass
	invariant(bar == 10)
	
	var bar: Int = 10	

	fun foo(x: Int)
	do
		[...]
	end
end
```

Representation of the compiled class

```nit
class Object
	fun _invariant
	do
		[Empty body]
	end
end

class MyClass
	invariant(bar == 10)
	
	var bar: Int = 10	
	
	fun _invariant
	do
		super
		assert bar == 10
	end

	fun _contract_bar=(x: Int)
	do
		foo(x)
	end

	fun _contract_inv_bar(x: Int)
	do
		_contract_bar
		_invariant
	end

	fun foo(x: Int)
	do
		[...]
	end
	
	fun _contract_inv_foo(x: Int)
	do
		_contract_foo(x)
		_invariant
	end	
	
	fun _contract_foo(x: Int)
	do
		foo(x)
	end	
end
```

The invariant method has added on the object class to resolve multi inheritance problem.

# Old generation process

Now when a `ensure` contract has been declared a check is made to see if a call with the name `old` is made. If this is the case we :
	
- Store all expressions that call `old`.
- Create a new old class for the visited ensure.
- Add new attributes in the class to capture old values.
- Create a method to instantiate our new old class. 

Note: The information that is kept by the `old` is a reference to the designated object. If the `old` designate a non-immutable complex object, it will be necessary to use a cloning method to duplicate the object.

### Exemple: 

```nit
class MyClass
	fun add_one(i: Int): Int 
	is 
		ensure(old(i) + 1 == result)
	do
		return i + 1
	end
end
```

Representation of the compiled class

```nit
class MyClass
	fun add_one(i: Int): Int 
	is 
		ensure(old(i) + 1 == result)
	do
		return i + 1
	end

	fun _contract_add_one(i: Int): Int
	do
		var old =  _init_old_add_one(i, new Old_MyClass_add_one)
		result = add_one(i)
		ensure_add_one(i, result, old)
		return result
	end

	fun _init_old_add_one(i: Int, old: Old_MyClass_add_one): Old_MyClass_add_one
	do
		old.i = i
		return old
	end
end


class Old_MyClass_add_one
	var i: nullable Int
end
```

# Option

Invariant contracts are normally supposed to be checked in enter and exit. But in Nit the verification is only made at the exit of the method. It is however possible to activate the checking of the input and output invariants with the `--in-out-invariant` option.

# Other features

## Option to disable contract verification in self

The `--no-self-contract` was added to disable the contract verification on self.

## Add contrat on attribut

It is now possible to add contracts on the attributes (expect and ensure). Only the setter have a contract feature.

### Exemple:

```nit
class MyClass
	
	var bar: Int is ensure(self.bar != 10)	
end
```

Representation of the compiled class

```nit
class MyClass
	
	var _bar: Int

	fun bar=(x: Int)
	do
		_bar = x
	end
	
	fun contract_bar=(x: Int)
	do	
		bar=(x)
		ensure_bar(x)
	end

	fun ensure_bar(x: Int)
	do
		assert(self.bar != 10)
	end
end

```

## Disable warning on TypingVisitor

This pr adds a way to disable warnings in typing when we are manipulating generate code.This pr include the invariant contract.

## NitBuilder introduction

This module help the instantiation and transformation of language entities (AST and model). The objectif of this module is to help the creation of entities language (Attributes, Methods, Class).
