### PR TITLE
doc: fixed some typos and other misc. corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,5 +18,5 @@ We are always open for suggestions or any other kind of contribution.
 If you do not want to submit code for some reason, you are always welcome to ask questions about the language or related topics via the issue system.
 
 You may also proof-read and correct documentation if you are willing!
-All the documents on this repository are written in English, however most of our contributors are not native anglophones.
+All the documents in this repository are written in English. However, most of our contributors are not native anglophones.
 Therefore we encourage people, especially those coming of an english-speaking culture to read the documentation available and submit patches to correct bad formulations, typos or related mistakes on our part through the usual system.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Important files and directories:
  * lib/		Nit standard library
  * LICENCE	License of the software
  * Makefile	Bootstrap the Nit tools
- * misc/	Some additional files for commons text editors and tools
+ * misc/	Some additional files for common text editors and tools
  * NOTICE.md	List of the authors
  * README	This file
  * share/	Common resources used by tools

--- a/doc/manual/basic_type.md
+++ b/doc/manual/basic_type.md
@@ -35,8 +35,8 @@ the `to_f` and `to_i` methods.
 Literal strings are enclosed within quotes (`"`).
 To insert a value
 inside a literal string, include the values inside braces (`{}`).
-Braces has to be escaped.
-`+` is the concatenation operator but is less efficient than the brace form.
+Braces have to be escaped.
+`+` is the concatenation operator, but is less efficient than the brace form.
 
 ~~~
 var j = 5
@@ -52,7 +52,7 @@ print "hel\"lo\nwo\{rld"
 ~~~
 
 Multi-line strings are enclosed with triple quotes (`"""`).
-Values are inserted with a triple braces (`{{{value}}}`).
+Values are inserted with triple braces (`{{{value}}}`).
 The multi-line form thus allows verbatim new-lines, quotes and braces
 
 ~~~
@@ -65,8 +65,8 @@ but {{{ 1+2 }}} is rendered as 3
 
 All objects have a `to_s` method that converts the object to a String.
 `print` is a top-level method that takes any number of arguments and
-prints to the standard output. `print` always add a newline, another
-top-level method, `printn`, does not add the newline.
+prints them to the standard output. `print` always adds a newline to the output, another
+top-level method, `printn`, does not add a newline.
 
 ~~~
 var x: String
@@ -84,7 +84,7 @@ Common comparison operators are available: `==` and `!=` on all objects;
 `<`, `>`, `<=`, `>=` and `<=>` on `Comparable` objects (which include
 `Int`, `String` and others).
 
-- `==`, `<`, `>`, `<=`, `>=` and `<=>` are standard Nit operators (so they are redefinable).
+- `==`, `<`, `>`, `<=`, `>=` and `<=>` are standard Nit operators thus are redefinable.
 
 - `and`, `or` and `not` are not standard Nit operators: they are not
   redefinable, also they are lazy and have adaptive typing flow
@@ -93,7 +93,7 @@ Common comparison operators are available: `==` and `!=` on all objects;
 - `==` is not for reference equality but for value equality (like
   `equals` in Java). There is a special reference equality operator,
   `is`, but it cannot be redefined and its usage is not recommended.
-  Note also that while `==` is redefinable, it has a special adaptive
+  Note that while `==` is redefinable, it has a special adaptive
   typing flow effect when used with `null`.
 
 - `!=` is not a standard Nit operator. In fact `x != y` is

--- a/doc/manual/class.md
+++ b/doc/manual/class.md
@@ -12,7 +12,7 @@ Here are the differences:
 
 -   enums (e.g. `Int` or `Bool`) can only specialize interfaces, cannot have attributes, cannot have constructors, have proper instances but they are not instantiated by the programmer—it means no `new Int`. Note that at this point there is no user-defined enums.
 
-All kinds of classes must have a name, can have some superclasses and can have some definitions of properties. Properties are methods, attributes, constructors and virtual types. All kinds of classes can also be generic. When we talk about “classes” in general, it means all these four kinds. We say “concrete classes” to designate only the classes declared with the `class` keyword alone.
+All kinds of classes must have a name, can have some superclasses and can have some definitions of properties. Properties are methods, attributes, constructors and virtual types. All kinds of classes can also be generic. When documentation refers to “classes” , it generally refers to all four kinds. The term “concrete classes” is used to designate the classes declared with the `class` keyword alone.
 
 ## Class Specialization
 
@@ -32,7 +32,7 @@ There is no repeated inheritance nor private inheritance. The specialization bet
 
 -   adding new superclasses.
 
-Note that the kind or the visibility of a class cannot be changed by a refinement. Therefore, it is allowed to just write `redef class X` whatever is the kind or the visibility of `X`.
+Note that the kind or the visibility of a class cannot be changed by a refinement. Therefore, it is allowed to just write `redef class X` regardless of the kind or the visibility of `X`.
 
 In programs, the real instantiated classes are always the combination of all their refinements.
 

--- a/doc/manual/constructor.md
+++ b/doc/manual/constructor.md
@@ -12,7 +12,7 @@ Their objective is double :
 
 Classes in OO models are often a simple aggregates of attributes and methods.
 
-By default, the `new` construction require a value for each attribute defined in a class without a default value.
+By default, the `new` construction requires a value for each attribute defined in a class without a default value.
 
 ~~~
 class Product
@@ -68,7 +68,7 @@ assert op.price.is_approx(159.50, 0.001)
 
 ## Uncollected attributes
 
-There is three cases for an attributes to not be collected in the `new`.
+There are three cases for which an attribute is not collected in a `new` construction.
 
 * Attributes with a default value
 * Attributes with the annotation `noinit`
@@ -104,8 +104,8 @@ Therefore, `total_price` cannot be initialised with a default value, because at 
 
 ## Generalized initializers
 
-Initializers are methods that are automatically invoked by the new.
-In fact, by default, the setter of an attribute is used as a initializer.
+Initializers are methods that are automatically invoked by `new`.
+In fact, by default, the setter of an attribute is used as an initializer.
 
 `autoinit` is used to register a method as a setter.
 
@@ -124,8 +124,8 @@ var fp = new FooProduct("ABC", "Bla bla", 15.96, 1, 3)
 assert fp.z == 13
 ~~~
 
-Generalized setters are a powerful tool but often needed in only rare specific cases.
-In most case, there is no reason that an argument of a `new` construction is not stored in the object as a real attribute.
+Generalized setters are a powerful tool, but only needed in rare specific cases.
+In most cases, there is no reason for an argument of a `new` construction to not be stored in the object as a real attribute.
 
 
 ## Inheritance
@@ -213,7 +213,7 @@ They should not be used since they will be removed in a near future.
 
 ## `new` factories
 
-`new` factories permit to completely shortcut the class instantiation mechanim.
+`new` factories allow to completely shortcut the class instantiation mechanism.
 It could be used to provide `new` syntax on non-concrete class (mainly `extern class`).
 
 `new` factories behave like a top-level function that return the result of the construction.

--- a/doc/manual/method.md
+++ b/doc/manual/method.md
@@ -81,10 +81,10 @@ Concrete classes may have abstract methods. It is up to a refinement to provide 
 
 `super` calls the “previous” definition of the method. It is used in a redefinition of a method in a subclass or in a refinement, It can be used with or without arguments; in the latter case, the original arguments are implicitly used.
 
-The `super` of Nit behave more like the `call-next-method` of CLOS that the `super` of Java or Smalltalk. It permits the traversal of complex class hierarchies and refinement. Basically, `super` is polymorphic: the method called by `super` is not only determined by the class of
-definition of the method but also by the dynamic type of `self`.
+The `super` of Nit behaves more like the `call-next-method` of CLOS than the `super` of Java or Smalltalk. It permits the traversal of complex class hierarchies and refinement. Basically, `super` is polymorphic: the method called by `super` is not only determined by the class of
+definition of the method, but also by the dynamic type of `self`.
 
-The principle it to produce a strict order of the redefinitions of a method (the linearization). Each call to `super` call the next method definition in the linearization. From a technical point of view, the linearization algorithm used is based on C3. It ensures that:
+The principle is to produce a strict order of the redefinitions of a method (the linearization). Each call to `super` call the next method definition in the linearization. From a technical point of view, the linearization algorithm used is based on C3. It ensures that:
 
 -   A definition comes after its redefinition.
 
@@ -134,7 +134,7 @@ Operators and setters are methods that require a special syntax for their defini
 
 -   bracket operator: `[]`. Its definition requires one parameter or more and a return value. Its invocation is done with `x[y, z]` where `x` is the receiver, `y` the first argument and `z` the second argument.
 
--   setters: `something=` where `something` can be any valid method identifier. Their definitions require one parameter or more and no return value. If there is only one parameter, the invocation is done with `x.something = y` where `x` is the receiver and y the argument. If there is more that one parameter, the invocation is done with `x.something(y, z) = t` where `x` is the receiver, `y` the first argument, `z` the second argument and `t` the last argument.
+-   setters: `something=` where `something` can be any valid method identifier. Their definitions require one parameter or more and no return value. If there is only one parameter, the invocation is done with `x.something = y` where `x` is the receiver and `y` the argument. If there is more that one parameter, the invocation is done with `x.something(y, z) = t` where `x` is the receiver, `y` the first argument, `z` the second argument and `t` the last argument.
 
 -   bracket setter: `[]=`. Its definition requires two parameters or more and no return value. Its invocation is done with `x[y, z] = t` where `x` is the receiver, `y` the first argument, `z` the second argument and `t` the last argument.
 

--- a/doc/manual/module.md
+++ b/doc/manual/module.md
@@ -1,6 +1,6 @@
 # Modules
 
-`module` declares the name of a module. While optional it is recommended to use it, at least for documentation purpose. The basename of the source file must match the name declared with `module`. The extension of the source file must be `nit`.
+`module` declares the name of a module. While optional, it is recommended to use it, at least for documentation purposes. The basename of the source file must match the name declared with `module`. The extension of the source file must be `nit`.
 
 A module is made of, in order:
 
@@ -18,7 +18,7 @@ A module is made of, in order:
 
 -   `private import` indicates a private importation. Importers of a given module will not  automatically import its privately imported modules. An analogy is using `#include` in a body file (`.c`) in C/C++.
 
--   `intrude import` indicates an intrusive importation. `intrude` `import` bypasses the `private` visibility and gives to the importer module a full access on the imported module. Such an import may only be considered when modules are strongly bounded and developed together. The closest, but insufficient, analogy is something like including a body file in a body file in C/C++.
+-   `intrude import` indicates an intrusive importation. `intrude` `import` bypasses the `private` visibility and gives to the importer module full access on the imported module. Such an import may only be considered when modules are strongly bounded and developed together. The closest, but insufficient, analogy is something like including a body file in a body file in C/C++.
 
 ## Visibility
 

--- a/doc/manual/nitreference.tex
+++ b/doc/manual/nitreference.tex
@@ -65,7 +65,7 @@
 
 \noindent\textbf{A Concise Reference of the Nit Language}
 
-This document attempts to be as short as possible while covering all features of the language in deepth.
+This document attempts to be as short as possible while covering all features of the language in depth.
 It is not a real manual to learn the language since concepts are covered when required.
 %Forward and backward references about concepts are written like this~\goto{redef} which means Section~\ref*{redef}.
 %An index\goto{index} also lists concepts and keywords for an improved navigation.

--- a/doc/manual/structure.md
+++ b/doc/manual/structure.md
@@ -16,7 +16,7 @@ program. Nit heavily refers to the control flow in its specification:
 
 -   Adaptive typing.
 
-Some structures alter the control flow but are not described in this
+Some structures alter the control flow, but are not described in this
 section: `and`, `or`, `not`, `or else` and `return`.
 
 Note that the control flow is determined only from the position, the
@@ -118,11 +118,11 @@ loop
 end
 ~~~
 
-Note that `loop` is different from `while true` because the control flow does not consider the values of expression.
+Note that `loop` is different from `while true` because the control flow does not consider the values of expressions.
 
 ## do
 
-Single `do` are used to create scope for variables or to be attached with labeled breaks.
+Single `do` are used to create scoped variables or to be attached with labeled breaks.
 
 ~~~
 do

--- a/doc/manual/variable.md
+++ b/doc/manual/variable.md
@@ -1,6 +1,6 @@
 # Local Variables and Static Typing
 
-`var` declares local variables. In fact there is no global variable in Nit, so in this document *variable* always refers to a local variable. A variable is visible up to the end of the current
+`var` declares local variables. In fact, there is no global variable in Nit, so in this document *variable* always refers to a local variable. A variable is visible up to the end of the current
 control structure. Two variables with the same name cannot coexist: no nesting nor masking.
 
 Variables are bound to values. A variable cannot be used unless it has a value in all control flow paths (à la Java).
@@ -54,7 +54,7 @@ print d + 1
 
 ## Variable Upper Bound
 
-An optional type information can be added to a variable declaration. This type is used as an upper bound of the type of the variable. When a initial value is given in a variable declaration without a specific type information, the static type of the initial value is used as an upper bound. If no type and no initial value are given, the upper bound is set to `nullable Object`.
+An optional type information can be added to a variable declaration. This type is used as an upper bound of the type of the variable. When an initial value is given in a variable declaration without a specific type information, the static type of the initial value is used as an upper bound. If no type and no initial value are given, the upper bound is set to `nullable Object`.
 
 ~~~nitish
 var e: Int # Upper bound is Int
@@ -130,7 +130,7 @@ end
 print max # outputs 11
 ~~~
 
-Note that type adaptation occurs only in an `isa` if the target type is more specific that the current type.
+Note that type adaptation occurs only in an `isa` if the target type is more specific than the current type.
 
 ~~~
 var col: Collection[Int] = [1, 2, 3]

--- a/src/metrics/mclassdef_collect.nit
+++ b/src/metrics/mclassdef_collect.nit
@@ -16,7 +16,7 @@
 module mclassdef_collect
 
 # We usualy need specific phases
-# NOTE: `frontend` is sufficent in most case (it is often too much)
+# NOTE: `frontend` is sufficent in most cases (it is often too much)
 import frontend
 import model_collect
 

--- a/src/metrics/method_analyze_metrics.nit
+++ b/src/metrics/method_analyze_metrics.nit
@@ -16,7 +16,7 @@
 module method_analyze_metrics
 
 # We usualy need specific phases
-# NOTE: `frontend` is sufficent in most case (it is often too much)
+# NOTE: `frontend` is sufficent in most cases (it is often too much)
 import nitsmell_toolcontext
 import mclassdef_collect
 

--- a/src/test_test_phase.nit
+++ b/src/test_test_phase.nit
@@ -21,7 +21,7 @@ module test_test_phase
 import test_phase
 
 # We usualy need specific phases
-# NOTE: `frontend` is sufficient in most case (it is often too much)
+# NOTE: `frontend` is sufficient in most cases (it is often too much)
 import frontend
 
 # The body of the specific work.


### PR DESCRIPTION
This PR is fairly basic and only contains the following changes:
- Corrected various sentence structures, typos and text formatting across several markdown pages (language doc, README, etc.)

Note: There are a few sections I would rewrite differently to sound more professional/neutral and to include more details about how the language behaves in certain cases, but I felt like it was outside of this PR's scope.