### PR TITLE
Make 'Unreachable statement' a warning

### DIFF
--- a/src/semantize/flow.nit
+++ b/src/semantize/flow.nit
@@ -305,7 +305,7 @@ redef class ABlockExpr
 				v.enter_visit(e)
 			else if not v.current_flow_context.is_already_unreachable then
 				v.current_flow_context.is_already_unreachable = true
-				v.toolcontext.error(e.hot_location, "Error: unreachable statement.")
+				v.toolcontext.warning(e.hot_location, "unreachable", "Warning: unreachable statement.")
 			end
 		end
 	end

--- a/src/semantize/local_var_init.nit
+++ b/src/semantize/local_var_init.nit
@@ -59,8 +59,8 @@ private class LocalVarInitVisitor
 		assert variable != null
 		if not maybe_unset_vars.has(variable) then return
 
-		var flow = node.after_flow_context.as(not null)
-		flow.set_vars.add(variable)
+		var flow = node.after_flow_context
+		if flow != null then flow.set_vars.add(variable)
 	end
 
 	fun check_is_set(node: AExpr, variable: nullable Variable)
@@ -68,8 +68,8 @@ private class LocalVarInitVisitor
 		assert variable != null
 		if not maybe_unset_vars.has(variable) then return
 
-		var flow = node.after_flow_context.as(not null)
-		if not flow.is_variable_set(variable) then
+		var flow = node.after_flow_context
+		if flow != null and not flow.is_variable_set(variable) then
 			self.toolcontext.error(node.hot_location, "Error: possibly unset variable `{variable}`.")
 			# Remove the variable to avoid repeating errors
 			self.maybe_unset_vars.remove(variable)

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -634,9 +634,7 @@ private class TypeVisitor
 	fun set_variable(node: AExpr, variable: Variable, mtype: nullable MType)
 	do
 		var flow = node.after_flow_context
-		assert flow != null
-
-		flow.set_var(self, variable, mtype)
+		if flow != null then flow.set_var(self, variable, mtype)
 	end
 
 	# Find the exact representable most specific common super-type in `col`.

--- a/tests/base_control_flow3.nit
+++ b/tests/base_control_flow3.nit
@@ -1,0 +1,49 @@
+# This file is part of NIT ( http://www.nitlanguage.org ).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import kernel
+
+var a
+a = null
+a = 1
+
+a.output
+return
+# Below this line the code is unreachable
+
+var b
+b = null
+b = 1
+a.output
+b.output
+a = b
+b = a
+
+if a == b then
+	a = b
+	b = a
+else
+	a = null
+	b = null
+end
+a.output
+b.output
+var c = a.as(not null)
+var d = b.as(Int)
+var e
+e.output
+
+#alt1#(b+1).output # Error
+b = 1
+#alt1#(b+1).output # Still error

--- a/tests/sav/base_control_flow2_alt1.res
+++ b/tests/sav/base_control_flow2_alt1.res
@@ -1,4 +1,4 @@
-alt/base_control_flow2_alt1.nit:24,2: Error: unreachable statement.
+alt/base_control_flow2_alt1.nit:24,2: Warning: unreachable statement.
 alt/base_control_flow2_alt1.nit:21,1--25,3: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt1.nit:39,1--43,3: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt1.nit:47,2--51,4: Warning: use `loop` instead of `while true do`.

--- a/tests/sav/base_control_flow2_alt2.res
+++ b/tests/sav/base_control_flow2_alt2.res
@@ -1,5 +1,5 @@
 alt/base_control_flow2_alt2.nit:21,1--25,3: Warning: use `loop` instead of `while true do`.
-alt/base_control_flow2_alt2.nit:30,2: Error: unreachable statement.
+alt/base_control_flow2_alt2.nit:30,2: Warning: unreachable statement.
 alt/base_control_flow2_alt2.nit:39,1--43,3: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt2.nit:47,2--51,4: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt2.nit:45,1--55,3: Warning: use `loop` instead of `while true do`.

--- a/tests/sav/base_control_flow2_alt3.res
+++ b/tests/sav/base_control_flow2_alt3.res
@@ -1,5 +1,5 @@
 alt/base_control_flow2_alt3.nit:21,1--25,3: Warning: use `loop` instead of `while true do`.
-alt/base_control_flow2_alt3.nit:42,2: Error: unreachable statement.
+alt/base_control_flow2_alt3.nit:42,2: Warning: unreachable statement.
 alt/base_control_flow2_alt3.nit:39,1--43,3: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt3.nit:47,2--51,4: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt3.nit:45,1--55,3: Warning: use `loop` instead of `while true do`.

--- a/tests/sav/base_control_flow2_alt4.res
+++ b/tests/sav/base_control_flow2_alt4.res
@@ -1,5 +1,5 @@
 alt/base_control_flow2_alt4.nit:21,1--25,3: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt4.nit:39,1--43,3: Warning: use `loop` instead of `while true do`.
-alt/base_control_flow2_alt4.nit:50,3: Error: unreachable statement.
+alt/base_control_flow2_alt4.nit:50,3: Warning: unreachable statement.
 alt/base_control_flow2_alt4.nit:47,2--51,4: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt4.nit:45,1--55,3: Warning: use `loop` instead of `while true do`.

--- a/tests/sav/base_control_flow2_alt5.res
+++ b/tests/sav/base_control_flow2_alt5.res
@@ -1,5 +1,5 @@
 alt/base_control_flow2_alt5.nit:21,1--25,3: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt5.nit:39,1--43,3: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt5.nit:47,2--51,4: Warning: use `loop` instead of `while true do`.
-alt/base_control_flow2_alt5.nit:54,2: Error: unreachable statement.
+alt/base_control_flow2_alt5.nit:54,2: Warning: unreachable statement.
 alt/base_control_flow2_alt5.nit:45,1--55,3: Warning: use `loop` instead of `while true do`.

--- a/tests/sav/base_control_flow2_alt6.res
+++ b/tests/sav/base_control_flow2_alt6.res
@@ -2,4 +2,4 @@ alt/base_control_flow2_alt6.nit:21,1--25,3: Warning: use `loop` instead of `whil
 alt/base_control_flow2_alt6.nit:39,1--43,3: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt6.nit:47,2--51,4: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt6.nit:45,1--55,3: Warning: use `loop` instead of `while true do`.
-alt/base_control_flow2_alt6.nit:60,2: Error: unreachable statement.
+alt/base_control_flow2_alt6.nit:60,2: Warning: unreachable statement.

--- a/tests/sav/base_control_flow2_alt7.res
+++ b/tests/sav/base_control_flow2_alt7.res
@@ -2,4 +2,4 @@ alt/base_control_flow2_alt7.nit:21,1--25,3: Warning: use `loop` instead of `whil
 alt/base_control_flow2_alt7.nit:39,1--43,3: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt7.nit:47,2--51,4: Warning: use `loop` instead of `while true do`.
 alt/base_control_flow2_alt7.nit:45,1--55,3: Warning: use `loop` instead of `while true do`.
-alt/base_control_flow2_alt7.nit:67,2: Error: unreachable statement.
+alt/base_control_flow2_alt7.nit:67,2: Warning: unreachable statement.

--- a/tests/sav/base_control_flow3.res
+++ b/tests/sav/base_control_flow3.res
@@ -1,0 +1,2 @@
+base_control_flow3.nit:25,1--5: Warning: unreachable statement.
+1

--- a/tests/sav/base_control_flow3_alt1.res
+++ b/tests/sav/base_control_flow3_alt1.res
@@ -1,0 +1,3 @@
+alt/base_control_flow3_alt1.nit:25,1--5: Warning: unreachable statement.
+alt/base_control_flow3_alt1.nit:47,3: Error: method `+` does not exists in `nullable Object`.
+alt/base_control_flow3_alt1.nit:49,3: Error: method `+` does not exists in `nullable Object`.

--- a/tests/sav/base_control_flow_alt2.res
+++ b/tests/sav/base_control_flow_alt2.res
@@ -1,1 +1,1 @@
-alt/base_control_flow_alt2.nit:23,2: Error: unreachable statement.
+alt/base_control_flow_alt2.nit:23,2: Warning: unreachable statement.

--- a/tests/sav/base_control_flow_alt3.res
+++ b/tests/sav/base_control_flow_alt3.res
@@ -1,1 +1,1 @@
-alt/base_control_flow_alt3.nit:54,2: Error: unreachable statement.
+alt/base_control_flow_alt3.nit:54,2: Warning: unreachable statement.

--- a/tests/sav/nit_args9.res
+++ b/tests/sav/nit_args9.res
@@ -1,9 +1,6 @@
 [0;33mtest_keep_going.nit:15,11--14[0m: Error: class `Fail` not found in module `test_keep_going`.
 	fun plop: [1;31mFail[0m
 	          ^
-[0;33mtest_keep_going.nit:40,2--11[0m: Error: unreachable statement.
-		[1;31m999.output[0m
-		^
 [0;33mtest_keep_going.nit:26,2--5[0m: Error: method or variable `fail` unknown in `Sys`.
 		[1;31mfail[0m
 		^
@@ -13,10 +10,13 @@
 [0;33mtest_keep_going.nit:35,5[0m: Type Error: expected `Bool`, got `Int`.
 		if [1;31m1[0m then abort
 		   ^
+[0;33mtest_keep_going.nit:40,2--11[0m: Warning: unreachable statement. (unreachable)
+		[1;31m999.output[0m
+		^
 [0;33mtest_keep_going.nit:44,18--21[0m: Error: method `fail` does not exists in `Sys`.
 		var a = new Sys.[1;31mfail[0m
 		                ^
-Errors: 6. Warnings: 0.
+Errors: 5. Warnings: 1.
 1
 2
 3

--- a/tests/sav/nitc_args12.res
+++ b/tests/sav/nitc_args12.res
@@ -1,9 +1,6 @@
 [0;33mtest_keep_going.nit:15,11--14[0m: Error: class `Fail` not found in module `test_keep_going`.
 	fun plop: [1;31mFail[0m
 	          ^
-[0;33mtest_keep_going.nit:40,2--11[0m: Error: unreachable statement.
-		[1;31m999.output[0m
-		^
 [0;33mtest_keep_going.nit:26,2--5[0m: Error: method or variable `fail` unknown in `Sys`.
 		[1;31mfail[0m
 		^
@@ -13,10 +10,13 @@
 [0;33mtest_keep_going.nit:35,5[0m: Type Error: expected `Bool`, got `Int`.
 		if [1;31m1[0m then abort
 		   ^
+[0;33mtest_keep_going.nit:40,2--11[0m: Warning: unreachable statement. (unreachable)
+		[1;31m999.output[0m
+		^
 [0;33mtest_keep_going.nit:44,18--21[0m: Error: method `fail` does not exists in `Sys`.
 		var a = new Sys.[1;31mfail[0m
 		                ^
-Errors: 6. Warnings: 0.
+Errors: 5. Warnings: 1.
 1
 2
 3

--- a/tests/sav/syntax_lambda.res
+++ b/tests/sav/syntax_lambda.res
@@ -1,1 +1,17 @@
-syntax_lambda.nit:36,1--28: Error: unreachable statement.
+syntax_lambda.nit:24,9--18: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:26,9--22: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:28,11--24: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:31,9--33,7: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:36,9--28: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:36,1--28: Warning: unreachable statement.
+syntax_lambda.nit:37,10--26: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:39,9--30: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:41,9--48: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:43,10--29: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:45,5--18: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:46,5--18: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:49,1--51,8: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:55,2--15: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:56,1--14: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:58,9--60,10: no implemented accept_typing for ALambdaExpr
+syntax_lambda.nit:64,1--32: no implemented accept_typing for ALambdaExpr


### PR DESCRIPTION
From a language point of view, an unreachable statement is not an error, as the code is not executed. This is bad style at best.

However, surprisingly, in Nit it was en error because adaptive typing use the flow graph to compute the static type of variables and expression. Having unreachable code make the static type of those more complex to report to the user in a stable manner.

From a software engineering point of view, having a warning let the user shortcuts method when debugging. This is anyway cleaner than using opaque predicates à la `if true then return` that do not cause a warning (maybe it should, but it is another issue).

This, this PR tries to do the right thing by making unreachable statements a warning. The static type of things is however just let as is without additional type adaptation, undefined variable are also silenced.