### PR TITLE
modelize_property: Split the build_property method of AAttrPropdef

### DIFF
--- a/src/frontend/serialization_model_phase.nit
+++ b/src/frontend/serialization_model_phase.nit
@@ -267,8 +267,6 @@ redef init from_deserializer(v) do abort"""
 end
 
 redef class AAttrPropdef
-	private fun name: String do return n_id2.text
-
 	# Name of this attribute in the serialized format
 	private var serialize_name: String = name is lazy
 end


### PR DESCRIPTION
This pr split the `build property` method into several methods. The objective is to be able to build the entities of the model (read, write...) more independently according to the current state. The construction of the signature was also split for the same purpose.