### PR TITLE
gitlabci: no auth for postgress in tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ services:
 
 variables:
   NEO4J_AUTH: none
+  POSTGRES_HOST_AUTH_METHOD: trust
 
 cache:
   paths:


### PR DESCRIPTION
This should fix recent CICD issues
