### PR TITLE
modelize_property: Add `unsafe_add_mclassdef2nclassdef`

### DIFF
--- a/src/modelize/modelize_property.nit
+++ b/src/modelize/modelize_property.nit
@@ -53,6 +53,17 @@ redef class ModelBuilder
 		mpropdef2npropdef[mpropdef] = npropdef
 	end
 
+	# Associate a `nclassdef` with its `mclassdef`
+	#
+	# Be careful, this method is unsafe, no checking is done when it's used.
+	# The safe way to add mclass it's to use the `build_property`
+	#
+	# See `mclassdef2nclassdef`
+	fun unsafe_add_mclassdef2nclassdef(mclassdef: MClassDef, nclassdef: AClassdef)
+	do
+		mclassdef2nclassdef[mclassdef] = nclassdef
+	end
+
 	# Retrieve the associated AST node of a mpropertydef.
 	# This method is used to associate model entity with syntactic entities.
 	#


### PR DESCRIPTION
Add a way to associate a `nclassdef` with its `mclassdef` without verification.

Currently, to attach an AClass with an MClass, you must use the `build_property` method which performs all the checks and builds the representation in the model. Thanks to the Nitbuilder which facilitates the construction of entities, we find ourselves in a case where we can build the representation of a class in the model and then build the corresponding ast. It is therefore necessary to provide a service to associate the both elements.