### PR TITLE
niti: cache anchor_to and some other optimizations

### DIFF
--- a/contrib/nitin/nitin.nit
+++ b/contrib/nitin/nitin.nit
@@ -145,20 +145,19 @@ redef class AMethPropdef
 		if injected_variables == null then return super
 
 		# Inject main variables in the frame
-		assert f isa InterpreterFrame
 		for variable, i in injected_variables do
-			f.map[variable] = i
+			f.write_variable(variable, v, i)
 		end
 
 		var res = super
 
 		# Update the values of the variables
 		for variable in injected_variables.keys do
-			injected_variables[variable] = f.map[variable]
+			injected_variables[variable] = f.read_variable(variable, v)
 		end
 		# Retrieve the values of the new main variables
 		for variable in new_variables.as(not null) do
-			injected_variables[variable] = f.map[variable]
+			injected_variables[variable] = f.read_variable(variable, v)
 		end
 
 		return res

--- a/contrib/nitin/nitin.nit
+++ b/contrib/nitin/nitin.nit
@@ -256,6 +256,7 @@ loop
 	# Run the main if the AST contains a main
 	if main_method != null then
 		do
+			interpreter.clear_caches
 			interpreter.catch_count += 1
 			interpreter.send(mainprop, [mainobj])
 		catch

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -116,6 +116,7 @@ class NaiveInterpreter
 	fun clear_caches
 	do
 		anchor_to_cache.clear
+		lookup_first_definition_cache.clear
 	end
 
 	# Subtype test in the context of the mainmodule
@@ -645,8 +646,21 @@ class NaiveInterpreter
 		var mtype = recv.mtype
 		var ret = send_commons(mproperty, args, mtype)
 		if ret != null then return ret
-		var propdef = mproperty.lookup_first_definition(self.mainmodule, mtype)
+		var propdef = lookup_first_definition(mtype, mproperty)
 		return self.call(propdef, args)
+	end
+
+	private var lookup_first_definition_cache = new HashMap2[MType, MMethod, MMethodDef]
+
+	# Cached version of lookup_first_definition for the main module
+	fun lookup_first_definition(mtype: MType, mproperty: MMethod): MMethodDef
+	do
+		if mproperty.mpropdefs.length == 1 then return mproperty.mpropdefs.first
+		var res = lookup_first_definition_cache[mtype, mproperty]
+		if res != null then return res
+		res = mproperty.lookup_first_definition(self.mainmodule, mtype)
+		lookup_first_definition_cache[mtype, mproperty] = res
+		return res
 	end
 
 	# Read the attribute `mproperty` of an instance `recv` and return its value.

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -113,6 +113,11 @@ class NaiveInterpreter
 		end
 	end
 
+	fun clear_caches
+	do
+		anchor_to_cache.clear
+	end
+
 	# Subtype test in the context of the mainmodule
 	fun is_subtype(sub, sup: MType): Bool
 	do

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -513,7 +513,7 @@ class NaiveInterpreter
 
 		if msignature.arity == 0 then return res
 
-		if map == null then
+		if map == null or map.straight then
 			assert args.length == msignature.arity else debug("Expected {msignature.arity} args, got {args.length}")
 			if aexprs_to_instances(args, res) == null then return null
 			return res

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -2313,6 +2313,9 @@ redef class AOnceExpr
 end
 
 redef class ASendExpr
+	# We assume the node will not change, so we can cache the raw arguments array once and for all
+	private var raw_arguments_cache: Array[AExpr] = self.raw_arguments is lazy
+
 	redef fun expr(v)
 	do
 		var recv = v.expr(self.n_expr)
@@ -2323,7 +2326,7 @@ redef class ASendExpr
 			return recv
 		end
 
-		var args = v.varargize(callsite.mpropdef, callsite.signaturemap, recv, self.raw_arguments)
+		var args = v.varargize(callsite.mpropdef, callsite.signaturemap, recv, self.raw_arguments_cache)
 		if args == null then return null
 		var res = v.callsite(callsite, args)
 		return res

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -855,7 +855,12 @@ class PrimitiveInstance[E]
 		return self.val.is_same_instance(o.val)
 	end
 
-	redef fun to_s do return "{mtype}#{val.object_id}({val or else "null"})"
+	redef fun to_s
+	do
+		var val = self.val
+		if val == null then return "{mtype}#null"
+		return "{mtype}#{val.object_id}({val})"
+	end
 
 	redef fun to_i do return val.as(Int)
 

--- a/src/interpreter/naive_interpreter.nit
+++ b/src/interpreter/naive_interpreter.nit
@@ -117,6 +117,7 @@ class NaiveInterpreter
 	do
 		anchor_to_cache.clear
 		lookup_first_definition_cache.clear
+		collect_attr_propdef_cache.clear
 	end
 
 	# Subtype test in the context of the mainmodule

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -523,6 +523,7 @@ private class TypeVisitor
 				var paramtype = param.mtype
 				self.visit_expr_subtype(arg, paramtype)
 			else
+				straight = false
 				check_one_vararg(arg, param)
 			end
 		end

--- a/src/semantize/typing.nit
+++ b/src/semantize/typing.nit
@@ -454,6 +454,7 @@ private class TypeVisitor
 
 		# Associate each parameter to a position in the arguments
 		var map = new SignatureMap
+		var straight = args.length == msignature.arity
 
 		# Special case for the isolated last argument
 		# TODO: reify this method characteristics (where? the param, the signature, the method?)
@@ -483,6 +484,7 @@ private class TypeVisitor
 				return null
 			end
 			map.map[idx] = i
+			if idx != i then straight = false
 			e.mtype = self.visit_expr_subtype(e.n_expr, param.mtype)
 		end
 
@@ -509,6 +511,7 @@ private class TypeVisitor
 			end
 			var arg = args[j]
 			map.map[i] = j
+			if i != j then straight = false
 			j += 1
 
 			if i == vararg_rank then
@@ -536,6 +539,7 @@ private class TypeVisitor
 
 		# Third, check varargs
 		if vararg_rank >= 0 then
+			straight = false
 			var paramtype = msignature.mparameters[vararg_rank].mtype
 			var first = args[vararg_rank]
 			if vararg_decl == 0 then
@@ -548,6 +552,7 @@ private class TypeVisitor
 			end
 		end
 
+		map.straight = straight
 		return map
 	end
 
@@ -761,6 +766,9 @@ end
 class SignatureMap
 	# Associate a parameter to an argument
 	var map = new ArrayMap[Int, Int]
+
+	# Is trivially the ith parameter associated to the ith argument?
+	var straight = true
 end
 
 # A specific method call site with its associated informations.


### PR DESCRIPTION
Some low-hanging-fruit optimizations in the interpreter. Most are simple caching.

The improvements are impressive for microbenches

```
$ ./difftime.sh nit ./nit fib.nit 28
+ nit fib.nit 28
317811
User time: 6.19
+ ./nit fib.nit 28
317811
User time: 2.08
Gain: 66.397
```

But less impressive for more complex programs

```
$ ./difftime.sh nit ./nit nit.nit ../tests/base_simple3.nit
+ nit nit.nit ../tests/base_simple3.nit
1
2
3
4
5
6
7
8
9
10
User time: 2.42
+ ./nit nit.nit ../tests/base_simple3.nit
1
2
3
4
5
6
7
8
9
10
User time: 1.96
Gain: 19.008

```