### PR TITLE
nitcc: add LRAutomaton::to_dot_lr0

### DIFF
--- a/contrib/nitcc/src/grammar.nit
+++ b/contrib/nitcc/src/grammar.nit
@@ -590,6 +590,39 @@ class LRAutomaton
 	end
 
 	# Generate a graphviz file of the automaton
+	# This generate a simple executable LR0 without much information
+	fun to_dot_lr0(path: String)
+	do
+		var f = new FileWriter.open(path)
+		f.write("digraph \{\n")
+		f.write("rankdir=TB;\n")
+		f.write("node[shape=box,style=rounded];\n")
+
+		f.write("entry [style=invis];\nentry -> s{states.first.number}\n")
+		for s in states do
+			f.write "s{s.number} [label=\""
+			for a in s.reduces do
+				if a.prod.accept then
+					f.write "ACCEPT\\n"
+				else
+					f.write "REDUCE {a.prod.name.escape_to_dot} WITH {a.elems.length} ELEMENTS\\n"
+				end
+			end
+			if s.shifts.length > 0 then
+				f.write "SHIFT\\n"
+			end
+			f.write "\""
+			if not s.is_lr0 then f.write ",color=red"
+			f.write "];\n"
+			for t in s.outs do
+				f.write "s{s.number} -> s{t.to.number} [label=\"{t.elem.to_s.escape_to_dot}\"];\n"
+			end
+		end
+		f.write("\}\n")
+		f.close
+	end
+
+	# Generate a graphviz file of the automaton
 	fun to_dot(path: String)
 	do
 		var f = new FileWriter.open(path)

--- a/contrib/nitcc/src/nitcc.nit
+++ b/contrib/nitcc/src/nitcc.nit
@@ -99,8 +99,9 @@ f.write "// Concrete grammar of {name}\n"
 f.write pretty
 f.close
 
-print "LR automaton: {lr.states.length} states (see {name}.lr.dot and {name}.lr.out)"
+print "LR automaton: {lr.states.length} states (see {name}.lr.dot, {name}.lr0.dot and {name}.lr.out)"
 lr.to_dot("{name}.lr.dot")
+lr.to_dot_lr0("{name}.lr0.dot")
 pretty = lr.pretty
 f = new FileWriter.open("{name}.lr.out")
 f.write "// LR automaton of {name}\n"


### PR DESCRIPTION
This draw runnable pure LR0 automation that should scale because there is no much annotation.

Here an example with tests/not_slr.sablecc. The conflicting state, with two actions, is red

![not_slr lr0](https://github.com/nitlang/nit/assets/135828/d9d33473-c58a-423b-993c-6b51472afc6c)
