### PR TITLE
New class and facility CallSiteBuilder

### DIFF
--- a/src/astbuilder.nit
+++ b/src/astbuilder.nit
@@ -24,12 +24,11 @@ intrude import modelize_property
 
 # General factory to build semantic nodes in the AST of expressions
 class ASTBuilder
-	# The module used as reference for the building
-	# It is used to gather types and other stuff
-	var mmodule: MModule
+	super TypeContext
 
-	# The anchor used for some mechanism relying on types
-	var anchor: nullable MClassType
+	redef var mmodule: MModule
+
+	redef var anchor: nullable MClassType
 
 	# Check mmodule to avoid a new instantiation of ASTBuilder
 	fun check_mmodule(mmodule: MModule)

--- a/src/astbuilder.nit
+++ b/src/astbuilder.nit
@@ -969,7 +969,7 @@ end
 
 redef class MClassDef
 	redef fun create_ast_representation(astbuilder: nullable ASTBuilder): AStdClassdef do
-		if astbuilder == null then astbuilder = new ASTBuilder(mmodule)
+		if astbuilder == null then astbuilder = new ASTBuilder(mmodule, bound_mtype)
 		var n_propdefs = new Array[APropdef]
 		for mpropdef in self.mpropdefs do
 			n_propdefs.add(mpropdef.create_ast_representation(astbuilder))
@@ -983,7 +983,7 @@ end
 
 redef class MAttributeDef
 	redef fun create_ast_representation(astbuilder: nullable ASTBuilder): AAttrPropdef do
-		if astbuilder == null then astbuilder = new ASTBuilder(mclassdef.mmodule)
+		if astbuilder == null then astbuilder = new ASTBuilder(mclassdef.mmodule, mclassdef.bound_mtype)
 		var ntype = null
 		if self.static_mtype != null then ntype = static_mtype.create_ast_representation(astbuilder)
 		return astbuilder.make_attribute("_" + self.name, ntype, self.visibility.create_ast_representation(astbuilder), null, null, self, null, null)
@@ -992,7 +992,7 @@ end
 
 redef class MMethodDef
 	redef fun create_ast_representation(astbuilder: nullable ASTBuilder): AMethPropdef do
-		if astbuilder == null then astbuilder = new ASTBuilder(mclassdef.mmodule)
+		if astbuilder == null then astbuilder = new ASTBuilder(mclassdef.mmodule, mclassdef.bound_mtype)
 		var tk_redef = null
 		if self.mproperty.intro != self then tk_redef = new TKwredef
 		var  n_signature = if self.msignature == null then new ASignature else self.msignature.create_ast_representation(astbuilder)

--- a/src/astbuilder.nit
+++ b/src/astbuilder.nit
@@ -202,11 +202,11 @@ class ASTBuilder
 
 	# Build a callsite to call the `mproperty` in the current method `caller_method`.
 	# `is_self_call` indicate if the method caller is a property of `self`
-	fun create_callsite(modelbuilder: ModelBuilder, caller_property: APropdef, mproperty: MMethod, is_self_call: Bool): CallSite
+	fun create_callsite(mproperty: MMethod, is_self_call: Bool): CallSite
 	do
-		# FIXME It's not the better solution to call `TypeVisitor` here to build a model entity, but some make need to have a callsite
-		var type_visitor = new TypeVisitor(modelbuilder, caller_property.mpropdef.as(not null))
-		var callsite = type_visitor.build_callsite_by_property(caller_property, mproperty.intro_mclassdef.bound_mtype, mproperty, is_self_call)
+		var recv = mproperty.intro_mclassdef.bound_mtype
+		var builder = new CallSiteBuilder(mmodule.model.no_location, recv, self)
+		var callsite = builder.recv_is_self(is_self_call).by_property(mproperty)
 		assert callsite != null
 		return callsite
 	end

--- a/src/contracts.nit
+++ b/src/contracts.nit
@@ -244,12 +244,12 @@ private class ContractsVisitor
 	private fun encapsulated_contract_call(visited_method: AMethPropdef, call_to_contracts: Array[ACallExpr]): AIfExpr
 	do
 		var sys_property = toolcontext.modelbuilder.model.get_mproperties_by_name("sys").first.as(MMethod)
-		var callsite_sys = ast_builder.create_callsite(toolcontext.modelbuilder, visited_method, sys_property, true)
+		var callsite_sys = ast_builder.create_callsite(sys_property, true)
 
 		var incontract_attribute = get_incontract
 
-		var callsite_get_incontract = ast_builder.create_callsite(toolcontext.modelbuilder, visited_method, incontract_attribute.getter.as(MMethod), false)
-		var callsite_set_incontract = ast_builder.create_callsite(toolcontext.modelbuilder, visited_method, incontract_attribute.setter.as(MMethod), false)
+		var callsite_get_incontract = ast_builder.create_callsite(incontract_attribute.getter.as(MMethod), false)
+		var callsite_set_incontract = ast_builder.create_callsite(incontract_attribute.setter.as(MMethod), false)
 
 		var n_condition = ast_builder.make_not(ast_builder.make_call(ast_builder.make_call(new ASelfExpr, callsite_sys, null), callsite_get_incontract, null))
 
@@ -302,7 +302,7 @@ private class CallSiteVisitor
 			facet = contract_facet
 		end
 
-		return ast_builder.create_callsite(toolcontext.modelbuilder, visited_propdef, facet, callsite.recv_is_self)
+		return ast_builder.create_callsite(facet, callsite.recv_is_self)
 	end
 end
 
@@ -486,7 +486,7 @@ redef class MExpect
 
 	redef fun adapt_method_to_contract(v: ContractsVisitor, mfacet: MFacet, n_mpropdef: AMethPropdef)
 	do
-		var callsite = v.ast_builder.create_callsite(v.toolcontext.modelbuilder, n_mpropdef, self, true)
+		var callsite = v.ast_builder.create_callsite(self, true)
 		var args = n_mpropdef.n_signature.make_parameter_read(v.ast_builder)
 		var n_callexpect = v.ast_builder.make_call(new ASelfExpr, callsite,args)
 		# Creation of the new instruction block with the call to expect condition
@@ -578,7 +578,7 @@ redef class MEnsure
 
 	redef fun adapt_method_to_contract(v: ContractsVisitor, mfacet: MFacet, n_mpropdef: AMethPropdef)
 	do
-		var callsite = v.ast_builder.create_callsite(v.toolcontext.modelbuilder, n_mpropdef, self, true)
+		var callsite = v.ast_builder.create_callsite(self, true)
 		var n_self = new ASelfExpr
 		# argument to call the contract method
 		var args = n_mpropdef.n_signature.make_parameter_read(v.ast_builder)
@@ -613,7 +613,7 @@ redef class MInvariant
 
 	redef fun adapt_method_to_contract(v: ContractsVisitor, mfacet: MFacet, n_mpropdef: AMethPropdef)
 	do
-		var callsite = v.ast_builder.create_callsite(v.toolcontext.modelbuilder, n_mpropdef, self, true)
+		var callsite = v.ast_builder.create_callsite(self, true)
 		var n_self = new ASelfExpr
 		# build the call to the contract method
 		var n_call = v.ast_builder.make_call(n_self, callsite, null)
@@ -880,7 +880,7 @@ redef class MMethod
 		var args: Array[AExpr]
 		args = n_contractdef.n_signature.make_parameter_read(v.ast_builder)
 
-		var callsite = v.ast_builder.create_callsite(v.toolcontext.modelbuilder, n_contractdef, called, true)
+		var callsite = v.ast_builder.create_callsite(called, true)
 		var n_call = v.ast_builder.make_call(new ASelfExpr, callsite, args)
 
 		if self.intro.msignature.return_mtype == null then

--- a/src/frontend/explain_assert.nit
+++ b/src/frontend/explain_assert.nit
@@ -75,9 +75,6 @@ private class ExplainAssertVisitor
 	# Type of `String` (the generated code does not work without a `String`)
 	var string_mtype: MType
 
-	# Tool to modify the AST
-	var builder = new ASTBuilder(mmodule) is lazy
-
 	redef fun visit(node)
 	do
 		# Recursively visit all sub-nodes


### PR DESCRIPTION
First, a helper interface, `TypeContext`, is extracted from `TypeVisitor`
Then `CallSiteBuilder` is created and used.