### PR TITLE
Contract: Fix null argument error 

### DIFF
--- a/src/contracts.nit
+++ b/src/contracts.nit
@@ -587,7 +587,9 @@ redef class MMethod
 		if not exist_contract_facet then
 			# If has no contract facet in intro just create it
 			if classdef != intro_mclassdef then
-				create_facet(v, intro_mclassdef, contract_facet, self)
+				var n_intro_face = create_facet(v, intro_mclassdef, contract_facet, self)
+				n_intro_face.location = self.intro.location
+				n_intro_face.do_all(v.toolcontext)
 			end
 			n_contract_facet = create_facet(v, classdef, contract_facet, self)
 		else
@@ -834,6 +836,8 @@ redef class ASendExpr
 		var actual_callsite = callsite
 		if actual_callsite != null then
 			callsite = v.drive_callsite_to_contract(actual_callsite)
+			# Set the signature mapping with the old value, this avoids having to re-check the callsite.
+			callsite.signaturemap = actual_callsite.signaturemap
 		end
 	end
 end
@@ -844,6 +848,8 @@ redef class ANewExpr
 		var actual_callsite = callsite
 		if actual_callsite != null then
 			callsite = v.drive_callsite_to_contract(actual_callsite)
+			# Set the signature mapping with the old value, this avoids having to re-check the callsite
+			callsite.signaturemap = actual_callsite.signaturemap
 		end
 	end
 end

--- a/tests/contracts_null_parameter.nit
+++ b/tests/contracts_null_parameter.nit
@@ -1,0 +1,31 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class A
+
+	var null_attribut: nullable Int
+
+	fun set_null_attribut(i: nullable Int)
+	is
+		ensure(null_attribut == i)
+	do
+		null_attribut = i
+	end
+end
+
+
+var a = new A
+a.set_null_attribut
+a.set_null_attribut(10)
+a.set_null_attribut


### PR DESCRIPTION
This pull request fixes a bug when the contract is used with a `null` argument omitted.