### PR TITLE
Contract with `threaded` method

### DIFF
--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -23,6 +23,7 @@ private import parser::tables
 import mixin
 private import model::serialize_model
 private import frontend::explain_assert_api
+private import contracts
 
 redef class ToolContext
 	# --discover-call-trace
@@ -73,6 +74,9 @@ class NaiveInterpreter
 
 	# Name of all supported functional names
 	var routine_types: Set[String] = new HashSet[String]
+
+	# Flag used to know if we are currently checking some assertions.
+	var in_assertion: Bool = false
 
 	init
 	do
@@ -1823,6 +1827,18 @@ redef class AIfexprExpr
 			return v.expr(self.n_then)
 		else
 			return v.expr(self.n_else)
+		end
+	end
+end
+
+
+redef class AIfInAssertion
+	redef fun stmt(v)
+	do
+		if not v.in_assertion then
+			v.in_assertion = true
+			v.stmt(self.n_body)
+			v.in_assertion = false
 		end
 	end
 end

--- a/tests/contracts_threaded.nit
+++ b/tests/contracts_threaded.nit
@@ -1,0 +1,52 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This test shows the verification of contracts in a parallel execution.
+
+import pthreads
+
+fun foo is
+	threaded
+	expect(contract_foo)
+do
+	print "Foo"
+	bar("Foo thread")
+end
+
+fun bar(thread_name: String)
+is
+	threaded
+	expect(contract_bar(thread_name))
+do
+	print "Bar called from {thread_name}"
+end
+
+fun contract_foo: Bool
+do
+	print("Foo contract")
+	return true
+end
+
+fun contract_bar(thread_name: String): Bool
+do
+	sys.nanosleep(3,0)
+	print("Bar contract called from {thread_name}")
+	return true
+end
+
+
+foo
+sys.nanosleep(1,0)
+bar("Main thread")
+sys.nanosleep(5,0)

--- a/tests/sav/contracts_threaded.res
+++ b/tests/sav/contracts_threaded.res
@@ -1,0 +1,6 @@
+Foo contract
+Foo
+Bar contract called from Foo thread
+Bar called from Foo thread
+Bar contract called from Main thread
+Bar called from Main thread


### PR DESCRIPTION
This pr makes it possible to prevent that contracts in different threads to interfere with the same flag to know if a contract evaluation should be performed.

Instead of using a flag contained in the `Sys` instance, we are now using a new AST node which:

- During compilation it will be transformed into an `if` with for condition the evaluation of a variable whose value is specific to each threat (` in_assertion`). Note we used the keyword `__thread`.

- During the interpretation the node will be evaluated in the same way as an `if` (without an` else` block) with for condition the value of the attribute `in_assertion` defined in the interpreter.

Note: When you evaluate a contract, the evaluation is performed in the same thread as the caller. (only the method will be executed in a new thread)
