### PR TITLE
Contract refactoring

### DIFF
--- a/src/contracts.nit
+++ b/src/contracts.nit
@@ -296,9 +296,6 @@ end
 
 redef class MContract
 
-	# Define the name of the contract
-	fun contract_name: String is abstract
-
 	# Method use to diplay warning when the contract is not present at the introduction
 	private fun no_intro_contract(v: ContractsVisitor, a: Array[AAnnotation])do end
 
@@ -396,9 +393,6 @@ redef class MContract
 end
 
 redef class MExpect
-
-	# Define the name of the contract
-	redef fun contract_name: String do return "expect"
 
 	# Display warning if no contract is defined at introduction `expect`,
 	# because if no contract is defined at the introduction the added
@@ -527,9 +521,6 @@ redef class BottomMContract
 end
 
 redef class MEnsure
-
-	# Define the name of the contract
-	redef fun contract_name: String do return "ensure"
 
 	redef fun adapt_specific_msignature(m_signature: MSignature): MSignature
 	do

--- a/src/contracts.nit
+++ b/src/contracts.nit
@@ -124,7 +124,7 @@ private class ContractsVisitor
 	end
 
 	# Define the new contract take in consideration that an old contract exist or not
-	private fun build_contract(n_annotation: AAnnotation, mcontract: MContract, mclassdef: MClassDef): MMethodDef
+	private fun build_contract(n_annotation: AAnnotation, mcontract: MContract, mclassdef: MClassDef)
 	do
 		self.current_location = n_annotation.location
 		# Retrieving the expression provided in the annotation
@@ -132,15 +132,11 @@ private class ContractsVisitor
 		var m_contractdef: AMethPropdef
 		if is_intro_contract then
 			# Create new contract method
-			m_contractdef = mcontract.create_intro_contract(self, n_condition, mclassdef)
+			mcontract.create_intro_contract(self, n_condition, mclassdef)
 		else
 			# Create a redef of contract to take in consideration the new condition
-			m_contractdef = mcontract.create_subcontract(self, n_condition, mclassdef)
+			mcontract.create_subcontract(self, n_condition, mclassdef)
 		end
-		var contract_propdef = m_contractdef.mpropdef
-		# The contract has a null mpropdef, this should never happen
-		assert contract_propdef != null
-		return contract_propdef
 	end
 
 	# Verification if the construction of the contract is necessary.
@@ -353,7 +349,7 @@ redef class MContract
 	# end
 	# ~~~
 	#
-	private fun create_intro_contract(v: ContractsVisitor, n_condition: nullable AExpr, mclassdef: MClassDef): AMethPropdef
+	private fun create_intro_contract(v: ContractsVisitor, n_condition: nullable AExpr, mclassdef: MClassDef)
 	do
 		var n_block = v.ast_builder.make_block
 		if n_condition != null then
@@ -362,27 +358,26 @@ redef class MContract
 			tid.text = "{self.contract_name}"
 			n_block.add v.ast_builder.make_assert(tid, n_condition, null)
 		end
-		return make_contract(v, n_block, mclassdef)
+		make_contract(v, n_block, mclassdef)
 	end
 
 	# Create a contract with old (super) and the new conditions
-	private fun create_subcontract(v: ContractsVisitor, ncondition: nullable AExpr, mclassdef: MClassDef): AMethPropdef
+	private fun create_subcontract(v: ContractsVisitor, ncondition: nullable AExpr, mclassdef: MClassDef)
 	do
 		var args = v.n_signature.make_parameter_read(v.ast_builder)
 		var n_block = v.ast_builder.make_block
 		if ncondition != null then n_block = self.create_nblock(v, ncondition, args)
-		return make_contract(v, n_block, mclassdef)
+		make_contract(v, n_block, mclassdef)
 	end
 
 	# Build a method with a specific block `n_block` in a specified `mclassdef`
-	private fun make_contract(v: ContractsVisitor, n_block: AExpr, mclassdef: MClassDef): AMethPropdef
+	private fun make_contract(v: ContractsVisitor, n_block: AExpr, mclassdef: MClassDef)
 	do
 		var n_contractdef = intro_mclassdef.mclass.create_empty_method(v, self, mclassdef, v.m_signature, v.n_signature)
 		n_contractdef.n_block = n_block
 		# Define the location of the new method for corresponding of the annotation location
 		n_contractdef.location = v.current_location
 		n_contractdef.do_all(v.toolcontext)
-		return n_contractdef
 	end
 end
 
@@ -670,7 +665,7 @@ redef class MMethodDef
 		if not exist_contract and not is_intro then no_intro_contract(v, n_signature, mcontract, n_annotation)
 		v.define_signature(mcontract, n_signature, mproperty.intro.msignature)
 
-		var conditiondef = v.build_contract(n_annotation, mcontract, mclassdef)
+		v.build_contract(n_annotation, mcontract, mclassdef)
 		check_contract_facet(v, n_signature.clone, mclassdef, mcontract, exist_contract)
 		has_contract = true
 	end

--- a/tests/sav/contracts.res
+++ b/tests/sav/contracts.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expect' failed (contracts.nit:31)
+Runtime error: Assert 'expect(not bool)' failed (contracts.nit:31)

--- a/tests/sav/contracts_abstract.res
+++ b/tests/sav/contracts_abstract.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensure' failed (contracts_abstract.nit:26)
+Runtime error: Assert 'ensure(y <= 10.0, y == 42.0)' failed (contracts_abstract.nit:26)

--- a/tests/sav/contracts_add.res
+++ b/tests/sav/contracts_add.res
@@ -1,2 +1,2 @@
 contracts_add.nit:46,3--16: Useless contract: No contract defined at the introduction of the method
-Runtime error: Assert 'ensure' failed (contracts_add.nit:39)
+Runtime error: Assert 'ensure(x == 0)' failed (contracts_add.nit:39)

--- a/tests/sav/contracts_constructor.res
+++ b/tests/sav/contracts_constructor.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expect' failed (contracts_constructor.nit:20)
+Runtime error: Assert 'expect(test > 10)' failed (contracts_constructor.nit:20)

--- a/tests/sav/contracts_ensures.res
+++ b/tests/sav/contracts_ensures.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensure' failed (contracts_ensures.nit:29)
+Runtime error: Assert 'ensure(not bool)' failed (contracts_ensures.nit:29)

--- a/tests/sav/contracts_ensures_1.res
+++ b/tests/sav/contracts_ensures_1.res
@@ -1,3 +1,3 @@
-Runtime error: Assert 'ensure' failed (contracts_ensures_1.nit:20)
+Runtime error: Assert 'ensure(x > 0)' failed (contracts_ensures_1.nit:20)
 Good
 Fail

--- a/tests/sav/contracts_ensures_2.res
+++ b/tests/sav/contracts_ensures_2.res
@@ -1,4 +1,4 @@
-Runtime error: Assert 'ensure' failed (contracts_ensures_2.nit:31)
+Runtime error: Assert 'ensure(y == 1.2)' failed (contracts_ensures_2.nit:31)
 Good
 Good
 Good

--- a/tests/sav/contracts_ensures_3.res
+++ b/tests/sav/contracts_ensures_3.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensure' failed (contracts_ensures_3.nit:20)
+Runtime error: Assert 'ensure(result > 0)' failed (contracts_ensures_3.nit:20)

--- a/tests/sav/contracts_ensures_4.res
+++ b/tests/sav/contracts_ensures_4.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensure' failed (contracts_ensures_4.nit:31)
+Runtime error: Assert 'ensure(not result)' failed (contracts_ensures_4.nit:31)

--- a/tests/sav/contracts_ensures_sequence.res
+++ b/tests/sav/contracts_ensures_sequence.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'ensure' failed (contracts_ensures_sequence.nit:18)
+Runtime error: Assert 'ensure(x > 2)' failed (contracts_ensures_sequence.nit:18)

--- a/tests/sav/contracts_error.res
+++ b/tests/sav/contracts_error.res
@@ -1,2 +1,2 @@
-contracts_error.nit:23,10--22: Error: expected an expression.
-contracts_error.nit:24,10--22: Error: expected an expression.
+contracts_error.nit:23,3--23: Error: expected an expression.
+contracts_error.nit:24,3--23: Error: expected an expression.

--- a/tests/sav/contracts_expects_1.res
+++ b/tests/sav/contracts_expects_1.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expect' failed (contracts_expects_1.nit:20)
+Runtime error: Assert 'expect(x > 0)' failed (contracts_expects_1.nit:20)

--- a/tests/sav/contracts_generic_type.res
+++ b/tests/sav/contracts_generic_type.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expect' failed (contracts_generic_type.nit:33)
+Runtime error: Assert 'expect(x.length != 0)' failed (contracts_generic_type.nit:33)

--- a/tests/sav/contracts_inheritance.res
+++ b/tests/sav/contracts_inheritance.res
@@ -1,5 +1,5 @@
 contracts_inheritance.nit:58,6--9: Warning: conflicting property definitions for property `toto` in `MySubArray`: contracts_inheritance$MyArrayInt$toto contracts_inheritance$MyArrayInt2$toto
-Runtime error: Assert 'ensure' failed (contracts_inheritance.nit:32)
+Runtime error: Assert 'ensure(e == 12)' failed (contracts_inheritance.nit:32)
 toto MyArrayInt2
 toto MyArrayInt
 toto ArrayInt

--- a/tests/sav/contracts_same_contract.res
+++ b/tests/sav/contracts_same_contract.res
@@ -1,1 +1,0 @@
-contracts_same_contract.nit:22,3--17: The method already has a defined `expect` contract at line 21

--- a/tests/sav/contracts_static.res
+++ b/tests/sav/contracts_static.res
@@ -1,2 +1,2 @@
-Runtime error: Assert 'ensure' failed (contracts_static.nit:29)
+Runtime error: Assert 'ensure(x > 10)' failed (contracts_static.nit:29)
 Error

--- a/tests/sav/contracts_virtual_type.res
+++ b/tests/sav/contracts_virtual_type.res
@@ -1,1 +1,1 @@
-Runtime error: Assert 'expect' failed (contracts_virtual_type.nit:23)
+Runtime error: Assert 'expect(x == 1)' failed (contracts_virtual_type.nit:23)


### PR DESCRIPTION
This pr do the following changes:

* Authorize the declaration of identical contracts on the same method in order to facilitate the reading of contracts. Example
```nit
fun foo(x, y: Int)
is
	expect(x > 0)
	expect(y > 0)
do end
```

* Modification of the generation of contracts. In the default mode, the contracts are now generated even if they are not used, only the public facet is generated only if it is necessary. The objective is to provide the contracts verification when you are in a redefinition in a module where contracts must be applied. This solution is a compromise to try to keep acceptable performance in the default mode. Example

```nit
module one
import two
[...]

module two
import three

redef class C
	# Now all calls to foo of c (only in module one or two) check the `expect` property defined in module three (as defined by the default contract rule). 
	redef foo ...
end

module three

class C
	fun foo is expect(true), ensure(true)
end
```

* When a contract is not fulfilled the messages displayed to the user are now more explicit. Example:

```nit\
class A
	fun foo(i: Int) is expect(i > 0) do end
end

var a = new A
a.foo(0)
```
This is the output of the program
```
Runtime error: Assert 'expect(i > 0)' failed
```

* Cosmetic modifications have been made to remove useless methods, modify the names and comments of certain methods to be more explicit.