### PR TITLE
phase: Introduction of new hook method

### DIFF
--- a/src/compiler/abstract_compiler.nit
+++ b/src/compiler/abstract_compiler.nit
@@ -26,6 +26,7 @@ import mixin
 import counter
 import pkgconfig
 private import explain_assert_api
+import contracts
 
 # Add compiling options
 redef class ToolContext

--- a/src/compiler/global_compiler.nit
+++ b/src/compiler/global_compiler.nit
@@ -30,7 +30,7 @@ redef class ToolContext
 	# option --global
 	var opt_global = new OptionBool("Use global compilation", "--global")
 
-	var global_compiler_phase = new GlobalCompilerPhase(self, null)
+	var global_compiler_phase = new GlobalCompilerPhase(self, [contracts_phase])
 
 	redef init do
 		super

--- a/src/compiler/separate_compiler.nit
+++ b/src/compiler/separate_compiler.nit
@@ -97,7 +97,7 @@ redef class ToolContext
 		end
 	end
 
-	var separate_compiler_phase = new SeparateCompilerPhase(self, null)
+	var separate_compiler_phase = new SeparateCompilerPhase(self, [contracts_phase])
 end
 
 class SeparateCompilerPhase

--- a/src/compiler/separate_erasure_compiler.nit
+++ b/src/compiler/separate_erasure_compiler.nit
@@ -46,7 +46,7 @@ redef class ToolContext
 		end
 	end
 
-	var erasure_compiler_phase = new ErasureCompilerPhase(self, null)
+	var erasure_compiler_phase = new ErasureCompilerPhase(self, [contracts_phase])
 end
 
 class ErasureCompilerPhase

--- a/src/nit.nit
+++ b/src/nit.nit
@@ -75,6 +75,7 @@ else
 end
 
 modelbuilder.run_phases
+toolcontext.run_global_phases(modelbuilder.parsed_modules)
 
 if toolcontext.opt_only_metamodel.value then toolcontext.quit
 

--- a/tests/sav/nit_args9.res
+++ b/tests/sav/nit_args9.res
@@ -16,6 +16,7 @@
 [0;33mtest_keep_going.nit:44,18--21[0m: Error: method `fail` does not exists in `Sys`.
 		var a = new Sys.[1;31mfail[0m
 		                ^
+Errors: 6. Warnings: 0.
 1
 2
 3


### PR DESCRIPTION
This pr introduces a new hook method in the execution of the `process_nmodule_after_phases` phases. This method makes it possible to analyze each module again after the execution of all phases in order to benefit from the information of the whole program.

This method is useful in the context of contracts. Example:

```nit  
module b

redef class A
	redef fun foo
	is
		ensure(result > 2)
	do
		return 2
	end 
end

var a = new A
a.bar
```
```nit
module a

class A
	fun foo: Int do
		return 1
	end
	
	fun bar do
		self.foo
	end
end
```

Actually, when you call the foo property in the bar method, no contract is called, while a postcondition was added by refinement in the `b` module. In fact it was not possible to call the contract face because it was not yet introduced during the analysis of module `a`. It is now possible to re-analyze all the modules to make the redirection once all the information are known.

