### PR TITLE
Removed `ModelBuilder` refinement from `naive_interpreter.nit`

### DIFF
--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -35,26 +35,6 @@ redef class ToolContext
 	end
 end
 
-redef class ModelBuilder
-	# Execute the program from the entry point (`Sys::main`) of the `mainmodule`
-	# `arguments` are the command-line arguments in order
-	# REQUIRE that:
-	#   1. the AST is fully loaded.
-	#   2. the model is fully built.
-	#   3. the instructions are fully analysed.
-	fun run_naive_interpreter(mainmodule: MModule, arguments: Array[String])
-	do
-		var time0 = get_time
-		self.toolcontext.info("*** START INTERPRETING ***", 1)
-
-		var interpreter = new NaiveInterpreter(self, mainmodule, arguments)
-		interpreter.start(mainmodule)
-
-		var time1 = get_time
-		self.toolcontext.info("*** END INTERPRETING: {time1-time0} ***", 2)
-	end
-end
-
 # The visitor that interprets the Nit Program by walking on the AST
 class NaiveInterpreter
 	# The modelbuilder that know the AST and its associations with the model

--- a/src/nit.nit
+++ b/src/nit.nit
@@ -22,6 +22,16 @@ import frontend::code_gen
 import parser_util
 import vm
 
+# Factory method used to build an interpreter.
+fun build_interpreter(is_vm: Bool, mb: ModelBuilder, mmodule: MModule, args: Array[String]): NaiveInterpreter
+do
+	if is_vm then
+		return new VirtualMachine(mb, mmodule, args)
+	else
+		return new NaiveInterpreter(mb, mmodule, args)
+	end
+end
+
 # Create a tool context to handle options and paths
 var toolcontext = new ToolContext
 toolcontext.option_context.options_before_rest = true
@@ -83,9 +93,19 @@ var mainmodule = toolcontext.make_main_module(mmodules)
 var self_mm = mainmodule
 var self_args = arguments
 
+var interpreter = build_interpreter(opt_vm.value, modelbuilder, self_mm, self_args)
 if opt_vm.value then
-	modelbuilder.run_virtual_machine(self_mm, self_args)
+	toolcontext.info("*** NITVM STARTING ***", 1)
 else
-	modelbuilder.run_naive_interpreter(self_mm, self_args)
+	toolcontext.info("*** START INTERPRETING ***", 1)
+end
+var time0 = get_time
+interpreter.start(self_mm)
+var time1 = get_time
+
+if opt_vm.value then
+	toolcontext.info("*** NITVM STOPPING : {time1-time0} ***", 2)
+else
+	toolcontext.info("*** END INTERPRETING: {time1-time0} ***", 2)
 end
 

--- a/src/test_astbuilder.nit
+++ b/src/test_astbuilder.nit
@@ -22,15 +22,14 @@ module test_astbuilder
 import nit
 import astbuilder
 
-redef class ModelBuilder
-	redef fun run_naive_interpreter(mainmodule: MModule, arguments: Array[String])
-	do
-		var clone_visitor = new CloneVisitor
-		for nmodule in self.nmodules do
-			clone_visitor.enter_visit(nmodule)
-		end
-		super
+redef fun build_interpreter(is_vm, mb, mmodule, args)
+do
+
+	var clone_visitor = new CloneVisitor
+	for nmodule in mb.nmodules do
+		clone_visitor.enter_visit(nmodule)
 	end
+	return super
 end
 
 private class CloneVisitor

--- a/src/vm/virtual_machine.nit
+++ b/src/vm/virtual_machine.nit
@@ -20,20 +20,6 @@ module virtual_machine
 import interpreter::naive_interpreter
 import perfect_hashing
 
-redef class ModelBuilder
-	fun run_virtual_machine(mainmodule: MModule, arguments: Array[String])
-	do
-		var time0 = get_time
-		self.toolcontext.info("*** NITVM STARTING ***", 1)
-
-		var interpreter = new VirtualMachine(self, mainmodule, arguments)
-		interpreter.start(mainmodule)
-
-		var time1 = get_time
-		self.toolcontext.info("*** NITVM STOPPING : {time1-time0} ***", 2)
-	end
-end
-
 # A virtual machine based on the naive_interpreter
 class VirtualMachine super NaiveInterpreter
 


### PR DESCRIPTION
# Dangerous refinement

Since refinement is really powerful, we should be particularly careful when adding new
dependancies into a class. Here's the problem

```nit
interface IA
end

# module 1
class A1
    super IA
    ...
end

# module2
class A2
    super IA
    ...
end

redef class ConsumerOfIA
    # new dependency
    var a: IA
end
```
The challenge here is: how do we instantiate `ConsumerOfIA:a`. Currently, most users will resolve this issue like this :

```nit
import module2
redef class ConsumerOfIA
    var a: IA
    init
    do
        a = new A2(...)
    end
end
```
This solution is bad since we create a strong dependency between the consumer and the service provider. Thus, if we need to change the implementation of the service we would need to change the code since we don't really code against an abstract (`I` in `SOLID`). Moreover, we make our consumer dependent on all `module2` and `A2` dependencies.
This is classic bad coupling between classes, but the problem is worse with refinement, here's why:

We divide the construction of a class between all modules. Instead of having a single composition root (where we create our object graph), the object creation process is shared between module, thus
making it very hard to understand what goes where and in which order (smells like temporal dependency).

## The interpreter
Currently, we can't add a new abstract dependency in the interpreter by simply refining the interpreter. This is due to the strong coupling between `ModelBuilder` and `NaiveInterpreter`. If we want a new dependency in NaiveInterpreter without manually creating it, we must redefine `ModeBuilder` to instantiate dependency, but it is equivalent to the original problem since we have to redefine the `ModelBuilder` in the same module.

## My suggestion
We should not code the instantiation logic inside the `naive_interpreter.nit` module itself.
We should have only one composition root : `nit.nit` which resolves the dependency graph.

If we add a new dependency, we change the `nit.nit` file. We can't get out of it without at least
changing one file since when we do a refinement we need to change `interpreter.nit` to publicly import the new features. However, this change would make dependency management less
sparsed are more controlled.

Signed-off-by: Louis-Vincent Boudreault <lv.boudreault95@gmail.com>